### PR TITLE
fix(web): improve print output and use CSS classes for node status

### DIFF
--- a/apps/server/web/src/app.css
+++ b/apps/server/web/src/app.css
@@ -355,7 +355,7 @@ body {
 .text-theme-text-emphasis { color: var(--color-text-emphasis); }
 .border-theme-border { border-color: var(--border); }
 
-/* Print styles — show only the SVG diagram */
+/* Print styles — show only the pure SVG topology */
 @media print {
   html, body {
     overflow: visible !important;
@@ -376,6 +376,16 @@ body {
     visibility: visible !important;
   }
 
+  /* Hide weathermap overlays — print the clean topology */
+  .svg-wrapper .wm-overlay {
+    display: none !important;
+  }
+
+  /* Restore original link paths hidden by weathermap */
+  .svg-wrapper path.link {
+    opacity: 1 !important;
+  }
+
   .svg-wrapper {
     position: fixed !important;
     inset: 0 !important;
@@ -385,7 +395,6 @@ body {
     align-items: center !important;
     justify-content: center !important;
     background: white !important;
-    /* Reset panzoom transform so the full diagram prints */
     transform: none !important;
   }
 
@@ -396,8 +405,20 @@ body {
     height: auto !important;
   }
 
-  /* Remove dot-grid and other background images */
+  /* Remove all filters (shadows etc.) for clean vector output */
+  .svg-wrapper * {
+    filter: none !important;
+  }
+
+  /* Remove backgrounds */
   * {
     background-image: none !important;
+  }
+
+  /* Reset live status indicators */
+  .svg-wrapper g.node.status-up .node-bg rect,
+  .svg-wrapper g.node.status-down .node-bg rect {
+    stroke: unset !important;
+    stroke-width: unset !important;
   }
 }

--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -772,17 +772,6 @@ function applyMetrics(
 
       nodeGroup.classList.remove('status-up', 'status-down', 'status-unknown')
       nodeGroup.classList.add(`status-${nodeMetrics.status}`)
-
-      const rect = nodeGroup.querySelector('.node-bg rect, rect.node-bg') as SVGRectElement
-      if (rect) {
-        if (nodeMetrics.status === 'down') {
-          rect.setAttribute('stroke', '#ef4444')
-          rect.setAttribute('stroke-width', '2')
-        } else if (nodeMetrics.status === 'up') {
-          rect.setAttribute('stroke', '#22c55e')
-          rect.setAttribute('stroke-width', '2')
-        }
-      }
     }
   }
 }
@@ -797,11 +786,6 @@ function resetNodeStyles() {
   const nodeGroups = svgElement.querySelectorAll('g.node')
   nodeGroups.forEach((node) => {
     node.classList.remove('status-up', 'status-down', 'status-unknown')
-    const rect = node.querySelector('.node-bg rect, rect.node-bg') as SVGRectElement
-    if (rect) {
-      rect.removeAttribute('stroke')
-      rect.removeAttribute('stroke-width')
-    }
   })
 }
 
@@ -1080,6 +1064,17 @@ onDestroy(() => {
     stroke-width: 2px !important;
   }
 
+  /* Node status indicators */
+  .svg-wrapper :global(g.node.status-up .node-bg rect) {
+    stroke: #22c55e;
+    stroke-width: 2px;
+  }
+
+  .svg-wrapper :global(g.node.status-down .node-bg rect) {
+    stroke: #ef4444;
+    stroke-width: 2px;
+  }
+
   /* Search highlight pulse */
   .svg-wrapper :global(g.node.search-highlight .node-bg rect) {
     stroke: #f59e0b !important;
@@ -1298,5 +1293,22 @@ onDestroy(() => {
 
   .warning-text {
     white-space: nowrap;
+  }
+
+  /* Print: hide UI chrome (main print styles in app.css) */
+  @media print {
+    .diagram-container {
+      overflow: visible !important;
+      background: white !important;
+      background-image: none !important;
+    }
+
+    .controls,
+    .tooltip,
+    .breadcrumb,
+    .legend,
+    .warnings-banner {
+      display: none !important;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- Add `@media print` styles for clean vector SVG output (hide weathermap overlays, remove filters, hide UI chrome)
- Replace `setAttribute` for node up/down status with CSS class selectors (`status-up`/`status-down`) so print styles can cleanly override without `!important` hacks

## Test plan
- [ ] Ctrl+P on topology page shows clean SVG without colored borders or blurry nodes
- [ ] Live mode still shows green/red node borders for up/down status
- [ ] Weathermap overlays hidden in print, original link paths restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)