### PR TITLE
ci: enable Docker image build and push on PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
+      - name: Log in to Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -38,17 +37,18 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha
+            type=sha,enable={{is_default_branch}}
+            type=ref,event=pr
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/server/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- PRでもghcr.ioへDockerイメージをビルド・pushするように変更
- PRの場合は `pr-<番号>` タグで publish
- mainの場合は `latest` + `sha-<SHA>` + semver タグ

## Changes
- `push: true` に変更（PR時もpush）
- `type=ref,event=pr` タグを追加
- `type=raw,value=latest` と `type=sha` は `enable={{is_default_branch}}` でmain限定
- login stepの `if` 条件を削除（PRでもログインが必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)