### PR TITLE
feat(server): Kubernetesデプロイ用のHelmChartを追加

### DIFF
--- a/apps/server/chart/shumoku/.helmignore
+++ b/apps/server/chart/shumoku/.helmignore
@@ -1,0 +1,13 @@
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~

--- a/apps/server/chart/shumoku/Chart.yaml
+++ b/apps/server/chart/shumoku/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: shumoku
+description: Network topology visualization server
+type: application
+version: 0.1.0
+appVersion: "0.1.1"
+home: https://shumoku.packof.me/
+sources:
+  - https://github.com/konoe-akitoshi/shumoku
+maintainers:
+  - name: konoe-akitoshi

--- a/apps/server/chart/shumoku/templates/_helpers.tpl
+++ b/apps/server/chart/shumoku/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "shumoku.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "shumoku.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "shumoku.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "shumoku.labels" -}}
+helm.sh/chart: {{ include "shumoku.chart" . }}
+{{ include "shumoku.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "shumoku.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "shumoku.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "shumoku.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "shumoku.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/apps/server/chart/shumoku/templates/configmap.yaml
+++ b/apps/server/chart/shumoku/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.config -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "shumoku.fullname" . }}
+  labels:
+    {{- include "shumoku.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}
+{{- end }}

--- a/apps/server/chart/shumoku/templates/deployment.yaml
+++ b/apps/server/chart/shumoku/templates/deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "shumoku.fullname" . }}
+  labels:
+    {{- include "shumoku.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "shumoku.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "shumoku.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "shumoku.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: PORT
+              value: "8080"
+            - name: HOST
+              value: "0.0.0.0"
+            - name: DATA_DIR
+              value: /data
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            {{- if .Values.config }}
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "shumoku.fullname" .) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.config }}
+        - name: config
+          configMap:
+            name: {{ include "shumoku.fullname" . }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/apps/server/chart/shumoku/templates/ingress.yaml
+++ b/apps/server/chart/shumoku/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "shumoku.fullname" . }}
+  labels:
+    {{- include "shumoku.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "shumoku.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/apps/server/chart/shumoku/templates/pvc.yaml
+++ b/apps/server/chart/shumoku/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "shumoku.fullname" . }}
+  labels:
+    {{- include "shumoku.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/apps/server/chart/shumoku/templates/service.yaml
+++ b/apps/server/chart/shumoku/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "shumoku.fullname" . }}
+  labels:
+    {{- include "shumoku.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "shumoku.selectorLabels" . | nindent 4 }}

--- a/apps/server/chart/shumoku/templates/serviceaccount.yaml
+++ b/apps/server/chart/shumoku/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "shumoku.serviceAccountName" . }}
+  labels:
+    {{- include "shumoku.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/apps/server/chart/shumoku/values.yaml
+++ b/apps/server/chart/shumoku/values.yaml
@@ -1,0 +1,82 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/konoe-akitoshi/shumoku
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: shumoku.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources: {}
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 1Gi
+  storageClass: ""
+  existingClaim: ""
+
+config: {}
+  # server:
+  #   port: 8080
+  #   host: 0.0.0.0
+  #   dataDir: /data
+  # topologies:
+  #   - name: main-network
+  #     file: /data/topologies/main.yaml
+  # weathermap:
+  #   thresholds:
+  #     - value: 0
+  #       color: '#73BF69'
+  #     - value: 50
+  #       color: '#FADE2A'
+  #     - value: 75
+  #       color: '#FF9830'
+  #     - value: 90
+  #       color: '#FF0000'
+
+env: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/apps/server/docs/helm-chart.md
+++ b/apps/server/docs/helm-chart.md
@@ -1,0 +1,166 @@
+# Helm Chart
+
+Shumoku Server を Kubernetes にデプロイするための Helm chart です。
+
+## Prerequisites
+
+- Kubernetes 1.25+
+- Helm 3.x
+- コンテナイメージが利用可能であること（ビルド済み or レジストリにプッシュ済み）
+
+## Quick Start
+
+```bash
+# デフォルト設定でインストール
+helm install shumoku apps/server/chart/shumoku
+
+# namespace を指定してインストール
+helm install shumoku apps/server/chart/shumoku -n shumoku --create-namespace
+
+# values ファイルを指定してインストール
+helm install shumoku apps/server/chart/shumoku -f my-values.yaml
+```
+
+## Configuration
+
+`values.yaml` で設定可能なパラメータ一覧です。
+
+### Image
+
+| Parameter | Description | Default |
+|---|---|---|
+| `image.repository` | コンテナイメージのリポジトリ | `ghcr.io/konoe-akitoshi/shumoku` |
+| `image.tag` | イメージタグ（未指定時は `appVersion`） | `""` |
+| `image.pullPolicy` | イメージの pull ポリシー | `IfNotPresent` |
+
+### Service / Ingress
+
+| Parameter | Description | Default |
+|---|---|---|
+| `service.type` | Service の type | `ClusterIP` |
+| `service.port` | Service のポート番号 | `8080` |
+| `ingress.enabled` | Ingress を有効にするか | `false` |
+| `ingress.className` | IngressClass 名 | `""` |
+| `ingress.annotations` | Ingress の annotations | `{}` |
+| `ingress.hosts` | ホスト・パスの設定 | `[{host: shumoku.local, paths: [{path: /, pathType: Prefix}]}]` |
+| `ingress.tls` | TLS 設定 | `[]` |
+
+### Persistence
+
+| Parameter | Description | Default |
+|---|---|---|
+| `persistence.enabled` | PVC を作成するか | `true` |
+| `persistence.accessMode` | アクセスモード | `ReadWriteOnce` |
+| `persistence.size` | ストレージサイズ | `1Gi` |
+| `persistence.storageClass` | StorageClass 名 | `""` |
+| `persistence.existingClaim` | 既存の PVC 名を指定 | `""` |
+
+### Application Config
+
+`config` に値を設定すると ConfigMap としてマウントされます。
+
+```yaml
+config:
+  server:
+    port: 8080
+    host: 0.0.0.0
+    dataDir: /data
+  topologies:
+    - name: main-network
+      file: /data/topologies/main.yaml
+  weathermap:
+    thresholds:
+      - value: 0
+        color: '#73BF69'
+      - value: 50
+        color: '#FADE2A'
+      - value: 75
+        color: '#FF9830'
+      - value: 90
+        color: '#FF0000'
+```
+
+### Security
+
+| Parameter | Description | Default |
+|---|---|---|
+| `podSecurityContext.runAsUser` | Pod の実行ユーザー | `1000` |
+| `podSecurityContext.runAsGroup` | Pod の実行グループ | `1000` |
+| `podSecurityContext.fsGroup` | ファイルシステムのグループ | `1000` |
+| `securityContext.readOnlyRootFilesystem` | ルートFS を読み取り専用にするか | `true` |
+
+### Other
+
+| Parameter | Description | Default |
+|---|---|---|
+| `replicaCount` | レプリカ数 | `1` |
+| `resources` | CPU/メモリの requests/limits | `{}` |
+| `env` | 追加の環境変数 | `[]` |
+| `nodeSelector` | Node selector | `{}` |
+| `tolerations` | Tolerations | `[]` |
+| `affinity` | Affinity ルール | `{}` |
+| `serviceAccount.create` | ServiceAccount を作成するか | `true` |
+
+## Examples
+
+### Ingress を有効にして TLS 設定
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: shumoku.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: shumoku-tls
+      hosts:
+        - shumoku.example.com
+```
+
+### リソース制限を設定
+
+```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+```
+
+## Verification
+
+chart の動作確認には以下のコマンドが使えます。
+
+```bash
+# テンプレートの構文チェック
+helm lint apps/server/chart/shumoku
+
+# レンダリング結果のプレビュー（クラスタ不要）
+helm template test apps/server/chart/shumoku
+
+# config や ingress 有効時のプレビュー
+helm template test apps/server/chart/shumoku -f my-values.yaml
+
+# dry-run でインストールをシミュレーション（クラスタ必要）
+helm install shumoku apps/server/chart/shumoku --dry-run
+
+# インストール後の状態確認
+helm status shumoku
+kubectl get pods -l app.kubernetes.io/name=shumoku
+kubectl logs -l app.kubernetes.io/name=shumoku
+```
+
+## Uninstall
+
+```bash
+helm uninstall shumoku
+# PVC は helm uninstall では削除されません。手動で削除してください：
+# kubectl delete pvc shumoku
+```


### PR DESCRIPTION
## Summary
- Kubernetes デプロイ用の Helm chart を `apps/server/chart/shumoku/` に追加
- Deployment, Service, Ingress, PVC, ConfigMap, ServiceAccount をサポート
- セキュリティ設定（non-root実行、capabilities drop）をデフォルトで有効化
- ドキュメントを `apps/server/docs/helm-chart.md` に追加

## Included templates
- `deployment.yaml` — liveness/readiness probe (`/api/health`), persistent volume, config mount
- `service.yaml` — ClusterIP (port 8080)
- `ingress.yaml` — optional, TLS対応
- `pvc.yaml` — `/data` 用の永続ボリューム (1Gi default)
- `configmap.yaml` — `values.config` で application config を注入
- `serviceaccount.yaml`

## Test plan
- [x] `helm lint` pass
- [x] `helm template` renders correctly (default / with config / with ingress)
- [x] OrbStack local k8s でデプロイ・起動確認済み
- [x] `/api/health` レスポンス確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)