### PR TITLE
feat: unify all packages on custom layout engine (#68)

### DIFF
--- a/apps/cli/src/shumoku.ts
+++ b/apps/cli/src/shumoku.ts
@@ -11,7 +11,7 @@ import { dirname, extname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
 import type { NetworkGraph } from '@shumoku/core'
-import { buildHierarchicalSheets, HierarchicalLayout, parser } from '@shumoku/core'
+import { buildHierarchicalSheets, createNetworkLayoutEngine, parser } from '@shumoku/core'
 import {
   render as renderHtml,
   renderHierarchical as renderHtmlHierarchical,
@@ -161,7 +161,7 @@ async function main(): Promise<void> {
 
     // Layout
     console.log('Generating layout...')
-    const layout = new HierarchicalLayout()
+    const layout = createNetworkLayoutEngine()
     const layoutResult = await layout.layoutAsync(graph)
 
     // Render

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -6,7 +6,7 @@
 import { buildHierarchicalSheets, mergeWithOverlays, type OverlayConfig } from '@shumoku/core'
 import { type EmbeddableRenderOutput, renderEmbeddable } from '@shumoku/renderer-svg'
 import { Hono } from 'hono'
-import { BunHierarchicalLayout } from '../layout.js'
+import { getLayoutEngine } from '../layout.js'
 import { DataSourceService } from '../services/datasource.js'
 import { TopologyService } from '../services/topology.js'
 import { TopologySourcesService } from '../services/topology-sources.js'
@@ -20,10 +20,7 @@ export async function buildRenderOutput(parsed: import('../services/topology.js'
   const hasSubgraphs = parsed.graph.subgraphs && parsed.graph.subgraphs.length > 0
 
   if (hasSubgraphs) {
-    const layoutEngine = new BunHierarchicalLayout({
-      iconDimensions: parsed.iconDimensions.byKey,
-    })
-    const sheets = await buildHierarchicalSheets(parsed.graph, parsed.layout, layoutEngine)
+    const sheets = await buildHierarchicalSheets(parsed.graph, parsed.layout, getLayoutEngine())
 
     const renderedSheets: Record<
       string,

--- a/apps/server/api/src/layout.ts
+++ b/apps/server/api/src/layout.ts
@@ -1,73 +1,22 @@
 /**
- * Bun-compatible layout wrapper
- * Uses web-worker package to make elkjs work in Bun
+ * Layout engine for server
+ * Uses the unified network layout engine (custom layout + libavoid)
  */
 
-import { createRequire } from 'node:module'
-import {
-  HierarchicalLayout,
-  type HierarchicalLayoutOptions,
-  type IconDimensions,
-  type LayoutResult,
-  type NetworkGraph,
-} from '@shumoku/core'
-import ELKApi from 'elkjs/lib/elk-api.js'
-import Worker from 'web-worker'
+import { createNetworkLayoutEngine, type LayoutResult, type NetworkGraph } from '@shumoku/core'
 
-// Get the path to elk-worker.min.js
-const require = createRequire(import.meta.url)
-const elkWorkerPath = require.resolve('elkjs/lib/elk-worker.min.js')
+const engine = createNetworkLayoutEngine()
 
 /**
- * Singleton ELK instance to avoid creating new Workers on every layout call
- * Workers are expensive resources and should be reused
+ * Compute layout asynchronously using the network layout engine.
  */
-let elkInstance: InstanceType<typeof ELKApi> | null = null
-
-function getElkInstance() {
-  if (!elkInstance) {
-    elkInstance = new ELKApi({
-      workerFactory: () => new Worker(elkWorkerPath) as never,
-    })
-  }
-  return elkInstance
+export async function computeLayout(graph: NetworkGraph): Promise<LayoutResult> {
+  return engine.layoutAsync(graph)
 }
 
 /**
- * Bun-compatible HierarchicalLayout wrapper
- * Creates a HierarchicalLayout with a Bun-compatible ELK instance (singleton)
+ * Get the layout engine instance (for buildHierarchicalSheets)
  */
-export class BunHierarchicalLayout {
-  private options: Omit<HierarchicalLayoutOptions, 'elk'>
-
-  constructor(options?: Omit<HierarchicalLayoutOptions, 'elk'>) {
-    this.options = options ?? {}
-  }
-
-  /**
-   * Compute layout (wrapper for HierarchicalLayout.layout)
-   */
-  layout(graph: NetworkGraph, iconDimensions?: Map<string, IconDimensions>): LayoutResult {
-    const layoutInstance = new HierarchicalLayout({
-      ...this.options,
-      iconDimensions,
-      elk: getElkInstance(),
-    })
-    return layoutInstance.layout(graph)
-  }
-
-  /**
-   * Compute layout asynchronously (wrapper for HierarchicalLayout.layoutAsync)
-   */
-  layoutAsync(
-    graph: NetworkGraph,
-    iconDimensions?: Map<string, IconDimensions>,
-  ): Promise<LayoutResult> {
-    const layoutInstance = new HierarchicalLayout({
-      ...this.options,
-      iconDimensions,
-      elk: getElkInstance(),
-    })
-    return layoutInstance.layoutAsync(graph)
-  }
+export function getLayoutEngine() {
+  return engine
 }

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -16,7 +16,7 @@ import {
 } from '@shumoku/core'
 import { collectIconUrls, resolveIconDimensionsForGraph } from '@shumoku/renderer-svg'
 import { generateId, getDatabase, timestamp } from '../db/index.js'
-import { BunHierarchicalLayout } from '../layout.js'
+import { computeLayout } from '../layout.js'
 import type { MetricsData, MetricsMapping, Topology, TopologyInput } from '../types.js'
 
 interface TopologyRow {
@@ -107,14 +107,12 @@ export async function parseYamlToNetworkGraph(
 
 export class TopologyService {
   private db: Database
-  private layout: BunHierarchicalLayout
   private cache: Map<string, ParsedTopology> = new Map()
   private renderCache: Map<string, object> = new Map()
   private errorCache: Map<string, TopologyParseError> = new Map()
 
   constructor() {
     this.db = getDatabase()
-    this.layout = new BunHierarchicalLayout()
   }
 
   /**
@@ -395,7 +393,7 @@ export class TopologyService {
 
     // Compute layout with icon dimensions for proper node sizing
     // Use byKey (vendor/model format) for layout engine
-    const layoutResult = await this.layout.layoutAsync(graph, iconDimensions.byKey)
+    const layoutResult = await computeLayout(graph)
     const metrics = this.createEmptyMetrics(graph)
 
     let mapping: MetricsMapping | undefined

--- a/apps/server/api/src/topology.ts
+++ b/apps/server/api/src/topology.ts
@@ -14,7 +14,7 @@ import {
   YamlParser,
 } from '@shumoku/core'
 import { resolvePath } from './config.js'
-import { BunHierarchicalLayout } from './layout.js'
+import { computeLayout } from './layout.js'
 import type { Config, MetricsData, TopologyConfig, TopologyInstance } from './types.js'
 
 /**
@@ -35,11 +35,8 @@ function createFileResolver(): FileResolver {
 export class TopologyManager {
   private config: Config
   private topologies: Map<string, TopologyInstance> = new Map()
-  private layout: BunHierarchicalLayout
-
   constructor(config: Config) {
     this.config = config
-    this.layout = new BunHierarchicalLayout()
   }
 
   /**
@@ -91,7 +88,7 @@ export class TopologyManager {
       graph = result.graph
     }
 
-    const layoutResult = this.layout.layout(graph)
+    const layoutResult = await computeLayout(graph)
 
     const instance: TopologyInstance = {
       name: topoConfig.name,
@@ -127,7 +124,7 @@ export class TopologyManager {
     const result = await hierarchicalParser.parse(mainFile.content, 'main.yaml')
     const graph = result.graph
 
-    const layoutResult = this.layout.layout(graph)
+    const layoutResult = await computeLayout(graph)
 
     const instance: TopologyInstance = {
       name: 'sample-network',

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -18,6 +18,8 @@ export { layoutNetwork } from './network-layout.js'
 export { placePorts } from './port-placement.js'
 // Conversion utilities (for backward compatibility with legacy LayoutResult)
 export { resolveLayout, unresolveLayout } from './resolve.js'
+// Unified layout engine (wraps network layout + libavoid)
+export { computeNetworkLayout, createNetworkLayoutEngine } from './unified-engine.js'
 // Resolved layout model (Node/Port/Edge as independent objects)
 export type {
   ResolvedEdge,

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -18,8 +18,6 @@ export { layoutNetwork } from './network-layout.js'
 export { placePorts } from './port-placement.js'
 // Conversion utilities (for backward compatibility with legacy LayoutResult)
 export { resolveLayout, unresolveLayout } from './resolve.js'
-// Unified layout engine (wraps network layout + libavoid)
-export { computeNetworkLayout, createNetworkLayoutEngine } from './unified-engine.js'
 // Resolved layout model (Node/Port/Edge as independent objects)
 export type {
   ResolvedEdge,
@@ -28,3 +26,5 @@ export type {
   ResolvedPort,
   ResolvedSubgraph,
 } from './resolved-types.js'
+// Unified layout engine (wraps network layout + libavoid)
+export { computeNetworkLayout, createNetworkLayoutEngine } from './unified-engine.js'

--- a/libs/@shumoku/core/src/layout/unified-engine.ts
+++ b/libs/@shumoku/core/src/layout/unified-engine.ts
@@ -1,0 +1,85 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Unified layout engine adapter
+ *
+ * Wraps layoutNetwork + routeEdges into a LayoutEngine-compatible interface.
+ * Used by server, CLI, renderer-html, and renderer-svg for consistent layout.
+ */
+
+import type { LayoutEngine } from '../hierarchical.js'
+import type { LayoutResult, NetworkGraph } from '../models/types.js'
+import { routeEdges } from './libavoid-router.js'
+import { layoutNetwork } from './network-layout.js'
+import type { ResolvedLayout } from './resolved-types.js'
+
+/**
+ * Create a LayoutEngine that uses the custom network layout + libavoid routing.
+ * Returns LayoutResult for backward compatibility with existing consumers.
+ */
+export function createNetworkLayoutEngine(): LayoutEngine {
+  return {
+    async layoutAsync(graph: NetworkGraph): Promise<LayoutResult> {
+      const { layout } = await computeNetworkLayout(graph)
+      return layout
+    },
+  }
+}
+
+/**
+ * Compute layout and return both ResolvedLayout and legacy LayoutResult.
+ * Use this when you need both (e.g., renderer-svg uses ResolvedLayout directly).
+ */
+export async function computeNetworkLayout(graph: NetworkGraph): Promise<{
+  resolved: ResolvedLayout
+  layout: LayoutResult
+}> {
+  const direction = graph.settings?.direction ?? 'TB'
+  const edgeStyle = graph.settings?.edgeStyle ?? 'orthogonal'
+
+  const { nodes, ports, subgraphs, bounds } = layoutNetwork(graph, { direction })
+  const edges = await routeEdges(nodes, ports, graph.links, {
+    edgeStyle: edgeStyle === 'splines' ? 'polyline' : edgeStyle,
+  })
+
+  const resolved: ResolvedLayout = {
+    nodes,
+    ports,
+    edges,
+    subgraphs,
+    bounds,
+    metadata: { algorithm: 'network-layout+libavoid', duration: 0 },
+  }
+
+  const layout: LayoutResult = {
+    nodes: new Map(
+      [...nodes].map(([id, rn]) => [
+        id,
+        { id, position: rn.position, size: rn.size, node: rn.node },
+      ]),
+    ),
+    links: new Map(
+      [...edges].map(([id, re]) => [
+        id,
+        {
+          id,
+          from: re.fromNodeId,
+          to: re.toNodeId,
+          fromEndpoint: re.fromEndpoint,
+          toEndpoint: re.toEndpoint,
+          points: re.points,
+          link: re.link,
+        },
+      ]),
+    ),
+    subgraphs: new Map(
+      [...subgraphs].map(([id, rs]) => [id, { id, bounds: rs.bounds, subgraph: rs.subgraph }]),
+    ),
+    bounds,
+    metadata: resolved.metadata,
+  }
+
+  return { resolved, layout }
+}

--- a/libs/@shumoku/renderer-html/src/pipeline.ts
+++ b/libs/@shumoku/renderer-html/src/pipeline.ts
@@ -9,7 +9,7 @@
 
 import {
   buildHierarchicalSheets,
-  HierarchicalLayout,
+  createNetworkLayoutEngine,
   type NetworkGraph,
   type SheetData,
 } from '@shumoku/core'
@@ -44,7 +44,7 @@ export async function renderHtmlHierarchical(
 ): Promise<string> {
   const sheets =
     options?.sheets ??
-    (await buildHierarchicalSheets(prepared.graph, prepared.layout, new HierarchicalLayout()))
+    (await buildHierarchicalSheets(prepared.graph, prepared.layout, createNetworkLayoutEngine()))
   return html.renderHierarchical(sheets, options)
 }
 

--- a/libs/@shumoku/renderer-svg/src/pipeline.ts
+++ b/libs/@shumoku/renderer-svg/src/pipeline.ts
@@ -10,14 +10,13 @@
  */
 
 import {
+  computeNetworkLayout,
   darkTheme,
   type HierarchicalLayoutOptions,
   type LayoutResult,
-  layoutNetwork,
   lightTheme,
   type NetworkGraph,
   type ResolvedLayout,
-  routeEdges,
   type SurfaceToken,
 } from '@shumoku/core'
 import { type ResolvedIconDimensions, resolveIconDimensionsForGraph } from './cdn-icons.js'
@@ -112,53 +111,8 @@ export async function prepareRender(
     return { graph, layout: options.layout, iconDimensions }
   }
 
-  // Custom network layout + libavoid routing
-  // 3 steps: place nodes+ports → route edges → done
-  const direction = graph.settings?.direction ?? options?.layoutOptions?.direction ?? 'TB'
-  const edgeStyle = graph.settings?.edgeStyle ?? options?.layoutOptions?.edgeStyle ?? 'orthogonal'
-
-  const { nodes, ports, subgraphs, bounds } = layoutNetwork(graph, { direction })
-  const edges = await routeEdges(nodes, ports, graph.links, {
-    edgeStyle: edgeStyle === 'splines' ? 'polyline' : edgeStyle,
-  })
-
-  const resolved: ResolvedLayout = {
-    nodes,
-    ports,
-    edges,
-    subgraphs,
-    bounds,
-    metadata: { algorithm: 'network-layout+libavoid', duration: 0 },
-  }
-
-  // Also provide legacy layout for backward compatibility
-  const layout: LayoutResult = {
-    nodes: new Map(
-      [...nodes].map(([id, rn]) => [
-        id,
-        { id, position: rn.position, size: rn.size, node: rn.node },
-      ]),
-    ),
-    links: new Map(
-      [...edges].map(([id, re]) => [
-        id,
-        {
-          id,
-          from: re.fromNodeId,
-          to: re.toNodeId,
-          fromEndpoint: re.fromEndpoint,
-          toEndpoint: re.toEndpoint,
-          points: re.points,
-          link: re.link,
-        },
-      ]),
-    ),
-    subgraphs: new Map(
-      [...subgraphs].map(([id, rs]) => [id, { id, bounds: rs.bounds, subgraph: rs.subgraph }]),
-    ),
-    bounds,
-    metadata: resolved.metadata,
-  }
+  // Custom network layout + libavoid routing (shared with server/CLI)
+  const { resolved, layout } = await computeNetworkLayout(graph)
 
   return { graph, layout, resolved, iconDimensions }
 }


### PR DESCRIPTION
## Summary

全パッケージをELKからカスタムレイアウトエンジン（layoutNetwork + libavoid）に統合。

## Changes

- `createNetworkLayoutEngine()` — LayoutEngine互換アダプタ（core）
- `computeNetworkLayout()` — ResolvedLayout + LayoutResult両方を返す共通関数
- **renderer-svg**: `computeNetworkLayout()`を使用（重複コード削除）
- **CLI**: `HierarchicalLayout` → `createNetworkLayoutEngine()`
- **renderer-html**: `HierarchicalLayout` → `createNetworkLayoutEngine()`
- **server**: `BunHierarchicalLayout`クラス → `computeLayout()`/`getLayoutEngine()`関数に簡素化
  - ELK Worker/singleton管理コードを削除
  - sync `layout()` → async `computeLayout()`

## Impact

全パッケージが同じレイアウトエンジンを使用。ELKはどのレンダリングパスでも使用されなくなった。
（HierarchicalLayoutのコード自体はまだcore内に残存 — 削除は別PR）

## Test plan
- [x] `bun tsc` — core, renderer-svg, renderer-html 全ビルドOK
- [x] `bun run test` — 66テスト全通過
- [x] playground（ローカル）で描画確認 — 前回と同一
- [ ] Vercelプレビュー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)