### PR TITLE
feat: SvelteKit editor app — native WASM, no base64 (#91)

### DIFF
--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/editor/.gitignore
+++ b/apps/editor/.gitignore
@@ -1,0 +1,4 @@
+.svelte-kit
+.vercel
+build
+node_modules

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@shumoku/editor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "lint": "biome check .",
+    "format": "biome check --write ."
+  },
+  "dependencies": {
+    "@shumoku/core": "workspace:*",
+    "@shumoku/renderer": "workspace:*",
+    "bits-ui": "^2.15.4",
+    "phosphor-svelte": "^3.0.1",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^3.4.0",
+    "tailwind-variants": "^1.0.0"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-auto": "^6.0.0",
+    "@sveltejs/kit": "^2.15.2",
+    "@sveltejs/vite-plugin-svelte": "^5.0.3",
+    "@tailwindcss/vite": "^4.1.18",
+    "svelte": "^5.17.3",
+    "svelte-check": "^4.1.4",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.6.3",
+    "vite": "^6.4.1",
+    "vite-plugin-wasm": "^3.4.1"
+  }
+}

--- a/apps/editor/src/app.css
+++ b/apps/editor/src/app.css
@@ -1,0 +1,12 @@
+@import "tailwindcss";
+
+:root {
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  color-scheme: light dark;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}

--- a/apps/editor/src/app.html
+++ b/apps/editor/src/app.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    >
+    <script>
+      try {
+        if (
+          localStorage.getItem('theme') === 'dark' ||
+          (!localStorage.getItem('theme') &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches)
+        ) {
+          document.documentElement.classList.add('dark')
+        }
+      } catch {}
+    </script>
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/apps/editor/src/lib/components/LabelEditPopover.svelte
+++ b/apps/editor/src/lib/components/LabelEditPopover.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  let {
+    portId,
+    label,
+    x,
+    y,
+    oncommit,
+    onclose,
+  }: {
+    portId: string
+    label: string
+    x: number
+    y: number
+    oncommit?: (portId: string, value: string) => void
+    onclose?: () => void
+  } = $props()
+
+  let inputEl: HTMLInputElement | undefined = $state()
+
+  $effect(() => {
+    inputEl?.focus()
+  })
+
+  function commit(value: string) {
+    const trimmed = value.trim()
+    if (trimmed && trimmed !== label) {
+      oncommit?.(portId, trimmed)
+    }
+    onclose?.()
+  }
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<div class="fixed inset-0 z-40" onclick={() => onclose?.()}></div>
+<div
+  class="fixed z-50 bg-white dark:bg-neutral-800 border border-slate-200 dark:border-neutral-600 rounded-lg shadow-lg p-2"
+  style="top: {y - 10}px; left: {x - 4}px;"
+>
+  <input
+    bind:this={inputEl}
+    type="text"
+    value={label}
+    class="text-sm px-2 py-1 border border-blue-300 rounded outline-none focus:ring-2 focus:ring-blue-200 w-32 text-slate-900 dark:text-neutral-100 bg-white dark:bg-neutral-700"
+    onkeydown={(e) => {
+      if (e.key === 'Enter') commit((e.target as HTMLInputElement).value)
+      if (e.key === 'Escape') onclose?.()
+    }}
+    onblur={(e) => commit((e.target as HTMLInputElement).value)}
+  >
+</div>

--- a/apps/editor/src/lib/components/Toolbar.svelte
+++ b/apps/editor/src/lib/components/Toolbar.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+  import { Tooltip } from 'bits-ui'
+  import {
+    Cube,
+    DownloadSimple,
+    Eye,
+    FloppyDisk,
+    Info,
+    MouseSimple,
+    Pencil,
+    Plus,
+    SquaresFour,
+    TreeStructure,
+    UploadSimple,
+  } from 'phosphor-svelte'
+
+  let {
+    mode = 'view',
+    stats = { nodes: 0, links: 0, subgraphs: 0 },
+    selected = null,
+    status = 'Loading...',
+    onmodechange,
+    onaddnode,
+    onaddsubgraph,
+    onsave,
+    onload,
+  }: {
+    mode: 'edit' | 'view'
+    stats: { nodes: number; links: number; subgraphs: number }
+    selected: { id: string; type: string } | null
+    status: string
+    onmodechange?: (mode: 'edit' | 'view') => void
+    onaddnode?: () => void
+    onaddsubgraph?: () => void
+    onsave?: () => void
+    onload?: () => void
+  } = $props()
+</script>
+
+<div
+  class="flex items-center gap-2 px-4 py-2.5 border-b bg-white dark:bg-neutral-900 border-neutral-200 dark:border-neutral-700 shadow-sm z-10"
+>
+  <TreeStructure class="w-5 h-5 text-blue-500" weight="bold" />
+  <h1 class="text-base font-semibold text-slate-800 dark:text-neutral-100">Network Editor</h1>
+
+  <div class="w-px h-5 bg-slate-200 dark:bg-neutral-700 mx-2"></div>
+
+  <!-- Mode toggle -->
+  <div class="flex items-center bg-slate-100 dark:bg-neutral-800 rounded-md p-0.5">
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          class="flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium transition-colors {mode === 'edit' ? 'bg-white dark:bg-neutral-700 text-blue-600 dark:text-blue-400 shadow-sm' : 'text-slate-500 dark:text-neutral-400 hover:text-slate-700 dark:hover:text-neutral-200'}"
+          onclick={() => onmodechange?.('edit')}
+        >
+          <Pencil class="w-3.5 h-3.5" />
+          Edit
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg">
+        Edit mode — drag, add, delete
+      </Tooltip.Content>
+    </Tooltip.Root>
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          class="flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium transition-colors {mode === 'view' ? 'bg-white dark:bg-neutral-700 text-blue-600 dark:text-blue-400 shadow-sm' : 'text-slate-500 dark:text-neutral-400 hover:text-slate-700 dark:hover:text-neutral-200'}"
+          onclick={() => onmodechange?.('view')}
+        >
+          <Eye class="w-3.5 h-3.5" />
+          View
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg">
+        View mode — pan and zoom only
+      </Tooltip.Content>
+    </Tooltip.Root>
+  </div>
+
+  <div class="w-px h-5 bg-slate-200 dark:bg-neutral-700 mx-2"></div>
+
+  <!-- Stats -->
+  <div class="flex items-center gap-3 text-xs text-slate-500 dark:text-neutral-400">
+    <span>{stats.nodes} nodes</span>
+    <span>{stats.links} links</span>
+    <span>{stats.subgraphs} groups</span>
+  </div>
+
+  <div class="w-px h-5 bg-slate-200 dark:bg-neutral-700 mx-2"></div>
+
+  <!-- Add buttons (edit mode only) -->
+  {#if mode === 'edit'}
+    <div class="flex items-center gap-1">
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          <button
+            type="button"
+            class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-slate-600 dark:text-neutral-300 hover:bg-slate-100 dark:hover:bg-neutral-700 transition-colors"
+            onclick={() => onaddnode?.()}
+          >
+            <Cube class="w-3.5 h-3.5" />
+            <Plus class="w-3 h-3" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg">
+          Add node
+        </Tooltip.Content>
+      </Tooltip.Root>
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          <button
+            type="button"
+            class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-slate-600 dark:text-neutral-300 hover:bg-slate-100 dark:hover:bg-neutral-700 transition-colors"
+            onclick={() => onaddsubgraph?.()}
+          >
+            <SquaresFour class="w-3.5 h-3.5" />
+            <Plus class="w-3 h-3" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg">
+          Add group
+        </Tooltip.Content>
+      </Tooltip.Root>
+    </div>
+
+    <div class="w-px h-5 bg-slate-200 dark:bg-neutral-700 mx-2"></div>
+  {/if}
+
+  <!-- Save/Load -->
+  <div class="flex items-center gap-1">
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-slate-600 dark:text-neutral-300 hover:bg-slate-100 dark:hover:bg-neutral-700 transition-colors"
+          onclick={() => onsave?.()}
+        >
+          <DownloadSimple class="w-3.5 h-3.5" />
+          <span>Save</span>
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg">
+        Save diagram as JSON
+      </Tooltip.Content>
+    </Tooltip.Root>
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-slate-600 dark:text-neutral-300 hover:bg-slate-100 dark:hover:bg-neutral-700 transition-colors"
+          onclick={() => onload?.()}
+        >
+          <UploadSimple class="w-3.5 h-3.5" />
+          <span>Load</span>
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg">
+        Load diagram from JSON
+      </Tooltip.Content>
+    </Tooltip.Root>
+  </div>
+
+  <div class="flex-1"></div>
+
+  <!-- Selection display -->
+  {#if selected}
+    <div
+      class="flex items-center gap-1.5 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 px-2.5 py-1 rounded-full text-xs font-medium"
+    >
+      <span class="capitalize">{selected.type}</span>
+      <span class="text-blue-400">·</span>
+      <span class="font-mono">{selected.id}</span>
+    </div>
+  {:else}
+    <div class="flex items-center gap-1.5 text-xs text-slate-400">
+      <MouseSimple class="w-3.5 h-3.5" />
+      <span>Click to select</span>
+    </div>
+  {/if}
+
+  <div class="w-px h-5 bg-slate-200 dark:bg-neutral-700 mx-2"></div>
+
+  <!-- Status -->
+  <div class="flex items-center gap-1.5">
+    <div
+      class="w-2 h-2 rounded-full {status === 'Ready' ? 'bg-green-400' : 'bg-amber-400 animate-pulse'}"
+    ></div>
+    <span class="text-xs text-slate-500 dark:text-neutral-400">{status}</span>
+  </div>
+</div>

--- a/apps/editor/src/lib/utils.ts
+++ b/apps/editor/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/apps/editor/src/routes/+layout.svelte
+++ b/apps/editor/src/routes/+layout.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { Tooltip } from 'bits-ui'
+  import '../app.css'
+
+  let { children } = $props()
+</script>
+
+<svelte:head>
+  <title>Shumoku Editor</title>
+  <meta name="description" content="Interactive network topology diagram editor">
+</svelte:head>
+
+<Tooltip.Provider delayDuration={200}> {@render children()} </Tooltip.Provider>

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+  import {
+    computeNetworkLayout,
+    createMemoryFileResolver,
+    darkTheme,
+    HierarchicalParser,
+    type Link,
+    lightTheme,
+    type ResolvedLayout,
+    sampleNetwork,
+    type Theme,
+  } from '@shumoku/core'
+  // @ts-expect-error — SvelteKit resolves the svelte condition from package.json exports
+  import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
+  import LabelEditPopover from '$lib/components/LabelEditPopover.svelte'
+  import Toolbar from '$lib/components/Toolbar.svelte'
+
+  // --- State ---
+
+  let renderer: ShumokuRenderer | undefined = $state()
+  let status = $state('Loading...')
+  let mode = $state<'edit' | 'view'>('view')
+  let selected = $state<{ id: string; type: string } | null>(null)
+  let stats = $state({ nodes: 0, links: 0, subgraphs: 0 })
+  let layout = $state<ResolvedLayout | undefined>(undefined)
+  let graph = $state<{ links: Link[] } | undefined>(undefined)
+  let isDark = $state(false)
+  let labelEdit = $state<{ portId: string; label: string; x: number; y: number } | null>(null)
+
+  const theme: Theme | undefined = $derived(isDark ? darkTheme : lightTheme)
+
+  // --- Dark mode detection ---
+
+  $effect(() => {
+    isDark = document.documentElement.classList.contains('dark')
+    const obs = new MutationObserver(() => {
+      isDark = document.documentElement.classList.contains('dark')
+    })
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => obs.disconnect()
+  })
+
+  // --- Init ---
+
+  async function parseSampleNetwork() {
+    const fileMap = new Map<string, string>()
+    for (const f of sampleNetwork) {
+      fileMap.set(f.name, f.content)
+      fileMap.set(`./${f.name}`, f.content)
+      fileMap.set(`/${f.name}`, f.content)
+    }
+    const resolver = createMemoryFileResolver(fileMap, '/')
+    const hp = new HierarchicalParser(resolver)
+    const mainFile = sampleNetwork.find((f) => f.name === 'main.yaml')
+    if (!mainFile) throw new Error('main.yaml not found')
+    return (await hp.parse(mainFile.content, '/main.yaml')).graph
+  }
+
+  $effect(() => {
+    ;(async () => {
+      try {
+        status = 'Parsing network...'
+        const g = await parseSampleNetwork()
+
+        status = 'Computing layout...'
+        const { resolved } = await computeNetworkLayout(g)
+
+        graph = { links: g.links }
+        layout = resolved
+        stats = {
+          nodes: resolved.nodes.size,
+          links: g.links.length,
+          subgraphs: resolved.subgraphs.size,
+        }
+        status = 'Ready'
+      } catch (e) {
+        status = `Error: ${e instanceof Error ? e.message : String(e)}`
+      }
+    })()
+  })
+
+  // --- Serialization ---
+
+  function mapToObj(l: ResolvedLayout) {
+    return {
+      nodes: Object.fromEntries(new Map(l.nodes)),
+      ports: Object.fromEntries(new Map(l.ports)),
+      edges: Object.fromEntries(new Map(l.edges)),
+      subgraphs: Object.fromEntries(new Map(l.subgraphs)),
+      bounds: { ...l.bounds },
+    }
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: JSON deserialization
+  function objToMap(data: any): ResolvedLayout {
+    return {
+      nodes: new Map(Object.entries(data.nodes ?? {})),
+      ports: new Map(Object.entries(data.ports ?? {})),
+      edges: new Map(Object.entries(data.edges ?? {})),
+      subgraphs: new Map(Object.entries(data.subgraphs ?? {})),
+      bounds: data.bounds ?? { x: 0, y: 0, width: 800, height: 600 },
+    } as ResolvedLayout
+  }
+
+  // --- Handlers ---
+
+  function handleSave() {
+    const snap = renderer?.getSnapshot()
+    if (!snap) return
+    const data = JSON.stringify({ layout: mapToObj(snap.layout), links: snap.links }, null, 2)
+    const blob = new Blob([data], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'network-diagram.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  function handleLoad() {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.json'
+    input.onchange = async () => {
+      const file = input.files?.[0]
+      if (!file) return
+      const text = await file.text()
+      const data = JSON.parse(text)
+      const loaded = objToMap(data.layout)
+      graph = { links: data.links ?? [] }
+      layout = loaded
+      stats = {
+        nodes: loaded.nodes.size,
+        links: data.links?.length ?? 0,
+        subgraphs: loaded.subgraphs.size,
+      }
+    }
+    input.click()
+  }
+
+  function handleAddNode() {
+    renderer?.addNewNode()
+    stats = { ...stats, nodes: stats.nodes + 1 }
+  }
+
+  function handleAddSubgraph() {
+    renderer?.addNewSubgraph()
+    stats = { ...stats, subgraphs: stats.subgraphs + 1 }
+  }
+</script>
+
+<div class="flex flex-col h-screen">
+  <Toolbar
+    {mode}
+    {stats}
+    {selected}
+    {status}
+    onmodechange={(m) => { mode = m }}
+    onaddnode={handleAddNode}
+    onaddsubgraph={handleAddSubgraph}
+    onsave={handleSave}
+    onload={handleLoad}
+  />
+
+  <div class="flex-1 overflow-hidden relative">
+    {#if layout}
+      <ShumokuRenderer
+        bind:this={renderer}
+        {layout}
+        {graph}
+        {theme}
+        {mode}
+        onselect={(id: string | null, type: string | null) => { selected = id ? { id, type: type ?? 'node' } : null }}
+        onchange={(links: Link[]) => { stats = { ...stats, links: links.length } }}
+        onlabeledit={(portId: string, label: string, screenX: number, screenY: number) => {
+          labelEdit = { portId, label, x: screenX, y: screenY }
+        }}
+      />
+    {:else}
+      <div class="flex items-center justify-center h-full text-slate-500 dark:text-neutral-400">
+        {status}
+      </div>
+    {/if}
+
+    {#if labelEdit}
+      <LabelEditPopover
+        portId={labelEdit.portId}
+        label={labelEdit.label}
+        x={labelEdit.x}
+        y={labelEdit.y}
+        oncommit={(portId, value) => renderer?.commitLabel(portId, value)}
+        onclose={() => { labelEdit = null }}
+      />
+    {/if}
+  </div>
+</div>

--- a/apps/editor/svelte.config.js
+++ b/apps/editor/svelte.config.js
@@ -1,0 +1,12 @@
+import adapter from '@sveltejs/adapter-auto'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter(),
+  },
+}
+
+export default config

--- a/apps/editor/tsconfig.json
+++ b/apps/editor/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}

--- a/apps/editor/vite.config.ts
+++ b/apps/editor/vite.config.ts
@@ -1,0 +1,8 @@
+import { sveltekit } from '@sveltejs/kit/vite'
+import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'vite'
+import wasm from 'vite-plugin-wasm'
+
+export default defineConfig({
+  plugins: [tailwindcss(), wasm(), sveltekit()],
+})

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -61,6 +61,7 @@
       "!**/.next",
       "!**/.turbo",
       "!**/.svelte-kit",
+      "!**/.vercel",
       "!**/*.webmanifest",
       "!**/public/renderer"
     ]

--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,31 @@
         "typescript": "^5.9.3",
       },
     },
+    "apps/editor": {
+      "name": "@shumoku/editor",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shumoku/core": "workspace:*",
+        "@shumoku/renderer": "workspace:*",
+        "bits-ui": "^2.15.4",
+        "clsx": "^2.1.1",
+        "phosphor-svelte": "^3.0.1",
+        "tailwind-merge": "^3.4.0",
+        "tailwind-variants": "^1.0.0",
+      },
+      "devDependencies": {
+        "@sveltejs/adapter-auto": "^6.0.0",
+        "@sveltejs/kit": "^2.15.2",
+        "@sveltejs/vite-plugin-svelte": "^5.0.3",
+        "@tailwindcss/vite": "^4.1.18",
+        "svelte": "^5.17.3",
+        "svelte-check": "^4.1.4",
+        "tailwindcss": "^4.1.18",
+        "typescript": "^5.6.3",
+        "vite": "^6.4.1",
+        "vite-plugin-wasm": "^3.4.1",
+      },
+    },
     "apps/server": {
       "name": "@shumoku/server",
       "version": "0.1.1",
@@ -708,6 +733,8 @@
 
     "@shumoku/docs": ["@shumoku/docs@workspace:apps/docs"],
 
+    "@shumoku/editor": ["@shumoku/editor@workspace:apps/editor"],
+
     "@shumoku/renderer": ["@shumoku/renderer@workspace:libs/@shumoku/renderer"],
 
     "@shumoku/renderer-html": ["@shumoku/renderer-html@workspace:libs/@shumoku/renderer-html"],
@@ -725,6 +752,8 @@
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.8", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA=="],
+
+    "@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@6.1.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-cBNt4jgH4KuaNO5gRSB2CZKkGtz+OCZ8lPjRQGjhvVUD4akotnj2weUia6imLl2v07K3IgsQRyM36909miSwoQ=="],
 
     "@sveltejs/adapter-static": ["@sveltejs/adapter-static@3.0.10", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew=="],
 
@@ -998,7 +1027,7 @@
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
-    "devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
+    "devalue": ["devalue@5.6.2", "", {}, "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
@@ -1632,7 +1661,7 @@
 
     "tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
 
-    "tailwind-variants": ["tailwind-variants@3.2.2", "", { "peerDependencies": { "tailwind-merge": ">=3.0.0", "tailwindcss": "*" }, "optionalPeers": ["tailwind-merge"] }, "sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg=="],
+    "tailwind-variants": ["tailwind-variants@1.0.0", "", { "dependencies": { "tailwind-merge": "3.0.2" }, "peerDependencies": { "tailwindcss": "*" } }, "sha512-2WSbv4ulEEyuBKomOunut65D8UZwxrHoRfYnxGcQNnHqlSCp2+B7Yz2W+yrNDrxRodOXtGD/1oCcKGNBnUqMqA=="],
 
     "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
 
@@ -1732,6 +1761,8 @@
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
+    "vite-plugin-wasm": ["vite-plugin-wasm@3.6.0", "", { "peerDependencies": { "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw=="],
+
     "vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
     "vitest": ["vitest@4.0.17", "", { "dependencies": { "@vitest/expect": "4.0.17", "@vitest/mocker": "4.0.17", "@vitest/pretty-format": "4.0.17", "@vitest/runner": "4.0.17", "@vitest/snapshot": "4.0.17", "@vitest/spy": "4.0.17", "@vitest/utils": "4.0.17", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.17", "@vitest/browser-preview": "4.0.17", "@vitest/browser-webdriverio": "4.0.17", "@vitest/ui": "4.0.17", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg=="],
@@ -1804,7 +1835,7 @@
 
     "@shumoku/server-web/svelte": ["svelte@5.48.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "^5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.2", "esm-env": "^1.2.1", "esrap": "^2.2.1", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-VPWD+UyoSFZ7Nxix5K/F8yWiKWOiROkLlWYXOZReE0TUycw+58YWB3D6lAKT+57xmN99wRX4H3oZmw0NPy7y3Q=="],
 
-    "@sveltejs/kit/devalue": ["devalue@5.6.2", "", {}, "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg=="],
+    "@shumoku/server-web/tailwind-variants": ["tailwind-variants@3.2.2", "", { "peerDependencies": { "tailwind-merge": ">=3.0.0", "tailwindcss": "*" }, "optionalPeers": ["tailwind-merge"] }, "sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
@@ -1840,7 +1871,11 @@
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "svelte/devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
+
     "svelte-check/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "tailwind-variants/tailwind-merge": ["tailwind-merge@3.0.2", "", {}, "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw=="],
 
     "tar/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
@@ -1911,8 +1946,6 @@
     "@shumoku/server-web/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@shumoku/server-web/svelte/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
-
-    "@shumoku/server-web/svelte/devalue": ["devalue@5.6.2", "", {}, "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg=="],
 
     "@shumoku/server-web/svelte/esrap": ["esrap@2.2.2", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ=="],
 

--- a/libs/@shumoku/renderer/package.json
+++ b/libs/@shumoku/renderer/package.json
@@ -23,6 +23,10 @@
       "types": "./dist/wc.svelte.d.ts",
       "default": "./dist/wc/wc.js"
     },
+    "./components/ShumokuRenderer.svelte": {
+      "svelte": "./src/components/ShumokuRenderer.svelte",
+      "default": "./dist/components/ShumokuRenderer.svelte"
+    },
     "./static": {
       "svelte": "./src/static.ts",
       "types": "./dist/static.d.ts",


### PR DESCRIPTION
## Summary
Closes #91 (partial — editor app creation, docs cleanup is follow-up)

SvelteKitベースの独立エディタアプリを`apps/editor/`に新規作成。

### アーキテクチャ
- **ShumokuRenderer.svelte を直接使用**（WebComponent層なし）
- **vite-plugin-wasm** でWASMネイティブバンドル（base64不要）
- **bits-ui + phosphor-svelte** でUI（server/webと同スタック）
- **Tailwind CSS v4**
- **adapter-auto**（Vercel互換）

### EditorClient.tsx (React) → +page.svelte (Svelte) 移植
- React hooks → Svelte $state/$derived/$effect
- WebComponent間接操作 → Svelte bind:this + export functions
- Radix UI Tooltip → bits-ui Tooltip
- lucide-react → phosphor-svelte

### コンポーネント構成
- `Toolbar.svelte` — モード切替、ノード/グループ追加、Save/Load、統計
- `LabelEditPopover.svelte` — ポートラベル編集ポップオーバー
- `+layout.svelte` — Tooltip.Provider、テーマ
- `+page.svelte` — メインエディタページ

### @shumoku/renderer変更
- `./components/ShumokuRenderer.svelte` exportを追加（Svelte直接利用用）

### 確認事項
- [ ] `cd apps/editor && bun run dev` → エディタ動作
- [ ] ノードドラッグ → エッジ再ルーティング
- [ ] ノード/サブグラフ追加・削除
- [ ] Save/Load JSON
- [ ] ダークモード

### 残作業（follow-up）
- [ ] docsからeditorページ削除 + リンク置換
- [ ] Vercelプロジェクト設定
- [ ] @shumoku/coreからbase64 WASM削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)