### PR TITLE
feat(editor): context menu, copy/paste, CanvasBlock unification

### DIFF
--- a/apps/editor/src/lib/components/NodeContextMenu.svelte
+++ b/apps/editor/src/lib/components/NodeContextMenu.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import { ArrowsOutCardinal, Copy, Pencil, Trash } from 'phosphor-svelte'
+
+  let {
+    id,
+    type,
+    x,
+    y,
+    ondelete,
+    onduplicate,
+    onclose,
+  }: {
+    id: string
+    type: string
+    x: number
+    y: number
+    ondelete?: (id: string, type: string) => void
+    onduplicate?: (id: string, type: string) => void
+    onclose?: () => void
+  } = $props()
+
+  function handleAction(action: () => void) {
+    action()
+    onclose?.()
+  }
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<div
+  class="fixed inset-0 z-40"
+  onclick={() => onclose?.()}
+  oncontextmenu={(e) => { e.preventDefault(); onclose?.() }}
+></div>
+<div
+  class="fixed z-50 min-w-[160px] bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-lg shadow-lg py-1 text-sm"
+  style="top: {y}px; left: {x}px;"
+  role="menu"
+>
+  <div
+    class="px-3 py-1.5 text-xs text-neutral-400 dark:text-neutral-500 font-medium uppercase tracking-wider"
+  >
+    {type}
+  </div>
+
+  <button
+    type="button"
+    role="menuitem"
+    class="flex items-center gap-2 w-full px-3 py-1.5 text-left text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+    onclick={() => handleAction(() => onduplicate?.(id, type))}
+  >
+    <Copy class="w-4 h-4 text-neutral-400" />
+    Duplicate
+  </button>
+
+  <div class="my-1 border-t border-neutral-200 dark:border-neutral-700"></div>
+
+  <button
+    type="button"
+    role="menuitem"
+    class="flex items-center gap-2 w-full px-3 py-1.5 text-left text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+    onclick={() => handleAction(() => ondelete?.(id, type))}
+  >
+    <Trash class="w-4 h-4" />
+    Delete
+  </button>
+</div>

--- a/apps/editor/src/lib/components/NodeContextMenu.svelte
+++ b/apps/editor/src/lib/components/NodeContextMenu.svelte
@@ -1,21 +1,25 @@
 <script lang="ts">
-  import { ArrowsOutCardinal, Copy, Pencil, Trash } from 'phosphor-svelte'
+  import { ClipboardText, Copy, Trash } from 'phosphor-svelte'
 
   let {
     id,
     type,
     x,
     y,
+    hasClipboard = false,
+    oncopy,
+    onpaste,
     ondelete,
-    onduplicate,
     onclose,
   }: {
     id: string
     type: string
     x: number
     y: number
+    hasClipboard?: boolean
+    oncopy?: (id: string, type: string) => void
+    onpaste?: (x: number, y: number) => void
     ondelete?: (id: string, type: string) => void
-    onduplicate?: (id: string, type: string) => void
     onclose?: () => void
   } = $props()
 
@@ -42,15 +46,29 @@
     {type}
   </div>
 
-  <button
-    type="button"
-    role="menuitem"
-    class="flex items-center gap-2 w-full px-3 py-1.5 text-left text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
-    onclick={() => handleAction(() => onduplicate?.(id, type))}
-  >
-    <Copy class="w-4 h-4 text-neutral-400" />
-    Duplicate
-  </button>
+  {#if type === 'node'}
+    <button
+      type="button"
+      role="menuitem"
+      class="flex items-center gap-2 w-full px-3 py-1.5 text-left text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+      onclick={() => handleAction(() => oncopy?.(id, type))}
+    >
+      <Copy class="w-4 h-4 text-neutral-400" />
+      Copy
+    </button>
+  {/if}
+
+  {#if hasClipboard}
+    <button
+      type="button"
+      role="menuitem"
+      class="flex items-center gap-2 w-full px-3 py-1.5 text-left text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+      onclick={() => handleAction(() => onpaste?.(x, y))}
+    >
+      <ClipboardText class="w-4 h-4 text-neutral-400" />
+      Paste here
+    </button>
+  {/if}
 
   <div class="my-1 border-t border-neutral-200 dark:border-neutral-700"></div>
 

--- a/apps/editor/src/lib/components/NodeContextMenu.svelte
+++ b/apps/editor/src/lib/components/NodeContextMenu.svelte
@@ -46,7 +46,7 @@
     {type}
   </div>
 
-  {#if type === 'node'}
+  {#if type === 'node' || type === 'subgraph'}
     <button
       type="button"
       role="menuitem"

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -23,7 +23,12 @@
   let mode = $state<'edit' | 'view'>('view')
   let selected = $state<{ id: string; type: string } | null>(null)
   let contextMenu = $state<{ id: string; type: string; x: number; y: number } | null>(null)
-  let clipboard = $state<{ label: string; shape?: string; type?: string } | null>(null)
+  let clipboard = $state<{
+    label: string
+    shape?: string
+    type?: string
+    elementKind: 'node' | 'subgraph'
+  } | null>(null)
   let stats = $state({ nodes: 0, links: 0, subgraphs: 0 })
   let layout = $state<ResolvedLayout | undefined>(undefined)
   let graph = $state<{ links: Link[] } | undefined>(undefined)
@@ -207,13 +212,19 @@
         y={contextMenu.y}
         hasClipboard={clipboard !== null}
         oncopy={(id) => {
-          clipboard = renderer?.getNodeInfo(id) ?? null
+          const info = renderer?.getElementInfo(id)
+          clipboard = info ? { label: info.label, shape: info.kind === 'node' ? info.shape : undefined, type: info.kind === 'node' ? info.type : undefined, elementKind: info.kind } : null
         }}
         onpaste={() => {
           if (!clipboard || !contextMenu) return
           const svgPos = renderer?.screenToSvg(contextMenu.x, contextMenu.y)
-          renderer?.addNewNode({ ...clipboard, position: svgPos })
-          stats = { ...stats, nodes: stats.nodes + 1 }
+          if (clipboard.elementKind === 'subgraph') {
+            renderer?.addNewSubgraph({ label: clipboard.label, position: svgPos })
+            stats = { ...stats, subgraphs: stats.subgraphs + 1 }
+          } else {
+            renderer?.addNewNode({ label: clipboard.label, type: clipboard.type, shape: clipboard.shape, position: svgPos })
+            stats = { ...stats, nodes: stats.nodes + 1 }
+          }
         }}
         ondelete={(id) => {
           renderer?.deleteById(id)

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -23,6 +23,7 @@
   let mode = $state<'edit' | 'view'>('view')
   let selected = $state<{ id: string; type: string } | null>(null)
   let contextMenu = $state<{ id: string; type: string; x: number; y: number } | null>(null)
+  let clipboard = $state<{ label: string; shape?: string; type?: string } | null>(null)
   let stats = $state({ nodes: 0, links: 0, subgraphs: 0 })
   let layout = $state<ResolvedLayout | undefined>(undefined)
   let graph = $state<{ links: Link[] } | undefined>(undefined)
@@ -204,13 +205,19 @@
         type={contextMenu.type}
         x={contextMenu.x}
         y={contextMenu.y}
+        hasClipboard={clipboard !== null}
+        oncopy={(id) => {
+          clipboard = renderer?.getNodeInfo(id) ?? null
+        }}
+        onpaste={() => {
+          if (!clipboard || !contextMenu) return
+          const svgPos = renderer?.screenToSvg(contextMenu.x, contextMenu.y)
+          renderer?.addNewNode({ ...clipboard, position: svgPos })
+          stats = { ...stats, nodes: stats.nodes + 1 }
+        }}
         ondelete={(id) => {
           renderer?.deleteById(id)
           stats = { ...stats, nodes: Math.max(0, stats.nodes - 1) }
-        }}
-        onduplicate={(_id, type) => {
-          if (type === 'node') renderer?.addNewNode()
-          else if (type === 'subgraph') renderer?.addNewSubgraph()
         }}
         onclose={() => { contextMenu = null }}
       />

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -13,6 +13,7 @@
   // @ts-expect-error — SvelteKit resolves the svelte condition from package.json exports
   import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
   import LabelEditPopover from '$lib/components/LabelEditPopover.svelte'
+  import NodeContextMenu from '$lib/components/NodeContextMenu.svelte'
   import Toolbar from '$lib/components/Toolbar.svelte'
 
   // --- State ---
@@ -21,6 +22,7 @@
   let status = $state('Loading...')
   let mode = $state<'edit' | 'view'>('view')
   let selected = $state<{ id: string; type: string } | null>(null)
+  let contextMenu = $state<{ id: string; type: string; x: number; y: number } | null>(null)
   let stats = $state({ nodes: 0, links: 0, subgraphs: 0 })
   let layout = $state<ResolvedLayout | undefined>(undefined)
   let graph = $state<{ links: Link[] } | undefined>(undefined)
@@ -175,6 +177,9 @@
         onlabeledit={(portId: string, label: string, screenX: number, screenY: number) => {
           labelEdit = { portId, label, x: screenX, y: screenY }
         }}
+        oncontextmenu={(id: string, type: string, screenX: number, screenY: number) => {
+          contextMenu = { id, type, x: screenX, y: screenY }
+        }}
       />
     {:else}
       <div class="flex items-center justify-center h-full text-slate-500 dark:text-neutral-400">
@@ -190,6 +195,24 @@
         y={labelEdit.y}
         oncommit={(portId, value) => renderer?.commitLabel(portId, value)}
         onclose={() => { labelEdit = null }}
+      />
+    {/if}
+
+    {#if contextMenu}
+      <NodeContextMenu
+        id={contextMenu.id}
+        type={contextMenu.type}
+        x={contextMenu.x}
+        y={contextMenu.y}
+        ondelete={(id) => {
+          renderer?.deleteById(id)
+          stats = { ...stats, nodes: Math.max(0, stats.nodes - 1) }
+        }}
+        onduplicate={(_id, type) => {
+          if (type === 'node') renderer?.addNewNode()
+          else if (type === 'subgraph') renderer?.addNewSubgraph()
+        }}
+        onclose={() => { contextMenu = null }}
       />
     {/if}
   </div>

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -27,7 +27,7 @@ export { ensureLibavoidLoaded, routeEdges } from './libavoid-router.js'
 export { getLinkWidth } from './link-utils.js'
 export type { NetworkLayoutOptions, NetworkLayoutResult } from './network-layout.js'
 // Custom network layout + libavoid routing
-export { layoutNetwork } from './network-layout.js'
+export { computeNodeSize, layoutNetwork } from './network-layout.js'
 export { placePorts } from './port-placement.js'
 // Remote client (browser → server API, avoids WASM in browser)
 export {

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -10,6 +10,7 @@
 export {
   addLink,
   addPort,
+  collectObstacles,
   detectClickSide,
   generatePortName,
   linkExists,

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -69,7 +69,7 @@ export function resolveCollision(
  * Collect all obstacles as center-based rects, excluding entities related to `excludeId`.
  * Unified: both nodes and subgraphs are treated as rectangles.
  */
-function collectObstacles(
+export function collectObstacles(
   excludeId: string,
   excludeParent: string | undefined,
   nodes: Map<string, ResolvedNode>,

--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -61,6 +61,32 @@ const DEFAULTS: Required<NetworkLayoutOptions> = {
   portLabelPadding: 8,
 }
 
+/**
+ * Compute the appropriate size for a node based on its content.
+ * Used by both the layout engine and interactive addNewNode.
+ */
+export function computeNodeSize(
+  node: { label?: string | string[]; type?: Parameters<typeof getDeviceIcon>[0] },
+  portCount = 0,
+): { width: number; height: number } {
+  const lines = Array.isArray(node.label) ? node.label.length : node.label ? 1 : 0
+  const hasIcon = !!(node.type && getDeviceIcon(node.type))
+  const iconH = hasIcon ? DEFAULT_ICON_SIZE : 0
+  const gapH = iconH > 0 ? ICON_LABEL_GAP : 0
+  const contentH = iconH + gapH + lines * LABEL_LINE_HEIGHT
+  const labelLines = Array.isArray(node.label) ? node.label : node.label ? [node.label] : []
+  const contentW = Math.max(0, ...labelLines.map((l) => l.length)) * ESTIMATED_CHAR_WIDTH
+
+  const w = Math.max(
+    DEFAULTS.nodeWidth,
+    contentW + NODE_HORIZONTAL_PADDING * 2,
+    portCount * DEFAULTS.minPortSpacing,
+  )
+  const h = Math.max(60, contentH + NODE_VERTICAL_PADDING, portCount * DEFAULTS.minPortSpacing)
+
+  return { width: w, height: h }
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -12,13 +12,14 @@
   } from '@shumoku/core'
   import {
     addPort,
+    collectObstacles,
     computeNodeSize,
     linkExists,
     moveNode,
     moveSubgraph,
     rebalanceSubgraphs,
     removePort,
-    resolveNodePosition,
+    resolvePosition,
     routeEdges,
   } from '@shumoku/core'
   import { themeToColors } from '../lib/render-colors'
@@ -49,7 +50,10 @@
   const colors = $derived(themeToColors(theme))
   const interactive = $derived(mode === 'edit')
 
-  // Layout state: mutable copies, synced from props via $effect
+  // =========================================================================
+  // Layout state (mutable copies, synced from props via $effect)
+  // =========================================================================
+
   let nodes = $state<Map<string, ResolvedNode>>(new Map())
   let ports = $state<Map<string, ResolvedPort>>(new Map())
   let edges = $state<Map<string, ResolvedEdge>>(new Map())
@@ -57,7 +61,6 @@
   let bounds = $state({ x: 0, y: 0, width: 0, height: 0 })
   let links = $state<Link[]>([])
 
-  // Sync from props when layout/graph changes externally (e.g. new layout loaded)
   $effect(() => {
     nodes = new Map(layout.nodes)
     ports = new Map(layout.ports)
@@ -69,7 +72,10 @@
     links = graph?.links ? [...graph.links] : []
   })
 
+  // =========================================================================
   // Edit state
+  // =========================================================================
+
   let selection = $state(new Set<string>())
   let linkDrag = $state<{
     fromPortId: string
@@ -89,7 +95,29 @@
     return ids
   })
 
-  // Keyboard (d3-zoom makes SVG focusable)
+  // =========================================================================
+  // Coordinate helpers
+  // =========================================================================
+
+  /** Get the SVG viewport's inverse screen CTM (for screen → SVG conversion) */
+  function getViewportInverseCTM(): DOMMatrix | null {
+    if (!svgEl) return null
+    const viewport = svgEl.querySelector('.viewport') as SVGGraphicsElement | null
+    return (viewport ?? svgEl).getScreenCTM()?.inverse() ?? null
+  }
+
+  /** Convert screen (clientX/Y) coordinates to SVG coordinates */
+  export function screenToSvg(screenX: number, screenY: number): { x: number; y: number } {
+    const ctm = getViewportInverseCTM()
+    if (!ctm) return { x: screenX, y: screenY }
+    const pt = new DOMPoint(screenX, screenY).matrixTransform(ctm)
+    return { x: pt.x, y: pt.y }
+  }
+
+  // =========================================================================
+  // Keyboard + selection notifications
+  // =========================================================================
+
   $effect(() => {
     if (!interactive || !svgEl) return
     const el = svgEl
@@ -97,7 +125,6 @@
     return () => el.removeEventListener('keydown', handleKeyDown)
   })
 
-  // Notify selection changes via callback
   $effect(() => {
     if (selection.size === 0) {
       onselect?.(null, null)
@@ -112,15 +139,218 @@
     }
   })
 
-  // --- Node drag ---
-  async function handleNodeDragMove(id: string, x: number, y: number) {
-    const result = await moveNode(id, x, y, { nodes, ports, subgraphs }, links)
+  function handleSelect(id: string) {
+    selection = new Set([id])
+  }
+  function handleBackgroundClick() {
+    selection = new Set()
+  }
+  function handleContextMenu(id: string, type: string, e: MouseEvent) {
+    selection = new Set([id])
+    onctx?.(id, type, e.clientX, e.clientY)
+  }
+
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      for (const id of selection) deleteById(id)
+    }
+    if (e.key === 'Escape') {
+      selection = new Set()
+      linkDrag = null
+    }
+  }
+
+  // =========================================================================
+  // Drag (unified for nodes and subgraphs)
+  // =========================================================================
+
+  async function handleDragMove(id: string, x: number, y: number) {
+    const state = { nodes, ports, subgraphs }
+    const result = nodes.has(id)
+      ? await moveNode(id, x, y, state, links)
+      : subgraphs.has(id)
+        ? await moveSubgraph(id, x, y, state, links)
+        : null
     if (!result) return
     nodes = result.nodes
     ports = result.ports
     edges = result.edges
     if (result.subgraphs) subgraphs = result.subgraphs
   }
+
+  // =========================================================================
+  // Add element (shared: parent detection → collision resolve → rebalance)
+  // =========================================================================
+
+  function resolveParentAndPosition(
+    position: { x: number; y: number } | undefined,
+    w: number,
+  ): { parent: string | undefined; initial: { x: number; y: number } } {
+    const selectedSgId = [...selection].find((sid) => subgraphs.has(sid))
+    const parentSg = selectedSgId ? subgraphs.get(selectedSgId) : undefined
+    if (parentSg) {
+      return {
+        parent: selectedSgId,
+        initial: position ?? {
+          x: parentSg.bounds.x + parentSg.bounds.width / 2,
+          y: parentSg.bounds.y + parentSg.bounds.height / 2,
+        },
+      }
+    }
+    return {
+      parent: undefined,
+      initial: position ?? {
+        x: bounds.x + bounds.width + 20 + w / 2,
+        y: bounds.y + bounds.height / 2,
+      },
+    }
+  }
+
+  function finalizeAdd(id: string, updatedSubgraphs: Map<string, ResolvedSubgraph>) {
+    rebalanceSubgraphs(nodes, updatedSubgraphs, ports)
+    subgraphs = updatedSubgraphs
+    selection = new Set([id])
+  }
+
+  export function addNewNode(opts?: {
+    label?: string
+    type?: DeviceType
+    shape?: NodeShape
+    position?: { x: number; y: number }
+  }) {
+    const id = `node-${Date.now()}`
+    const label = opts?.label ?? 'New Node'
+    const { width: w, height: h } = computeNodeSize({ label, type: opts?.type })
+    const { parent, initial } = resolveParentAndPosition(opts?.position, w)
+    const obstacles = collectObstacles(id, parent, nodes, subgraphs)
+    const pos = resolvePosition({ x: initial.x, y: initial.y, w, h }, obstacles)
+
+    const n = new Map(nodes)
+    n.set(id, {
+      id,
+      position: pos,
+      size: { width: w, height: h },
+      node: { id, label, type: opts?.type, shape: opts?.shape ?? 'rounded', parent },
+    })
+    nodes = n
+    finalizeAdd(id, new Map(subgraphs))
+    return id
+  }
+
+  export function addNewSubgraph(opts?: { label?: string; position?: { x: number; y: number } }) {
+    const id = `sg-${Date.now()}`
+    const w = 200
+    const h = 120
+    const { parent, initial } = resolveParentAndPosition(opts?.position, w)
+    const obstacles = collectObstacles(id, parent, nodes, subgraphs)
+    const pos = resolvePosition({ x: initial.x, y: initial.y, w, h }, obstacles)
+
+    const sg = new Map(subgraphs)
+    sg.set(id, {
+      id,
+      bounds: { x: pos.x - w / 2, y: pos.y - h / 2, width: w, height: h },
+      subgraph: { id, label: opts?.label ?? 'New Group', parent },
+    })
+    nodes = new Map(nodes) // trigger reactivity for rebalance
+    finalizeAdd(id, sg)
+    return id
+  }
+
+  // =========================================================================
+  // Delete (unified, recursive for subgraphs)
+  // =========================================================================
+
+  export function deleteById(id: string) {
+    if (nodes.has(id)) {
+      const n = new Map(nodes)
+      const p = new Map(ports)
+      n.delete(id)
+      for (const [portId, port] of p) {
+        if (port.nodeId === id) p.delete(portId)
+      }
+      nodes = n
+      ports = p
+      links = links.filter((l) => {
+        const from = typeof l.from === 'string' ? l.from : l.from.node
+        const to = typeof l.to === 'string' ? l.to : l.to.node
+        return from !== id && to !== id
+      })
+    } else if (edges.has(id)) {
+      const edge = edges.get(id)
+      if (edge?.link?.id) links = links.filter((l) => l.id !== edge.link?.id)
+    } else if (ports.has(id)) {
+      const result = removePort(id, nodes, ports, links)
+      if (result) {
+        nodes = result.nodes
+        ports = result.ports
+        links = result.links
+      }
+    } else if (subgraphs.has(id)) {
+      // Collect all descendants first, then delete in one pass
+      const toDeleteNodes = new Set<string>()
+      const toDeleteSgs = new Set<string>()
+      function collect(sgId: string) {
+        toDeleteSgs.add(sgId)
+        for (const [nid, n] of nodes) {
+          if (n.node.parent === sgId) toDeleteNodes.add(nid)
+        }
+        for (const [cid, c] of subgraphs) {
+          if (c.subgraph.parent === sgId) collect(cid)
+        }
+      }
+      collect(id)
+
+      const n = new Map(nodes)
+      const p = new Map(ports)
+      const sg = new Map(subgraphs)
+      for (const nid of toDeleteNodes) {
+        n.delete(nid)
+        for (const [portId, port] of p) {
+          if (port.nodeId === nid) p.delete(portId)
+        }
+      }
+      for (const sgId of toDeleteSgs) sg.delete(sgId)
+      nodes = n
+      ports = p
+      subgraphs = sg
+      links = links.filter((l) => {
+        const from = typeof l.from === 'string' ? l.from : l.from.node
+        const to = typeof l.to === 'string' ? l.to : l.to.node
+        return !toDeleteNodes.has(from) && !toDeleteNodes.has(to)
+      })
+    }
+
+    selection = new Set()
+    routeEdges(nodes, ports, links).then((e) => {
+      edges = e
+    })
+    onchange?.(links)
+  }
+
+  // =========================================================================
+  // Copy info (works for nodes and subgraphs)
+  // =========================================================================
+
+  export function getElementInfo(id: string) {
+    const node = nodes.get(id)
+    if (node) {
+      return {
+        kind: 'node' as const,
+        label: node.node.label ?? 'Node',
+        shape: node.node.shape,
+        type: node.node.type,
+      }
+    }
+    const sg = subgraphs.get(id)
+    if (sg) {
+      return { kind: 'subgraph' as const, label: sg.subgraph.label ?? 'Group' }
+    }
+    return null
+  }
+
+  // =========================================================================
+  // Port operations
+  // =========================================================================
 
   async function handleAddPort(nodeId: string, side: 'top' | 'bottom' | 'left' | 'right') {
     const result = addPort(nodeId, side, nodes, ports, links)
@@ -130,27 +360,34 @@
     edges = await routeEdges(result.nodes, result.ports, links)
   }
 
-  async function handleSubgraphMove(sgId: string, x: number, y: number) {
-    const result = await moveSubgraph(sgId, x, y, { nodes, ports, subgraphs }, links)
-    if (!result) return
-    nodes = result.nodes
-    ports = result.ports
-    edges = result.edges
-    subgraphs = result.subgraphs
+  export function commitLabel(portId: string, newLabel: string) {
+    const port = ports.get(portId)
+    if (!port || newLabel === port.label) return
+    const p = new Map(ports)
+    p.set(portId, { ...port, label: newLabel })
+    ports = p
   }
 
-  // --- Link ---
+  // =========================================================================
+  // Link operations
+  // =========================================================================
+
   let linkCleanup: (() => void) | null = null
 
-  function handleLinkStart(portId: string, x: number, y: number) {
-    linkDrag = { fromPortId: portId, fromX: x, fromY: y, toX: x, toY: y }
+  function handleLinkStart(portId: string, _x: number, _y: number) {
+    const port = ports.get(portId)
+    if (!port) return
+    linkDrag = {
+      fromPortId: portId,
+      fromX: port.absolutePosition.x,
+      fromY: port.absolutePosition.y,
+      toX: port.absolutePosition.x,
+      toY: port.absolutePosition.y,
+    }
     function onmove(e: PointerEvent) {
-      if (!linkDrag || !svgEl) return
-      const viewport = svgEl.querySelector('.viewport') as SVGGElement | null
-      const ctm = (viewport ?? svgEl).getScreenCTM()
-      if (!ctm) return
-      const p = new DOMPoint(e.clientX, e.clientY).matrixTransform(ctm.inverse())
-      linkDrag = { ...linkDrag, toX: p.x, toY: p.y }
+      if (!linkDrag) return
+      const svgPt = screenToSvg(e.clientX, e.clientY)
+      linkDrag = { ...linkDrag, toX: svgPt.x, toY: svgPt.y }
     }
     function onup(e: PointerEvent) {
       if ((e.target as Element).closest('.port')) return
@@ -181,14 +418,14 @@
   async function doAddLink(fromPortId: string, toPortId: string) {
     const fromParts = fromPortId.split(':')
     const toParts = toPortId.split(':')
-    let fromNode = fromParts[0] ?? '',
-      fromPort = fromParts.slice(1).join(':')
-    let toNode = toParts[0] ?? '',
-      toPort = toParts.slice(1).join(':')
+    let fromNode = fromParts[0] ?? ''
+    let fromPort = fromParts.slice(1).join(':')
+    let toNode = toParts[0] ?? ''
+    let toPort = toParts.slice(1).join(':')
     if (!fromNode || !fromPort || !toNode || !toPort) return
     if (linkExists(links, fromNode, fromPort, toNode, toPort)) return
-    const fromNodeObj = nodes.get(fromNode),
-      toNodeObj = nodes.get(toNode)
+    const fromNodeObj = nodes.get(fromNode)
+    const toNodeObj = nodes.get(toNode)
     if (fromNodeObj && toNodeObj && fromNodeObj.position.y > toNodeObj.position.y) {
       ;[fromNode, toNode] = [toNode, fromNode]
       ;[fromPort, toPort] = [toPort, fromPort]
@@ -205,114 +442,11 @@
     onchange?.(links)
   }
 
-  // --- Selection ---
-  function handleSelect(id: string) {
-    selection = new Set([id])
-  }
-  function handleBackgroundClick() {
-    selection = new Set()
-  }
-
-  function handleLabelEdit(portId: string, label: string, screenX: number, screenY: number) {
-    onlabeledit?.(portId, label, screenX, screenY)
-  }
-
-  function handleContextMenu(id: string, type: string, e: MouseEvent) {
-    selection = new Set([id])
-    onctx?.(id, type, e.clientX, e.clientY)
-  }
-
-  // --- Public methods (accessed via mount() return value) ---
-  /** Convert screen (clientX/Y) coordinates to SVG coordinates */
-  export function screenToSvg(screenX: number, screenY: number): { x: number; y: number } {
-    if (!svgEl) return { x: screenX, y: screenY }
-    const pt = svgEl.createSVGPoint()
-    pt.x = screenX
-    pt.y = screenY
-    // Use the viewport group's CTM (includes d3-zoom transform)
-    const viewport = svgEl.querySelector('.viewport') as SVGGraphicsElement | null
-    const ctm = viewport?.getScreenCTM()?.inverse()
-    if (ctm) {
-      const svgPt = pt.matrixTransform(ctm)
-      return { x: svgPt.x, y: svgPt.y }
-    }
-    return { x: screenX, y: screenY }
-  }
-
-  export function addNewNode(opts?: {
-    label?: string
-    type?: DeviceType
-    shape?: NodeShape
-    position?: { x: number; y: number }
-  }) {
-    const id = `node-${Date.now()}`
-    const label = opts?.label ?? 'New Node'
-    const { width: w, height: h } = computeNodeSize({ label, type: opts?.type })
-    const selectedSgId = [...selection].find((sid) => subgraphs.has(sid))
-    const parentSg = selectedSgId ? subgraphs.get(selectedSgId) : undefined
-    let parent: string | undefined
-    let initial: { x: number; y: number }
-    if (parentSg) {
-      parent = selectedSgId
-      initial = opts?.position ?? {
-        x: parentSg.bounds.x + parentSg.bounds.width / 2,
-        y: parentSg.bounds.y + parentSg.bounds.height / 2,
-      }
-    } else {
-      initial = opts?.position ?? {
-        x: bounds.x + bounds.width + 20 + w / 2,
-        y: bounds.y + bounds.height / 2,
-      }
-    }
-    const newNodes = new Map(nodes)
-    newNodes.set(id, {
-      id,
-      position: initial,
-      size: { width: w, height: h },
-      node: { id, label, type: opts?.type, shape: opts?.shape ?? 'rounded', parent },
-    })
-    const resolved = resolveNodePosition(id, initial.x, initial.y, newNodes, 8, subgraphs)
-    const created = newNodes.get(id)
-    if (created) newNodes.set(id, { ...created, position: resolved })
-    nodes = newNodes
-    if (parent) {
-      const sg = new Map(subgraphs)
-      rebalanceSubgraphs(newNodes, sg, ports)
-      subgraphs = sg
-    }
-    selection = new Set([id])
-    return id
-  }
-
-  export function addNewSubgraph(opts?: { label?: string; position?: { x: number; y: number } }) {
-    const id = `sg-${Date.now()}`
-    const w = 200,
-      h = 120
-    const center = opts?.position ?? {
-      x: bounds.x + bounds.width + 20 + w / 2,
-      y: bounds.y + bounds.height / 2,
-    }
-    const sg = new Map(subgraphs)
-    sg.set(id, {
-      id,
-      bounds: { x: center.x - w / 2, y: center.y - h / 2, width: w, height: h },
-      subgraph: { id, label: opts?.label ?? 'New Group' },
-    })
-    rebalanceSubgraphs(nodes, sg, ports)
-    subgraphs = sg
-    return id
-  }
-
-  export function commitLabel(portId: string, newLabel: string) {
-    const port = ports.get(portId)
-    if (!port || newLabel === port.label) return
-    const p = new Map(ports)
-    p.set(portId, { ...port, label: newLabel })
-    ports = p
-  }
+  // =========================================================================
+  // Snapshot
+  // =========================================================================
 
   export function getSnapshot() {
-    // Unwrap $state proxies into plain Maps for safe serialization
     return {
       layout: {
         nodes: new Map(nodes),
@@ -322,69 +456,6 @@
         bounds: { ...bounds },
       },
       links: [...links],
-    }
-  }
-
-  // --- Get node info (for copy in editor) ---
-  export function getNodeInfo(id: string) {
-    const node = nodes.get(id)
-    if (!node) return null
-    return {
-      label: node.node.label ?? 'Node',
-      shape: node.node.shape,
-      type: node.node.type,
-    }
-  }
-
-  // --- Delete ---
-  export function deleteById(id: string) {
-    if (nodes.has(id)) {
-      const n = new Map(nodes)
-      n.delete(id)
-      nodes = n
-      // Remove ports belonging to this node
-      const p = new Map(ports)
-      for (const [portId, port] of ports) {
-        if (port.nodeId === id) p.delete(portId)
-      }
-      ports = p
-      // Remove links connected to this node
-      links = links.filter((l) => {
-        const from = typeof l.from === 'string' ? l.from : l.from.node
-        const to = typeof l.to === 'string' ? l.to : l.to.node
-        return from !== id && to !== id
-      })
-    } else if (edges.has(id)) {
-      const edge = edges.get(id)
-      if (edge?.link?.id) links = links.filter((l) => l.id !== edge.link?.id)
-    } else if (ports.has(id)) {
-      const result = removePort(id, nodes, ports, links)
-      if (result) {
-        nodes = result.nodes
-        ports = result.ports
-        links = result.links
-      }
-    } else if (subgraphs.has(id)) {
-      const sg = new Map(subgraphs)
-      sg.delete(id)
-      subgraphs = sg
-    }
-    selection = new Set()
-    routeEdges(nodes, ports, links).then((e) => {
-      edges = e
-    })
-    onchange?.(links)
-  }
-
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Delete' || e.key === 'Backspace') {
-      for (const id of selection) {
-        deleteById(id)
-      }
-    }
-    if (e.key === 'Escape') {
-      selection = new Set()
-      linkDrag = null
     }
   }
 </script>
@@ -403,16 +474,12 @@
     {linkedPorts}
     linkPreview={linkDrag}
     bind:svgEl
-    onnodedragmove={handleNodeDragMove}
-    onnodeselect={handleSelect}
+    ondragmove={handleDragMove}
+    onselect={handleSelect}
     onaddport={handleAddPort}
     onlinkstart={handleLinkStart}
     onlinkend={handleLinkEnd}
-    onedgeselect={handleSelect}
-    onportselect={handleSelect}
-    onlabeledit={handleLabelEdit}
-    onsubgraphselect={handleSelect}
-    onsubgraphmove={handleSubgraphMove}
+    {onlabeledit}
     oncontextmenu={handleContextMenu}
     onbackgroundclick={handleBackgroundClick}
   />

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import type {
+    DeviceType,
     Link,
+    NodeShape,
     ResolvedEdge,
     ResolvedLayout,
     ResolvedNode,
@@ -10,6 +12,7 @@
   } from '@shumoku/core'
   import {
     addPort,
+    computeNodeSize,
     linkExists,
     moveNode,
     moveSubgraph,
@@ -220,10 +223,31 @@
   }
 
   // --- Public methods (accessed via mount() return value) ---
-  export function addNewNode(opts?: { label?: string; position?: { x: number; y: number } }) {
+  /** Convert screen (clientX/Y) coordinates to SVG coordinates */
+  export function screenToSvg(screenX: number, screenY: number): { x: number; y: number } {
+    if (!svgEl) return { x: screenX, y: screenY }
+    const pt = svgEl.createSVGPoint()
+    pt.x = screenX
+    pt.y = screenY
+    // Use the viewport group's CTM (includes d3-zoom transform)
+    const viewport = svgEl.querySelector('.viewport') as SVGGraphicsElement | null
+    const ctm = viewport?.getScreenCTM()?.inverse()
+    if (ctm) {
+      const svgPt = pt.matrixTransform(ctm)
+      return { x: svgPt.x, y: svgPt.y }
+    }
+    return { x: screenX, y: screenY }
+  }
+
+  export function addNewNode(opts?: {
+    label?: string
+    type?: DeviceType
+    shape?: NodeShape
+    position?: { x: number; y: number }
+  }) {
     const id = `node-${Date.now()}`
-    const w = 180,
-      h = 80
+    const label = opts?.label ?? 'New Node'
+    const { width: w, height: h } = computeNodeSize({ label, type: opts?.type })
     const selectedSgId = [...selection].find((sid) => subgraphs.has(sid))
     const parentSg = selectedSgId ? subgraphs.get(selectedSgId) : undefined
     let parent: string | undefined
@@ -245,7 +269,7 @@
       id,
       position: initial,
       size: { width: w, height: h },
-      node: { id, label: opts?.label ?? 'New Node', shape: 'rounded', parent },
+      node: { id, label, type: opts?.type, shape: opts?.shape ?? 'rounded', parent },
     })
     const resolved = resolveNodePosition(id, initial.x, initial.y, newNodes, 8, subgraphs)
     const created = newNodes.get(id)
@@ -298,6 +322,17 @@
         bounds: { ...bounds },
       },
       links: [...links],
+    }
+  }
+
+  // --- Get node info (for copy in editor) ---
+  export function getNodeInfo(id: string) {
+    const node = nodes.get(id)
+    if (!node) return null
+    return {
+      label: node.node.label ?? 'Node',
+      shape: node.node.shape,
+      type: node.node.type,
     }
   }
 

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -308,26 +308,50 @@
   }
 
   // --- Delete ---
+  export function deleteById(id: string) {
+    if (nodes.has(id)) {
+      const n = new Map(nodes)
+      n.delete(id)
+      nodes = n
+      // Remove ports belonging to this node
+      const p = new Map(ports)
+      for (const [portId, port] of ports) {
+        if (port.nodeId === id) p.delete(portId)
+      }
+      ports = p
+      // Remove links connected to this node
+      links = links.filter((l) => {
+        const from = typeof l.from === 'string' ? l.from : l.from.node
+        const to = typeof l.to === 'string' ? l.to : l.to.node
+        return from !== id && to !== id
+      })
+    } else if (edges.has(id)) {
+      const edge = edges.get(id)
+      if (edge?.link?.id) links = links.filter((l) => l.id !== edge.link?.id)
+    } else if (ports.has(id)) {
+      const result = removePort(id, nodes, ports, links)
+      if (result) {
+        nodes = result.nodes
+        ports = result.ports
+        links = result.links
+      }
+    } else if (subgraphs.has(id)) {
+      const sg = new Map(subgraphs)
+      sg.delete(id)
+      subgraphs = sg
+    }
+    selection = new Set()
+    routeEdges(nodes, ports, links).then((e) => {
+      edges = e
+    })
+    onchange?.(links)
+  }
+
   function handleKeyDown(e: KeyboardEvent) {
     if (e.key === 'Delete' || e.key === 'Backspace') {
       for (const id of selection) {
-        if (edges.has(id)) {
-          const edge = edges.get(id)
-          if (edge?.link?.id) links = links.filter((l) => l.id !== edge.link?.id)
-        } else if (ports.has(id)) {
-          const result = removePort(id, nodes, ports, links)
-          if (result) {
-            nodes = result.nodes
-            ports = result.ports
-            links = result.links
-          }
-        }
+        deleteById(id)
       }
-      routeEdges(nodes, ports, links).then((e) => {
-        edges = e
-      })
-      selection = new Set()
-      onchange?.(links)
     }
     if (e.key === 'Escape') {
       selection = new Set()

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -203,14 +203,8 @@
   }
 
   // --- Selection ---
-  function handleEdgeSelect(edgeId: string) {
-    selection = new Set([edgeId])
-  }
-  function handlePortSelect(portId: string) {
-    selection = new Set([portId])
-  }
-  function handleSubgraphSelect(sgId: string) {
-    selection = new Set([sgId])
+  function handleSelect(id: string) {
+    selection = new Set([id])
   }
   function handleBackgroundClick() {
     selection = new Set()
@@ -375,13 +369,14 @@
     linkPreview={linkDrag}
     bind:svgEl
     onnodedragmove={handleNodeDragMove}
+    onnodeselect={handleSelect}
     onaddport={handleAddPort}
     onlinkstart={handleLinkStart}
     onlinkend={handleLinkEnd}
-    onedgeselect={handleEdgeSelect}
-    onportselect={handlePortSelect}
+    onedgeselect={handleSelect}
+    onportselect={handleSelect}
     onlabeledit={handleLabelEdit}
-    onsubgraphselect={handleSubgraphSelect}
+    onsubgraphselect={handleSelect}
     onsubgraphmove={handleSubgraphMove}
     oncontextmenu={handleContextMenu}
     onbackgroundclick={handleBackgroundClick}

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -28,17 +28,13 @@
     linkedPorts = new Set<string>(),
     linkPreview = null,
     svgEl = $bindable<SVGSVGElement | null>(null),
-    // Callbacks
-    onnodedragmove,
-    onnodeselect,
+    // Callbacks (unified: ondragmove/onselect work for all element types)
+    ondragmove,
+    onselect,
     onaddport,
     onlinkstart,
     onlinkend,
-    onedgeselect,
-    onportselect,
     onlabeledit,
-    onsubgraphselect,
-    onsubgraphmove,
     oncontextmenu: onctx,
     onbackgroundclick,
   }: {
@@ -54,16 +50,12 @@
     linkedPorts?: Set<string>
     linkPreview?: { fromX: number; fromY: number; toX: number; toY: number } | null
     svgEl?: SVGSVGElement | null
-    onnodedragmove?: (id: string, x: number, y: number) => void
-    onnodeselect?: (id: string) => void
+    ondragmove?: (id: string, x: number, y: number) => void
+    onselect?: (id: string) => void
     onaddport?: (nodeId: string, side: 'top' | 'bottom' | 'left' | 'right') => void
     onlinkstart?: (portId: string, x: number, y: number) => void
     onlinkend?: (portId: string) => void
-    onedgeselect?: (edgeId: string) => void
-    onportselect?: (portId: string) => void
     onlabeledit?: (portId: string, label: string, screenX: number, screenY: number) => void
-    onsubgraphselect?: (sgId: string) => void
-    onsubgraphmove?: (sgId: string, x: number, y: number) => void
     oncontextmenu?: (id: string, type: string, e: MouseEvent) => void
     onbackgroundclick?: () => void
   } = $props()
@@ -141,14 +133,13 @@
     .link-label { font-family: ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace; font-size: 10px; fill: ${colors.textSecondary}; }
 
     /* Default: all interactive elements disabled */
-    .subgraph-bg, .port-hit, .link-hit, .edge-zone, [data-sg-drag] { pointer-events: none; }
+    .subgraph-bg, .port-hit, .link-hit, .edge-zone { pointer-events: none; }
 
     /* Edit mode: enable all interaction */
     svg.interactive .node[data-id] { cursor: grab; }
     svg.interactive .node[data-id]:active { cursor: grabbing; }
-    svg.interactive .subgraph-bg { pointer-events: fill; cursor: pointer; }
-    svg.interactive [data-sg-drag] { pointer-events: fill; cursor: grab; }
-    svg.interactive [data-sg-drag]:active { cursor: grabbing; }
+    svg.interactive .subgraph-bg { pointer-events: fill; cursor: grab; }
+    svg.interactive .subgraph-bg:active { cursor: grabbing; }
     svg.interactive .port-hit { pointer-events: fill; cursor: crosshair; }
     svg.interactive .port-hit.linked { cursor: pointer; }
     svg.interactive .link-hit { pointer-events: stroke; cursor: pointer; }
@@ -175,8 +166,8 @@
         {colors}
         {theme}
         selected={selection.has(subgraph.id)}
-        ondragmove={onsubgraphmove}
-        onselect={onsubgraphselect}
+        {ondragmove}
+        {onselect}
         oncontextmenu={(id, e) => onctx?.(id, 'subgraph', e)}
       />
     {/each}
@@ -187,7 +178,7 @@
         {colors}
         selected={selection.has(edge.id)}
         {interactive}
-        onselect={onedgeselect}
+        {onselect}
         oncontextmenu={(id, e) => onctx?.(id, 'edge', e)}
       />
     {/each}
@@ -199,8 +190,8 @@
         {colors}
         selected={selection.has(node.id)}
         {interactive}
-        ondragmove={onnodedragmove}
-        onselect={onnodeselect}
+        {ondragmove}
+        {onselect}
         {onaddport}
         oncontextmenu={(id, e) => onctx?.(id, 'node', e)}
       />
@@ -216,7 +207,7 @@
         linked={linkedPorts.has(port.id)}
         {onlinkstart}
         {onlinkend}
-        onselect={onportselect}
+        {onselect}
         {onlabeledit}
         oncontextmenu={(id, e) => onctx?.(id, 'port', e)}
       />

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -30,6 +30,7 @@
     svgEl = $bindable<SVGSVGElement | null>(null),
     // Callbacks
     onnodedragmove,
+    onnodeselect,
     onaddport,
     onlinkstart,
     onlinkend,
@@ -54,6 +55,7 @@
     linkPreview?: { fromX: number; fromY: number; toX: number; toY: number } | null
     svgEl?: SVGSVGElement | null
     onnodedragmove?: (id: string, x: number, y: number) => void
+    onnodeselect?: (id: string) => void
     onaddport?: (nodeId: string, side: 'top' | 'bottom' | 'left' | 'right') => void
     onlinkstart?: (portId: string, x: number, y: number) => void
     onlinkend?: (portId: string) => void
@@ -175,6 +177,7 @@
         selected={selection.has(subgraph.id)}
         ondragmove={onsubgraphmove}
         onselect={onsubgraphselect}
+        oncontextmenu={(id, e) => onctx?.(id, 'subgraph', e)}
       />
     {/each}
 
@@ -197,6 +200,7 @@
         selected={selection.has(node.id)}
         {interactive}
         ondragmove={onnodedragmove}
+        onselect={onnodeselect}
         {onaddport}
         oncontextmenu={(id, e) => onctx?.(id, 'node', e)}
       />

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -7,7 +7,7 @@
     LABEL_LINE_HEIGHT,
   } from '@shumoku/core'
   import type { RenderColors } from '../../lib/render-colors'
-  import { nodeDrag } from '../../lib/use-drag'
+  import { elementDrag } from '../../lib/use-drag'
 
   let {
     node,
@@ -124,7 +124,7 @@
   data-id={node.id}
   data-device-type={node.node.type ?? ''}
   filter="url(#{shadowFilterId})"
-  use:nodeDrag={() => ({
+  use:elementDrag={() => ({
     filter: (e) => {
       const t = e.target as Element
       return !t.closest('.port') && !t.closest('.edge-zone') && e.button === 0 && interactive

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -17,6 +17,7 @@
     interactive = false,
     ondragmove,
     onaddport,
+    onselect,
     oncontextmenu: onctx,
   }: {
     node: ResolvedNode
@@ -26,6 +27,7 @@
     interactive?: boolean
     ondragmove?: (id: string, x: number, y: number) => void
     onaddport?: (nodeId: string, side: 'top' | 'bottom' | 'left' | 'right') => void
+    onselect?: (id: string) => void
     oncontextmenu?: (id: string, e: MouseEvent) => void
   } = $props()
 
@@ -129,6 +131,7 @@
     },
     onDrag: (dx, dy) => ondragmove?.(node.id, node.position.x + dx, node.position.y + dy),
   })}
+  onclick={(e) => { e.stopPropagation(); onselect?.(node.id) }}
   onpointerenter={() => { if (interactive) hovered = true }}
   onpointerleave={() => { hovered = false }}
   oncontextmenu={handleContextMenu}

--- a/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { ResolvedSubgraph, SurfaceToken, Theme } from '@shumoku/core'
   import type { RenderColors } from '../../lib/render-colors'
-  import { subgraphDrag } from '../../lib/use-drag'
+  import { elementDrag } from '../../lib/use-drag'
 
   let {
     subgraph,
@@ -67,16 +67,7 @@
     stroke-dasharray={selected ? undefined : (strokeDasharray || undefined)}
     onclick={(e) => { e.stopPropagation(); onselect?.(subgraph.id) }}
     oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); onselect?.(subgraph.id); onctx?.(subgraph.id, e) }}
-  />
-  <!-- Label area: d3-drag via use: directive -->
-  <rect
-    data-sg-drag={subgraph.id}
-    x={subgraph.bounds.x}
-    y={subgraph.bounds.y}
-    width={subgraph.bounds.width}
-    height={28}
-    fill="transparent"
-    use:subgraphDrag={() => ({
+    use:elementDrag={() => ({
       onDrag: (dx, dy) => ondragmove?.(subgraph.id, subgraph.bounds.x + dx, subgraph.bounds.y + dy),
     })}
   />

--- a/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
@@ -10,6 +10,7 @@
     selected = false,
     ondragmove,
     onselect,
+    oncontextmenu: onctx,
   }: {
     subgraph: ResolvedSubgraph
     colors: RenderColors
@@ -17,6 +18,7 @@
     selected?: boolean
     ondragmove?: (sgId: string, x: number, y: number) => void
     onselect?: (sgId: string) => void
+    oncontextmenu?: (id: string, e: MouseEvent) => void
   } = $props()
 
   const style = $derived(subgraph.subgraph.style ?? {})
@@ -64,6 +66,7 @@
     stroke-width={selected ? 3 : strokeWidth}
     stroke-dasharray={selected ? undefined : (strokeDasharray || undefined)}
     onclick={(e) => { e.stopPropagation(); onselect?.(subgraph.id) }}
+    oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); onselect?.(subgraph.id); onctx?.(subgraph.id, e) }}
   />
   <!-- Label area: d3-drag via use: directive -->
   <rect

--- a/libs/@shumoku/renderer/src/lib/use-drag.ts
+++ b/libs/@shumoku/renderer/src/lib/use-drag.ts
@@ -6,19 +6,20 @@
 import { drag } from 'd3-drag'
 import { select } from 'd3-selection'
 
-interface NodeDragOptions {
+interface DragOptions {
   // biome-ignore lint/suspicious/noExplicitAny: d3-drag filter signature uses any for event
   filter?: (e: any) => boolean
   onDrag: (dx: number, dy: number) => void
 }
 
-export function nodeDrag(element: SVGGElement, opts: () => NodeDragOptions) {
+/** Generic drag action for any SVG element (nodes, subgraphs, etc.) */
+export function elementDrag(element: SVGElement, opts: () => DragOptions) {
   function apply() {
     const { filter, onDrag } = opts()
-    const behavior = drag<SVGGElement, unknown>()
+    const behavior = drag<SVGElement, unknown>()
     if (filter) behavior.filter(filter)
     behavior.on('drag', (e) => onDrag(e.dx, e.dy))
-    select<SVGGElement, unknown>(element).call(behavior)
+    select<SVGElement, unknown>(element).call(behavior)
   }
 
   apply()
@@ -33,24 +34,7 @@ export function nodeDrag(element: SVGGElement, opts: () => NodeDragOptions) {
   }
 }
 
-export function subgraphDrag(
-  element: SVGRectElement,
-  opts: () => { onDrag: (dx: number, dy: number) => void },
-) {
-  function apply() {
-    const { onDrag } = opts()
-    const behavior = drag<SVGRectElement, unknown>().on('drag', (e) => onDrag(e.dx, e.dy))
-    select<SVGRectElement, unknown>(element).call(behavior)
-  }
-
-  apply()
-
-  return {
-    update() {
-      apply()
-    },
-    destroy() {
-      select(element).on('.drag', null)
-    },
-  }
-}
+/** @deprecated Use elementDrag */
+export const nodeDrag = elementDrag
+/** @deprecated Use elementDrag */
+export const subgraphDrag = elementDrag


### PR DESCRIPTION
## Summary

エディタのUX改善とノード/サブグラフのロジック統一。

### コンテキストメニュー
- ノード/サブグラフを右クリック → Copy / Paste / Delete
- クリップボード管理はeditor側（renderer非依存）

### コピー&ペースト
- ノード/サブグラフのtype/shape/labelをコピー → 右クリック位置にペースト
- `screenToSvg()`でマウス座標→SVG座標変換
- `computeNodeSize()`でコンテンツベースのサイズ自動計算

### CanvasBlock統一（ノード/サブグラフ共通化）

**ドラッグ**: `elementDrag` — `nodeDrag`/`subgraphDrag`を統合。サブグラフも全体ドラッグ可能に（ラベルバーのみ→全面）

**追加**: 共通フロー `resolveParentAndPosition → resolvePosition → finalizeAdd`
- サブグラフ内にサブグラフ追加が動く（parent検出）
- 衝突回避が両方に効く

**削除**: `deleteById`がサブグラフの子要素を再帰削除（孤児バグ修正）

**選択**: SvgCanvasのコールバックを`ondragmove`/`onselect`に統一（旧: onnodedragmove/onsubgraphmove/onnodeselect/onsubgraphselect/onedgeselect/onportselect）

**コピー**: `getElementInfo`がノード・サブグラフ両対応

**カーソル**: サブグラフもgrab/grabbing（ノードと同一）

**リファクタ**:
- `getViewportInverseCTM`抽出（screenToSvg + linkドラッグ共有）
- `handleLabelEdit`パススルー削除
- セクションコメント整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)