### PR TITLE
feat(editor): island-style floating UI

### DIFF
--- a/apps/editor/src/lib/components/AppTitle.svelte
+++ b/apps/editor/src/lib/components/AppTitle.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { TreeStructure } from 'phosphor-svelte'
+</script>
+
+<div
+  class="flex items-center gap-2 px-3 py-2 bg-white/90 dark:bg-neutral-800/90 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-lg"
+>
+  <TreeStructure class="w-5 h-5 text-blue-500" weight="bold" />
+  <span class="text-sm font-semibold text-neutral-800 dark:text-neutral-100">Editor</span>
+</div>

--- a/apps/editor/src/lib/components/ExportMenu.svelte
+++ b/apps/editor/src/lib/components/ExportMenu.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { DropdownMenu, Tooltip } from 'bits-ui'
+  import { DownloadSimple, Export, UploadSimple } from 'phosphor-svelte'
+
+  let {
+    onsave,
+    onload,
+  }: {
+    onsave?: () => void
+    onload?: () => void
+  } = $props()
+</script>
+
+<DropdownMenu.Root>
+  <DropdownMenu.Trigger>
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          class="flex items-center gap-1.5 px-3 py-2 bg-white/90 dark:bg-neutral-800/90 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-lg text-sm font-medium text-neutral-700 dark:text-neutral-200 hover:bg-white dark:hover:bg-neutral-700 transition-colors"
+        >
+          <Export class="w-4 h-4" />
+          File
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg">
+        Save / Load / Export
+      </Tooltip.Content>
+    </Tooltip.Root>
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content
+    class="min-w-[180px] bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-lg py-1 text-sm z-50"
+    sideOffset={4}
+    align="end"
+  >
+    <DropdownMenu.Item
+      class="flex items-center gap-2 px-3 py-2 text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 cursor-pointer transition-colors"
+      onSelect={() => onsave?.()}
+    >
+      <DownloadSimple class="w-4 h-4 text-neutral-400" />
+      Save as JSON
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex items-center gap-2 px-3 py-2 text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 cursor-pointer transition-colors"
+      onSelect={() => onload?.()}
+    >
+      <UploadSimple class="w-4 h-4 text-neutral-400" />
+      Load from JSON
+    </DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/apps/editor/src/lib/components/SheetBar.svelte
+++ b/apps/editor/src/lib/components/SheetBar.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  // Placeholder for sheet/diagram switching
+</script>
+
+<div
+  class="flex items-center gap-2 px-4 py-2 bg-white/90 dark:bg-neutral-800/90 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-lg"
+>
+  <div class="flex items-center gap-1">
+    <button
+      type="button"
+      class="px-3 py-1 text-xs font-medium bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-md"
+    >
+      Sheet 1
+    </button>
+  </div>
+  <div class="text-neutral-300 dark:text-neutral-600">|</div>
+  <span class="text-xs text-neutral-400 dark:text-neutral-500">More sheets coming soon</span>
+</div>

--- a/apps/editor/src/lib/components/SideToolbar.svelte
+++ b/apps/editor/src/lib/components/SideToolbar.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { Tooltip } from 'bits-ui'
+  import { Cube, Eye, Pencil, Plus, SquaresFour } from 'phosphor-svelte'
+
+  let {
+    mode = 'view',
+    onmodechange,
+    onaddnode,
+    onaddsubgraph,
+  }: {
+    mode: 'edit' | 'view'
+    onmodechange?: (mode: 'edit' | 'view') => void
+    onaddnode?: () => void
+    onaddsubgraph?: () => void
+  } = $props()
+
+  const editing = $derived(mode === 'edit')
+</script>
+
+<div
+  class="flex flex-col gap-1.5 p-1.5 bg-white/90 dark:bg-neutral-800/90 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-lg transition-all duration-200"
+>
+  <!-- Edit tools (show when editing) -->
+  {#if editing}
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          class="flex items-center justify-center w-9 h-9 rounded-lg text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+          onclick={() => onaddnode?.()}
+        >
+          <div class="relative">
+            <Cube class="w-4.5 h-4.5" />
+            <Plus class="w-2.5 h-2.5 absolute -bottom-0.5 -right-0.5 text-blue-500" weight="bold" />
+          </div>
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content
+        side="left"
+        class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg"
+      >
+        Add node
+      </Tooltip.Content>
+    </Tooltip.Root>
+
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          class="flex items-center justify-center w-9 h-9 rounded-lg text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+          onclick={() => onaddsubgraph?.()}
+        >
+          <div class="relative">
+            <SquaresFour class="w-4.5 h-4.5" />
+            <Plus class="w-2.5 h-2.5 absolute -bottom-0.5 -right-0.5 text-blue-500" weight="bold" />
+          </div>
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content
+        side="left"
+        class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg"
+      >
+        Add group
+      </Tooltip.Content>
+    </Tooltip.Root>
+
+    <div class="border-t border-neutral-200 dark:border-neutral-700 my-0.5"></div>
+  {/if}
+
+  <!-- Edit/View toggle (bottom) -->
+  <Tooltip.Root>
+    <Tooltip.Trigger>
+      <button
+        type="button"
+        class="flex items-center justify-center w-9 h-9 rounded-lg transition-colors {editing ? 'bg-blue-500 text-white shadow-sm' : 'text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-700'}"
+        onclick={() => onmodechange?.(editing ? 'view' : 'edit')}
+      >
+        {#if editing}
+          <Eye class="w-4.5 h-4.5" weight="bold" />
+        {:else}
+          <Pencil class="w-4.5 h-4.5" />
+        {/if}
+      </button>
+    </Tooltip.Trigger>
+    <Tooltip.Content
+      side="left"
+      class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg"
+    >
+      {editing ? 'Switch to View mode' : 'Switch to Edit mode'}
+    </Tooltip.Content>
+  </Tooltip.Root>
+</div>

--- a/apps/editor/src/lib/components/StatusBadge.svelte
+++ b/apps/editor/src/lib/components/StatusBadge.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  let {
+    status = 'Ready',
+    stats = { nodes: 0, links: 0, subgraphs: 0 },
+    selected = null,
+  }: {
+    status: string
+    stats: { nodes: number; links: number; subgraphs: number }
+    selected: { id: string; type: string } | null
+  } = $props()
+</script>
+
+<div
+  class="flex items-center gap-3 px-3 py-2 bg-white/90 dark:bg-neutral-800/90 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-lg text-xs"
+>
+  <!-- Status dot -->
+  <div class="flex items-center gap-1.5">
+    <div
+      class="w-1.5 h-1.5 rounded-full {status === 'Ready' ? 'bg-green-400' : 'bg-amber-400 animate-pulse'}"
+    ></div>
+    <span class="text-neutral-500 dark:text-neutral-400">{status}</span>
+  </div>
+
+  <div class="text-neutral-300 dark:text-neutral-600">|</div>
+
+  <!-- Stats -->
+  <div class="flex items-center gap-2 text-neutral-400 dark:text-neutral-500">
+    <span>{stats.nodes}N</span>
+    <span>{stats.links}L</span>
+    <span>{stats.subgraphs}G</span>
+  </div>
+
+  <!-- Selection -->
+  {#if selected}
+    <div class="text-neutral-300 dark:text-neutral-600">|</div>
+    <div class="flex items-center gap-1 text-blue-600 dark:text-blue-400 font-medium">
+      <span class="capitalize">{selected.type}</span>
+      <span class="font-mono text-blue-400 dark:text-blue-500">{selected.id}</span>
+    </div>
+  {/if}
+</div>

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -12,17 +12,28 @@
   } from '@shumoku/core'
   // @ts-expect-error — SvelteKit resolves the svelte condition from package.json exports
   import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
+  import AppTitle from '$lib/components/AppTitle.svelte'
+  import ExportMenu from '$lib/components/ExportMenu.svelte'
   import LabelEditPopover from '$lib/components/LabelEditPopover.svelte'
   import NodeContextMenu from '$lib/components/NodeContextMenu.svelte'
-  import Toolbar from '$lib/components/Toolbar.svelte'
+  import SheetBar from '$lib/components/SheetBar.svelte'
+  import SideToolbar from '$lib/components/SideToolbar.svelte'
+  import StatusBadge from '$lib/components/StatusBadge.svelte'
 
-  // --- State ---
+  // =========================================================================
+  // State
+  // =========================================================================
 
   let renderer: ShumokuRenderer | undefined = $state()
   let status = $state('Loading...')
   let mode = $state<'edit' | 'view'>('view')
   let selected = $state<{ id: string; type: string } | null>(null)
-  let contextMenu = $state<{ id: string; type: string; x: number; y: number } | null>(null)
+  let contextMenu = $state<{
+    id: string
+    type: string
+    x: number
+    y: number
+  } | null>(null)
   let clipboard = $state<{
     label: string
     shape?: string
@@ -33,22 +44,34 @@
   let layout = $state<ResolvedLayout | undefined>(undefined)
   let graph = $state<{ links: Link[] } | undefined>(undefined)
   let isDark = $state(false)
-  let labelEdit = $state<{ portId: string; label: string; x: number; y: number } | null>(null)
+  let labelEdit = $state<{
+    portId: string
+    label: string
+    x: number
+    y: number
+  } | null>(null)
 
   const theme: Theme | undefined = $derived(isDark ? darkTheme : lightTheme)
 
-  // --- Dark mode detection ---
+  // =========================================================================
+  // Dark mode detection
+  // =========================================================================
 
   $effect(() => {
     isDark = document.documentElement.classList.contains('dark')
     const obs = new MutationObserver(() => {
       isDark = document.documentElement.classList.contains('dark')
     })
-    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    obs.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    })
     return () => obs.disconnect()
   })
 
-  // --- Init ---
+  // =========================================================================
+  // Init
+  // =========================================================================
 
   async function parseSampleNetwork() {
     const fileMap = new Map<string, string>()
@@ -87,7 +110,9 @@
     })()
   })
 
-  // --- Serialization ---
+  // =========================================================================
+  // Serialization
+  // =========================================================================
 
   function mapToObj(l: ResolvedLayout) {
     return {
@@ -110,7 +135,9 @@
     } as ResolvedLayout
   }
 
-  // --- Handlers ---
+  // =========================================================================
+  // Handlers
+  // =========================================================================
 
   function handleSave() {
     const snap = renderer?.getSnapshot()
@@ -157,81 +184,129 @@
   }
 </script>
 
-<div class="flex flex-col h-screen">
-  <Toolbar
-    {mode}
-    {stats}
-    {selected}
-    {status}
-    onmodechange={(m) => { mode = m }}
-    onaddnode={handleAddNode}
-    onaddsubgraph={handleAddSubgraph}
-    onsave={handleSave}
-    onload={handleLoad}
-  />
+<!-- Full-screen canvas with floating island UI -->
+<div class="relative h-screen w-screen overflow-hidden bg-neutral-50 dark:bg-neutral-950">
+  <!-- Canvas (full screen) -->
+  {#if layout}
+    <ShumokuRenderer
+      bind:this={renderer}
+      {layout}
+      {graph}
+      {theme}
+      {mode}
+      onselect={(id: string | null, type: string | null) => {
+        selected = id ? { id, type: type ?? 'node' } : null
+      }}
+      onchange={(links: Link[]) => {
+        stats = { ...stats, links: links.length }
+      }}
+      onlabeledit={(
+        portId: string,
+        label: string,
+        screenX: number,
+        screenY: number,
+      ) => {
+        labelEdit = { portId, label, x: screenX, y: screenY }
+      }}
+      oncontextmenu={(
+        id: string,
+        type: string,
+        screenX: number,
+        screenY: number,
+      ) => {
+        contextMenu = { id, type, x: screenX, y: screenY }
+      }}
+    />
+  {:else}
+    <div class="flex items-center justify-center h-full text-neutral-400 dark:text-neutral-500">
+      {status}
+    </div>
+  {/if}
 
-  <div class="flex-1 overflow-hidden relative">
-    {#if layout}
-      <ShumokuRenderer
-        bind:this={renderer}
-        {layout}
-        {graph}
-        {theme}
-        {mode}
-        onselect={(id: string | null, type: string | null) => { selected = id ? { id, type: type ?? 'node' } : null }}
-        onchange={(links: Link[]) => { stats = { ...stats, links: links.length } }}
-        onlabeledit={(portId: string, label: string, screenX: number, screenY: number) => {
-          labelEdit = { portId, label, x: screenX, y: screenY }
-        }}
-        oncontextmenu={(id: string, type: string, screenX: number, screenY: number) => {
-          contextMenu = { id, type, x: screenX, y: screenY }
-        }}
-      />
-    {:else}
-      <div class="flex items-center justify-center h-full text-slate-500 dark:text-neutral-400">
-        {status}
-      </div>
-    {/if}
+  <!-- ===== Floating Islands ===== -->
 
-    {#if labelEdit}
-      <LabelEditPopover
-        portId={labelEdit.portId}
-        label={labelEdit.label}
-        x={labelEdit.x}
-        y={labelEdit.y}
-        oncommit={(portId, value) => renderer?.commitLabel(portId, value)}
-        onclose={() => { labelEdit = null }}
-      />
-    {/if}
+  <!-- Top-left: App title -->
+  <div class="absolute top-4 left-4 z-20"><AppTitle /></div>
 
-    {#if contextMenu}
-      <NodeContextMenu
-        id={contextMenu.id}
-        type={contextMenu.type}
-        x={contextMenu.x}
-        y={contextMenu.y}
-        hasClipboard={clipboard !== null}
-        oncopy={(id) => {
-          const info = renderer?.getElementInfo(id)
-          clipboard = info ? { label: info.label, shape: info.kind === 'node' ? info.shape : undefined, type: info.kind === 'node' ? info.type : undefined, elementKind: info.kind } : null
-        }}
-        onpaste={() => {
-          if (!clipboard || !contextMenu) return
-          const svgPos = renderer?.screenToSvg(contextMenu.x, contextMenu.y)
-          if (clipboard.elementKind === 'subgraph') {
-            renderer?.addNewSubgraph({ label: clipboard.label, position: svgPos })
-            stats = { ...stats, subgraphs: stats.subgraphs + 1 }
-          } else {
-            renderer?.addNewNode({ label: clipboard.label, type: clipboard.type, shape: clipboard.shape, position: svgPos })
-            stats = { ...stats, nodes: stats.nodes + 1 }
-          }
-        }}
-        ondelete={(id) => {
-          renderer?.deleteById(id)
-          stats = { ...stats, nodes: Math.max(0, stats.nodes - 1) }
-        }}
-        onclose={() => { contextMenu = null }}
-      />
-    {/if}
+  <!-- Top-right: Export menu -->
+  <div class="absolute top-4 right-4 z-20">
+    <ExportMenu onsave={handleSave} onload={handleLoad} />
   </div>
+
+  <!-- Right: Side toolbar -->
+  <div class="absolute right-4 top-1/2 -translate-y-1/2 z-20">
+    <SideToolbar
+      {mode}
+      onmodechange={(m) => {
+        mode = m
+      }}
+      onaddnode={handleAddNode}
+      onaddsubgraph={handleAddSubgraph}
+    />
+  </div>
+
+  <!-- Bottom-left: Status -->
+  <div class="absolute bottom-4 left-4 z-20"><StatusBadge {status} {stats} {selected} /></div>
+
+  <!-- Bottom-center: Sheet bar -->
+  <div class="absolute bottom-4 left-1/2 -translate-x-1/2 z-20"><SheetBar /></div>
+
+  <!-- ===== Overlays ===== -->
+
+  {#if labelEdit}
+    <LabelEditPopover
+      portId={labelEdit.portId}
+      label={labelEdit.label}
+      x={labelEdit.x}
+      y={labelEdit.y}
+      oncommit={(portId, value) => renderer?.commitLabel(portId, value)}
+      onclose={() => {
+        labelEdit = null
+      }}
+    />
+  {/if}
+
+  {#if contextMenu}
+    <NodeContextMenu
+      id={contextMenu.id}
+      type={contextMenu.type}
+      x={contextMenu.x}
+      y={contextMenu.y}
+      hasClipboard={clipboard !== null}
+      oncopy={(id) => {
+        const info = renderer?.getElementInfo(id)
+        clipboard = info
+          ? {
+              label: info.label,
+              shape: info.kind === 'node' ? info.shape : undefined,
+              type: info.kind === 'node' ? info.type : undefined,
+              elementKind: info.kind,
+            }
+          : null
+      }}
+      onpaste={() => {
+        if (!clipboard || !contextMenu) return
+        const svgPos = renderer?.screenToSvg(contextMenu.x, contextMenu.y)
+        if (clipboard.elementKind === 'subgraph') {
+          renderer?.addNewSubgraph({ label: clipboard.label, position: svgPos })
+          stats = { ...stats, subgraphs: stats.subgraphs + 1 }
+        } else {
+          renderer?.addNewNode({
+            label: clipboard.label,
+            type: clipboard.type,
+            shape: clipboard.shape,
+            position: svgPos,
+          })
+          stats = { ...stats, nodes: stats.nodes + 1 }
+        }
+      }}
+      ondelete={(id) => {
+        renderer?.deleteById(id)
+        stats = { ...stats, nodes: Math.max(0, stats.nodes - 1) }
+      }}
+      onclose={() => {
+        contextMenu = null
+      }}
+    />
+  {/if}
 </div>


### PR DESCRIPTION
## Summary

エディタUIをアイランドスタイルのフローティングレイアウトに刷新。

### Before
- 画面上部に固定Toolbar（全機能が1行に詰め込み）

### After
- フルスクリーンキャンバス + フローティングアイランドUI
- **左上**: Editorタイトル
- **右上**: Fileメニュー（Save/Load JSON）
- **右中央**: SideToolbar
  - Edit/View切替（下部に配置、✏️=編集開始/👁️=閲覧に戻る）
  - Editモード時にツール展開（Add node, Add group）
- **左下**: StatusBadge（状態、統計、選択情報）
- **下部中央**: SheetBar（シート切替プレースホルダー）

### コンポーネント構成
- `AppTitle.svelte` — ロゴ + タイトル
- `ExportMenu.svelte` — bits-ui DropdownMenu
- `SideToolbar.svelte` — モード切替 + 編集ツール
- `StatusBadge.svelte` — ステータス表示
- `SheetBar.svelte` — シート切替（将来用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)