### PR TITLE
feat(editor): code panel + JSON-based state architecture

### DIFF
--- a/apps/editor/src/lib/components/CodePanel.svelte
+++ b/apps/editor/src/lib/components/CodePanel.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import { Tabs } from 'bits-ui'
+  import { CaretLeft, Code, Play } from 'phosphor-svelte'
+
+  let {
+    open = false,
+    yaml = '',
+    json = '',
+    ontoggle,
+    onyamlchange,
+    onjsonchange,
+    onyamlapply,
+    onjsonapply,
+  }: {
+    open?: boolean
+    yaml?: string
+    json?: string
+    ontoggle?: () => void
+    onyamlchange?: (value: string) => void
+    onjsonchange?: (value: string) => void
+    onyamlapply?: () => void
+    onjsonapply?: () => void
+  } = $props()
+</script>
+
+<div class="flex h-full items-stretch gap-1">
+  {#if open}
+    <div
+      class="w-[380px] bg-white/95 dark:bg-neutral-900/95 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-xl flex flex-col overflow-hidden"
+    >
+      <Tabs.Root value="yaml" class="flex flex-col h-full">
+        <Tabs.List class="flex border-b border-neutral-200 dark:border-neutral-700 shrink-0">
+          <Tabs.Trigger
+            value="yaml"
+            class="px-4 py-2.5 text-xs font-medium border-b-2 transition-colors data-[state=active]:border-blue-500 data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400 border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200"
+          >
+            YAML
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="json"
+            class="px-4 py-2.5 text-xs font-medium border-b-2 transition-colors data-[state=active]:border-blue-500 data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400 border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200"
+          >
+            JSON
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <Tabs.Content value="yaml" class="flex-1 min-h-0 flex flex-col">
+          <textarea
+            class="flex-1 w-full p-4 text-[12px] font-mono leading-relaxed bg-transparent text-neutral-700 dark:text-neutral-200 resize-none outline-none placeholder:text-neutral-400 themed-scrollbar"
+            spellcheck="false"
+            placeholder="# Network topology YAML..."
+            value={yaml}
+            oninput={(e) => onyamlchange?.((e.target as HTMLTextAreaElement).value)}
+          ></textarea>
+          <div
+            class="flex justify-end px-3 py-2 border-t border-neutral-200 dark:border-neutral-700 shrink-0"
+          >
+            <button
+              type="button"
+              class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+              onclick={() => onyamlapply?.()}
+            >
+              <Play class="w-3 h-3" weight="fill" />
+              Apply
+            </button>
+          </div>
+        </Tabs.Content>
+
+        <Tabs.Content value="json" class="flex-1 min-h-0 flex flex-col">
+          <textarea
+            class="flex-1 w-full p-4 text-[12px] font-mono leading-relaxed bg-transparent text-neutral-700 dark:text-neutral-200 resize-none outline-none placeholder:text-neutral-400 themed-scrollbar"
+            spellcheck="false"
+            value={json}
+            oninput={(e) => onjsonchange?.((e.target as HTMLTextAreaElement).value)}
+          ></textarea>
+          <div
+            class="flex justify-end px-3 py-2 border-t border-neutral-200 dark:border-neutral-700 shrink-0"
+          >
+            <button
+              type="button"
+              class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+              onclick={() => onjsonapply?.()}
+            >
+              <Play class="w-3 h-3" weight="fill" />
+              Apply
+            </button>
+          </div>
+        </Tabs.Content>
+      </Tabs.Root>
+    </div>
+  {/if}
+
+  <button
+    type="button"
+    class="self-center flex items-center justify-center shrink-0 bg-white/90 dark:bg-neutral-800/90 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-lg shadow-lg text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors {open ? 'w-6 h-10' : 'w-10 h-10'}"
+    onclick={() => ontoggle?.()}
+  >
+    {#if open}
+      <CaretLeft class="w-4 h-4" />
+    {:else}
+      <Code class="w-5 h-5" />
+    {/if}
+  </button>
+</div>
+
+<style>
+  .themed-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: #d4d4d4 transparent;
+  }
+  :global(.dark) .themed-scrollbar {
+    scrollbar-color: #525252 transparent;
+  }
+</style>

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -4,12 +4,17 @@
     createMemoryFileResolver,
     HierarchicalParser,
     type Link,
+    type ResolvedEdge,
     type ResolvedLayout,
+    type ResolvedNode,
+    type ResolvedPort,
+    type ResolvedSubgraph,
     sampleNetwork,
   } from '@shumoku/core'
   // @ts-expect-error — SvelteKit resolves the svelte condition from package.json exports
   import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
   import AppTitle from '$lib/components/AppTitle.svelte'
+  import CodePanel from '$lib/components/CodePanel.svelte'
   import DetailPanel from '$lib/components/DetailPanel.svelte'
   import ExportMenu from '$lib/components/ExportMenu.svelte'
   import LabelEditPopover from '$lib/components/LabelEditPopover.svelte'
@@ -20,47 +25,96 @@
   import { editorState, initDarkMode } from '$lib/context.svelte'
 
   // =========================================================================
-  // State (editor-specific, not shared globally)
+  // Layout state — THE source of truth
+  // =========================================================================
+
+  let nodes = $state<Map<string, ResolvedNode>>(new Map())
+  let ports = $state<Map<string, ResolvedPort>>(new Map())
+  let edges = $state<Map<string, ResolvedEdge>>(new Map())
+  let subgraphs = $state<Map<string, ResolvedSubgraph>>(new Map())
+  let bounds = $state({ x: 0, y: 0, width: 0, height: 0 })
+  let links = $state<Link[]>([])
+
+  // =========================================================================
+  // UI state
   // =========================================================================
 
   let renderer: ShumokuRenderer | undefined = $state()
   let status = $state('Loading...')
+  let codePanelOpen = $state(false)
+  let yamlSource = $state('')
   let selected = $state<{ id: string; type: string } | null>(null)
-  let contextMenu = $state<{
-    id: string
-    type: string
-    x: number
-    y: number
-  } | null>(null)
+  let contextMenu = $state<{ id: string; type: string; x: number; y: number } | null>(null)
   let clipboard = $state<{
     label: string
     shape?: string
     type?: string
     elementKind: 'node' | 'subgraph'
   } | null>(null)
-  let stats = $state({ nodes: 0, links: 0, subgraphs: 0 })
-  let layout = $state<ResolvedLayout | undefined>(undefined)
-  let graph = $state<{ links: Link[] } | undefined>(undefined)
   // biome-ignore lint/suspicious/noExplicitAny: mixed element detail data
   let detailData = $state<Record<string, any> | null>(null)
-  let labelEdit = $state<{
-    portId: string
-    label: string
-    x: number
-    y: number
-  } | null>(null)
+  let labelEdit = $state<{ portId: string; label: string; x: number; y: number } | null>(null)
 
   // =========================================================================
-  // Init dark mode observer
+  // Derived
+  // =========================================================================
+
+  const stats = $derived({ nodes: nodes.size, links: links.length, subgraphs: subgraphs.size })
+  let jsonSource = $state('{}')
+  $effect(() => {
+    jsonSource = stateToJson()
+  })
+
+  // =========================================================================
+  // Serialization
+  // =========================================================================
+
+  function stateToJson(): string {
+    return JSON.stringify(
+      {
+        layout: {
+          nodes: Object.fromEntries(new Map(nodes)),
+          ports: Object.fromEntries(new Map(ports)),
+          edges: Object.fromEntries(new Map(edges)),
+          subgraphs: Object.fromEntries(new Map(subgraphs)),
+          bounds: { ...bounds },
+        },
+        links: [...links],
+      },
+      null,
+      2,
+    )
+  }
+
+  function loadFromJson(jsonStr: string) {
+    const data = JSON.parse(jsonStr)
+    nodes = new Map(Object.entries(data.layout?.nodes ?? {})) as Map<string, ResolvedNode>
+    ports = new Map(Object.entries(data.layout?.ports ?? {})) as Map<string, ResolvedPort>
+    edges = new Map(Object.entries(data.layout?.edges ?? {})) as Map<string, ResolvedEdge>
+    subgraphs = new Map(Object.entries(data.layout?.subgraphs ?? {})) as Map<
+      string,
+      ResolvedSubgraph
+    >
+    bounds = data.layout?.bounds ?? { x: 0, y: 0, width: 800, height: 600 }
+    links = data.links ?? []
+  }
+
+  function loadFromResolved(resolved: ResolvedLayout, graphLinks: Link[]) {
+    nodes = new Map(resolved.nodes)
+    ports = new Map(resolved.ports)
+    edges = new Map(resolved.edges)
+    subgraphs = new Map(resolved.subgraphs)
+    bounds = resolved.bounds
+    links = [...graphLinks]
+  }
+
+  // =========================================================================
+  // Init
   // =========================================================================
 
   $effect(() => {
     return initDarkMode()
   })
-
-  // =========================================================================
-  // Init diagram
-  // =========================================================================
 
   async function parseSampleNetwork() {
     const fileMap = new Map<string, string>()
@@ -81,17 +135,11 @@
       try {
         status = 'Parsing network...'
         const g = await parseSampleNetwork()
-
         status = 'Computing layout...'
         const { resolved } = await computeNetworkLayout(g)
-
-        graph = { links: g.links }
-        layout = resolved
-        stats = {
-          nodes: resolved.nodes.size,
-          links: g.links.length,
-          subgraphs: resolved.subgraphs.size,
-        }
+        loadFromResolved(resolved, g.links)
+        const mainFile = sampleNetwork.find((f) => f.name === 'main.yaml')
+        if (mainFile) yamlSource = mainFile.content
         status = 'Ready'
       } catch (e) {
         status = `Error: ${e instanceof Error ? e.message : String(e)}`
@@ -100,39 +148,42 @@
   })
 
   // =========================================================================
-  // Serialization
+  // Apply
   // =========================================================================
 
-  function mapToObj(l: ResolvedLayout) {
-    return {
-      nodes: Object.fromEntries(new Map(l.nodes)),
-      ports: Object.fromEntries(new Map(l.ports)),
-      edges: Object.fromEntries(new Map(l.edges)),
-      subgraphs: Object.fromEntries(new Map(l.subgraphs)),
-      bounds: { ...l.bounds },
+  async function applyYaml(yamlStr: string) {
+    try {
+      status = 'Parsing YAML...'
+      const fileMap = new Map<string, string>()
+      fileMap.set('main.yaml', yamlStr)
+      fileMap.set('./main.yaml', yamlStr)
+      fileMap.set('/main.yaml', yamlStr)
+      const resolver = createMemoryFileResolver(fileMap, '/')
+      const hp = new HierarchicalParser(resolver)
+      const { graph: g } = await hp.parse(yamlStr, '/main.yaml')
+      const { resolved } = await computeNetworkLayout(g)
+      loadFromResolved(resolved, g.links)
+      status = 'Ready'
+    } catch (_e) {
+      status = 'YAML parse error'
     }
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: JSON deserialization
-  function objToMap(data: any): ResolvedLayout {
-    return {
-      nodes: new Map(Object.entries(data.nodes ?? {})),
-      ports: new Map(Object.entries(data.ports ?? {})),
-      edges: new Map(Object.entries(data.edges ?? {})),
-      subgraphs: new Map(Object.entries(data.subgraphs ?? {})),
-      bounds: data.bounds ?? { x: 0, y: 0, width: 800, height: 600 },
-    } as ResolvedLayout
+  function applyJson(jsonStr: string) {
+    try {
+      loadFromJson(jsonStr)
+      status = 'Ready'
+    } catch (_e) {
+      status = 'JSON parse error'
+    }
   }
 
   // =========================================================================
-  // Handlers
+  // File
   // =========================================================================
 
   function handleSave() {
-    const snap = renderer?.getSnapshot()
-    if (!snap) return
-    const data = JSON.stringify({ layout: mapToObj(snap.layout), links: snap.links }, null, 2)
-    const blob = new Blob([data], { type: 'application/json' })
+    const blob = new Blob([stateToJson()], { type: 'application/json' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
@@ -148,96 +199,82 @@
     input.onchange = async () => {
       const file = input.files?.[0]
       if (!file) return
-      const text = await file.text()
-      const data = JSON.parse(text)
-      const loaded = objToMap(data.layout)
-      graph = { links: data.links ?? [] }
-      layout = loaded
-      stats = {
-        nodes: loaded.nodes.size,
-        links: data.links?.length ?? 0,
-        subgraphs: loaded.subgraphs.size,
-      }
+      applyJson(await file.text())
     }
     input.click()
   }
-
-  function handleAddNode() {
-    renderer?.addNewNode()
-    stats = { ...stats, nodes: stats.nodes + 1 }
-  }
-
-  function handleAddSubgraph() {
-    renderer?.addNewSubgraph()
-    stats = { ...stats, subgraphs: stats.subgraphs + 1 }
-  }
 </script>
 
-<!-- Full-screen canvas with floating island UI -->
+<!--
+  Canvas = full screen, always.
+  UI = fixed overlays, each owns its corner.
+  They don't know about each other. Overlap is fine (same as Miro/Figma).
+-->
 <div class="relative h-screen w-screen overflow-hidden bg-neutral-50 dark:bg-neutral-950">
-  <!-- Canvas -->
-  {#if layout}
-    <ShumokuRenderer
-      bind:this={renderer}
-      {layout}
-      {graph}
-      theme={editorState.theme}
-      mode={editorState.mode}
-      onselect={(id: string | null, type: string | null) => {
-        selected = id ? { id, type: type ?? 'node' } : null
-      }}
-      onchange={(links: Link[]) => {
-        stats = { ...stats, links: links.length }
-      }}
-      onlabeledit={(
-        portId: string,
-        label: string,
-        screenX: number,
-        screenY: number,
-      ) => {
-        labelEdit = { portId, label, x: screenX, y: screenY }
-      }}
-      oncontextmenu={(
-        id: string,
-        type: string,
-        screenX: number,
-        screenY: number,
-      ) => {
-        contextMenu = { id, type, x: screenX, y: screenY }
-      }}
-    />
-  {:else}
-    <div class="flex items-center justify-center h-full text-neutral-400 dark:text-neutral-500">
-      {status}
-    </div>
-  {/if}
-
-  <!-- ===== Floating Islands ===== -->
-
-  <div class="absolute top-4 left-4 z-20"><AppTitle /></div>
-
-  <div class="absolute top-4 right-4 z-20">
-    <ExportMenu onsave={handleSave} onload={handleLoad} />
+  <!-- Canvas (full screen, z-0) -->
+  <div class="absolute inset-0">
+    {#if nodes.size > 0 || status !== 'Loading...'}
+      <ShumokuRenderer
+        bind:this={renderer}
+        bind:nodes
+        bind:ports
+        bind:edges
+        bind:subgraphs
+        bind:bounds
+        bind:links
+        theme={editorState.theme}
+        mode={editorState.mode}
+        onselect={(id: string | null, type: string | null) => { selected = id ? { id, type: type ?? 'node' } : null }}
+        onchange={() => {}}
+        onlabeledit={(portId: string, label: string, screenX: number, screenY: number) => { labelEdit = { portId, label, x: screenX, y: screenY } }}
+        oncontextmenu={(id: string, type: string, screenX: number, screenY: number) => { contextMenu = { id, type, x: screenX, y: screenY } }}
+      />
+    {:else}
+      <div class="flex items-center justify-center h-full text-neutral-400 dark:text-neutral-500">
+        {status}
+      </div>
+    {/if}
   </div>
 
-  <div class="absolute right-4 top-1/2 -translate-y-1/2 z-20">
+  <!-- Top-left: Title -->
+  <div class="fixed top-3 left-3 z-20"><AppTitle /></div>
+
+  <!-- Top-right: Export -->
+  <div class="fixed top-3 right-3 z-20"><ExportMenu onsave={handleSave} onload={handleLoad} /></div>
+
+  <!-- Left: Code panel (above other islands) -->
+  <div class="fixed top-3 bottom-3 left-3 z-30">
+    <CodePanel
+      open={codePanelOpen}
+      yaml={yamlSource}
+      json={jsonSource}
+      ontoggle={() => { codePanelOpen = !codePanelOpen }}
+      onyamlchange={(v) => { yamlSource = v }}
+      onjsonchange={(v) => { jsonSource = v }}
+      onyamlapply={() => applyYaml(yamlSource)}
+      onjsonapply={() => applyJson(jsonSource)}
+    />
+  </div>
+
+  <!-- Right: Side toolbar -->
+  <div class="fixed right-3 top-1/2 -translate-y-1/2 z-20">
     <SideToolbar
       mode={editorState.mode}
       isDark={editorState.isDark}
-      onmodechange={(m) => {
-        editorState.mode = m
-      }}
-      onaddnode={handleAddNode}
-      onaddsubgraph={handleAddSubgraph}
+      onmodechange={(m) => { editorState.mode = m }}
+      onaddnode={() => renderer?.addNewNode()}
+      onaddsubgraph={() => renderer?.addNewSubgraph()}
       onthemetoggle={() => editorState.toggleTheme()}
     />
   </div>
 
-  <div class="absolute bottom-4 left-4 z-20"><StatusBadge {status} {stats} {selected} /></div>
+  <!-- Bottom-left: Status -->
+  <div class="fixed bottom-3 left-3 z-20"><StatusBadge {status} {stats} {selected} /></div>
 
-  <div class="absolute bottom-4 left-1/2 -translate-x-1/2 z-20"><SheetBar /></div>
+  <!-- Bottom-center: Sheet bar -->
+  <div class="fixed bottom-3 left-1/2 -translate-x-1/2 z-20"><SheetBar /></div>
 
-  <!-- ===== Overlays ===== -->
+  <!-- Overlays (cursor-positioned) -->
 
   {#if labelEdit}
     <LabelEditPopover
@@ -246,9 +283,7 @@
       x={labelEdit.x}
       y={labelEdit.y}
       oncommit={(portId, value) => renderer?.commitLabel(portId, value)}
-      onclose={() => {
-        labelEdit = null
-      }}
+      onclose={() => { labelEdit = null }}
     />
   {/if}
 
@@ -262,44 +297,17 @@
       hasClipboard={clipboard !== null}
       oncopy={(id) => {
         const info = renderer?.getElementInfo(id)
-        clipboard = info
-          ? {
-              label: info.label,
-              shape: info.kind === 'node' ? info.shape : undefined,
-              type: info.kind === 'node' ? info.type : undefined,
-              elementKind: info.kind,
-            }
-          : null
+        clipboard = info ? { label: info.label, shape: info.kind === 'node' ? info.shape : undefined, type: info.kind === 'node' ? info.type : undefined, elementKind: info.kind } : null
       }}
       onpaste={() => {
         if (!clipboard || !contextMenu) return
         const svgPos = renderer?.screenToSvg(contextMenu.x, contextMenu.y)
-        if (clipboard.elementKind === 'subgraph') {
-          renderer?.addNewSubgraph({
-            label: clipboard.label,
-            position: svgPos,
-          })
-          stats = { ...stats, subgraphs: stats.subgraphs + 1 }
-        } else {
-          renderer?.addNewNode({
-            label: clipboard.label,
-            type: clipboard.type,
-            shape: clipboard.shape,
-            position: svgPos,
-          })
-          stats = { ...stats, nodes: stats.nodes + 1 }
-        }
+        if (clipboard.elementKind === 'subgraph') renderer?.addNewSubgraph({ label: clipboard.label, position: svgPos })
+        else renderer?.addNewNode({ label: clipboard.label, type: clipboard.type, shape: clipboard.shape, position: svgPos })
       }}
-      ondetails={(id) => {
-        detailData = renderer?.getElementDetails(id) ?? null
-      }}
-      ondelete={(id) => {
-        renderer?.deleteById(id)
-        stats = { ...stats, nodes: Math.max(0, stats.nodes - 1) }
-      }}
-      onclose={() => {
-        contextMenu = null
-      }}
+      ondetails={(id) => { detailData = renderer?.getElementDetails(id) ?? null }}
+      ondelete={(id) => { renderer?.deleteById(id) }}
+      onclose={() => { contextMenu = null }}
     />
   {/if}
 

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -26,7 +26,15 @@
   import SvgCanvas from './svg/SvgCanvas.svelte'
 
   interface RendererProps {
-    layout: ResolvedLayout
+    // Direct state (preferred — parent owns state)
+    nodes?: Map<string, ResolvedNode>
+    ports?: Map<string, ResolvedPort>
+    edges?: Map<string, ResolvedEdge>
+    subgraphs?: Map<string, ResolvedSubgraph>
+    bounds?: { x: number; y: number; width: number; height: number }
+    links?: Link[]
+    // Legacy: pass layout object (WebComponent compat)
+    layout?: ResolvedLayout
     graph?: { links: Link[] }
     theme?: Theme
     mode?: 'view' | 'edit'
@@ -37,8 +45,14 @@
   }
 
   let {
-    layout,
-    graph,
+    nodes = $bindable(new Map()),
+    ports = $bindable(new Map()),
+    edges = $bindable(new Map()),
+    subgraphs = $bindable(new Map()),
+    bounds = $bindable({ x: 0, y: 0, width: 0, height: 0 }),
+    links = $bindable([]),
+    layout = undefined,
+    graph = undefined,
     theme = undefined,
     mode = 'view',
     onchange,
@@ -50,26 +64,18 @@
   const colors = $derived(themeToColors(theme))
   const interactive = $derived(mode === 'edit')
 
-  // =========================================================================
-  // Layout state (mutable copies, synced from props via $effect)
-  // =========================================================================
-
-  let nodes = $state<Map<string, ResolvedNode>>(new Map())
-  let ports = $state<Map<string, ResolvedPort>>(new Map())
-  let edges = $state<Map<string, ResolvedEdge>>(new Map())
-  let subgraphs = $state<Map<string, ResolvedSubgraph>>(new Map())
-  let bounds = $state({ x: 0, y: 0, width: 0, height: 0 })
-  let links = $state<Link[]>([])
-
+  // Legacy compat: sync from layout/graph props (WebComponent uses these)
   $effect(() => {
-    nodes = new Map(layout.nodes)
-    ports = new Map(layout.ports)
-    edges = new Map(layout.edges)
-    subgraphs = new Map(layout.subgraphs)
-    bounds = layout.bounds
+    if (layout) {
+      nodes = new Map(layout.nodes)
+      ports = new Map(layout.ports)
+      edges = new Map(layout.edges)
+      subgraphs = new Map(layout.subgraphs)
+      bounds = layout.bounds
+    }
   })
   $effect(() => {
-    links = graph?.links ? [...graph.links] : []
+    if (graph?.links) links = [...graph.links]
   })
 
   // =========================================================================
@@ -500,23 +506,6 @@
     ]
     edges = await routeEdges(nodes, ports, links)
     onchange?.(links)
-  }
-
-  // =========================================================================
-  // Snapshot
-  // =========================================================================
-
-  export function getSnapshot() {
-    return {
-      layout: {
-        nodes: new Map(nodes),
-        ports: new Map(ports),
-        edges: new Map(edges),
-        subgraphs: new Map(subgraphs),
-        bounds: { ...bounds },
-      },
-      links: [...links],
-    }
   }
 </script>
 

--- a/libs/@shumoku/renderer/src/wc.svelte.ts
+++ b/libs/@shumoku/renderer/src/wc.svelte.ts
@@ -42,7 +42,7 @@ export class ShumokuRendererElement extends HTMLElement {
     this._props.layout = value
     if (!this._mounted) this._mount()
   }
-  get layout() {
+  get layout(): ResolvedLayout | undefined {
     return this._props.layout
   }
 
@@ -146,7 +146,7 @@ export class ShumokuRendererElement extends HTMLElement {
         ;(this as any)[prop] = value
       }
     }
-    if (this._props.layout.nodes.size > 0 && !this._mounted) this._mount()
+    if (this._props.layout?.nodes?.size && !this._mounted) this._mount()
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
## Summary

コードパネル追加 + rendererのJSONベースstate外部化。

### State Architecture
- **rendererのstateを$bindableで外部化**: nodes/ports/edges/subgraphs/bounds/linksを親が所有
- **JSONがsource of truth**: キャンバス操作→state変更→JSON自動更新
- **getSnapshot()削除**: 親が直接stateを持つため不要
- **WebComponent互換**: legacy layout/graph propsを$effectで内部stateに同期

### Code Panel
- 左サイドスライドパネル（YAML/JSONタブ）
- **YAML**: 編集 + Applyでパース→レイアウト計算→キャンバス更新
- **JSON**: キャンバスstateと自動同期、編集 + Applyで直接反映
- CSSカスタムスクロールバー（テーマ統一）
- `</>` コードアイコンでトグル

### Layout
- キャンバス常にフルスクリーン
- UIはfixedオーバーレイ（Miro/Figmaパターン）

### 関連Issue
- #98: 操作ロジックのrenderer→editor移動（次ステップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)