### PR TITLE
fix: prevent subgraph drag in view mode + editable details

### DIFF
--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -171,6 +171,7 @@
         {colors}
         {theme}
         selected={selection.has(subgraph.id)}
+        {interactive}
         {ondragmove}
         {onselect}
         oncontextmenu={(id, e) => onctx?.(id, 'subgraph', e)}

--- a/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
@@ -8,6 +8,7 @@
     colors,
     theme,
     selected = false,
+    interactive = false,
     ondragmove,
     onselect,
     oncontextmenu: onctx,
@@ -16,6 +17,7 @@
     colors: RenderColors
     theme?: Theme
     selected?: boolean
+    interactive?: boolean
     ondragmove?: (sgId: string, x: number, y: number) => void
     onselect?: (sgId: string) => void
     oncontextmenu?: (id: string, e: MouseEvent) => void
@@ -68,6 +70,7 @@
     onclick={(e) => { e.stopPropagation(); onselect?.(subgraph.id) }}
     oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); onselect?.(subgraph.id); onctx?.(subgraph.id, e) }}
     use:elementDrag={() => ({
+      filter: (e) => e.button === 0 && interactive,
       onDrag: (dx, dy) => ondragmove?.(subgraph.id, subgraph.bounds.x + dx, subgraph.bounds.y + dy),
     })}
   />

--- a/libs/@shumoku/renderer/src/lib/use-drag.ts
+++ b/libs/@shumoku/renderer/src/lib/use-drag.ts
@@ -1,12 +1,15 @@
 /**
  * Svelte use: directive for d3-drag on SVG elements.
  * Each element binds its own drag — no global re-selection needed.
+ * Drag is disabled when interactive=false (view mode).
  */
 
 import { drag } from 'd3-drag'
 import { select } from 'd3-selection'
 
 interface DragOptions {
+  /** Must be true for drag to work (edit mode). Defaults to true for backward compat. */
+  interactive?: boolean
   // biome-ignore lint/suspicious/noExplicitAny: d3-drag filter signature uses any for event
   filter?: (e: any) => boolean
   onDrag: (dx: number, dy: number) => void
@@ -15,9 +18,13 @@ interface DragOptions {
 /** Generic drag action for any SVG element (nodes, subgraphs, etc.) */
 export function elementDrag(element: SVGElement, opts: () => DragOptions) {
   function apply() {
-    const { filter, onDrag } = opts()
+    const { interactive = true, filter, onDrag } = opts()
     const behavior = drag<SVGElement, unknown>()
-    if (filter) behavior.filter(filter)
+    behavior.filter((e) => {
+      if (!interactive) return false
+      if (filter) return filter(e)
+      return e.button === 0
+    })
     behavior.on('drag', (e) => onDrag(e.dx, e.dy))
     select<SVGElement, unknown>(element).call(behavior)
   }
@@ -33,8 +40,3 @@ export function elementDrag(element: SVGElement, opts: () => DragOptions) {
     },
   }
 }
-
-/** @deprecated Use elementDrag */
-export const nodeDrag = elementDrag
-/** @deprecated Use elementDrag */
-export const subgraphDrag = elementDrag


### PR DESCRIPTION
## Summary

### Editable Detail Panel
- Editモードでlabel, type, vendor, model, shapeフィールドが入力可能
- blur/Enterで即反映 → state更新 → キャンバス + JSON自動同期

### Fix: Subgraph drag in view mode
- SvgSubgraphにinteractive prop追加 + elementDragのfilterで制御
- SvgCanvasからinteractiveをSvgSubgraphに渡す

### Fixture Labels
- HTML tags削除、配列→単一文字列、埋め込み情報除去

### Issue #98 更新
- コールバックベースのモード制御設計を追記
- interactive flagを各コンポーネントから廃止し、親がコールバックの有無で制御する方針

🤖 Generated with [Claude Code](https://claude.com/claude-code)