### PR TITLE
feat(editor): show all settable fields in Information dialog

### DIFF
--- a/apps/editor/src/lib/components/DetailPanel.svelte
+++ b/apps/editor/src/lib/components/DetailPanel.svelte
@@ -33,7 +33,7 @@
     return s.replace(/<[^>]*>/g, '')
   }
 
-  const iconPath = $derived(data?.device?.type ? getDeviceIcon(data.device.type) : undefined)
+  const iconPath = $derived(data?.spec?.type ? getDeviceIcon(data.spec.type) : undefined)
 
   function getDisplayFields(
     // biome-ignore lint/suspicious/noExplicitAny: mixed element data
@@ -41,7 +41,7 @@
   ): { key: string; label: string; value: string; editable: boolean }[] {
     const fields: { key: string; label: string; value: string; editable: boolean }[] = []
     const k = d.kind as string
-    const dev = d.device ?? {}
+    const dev = d.spec ?? {}
 
     if (k === 'node') {
       // All Node fields
@@ -52,27 +52,27 @@
         : ''
       fields.push({ key: 'label', label: 'Label', value: raw, editable: true })
       fields.push({ key: 'shape', label: 'Shape', value: d.shape ?? '', editable: true })
-      fields.push({ key: 'device.type', label: 'Type', value: dev.type ?? '', editable: true })
+      fields.push({ key: 'spec.type', label: 'Type', value: dev.type ?? '', editable: true })
       fields.push({
-        key: 'device.vendor',
+        key: 'spec.vendor',
         label: 'Vendor',
         value: dev.vendor ?? '',
         editable: true,
       })
-      fields.push({ key: 'device.model', label: 'Model', value: dev.model ?? '', editable: true })
+      fields.push({ key: 'spec.model', label: 'Model', value: dev.model ?? '', editable: true })
       fields.push({
-        key: 'device.service',
+        key: 'spec.service',
         label: 'Service',
         value: dev.service ?? '',
         editable: true,
       })
       fields.push({
-        key: 'device.resource',
+        key: 'spec.resource',
         label: 'Resource',
         value: dev.resource ?? '',
         editable: true,
       })
-      fields.push({ key: 'device.icon', label: 'Icon URL', value: dev.icon ?? '', editable: true })
+      fields.push({ key: 'spec.icon', label: 'Icon URL', value: dev.icon ?? '', editable: true })
       fields.push({ key: 'parent', label: 'Parent', value: d.parent ?? '', editable: false })
       fields.push({
         key: 'rank',
@@ -98,24 +98,24 @@
       // All Subgraph fields
       fields.push({ key: 'label', label: 'Label', value: d.label ?? '', editable: true })
       fields.push({
-        key: 'device.vendor',
+        key: 'spec.vendor',
         label: 'Vendor',
         value: dev.vendor ?? '',
         editable: true,
       })
       fields.push({
-        key: 'device.service',
+        key: 'spec.service',
         label: 'Service',
         value: dev.service ?? '',
         editable: true,
       })
       fields.push({
-        key: 'device.resource',
+        key: 'spec.resource',
         label: 'Resource',
         value: dev.resource ?? '',
         editable: true,
       })
-      fields.push({ key: 'device.icon', label: 'Icon URL', value: dev.icon ?? '', editable: true })
+      fields.push({ key: 'spec.icon', label: 'Icon URL', value: dev.icon ?? '', editable: true })
       fields.push({
         key: 'direction',
         label: 'Direction',

--- a/apps/editor/src/lib/components/DetailPanel.svelte
+++ b/apps/editor/src/lib/components/DetailPanel.svelte
@@ -35,75 +35,108 @@
 
   const iconPath = $derived(data?.type ? getDeviceIcon(data.type) : undefined)
 
-  // Editable fields for each element kind
-  const editableFields = new Set(['label', 'type', 'vendor', 'model', 'shape'])
-
-  // biome-ignore lint/suspicious/noExplicitAny: mixed data
   function getDisplayFields(
+    // biome-ignore lint/suspicious/noExplicitAny: mixed element data
     d: Record<string, any>,
   ): { key: string; label: string; value: string; editable: boolean }[] {
-    // biome-ignore lint/suspicious/noExplicitAny: mixed data
     const fields: { key: string; label: string; value: string; editable: boolean }[] = []
+    const k = d.kind as string
 
-    if (d.label) {
-      const raw = Array.isArray(d.label)
-        ? d.label.map(stripHtml).join('\n')
-        : stripHtml(String(d.label))
+    if (k === 'node') {
+      // All Node fields
+      const raw = d.label
+        ? Array.isArray(d.label)
+          ? d.label.map(stripHtml).join('\n')
+          : stripHtml(String(d.label))
+        : ''
       fields.push({ key: 'label', label: 'Label', value: raw, editable: true })
+      fields.push({ key: 'type', label: 'Type', value: d.type ?? '', editable: true })
+      fields.push({ key: 'shape', label: 'Shape', value: d.shape ?? '', editable: true })
+      fields.push({ key: 'vendor', label: 'Vendor', value: d.vendor ?? '', editable: true })
+      fields.push({ key: 'model', label: 'Model', value: d.model ?? '', editable: true })
+      fields.push({ key: 'service', label: 'Service', value: d.service ?? '', editable: true })
+      fields.push({ key: 'resource', label: 'Resource', value: d.resource ?? '', editable: true })
+      fields.push({ key: 'icon', label: 'Icon URL', value: d.icon ?? '', editable: true })
+      fields.push({ key: 'parent', label: 'Parent', value: d.parent ?? '', editable: false })
+      fields.push({
+        key: 'rank',
+        label: 'Rank',
+        value: d.rank != null ? String(d.rank) : '',
+        editable: true,
+      })
+      if (d.position)
+        fields.push({
+          key: 'position',
+          label: 'Position',
+          value: `${d.position.x.toFixed(1)}, ${d.position.y.toFixed(1)}`,
+          editable: false,
+        })
+      if (d.size)
+        fields.push({
+          key: 'size',
+          label: 'Size',
+          value: `${d.size.width} × ${d.size.height}`,
+          editable: false,
+        })
+    } else if (k === 'subgraph') {
+      // All Subgraph fields
+      fields.push({ key: 'label', label: 'Label', value: d.label ?? '', editable: true })
+      fields.push({ key: 'vendor', label: 'Vendor', value: d.vendor ?? '', editable: true })
+      fields.push({ key: 'service', label: 'Service', value: d.service ?? '', editable: true })
+      fields.push({ key: 'resource', label: 'Resource', value: d.resource ?? '', editable: true })
+      fields.push({ key: 'icon', label: 'Icon URL', value: d.icon ?? '', editable: true })
+      fields.push({
+        key: 'direction',
+        label: 'Direction',
+        value: d.direction ?? '',
+        editable: true,
+      })
+      fields.push({ key: 'parent', label: 'Parent', value: d.parent ?? '', editable: false })
+      if (d.bounds)
+        fields.push({
+          key: 'bounds',
+          label: 'Bounds',
+          value: `${d.bounds.width.toFixed(0)} × ${d.bounds.height.toFixed(0)} at (${d.bounds.x.toFixed(0)}, ${d.bounds.y.toFixed(0)})`,
+          editable: false,
+        })
+      if (d.children)
+        fields.push({
+          key: 'children',
+          label: 'Children',
+          value: `${d.children.nodes} nodes, ${d.children.subgraphs} groups`,
+          editable: false,
+        })
+    } else if (k === 'edge') {
+      if (d.from)
+        fields.push({
+          key: 'from',
+          label: 'From',
+          value: `${d.from.node}:${d.from.port}`,
+          editable: false,
+        })
+      if (d.to)
+        fields.push({ key: 'to', label: 'To', value: `${d.to.node}:${d.to.port}`, editable: false })
+      if (d.width)
+        fields.push({ key: 'width', label: 'Width', value: String(d.width), editable: false })
+      if (d.points)
+        fields.push({
+          key: 'points',
+          label: 'Points',
+          value: `${d.points} waypoints`,
+          editable: false,
+        })
+    } else if (k === 'port') {
+      fields.push({ key: 'label', label: 'Label', value: d.label ?? '', editable: true })
+      if (d.nodeId) fields.push({ key: 'nodeId', label: 'Node', value: d.nodeId, editable: false })
+      if (d.side) fields.push({ key: 'side', label: 'Side', value: d.side, editable: false })
+      if (d.position)
+        fields.push({
+          key: 'position',
+          label: 'Position',
+          value: `${d.position.x.toFixed(1)}, ${d.position.y.toFixed(1)}`,
+          editable: false,
+        })
     }
-    if (d.type) fields.push({ key: 'type', label: 'Type', value: d.type, editable: true })
-    if (d.vendor) fields.push({ key: 'vendor', label: 'Vendor', value: d.vendor, editable: true })
-    if (d.model) fields.push({ key: 'model', label: 'Model', value: d.model, editable: true })
-    if (d.shape) fields.push({ key: 'shape', label: 'Shape', value: d.shape, editable: true })
-    if (d.parent) fields.push({ key: 'parent', label: 'Parent', value: d.parent, editable: false })
-    if (d.position)
-      fields.push({
-        key: 'position',
-        label: 'Position',
-        value: `${d.position.x.toFixed(1)}, ${d.position.y.toFixed(1)}`,
-        editable: false,
-      })
-    if (d.size)
-      fields.push({
-        key: 'size',
-        label: 'Size',
-        value: `${d.size.width} × ${d.size.height}`,
-        editable: false,
-      })
-    if (d.bounds)
-      fields.push({
-        key: 'bounds',
-        label: 'Bounds',
-        value: `${d.bounds.width.toFixed(0)} × ${d.bounds.height.toFixed(0)} at (${d.bounds.x.toFixed(0)}, ${d.bounds.y.toFixed(0)})`,
-        editable: false,
-      })
-    if (d.from)
-      fields.push({
-        key: 'from',
-        label: 'From',
-        value: `${d.from.node}:${d.from.port}`,
-        editable: false,
-      })
-    if (d.to)
-      fields.push({ key: 'to', label: 'To', value: `${d.to.node}:${d.to.port}`, editable: false })
-    if (d.width)
-      fields.push({ key: 'width', label: 'Width', value: String(d.width), editable: false })
-    if (d.points)
-      fields.push({
-        key: 'points',
-        label: 'Points',
-        value: `${d.points} waypoints`,
-        editable: false,
-      })
-    if (d.nodeId) fields.push({ key: 'nodeId', label: 'Node', value: d.nodeId, editable: false })
-    if (d.side) fields.push({ key: 'side', label: 'Side', value: d.side, editable: false })
-    if (d.children)
-      fields.push({
-        key: 'children',
-        label: 'Children',
-        value: `${d.children.nodes} nodes, ${d.children.subgraphs} groups`,
-        editable: false,
-      })
 
     return fields
   }

--- a/apps/editor/src/lib/components/DetailPanel.svelte
+++ b/apps/editor/src/lib/components/DetailPanel.svelte
@@ -33,7 +33,7 @@
     return s.replace(/<[^>]*>/g, '')
   }
 
-  const iconPath = $derived(data?.type ? getDeviceIcon(data.type) : undefined)
+  const iconPath = $derived(data?.device?.type ? getDeviceIcon(data.device.type) : undefined)
 
   function getDisplayFields(
     // biome-ignore lint/suspicious/noExplicitAny: mixed element data
@@ -41,6 +41,7 @@
   ): { key: string; label: string; value: string; editable: boolean }[] {
     const fields: { key: string; label: string; value: string; editable: boolean }[] = []
     const k = d.kind as string
+    const dev = d.device ?? {}
 
     if (k === 'node') {
       // All Node fields
@@ -50,13 +51,28 @@
           : stripHtml(String(d.label))
         : ''
       fields.push({ key: 'label', label: 'Label', value: raw, editable: true })
-      fields.push({ key: 'type', label: 'Type', value: d.type ?? '', editable: true })
       fields.push({ key: 'shape', label: 'Shape', value: d.shape ?? '', editable: true })
-      fields.push({ key: 'vendor', label: 'Vendor', value: d.vendor ?? '', editable: true })
-      fields.push({ key: 'model', label: 'Model', value: d.model ?? '', editable: true })
-      fields.push({ key: 'service', label: 'Service', value: d.service ?? '', editable: true })
-      fields.push({ key: 'resource', label: 'Resource', value: d.resource ?? '', editable: true })
-      fields.push({ key: 'icon', label: 'Icon URL', value: d.icon ?? '', editable: true })
+      fields.push({ key: 'device.type', label: 'Type', value: dev.type ?? '', editable: true })
+      fields.push({
+        key: 'device.vendor',
+        label: 'Vendor',
+        value: dev.vendor ?? '',
+        editable: true,
+      })
+      fields.push({ key: 'device.model', label: 'Model', value: dev.model ?? '', editable: true })
+      fields.push({
+        key: 'device.service',
+        label: 'Service',
+        value: dev.service ?? '',
+        editable: true,
+      })
+      fields.push({
+        key: 'device.resource',
+        label: 'Resource',
+        value: dev.resource ?? '',
+        editable: true,
+      })
+      fields.push({ key: 'device.icon', label: 'Icon URL', value: dev.icon ?? '', editable: true })
       fields.push({ key: 'parent', label: 'Parent', value: d.parent ?? '', editable: false })
       fields.push({
         key: 'rank',
@@ -81,10 +97,25 @@
     } else if (k === 'subgraph') {
       // All Subgraph fields
       fields.push({ key: 'label', label: 'Label', value: d.label ?? '', editable: true })
-      fields.push({ key: 'vendor', label: 'Vendor', value: d.vendor ?? '', editable: true })
-      fields.push({ key: 'service', label: 'Service', value: d.service ?? '', editable: true })
-      fields.push({ key: 'resource', label: 'Resource', value: d.resource ?? '', editable: true })
-      fields.push({ key: 'icon', label: 'Icon URL', value: d.icon ?? '', editable: true })
+      fields.push({
+        key: 'device.vendor',
+        label: 'Vendor',
+        value: dev.vendor ?? '',
+        editable: true,
+      })
+      fields.push({
+        key: 'device.service',
+        label: 'Service',
+        value: dev.service ?? '',
+        editable: true,
+      })
+      fields.push({
+        key: 'device.resource',
+        label: 'Resource',
+        value: dev.resource ?? '',
+        editable: true,
+      })
+      fields.push({ key: 'device.icon', label: 'Icon URL', value: dev.icon ?? '', editable: true })
       fields.push({
         key: 'direction',
         label: 'Direction',

--- a/apps/server/api/src/api/share.ts
+++ b/apps/server/api/src/api/share.ts
@@ -35,7 +35,7 @@ export function createShareApi(): Hono {
         nodes: parsed.graph.nodes.map((n) => ({
           id: n.id,
           label: n.label || n.id,
-          type: n.type,
+          type: n.device?.type,
         })),
         edges: parsed.graph.links.map((l, i) => ({
           id: l.id || `link-${i}`,

--- a/apps/server/api/src/api/share.ts
+++ b/apps/server/api/src/api/share.ts
@@ -3,6 +3,7 @@
  * Public endpoints for viewing shared topologies and dashboards (no auth required)
  */
 
+import { specDeviceType } from '@shumoku/core'
 import { Hono } from 'hono'
 import { getDashboardService } from './dashboards.js'
 import { buildRenderOutput, getTopologyService } from './topologies.js'
@@ -35,7 +36,7 @@ export function createShareApi(): Hono {
         nodes: parsed.graph.nodes.map((n) => ({
           id: n.id,
           label: n.label || n.id,
-          type: n.device?.type,
+          type: specDeviceType(n.spec),
         })),
         edges: parsed.graph.links.map((l, i) => ({
           id: l.id || `link-${i}`,

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -3,7 +3,12 @@
  * CRUD endpoints for topology management
  */
 
-import { buildHierarchicalSheets, mergeWithOverlays, type OverlayConfig } from '@shumoku/core'
+import {
+  buildHierarchicalSheets,
+  mergeWithOverlays,
+  type OverlayConfig,
+  specDeviceType,
+} from '@shumoku/core'
 import { type EmbeddableRenderOutput, renderEmbeddable } from '@shumoku/renderer-svg'
 import { Hono } from 'hono'
 import { getLayoutEngine } from '../layout.js'
@@ -219,7 +224,7 @@ export function createTopologiesApi(): Hono {
         nodes: parsed.graph.nodes.map((n) => ({
           id: n.id,
           label: n.label || n.id,
-          type: n.device?.type,
+          type: specDeviceType(n.spec),
         })),
         edges: parsed.graph.links.map((l, i) => ({
           id: l.id || `link-${i}`,

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -219,7 +219,7 @@ export function createTopologiesApi(): Hono {
         nodes: parsed.graph.nodes.map((n) => ({
           id: n.id,
           label: n.label || n.id,
-          type: n.type,
+          type: n.device?.type,
         })),
         edges: parsed.graph.links.map((l, i) => ({
           id: l.id || `link-${i}`,

--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -3,9 +3,11 @@
   export interface NodeInfo {
     id: string
     label: string
-    type?: string
-    vendor?: string
-    model?: string
+    device?: {
+      type?: string
+      vendor?: string
+      model?: string
+    }
   }
 
   export interface NodeSelectEvent {
@@ -559,9 +561,11 @@
         const nodeInfo: NodeInfo = {
           id: nodeId,
           label,
-          type: nodeEl.getAttribute('data-device-type') || undefined,
-          vendor: nodeEl.getAttribute('data-device-vendor') || undefined,
-          model: nodeEl.getAttribute('data-device-model') || undefined,
+          device: {
+            type: nodeEl.getAttribute('data-device-type') || undefined,
+            vendor: nodeEl.getAttribute('data-device-vendor') || undefined,
+            model: nodeEl.getAttribute('data-device-model') || undefined,
+          },
         }
 
         // Find connected links

--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -3,7 +3,7 @@
   export interface NodeInfo {
     id: string
     label: string
-    device?: {
+    spec?: {
       type?: string
       vendor?: string
       model?: string
@@ -561,7 +561,7 @@
         const nodeInfo: NodeInfo = {
           id: nodeId,
           label,
-          device: {
+          spec: {
             type: nodeEl.getAttribute('data-device-type') || undefined,
             vendor: nodeEl.getAttribute('data-device-vendor') || undefined,
             model: nodeEl.getAttribute('data-device-model') || undefined,

--- a/apps/server/web/src/lib/components/NodeMappingModal.svelte
+++ b/apps/server/web/src/lib/components/NodeMappingModal.svelte
@@ -302,16 +302,16 @@
 
             <!-- Device Info -->
             <div class="flex flex-wrap gap-2 text-xs text-muted-foreground">
-              {#if nodeData.node.device?.type}
-                <span class="bg-background px-2 py-1 rounded">{nodeData.node.device.type}</span>
+              {#if nodeData.node.spec?.type}
+                <span class="bg-background px-2 py-1 rounded">{nodeData.node.spec.type}</span>
               {/if}
-              {#if nodeData.node.device?.vendor}
-                <span class="bg-background px-2 py-1 rounded">{nodeData.node.device.vendor}</span>
+              {#if nodeData.node.spec?.vendor}
+                <span class="bg-background px-2 py-1 rounded">{nodeData.node.spec.vendor}</span>
               {/if}
-              {#if nodeData.node.device?.model}
-                <span class="bg-background px-2 py-1 rounded">{nodeData.node.device.model}</span>
+              {#if nodeData.node.spec?.model}
+                <span class="bg-background px-2 py-1 rounded">{nodeData.node.spec.model}</span>
               {/if}
-              {#if !nodeData.node.device?.type && !nodeData.node.device?.vendor && !nodeData.node.device?.model}
+              {#if !nodeData.node.spec?.type && !nodeData.node.spec?.vendor && !nodeData.node.spec?.model}
                 <span class="text-muted-foreground italic">No device info</span>
               {/if}
             </div>

--- a/apps/server/web/src/lib/components/NodeMappingModal.svelte
+++ b/apps/server/web/src/lib/components/NodeMappingModal.svelte
@@ -302,16 +302,16 @@
 
             <!-- Device Info -->
             <div class="flex flex-wrap gap-2 text-xs text-muted-foreground">
-              {#if nodeData.node.type}
-                <span class="bg-background px-2 py-1 rounded">{nodeData.node.type}</span>
+              {#if nodeData.node.device?.type}
+                <span class="bg-background px-2 py-1 rounded">{nodeData.node.device.type}</span>
               {/if}
-              {#if nodeData.node.vendor}
-                <span class="bg-background px-2 py-1 rounded">{nodeData.node.vendor}</span>
+              {#if nodeData.node.device?.vendor}
+                <span class="bg-background px-2 py-1 rounded">{nodeData.node.device.vendor}</span>
               {/if}
-              {#if nodeData.node.model}
-                <span class="bg-background px-2 py-1 rounded">{nodeData.node.model}</span>
+              {#if nodeData.node.device?.model}
+                <span class="bg-background px-2 py-1 rounded">{nodeData.node.device.model}</span>
               {/if}
-              {#if !nodeData.node.type && !nodeData.node.vendor && !nodeData.node.model}
+              {#if !nodeData.node.device?.type && !nodeData.node.device?.vendor && !nodeData.node.device?.model}
                 <span class="text-muted-foreground italic">No device info</span>
               {/if}
             </div>

--- a/apps/server/web/src/lib/components/NodeSearchPalette.svelte
+++ b/apps/server/web/src/lib/components/NodeSearchPalette.svelte
@@ -4,7 +4,7 @@
   interface NodeEntry {
     id: string
     label: string
-    device?: {
+    spec?: {
       type?: string
       vendor?: string
       model?: string
@@ -33,7 +33,7 @@
       const type = el.getAttribute('data-device-type') || undefined
       const vendor = el.getAttribute('data-device-vendor') || undefined
       const model = el.getAttribute('data-device-model') || undefined
-      nodes.push({ id, label, device: { type, vendor, model } })
+      nodes.push({ id, label, spec: { type, vendor, model } })
     })
     return nodes
   })
@@ -74,13 +74,13 @@
       {#each allNodes as node (node.id)}
         <Command.Item
           value={node.label}
-          keywords={[node.id, node.device?.type ?? '', node.device?.vendor ?? '', node.device?.model ?? '']}
+          keywords={[node.id, node.spec?.type ?? '', node.spec?.vendor ?? '', node.spec?.model ?? '']}
           onSelect={() => handleSelect(node.id)}
         >
           <span>{node.label}</span>
-          {#if node.device?.vendor || node.device?.model || node.device?.type}
+          {#if node.spec?.vendor || node.spec?.model || node.spec?.type}
             <Command.Shortcut>
-              {[node.device?.vendor, node.device?.model, node.device?.type].filter(Boolean).join(' / ')}
+              {[node.spec?.vendor, node.spec?.model, node.spec?.type].filter(Boolean).join(' / ')}
             </Command.Shortcut>
           {/if}
         </Command.Item>

--- a/apps/server/web/src/lib/components/NodeSearchPalette.svelte
+++ b/apps/server/web/src/lib/components/NodeSearchPalette.svelte
@@ -4,9 +4,11 @@
   interface NodeEntry {
     id: string
     label: string
-    type?: string
-    vendor?: string
-    model?: string
+    device?: {
+      type?: string
+      vendor?: string
+      model?: string
+    }
   }
 
   interface Props {
@@ -31,7 +33,7 @@
       const type = el.getAttribute('data-device-type') || undefined
       const vendor = el.getAttribute('data-device-vendor') || undefined
       const model = el.getAttribute('data-device-model') || undefined
-      nodes.push({ id, label, type, vendor, model })
+      nodes.push({ id, label, device: { type, vendor, model } })
     })
     return nodes
   })
@@ -72,13 +74,13 @@
       {#each allNodes as node (node.id)}
         <Command.Item
           value={node.label}
-          keywords={[node.id, node.type ?? '', node.vendor ?? '', node.model ?? '']}
+          keywords={[node.id, node.device?.type ?? '', node.device?.vendor ?? '', node.device?.model ?? '']}
           onSelect={() => handleSelect(node.id)}
         >
           <span>{node.label}</span>
-          {#if node.vendor || node.model || node.type}
+          {#if node.device?.vendor || node.device?.model || node.device?.type}
             <Command.Shortcut>
-              {[node.vendor, node.model, node.type].filter(Boolean).join(' / ')}
+              {[node.device?.vendor, node.device?.model, node.device?.type].filter(Boolean).join(' / ')}
             </Command.Shortcut>
           {/if}
         </Command.Item>

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -404,7 +404,7 @@ export interface NetworkNode {
   label?: string | string[]
   parent?: string
   metadata?: Record<string, unknown>
-  device?: {
+  spec?: {
     type?: string
     vendor?: string
     model?: string
@@ -436,7 +436,7 @@ export interface NetworkSubgraph {
   label?: string
   parent?: string
   file?: string
-  device?: {
+  spec?: {
     vendor?: string
     service?: string
     resource?: string

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -402,12 +402,14 @@ export interface TopologyContext {
 export interface NetworkNode {
   id: string
   label?: string | string[]
-  type?: string
-  vendor?: string
-  model?: string
-  icon?: string
   parent?: string
   metadata?: Record<string, unknown>
+  device?: {
+    type?: string
+    vendor?: string
+    model?: string
+    icon?: string
+  }
 }
 
 export interface NetworkLinkEndpoint {
@@ -434,9 +436,11 @@ export interface NetworkSubgraph {
   label?: string
   parent?: string
   file?: string
-  vendor?: string
-  service?: string
-  resource?: string
+  device?: {
+    vendor?: string
+    service?: string
+    resource?: string
+  }
   style?: {
     fill?: string
     stroke?: string

--- a/apps/server/web/src/lib/widgets/DeviceStatusWidget.svelte
+++ b/apps/server/web/src/lib/widgets/DeviceStatusWidget.svelte
@@ -181,7 +181,7 @@
       { nodes: NetworkNode[]; up: number; down: number; unknown: number }
     >()
     for (const node of nodes) {
-      const type = node.type || 'unknown'
+      const type = node.device?.type || 'unknown'
       const g = groups.get(type) ?? { nodes: [], up: 0, down: 0, unknown: 0 }
       g.nodes.push(node)
       groups.set(type, g)
@@ -320,7 +320,7 @@
     const ids = nodes
       .filter(
         (n) =>
-          (n.type || 'unknown') === type && (nodeMetrics[n.id]?.status || 'unknown') === status,
+          (n.device?.type || 'unknown') === type && (nodeMetrics[n.id]?.status || 'unknown') === status,
       )
       .map((n) => n.id)
     if (ids.length > 0)

--- a/apps/server/web/src/lib/widgets/DeviceStatusWidget.svelte
+++ b/apps/server/web/src/lib/widgets/DeviceStatusWidget.svelte
@@ -181,7 +181,7 @@
       { nodes: NetworkNode[]; up: number; down: number; unknown: number }
     >()
     for (const node of nodes) {
-      const type = node.device?.type || 'unknown'
+      const type = node.spec?.type || 'unknown'
       const g = groups.get(type) ?? { nodes: [], up: 0, down: 0, unknown: 0 }
       g.nodes.push(node)
       groups.set(type, g)
@@ -320,7 +320,8 @@
     const ids = nodes
       .filter(
         (n) =>
-          (n.device?.type || 'unknown') === type && (nodeMetrics[n.id]?.status || 'unknown') === status,
+          (n.spec?.type || 'unknown') === type &&
+          (nodeMetrics[n.id]?.status || 'unknown') === status,
       )
       .map((n) => n.id)
     if (ids.length > 0)

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -268,8 +268,7 @@
           nodes: contextData.nodes.map((n) => ({
             id: n.id,
             label: n.label,
-            type: n.type,
-            vendor: n.vendor,
+            device: { type: n.type, vendor: n.vendor },
           })),
           links: contextData.edges.map((e) => ({
             id: e.id,
@@ -1535,7 +1534,7 @@
                         ></span>
                         {getNodeLabel(node)}
                       </p>
-                      <p class="text-xs text-theme-text-muted">{node.type || 'Unknown'}</p>
+                      <p class="text-xs text-theme-text-muted">{node.device?.type || 'Unknown'}</p>
                     </div>
                     <select
                       class="input"

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -268,7 +268,7 @@
           nodes: contextData.nodes.map((n) => ({
             id: n.id,
             label: n.label,
-            device: { type: n.type, vendor: n.vendor },
+            spec: { type: n.type, vendor: n.vendor },
           })),
           links: contextData.edges.map((e) => ({
             id: e.id,
@@ -1534,7 +1534,7 @@
                         ></span>
                         {getNodeLabel(node)}
                       </p>
-                      <p class="text-xs text-theme-text-muted">{node.device?.type || 'Unknown'}</p>
+                      <p class="text-xs text-theme-text-muted">{node.spec?.type || 'Unknown'}</p>
                     </div>
                     <select
                       class="input"

--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -23,7 +23,14 @@ import {
   SMALL_LABEL_CHAR_WIDTH,
 } from '../constants.js'
 import { getDeviceIcon } from '../icons/index.js'
-import type { Bounds, LinkEndpoint, NetworkGraph, Node, Subgraph } from '../models/types.js'
+import type {
+  Bounds,
+  LinkEndpoint,
+  NetworkGraph,
+  Node,
+  NodeSpec,
+  Subgraph,
+} from '../models/types.js'
 import type { ResolvedNode, ResolvedPort, ResolvedSubgraph } from './resolved-types.js'
 
 // ============================================================================
@@ -66,11 +73,12 @@ const DEFAULTS: Required<NetworkLayoutOptions> = {
  * Used by both the layout engine and interactive addNewNode.
  */
 export function computeNodeSize(
-  node: { label?: string | string[]; device?: { type?: Parameters<typeof getDeviceIcon>[0] } },
+  node: { label?: string | string[]; spec?: NodeSpec },
   portCount = 0,
 ): { width: number; height: number } {
   const lines = Array.isArray(node.label) ? node.label.length : node.label ? 1 : 0
-  const hasIcon = !!(node.device?.type && getDeviceIcon(node.device.type))
+  const specType = node.spec?.kind !== 'service' ? node.spec?.type : undefined
+  const hasIcon = !!(specType && getDeviceIcon(specType))
   const iconH = hasIcon ? DEFAULT_ICON_SIZE : 0
   const gapH = iconH > 0 ? ICON_LABEL_GAP : 0
   const contentH = iconH + gapH + lines * LABEL_LINE_HEIGHT
@@ -352,7 +360,8 @@ function measureNodeTree(
   const ports = pp.portsByNode.get(id) ?? []
 
   const lines = Array.isArray(node.label) ? node.label.length : node.label ? 1 : 0
-  const hasIcon = !!(node.device?.type && getDeviceIcon(node.device.type))
+  const specType = node.spec?.kind !== 'service' ? node.spec?.type : undefined
+  const hasIcon = !!(specType && getDeviceIcon(specType))
   const iconH = hasIcon ? DEFAULT_ICON_SIZE : 0
   const gapH = iconH > 0 ? ICON_LABEL_GAP : 0
   const contentH = iconH + gapH + lines * LABEL_LINE_HEIGHT

--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -66,11 +66,11 @@ const DEFAULTS: Required<NetworkLayoutOptions> = {
  * Used by both the layout engine and interactive addNewNode.
  */
 export function computeNodeSize(
-  node: { label?: string | string[]; type?: Parameters<typeof getDeviceIcon>[0] },
+  node: { label?: string | string[]; device?: { type?: Parameters<typeof getDeviceIcon>[0] } },
   portCount = 0,
 ): { width: number; height: number } {
   const lines = Array.isArray(node.label) ? node.label.length : node.label ? 1 : 0
-  const hasIcon = !!(node.type && getDeviceIcon(node.type))
+  const hasIcon = !!(node.device?.type && getDeviceIcon(node.device.type))
   const iconH = hasIcon ? DEFAULT_ICON_SIZE : 0
   const gapH = iconH > 0 ? ICON_LABEL_GAP : 0
   const contentH = iconH + gapH + lines * LABEL_LINE_HEIGHT
@@ -352,7 +352,7 @@ function measureNodeTree(
   const ports = pp.portsByNode.get(id) ?? []
 
   const lines = Array.isArray(node.label) ? node.label.length : node.label ? 1 : 0
-  const hasIcon = !!(node.type && getDeviceIcon(node.type))
+  const hasIcon = !!(node.device?.type && getDeviceIcon(node.device.type))
   const iconH = hasIcon ? DEFAULT_ICON_SIZE : 0
   const gapH = iconH > 0 ? ICON_LABEL_GAP : 0
   const contentH = iconH + gapH + lines * LABEL_LINE_HEIGHT

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -42,45 +42,17 @@ export interface NodeStyle {
   opacity?: number
 }
 
-export interface Node {
-  id: string
-
-  /**
-   * Display label - can be single line or multiple lines
-   * Supports basic HTML: <b>, <i>, <br/>
-   */
-  label: string | string[]
-
-  /**
-   * Node shape
-   */
-  shape: NodeShape
-
+/**
+ * Device/resource identification — shared by Node and Subgraph.
+ * Groups vendor, model, service, resource, and icon fields
+ * that describe *what* the element represents (as opposed to
+ * graph-structural fields like id, label, parent, rank).
+ */
+export interface DeviceInfo {
   /**
    * Device type (for default styling/icons)
    */
   type?: DeviceType
-
-  /**
-   * Parent subgraph ID
-   */
-  parent?: string
-
-  /**
-   * Rank/layer for horizontal alignment
-   * Nodes with the same rank value will be placed on the same horizontal level
-   */
-  rank?: number | string
-
-  /**
-   * Custom style
-   */
-  style?: NodeStyle
-
-  /**
-   * Additional metadata
-   */
-  metadata?: Record<string, unknown>
 
   /**
    * Vendor name for vendor-specific icons (e.g., 'aws', 'azure', 'gcp', 'yamaha')
@@ -109,6 +81,47 @@ export interface Node {
    * Supports any image URL (PNG, SVG, etc.)
    */
   icon?: string
+}
+
+export interface Node {
+  id: string
+
+  /**
+   * Display label - can be single line or multiple lines
+   * Supports basic HTML: <b>, <i>, <br/>
+   */
+  label: string | string[]
+
+  /**
+   * Node shape
+   */
+  shape: NodeShape
+
+  /**
+   * Parent subgraph ID
+   */
+  parent?: string
+
+  /**
+   * Rank/layer for horizontal alignment
+   * Nodes with the same rank value will be placed on the same horizontal level
+   */
+  rank?: number | string
+
+  /**
+   * Custom style
+   */
+  style?: NodeStyle
+
+  /**
+   * Additional metadata
+   */
+  metadata?: Record<string, unknown>
+
+  /**
+   * Device/resource identification
+   */
+  device?: DeviceInfo
 }
 
 // ============================================
@@ -339,32 +352,9 @@ export interface Subgraph {
   style?: SubgraphStyle
 
   /**
-   * Vendor name for vendor-specific icons (e.g., 'aws', 'azure', 'gcp', 'yamaha')
+   * Device/resource identification
    */
-  vendor?: string
-
-  /**
-   * Service name within the vendor (e.g., 'ec2', 'vpc', 'lambda')
-   * Used for cloud providers like AWS
-   */
-  service?: string
-
-  /**
-   * Model name for hardware vendors (e.g., 'rtx3510', 'ex4400')
-   * Alternative to service for equipment vendors
-   */
-  model?: string
-
-  /**
-   * Resource type within the service (e.g., 'instance', 'nat-gateway')
-   */
-  resource?: string
-
-  /**
-   * Custom icon URL (overrides vendor/type icons)
-   * Supports any image URL (PNG, SVG, etc.)
-   */
-  icon?: string
+  device?: DeviceInfo
 
   /**
    * File reference for external sheet definition (KiCad-style hierarchy)

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -42,45 +42,71 @@ export interface NodeStyle {
   opacity?: number
 }
 
+// ============================================
+// Node Spec — discriminated union by `kind`
+// ============================================
+
 /**
- * Device/resource identification — shared by Node and Subgraph.
- * Groups vendor, model, service, resource, and icon fields
- * that describe *what* the element represents (as opposed to
- * graph-structural fields like id, label, parent, rank).
+ * Shared fields across all spec kinds.
  */
-export interface DeviceInfo {
-  /**
-   * Device type (for default styling/icons)
-   */
-  type?: DeviceType
-
-  /**
-   * Vendor name for vendor-specific icons (e.g., 'aws', 'azure', 'gcp', 'yamaha')
-   */
-  vendor?: string
-
-  /**
-   * Service name within the vendor (e.g., 'ec2', 'vpc', 'lambda')
-   * Used for cloud providers like AWS
-   */
-  service?: string
-
-  /**
-   * Model name for hardware vendors (e.g., 'rtx3510', 'ex4400')
-   * Alternative to service for equipment vendors
-   */
-  model?: string
-
-  /**
-   * Resource type within the service (e.g., 'instance', 'nat-gateway')
-   */
-  resource?: string
-
-  /**
-   * Custom icon URL (overrides vendor/type icons)
-   * Supports any image URL (PNG, SVG, etc.)
-   */
+export interface SpecBase {
+  /** Custom icon URL (overrides vendor/type icons) */
   icon?: string
+  /** Vendor name for vendor-specific icons (e.g., 'aws', 'azure', 'gcp', 'yamaha') */
+  vendor?: string
+}
+
+/** Physical device (switch, router, AP, server, etc.) */
+export interface HardwareSpec extends SpecBase {
+  kind: 'hardware'
+  /** Device type (for default styling/icons) */
+  type?: DeviceType
+  /** Model name (e.g., 'catalyst-9300', 'rtx3510') */
+  model?: string
+}
+
+/** Virtual machine — on-prem or cloud-based (EC2, ESXi VM, etc.) */
+export interface ComputeSpec extends SpecBase {
+  kind: 'compute'
+  /** Device type (for default styling/icons) */
+  type?: DeviceType
+  /** Platform identifier (e.g., 'ec2', 'esxi', 'proxmox') */
+  platform?: string
+}
+
+/** Managed / cloud service (Lambda, S3, CloudFront, etc.) */
+export interface ServiceSpec extends SpecBase {
+  kind: 'service'
+  /** Service name within the vendor (e.g., 'lambda', 's3', 'rds') */
+  service: string
+  /** Resource type within the service (e.g., 'function', 'bucket') */
+  resource?: string
+}
+
+/**
+ * Node specification — describes *what* the element represents.
+ * Discriminated by `kind` so each variant carries only relevant fields.
+ */
+export type NodeSpec = HardwareSpec | ComputeSpec | ServiceSpec
+
+/** Extract DeviceType from a spec (hardware and compute only). */
+export function specDeviceType(spec: NodeSpec | undefined): DeviceType | undefined {
+  if (!spec || spec.kind === 'service') return undefined
+  return spec.type
+}
+
+/**
+ * Extract the icon lookup key for CDN icons.
+ * Hardware → model, Service → service/resource, Compute → platform.
+ */
+export function specIconKey(spec: NodeSpec | undefined): string | undefined {
+  if (!spec) return undefined
+  if (spec.kind === 'service') {
+    return spec.resource ? `${spec.service}/${spec.resource}` : spec.service
+  }
+  if (spec.kind === 'hardware') return spec.model
+  if (spec.kind === 'compute') return spec.platform
+  return undefined
 }
 
 export interface Node {
@@ -119,9 +145,9 @@ export interface Node {
   metadata?: Record<string, unknown>
 
   /**
-   * Device/resource identification
+   * What this node represents (hardware, compute, or service)
    */
-  device?: DeviceInfo
+  spec?: NodeSpec
 }
 
 // ============================================
@@ -352,9 +378,9 @@ export interface Subgraph {
   style?: SubgraphStyle
 
   /**
-   * Device/resource identification
+   * What this subgraph represents (hardware, compute, or service)
    */
-  device?: DeviceInfo
+  spec?: NodeSpec
 
   /**
    * File reference for external sheet definition (KiCad-style hierarchy)

--- a/libs/@shumoku/core/src/parser/hierarchical.ts
+++ b/libs/@shumoku/core/src/parser/hierarchical.ts
@@ -426,7 +426,7 @@ export class HierarchicalParser {
       id: `${EXPORT_NODE_PREFIX}${exportId}`,
       label: exportPoint.destSubgraphLabel,
       shape: 'stadium',
-      device: { type: 'connector' as DeviceType },
+      spec: { kind: 'hardware' as const, type: 'connector' as DeviceType },
       metadata: {
         _isExport: true,
         _destSubgraph: exportPoint.destSubgraphLabel,

--- a/libs/@shumoku/core/src/parser/hierarchical.ts
+++ b/libs/@shumoku/core/src/parser/hierarchical.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+  DeviceType,
   HierarchicalNetworkGraph,
   Link,
   NetworkGraph,
@@ -425,7 +426,7 @@ export class HierarchicalParser {
       id: `${EXPORT_NODE_PREFIX}${exportId}`,
       label: exportPoint.destSubgraphLabel,
       shape: 'stadium',
-      type: 'connector' as Node['type'],
+      device: { type: 'connector' as DeviceType },
       metadata: {
         _isExport: true,
         _destSubgraph: exportPoint.destSubgraphLabel,

--- a/libs/@shumoku/core/src/parser/parser.ts
+++ b/libs/@shumoku/core/src/parser/parser.ts
@@ -271,7 +271,6 @@ export class YamlParser {
         id: n.id || `node-${index}`,
         label: n.label || n.id || `Node ${index}`,
         shape: this.parseNodeShape(n.shape),
-        type: this.parseDeviceType(n.type),
         parent: n.parent,
         rank: n.rank,
         style: n.style
@@ -287,11 +286,14 @@ export class YamlParser {
             }
           : undefined,
         metadata: n.metadata,
-        vendor: n.vendor?.toLowerCase(),
-        service: n.service?.toLowerCase(),
-        model: n.model?.toLowerCase(),
-        resource: n.resource?.toLowerCase(),
-        icon: n.icon,
+        device: {
+          type: this.parseDeviceType(n.type),
+          vendor: n.vendor?.toLowerCase(),
+          service: n.service?.toLowerCase(),
+          model: n.model?.toLowerCase(),
+          resource: n.resource?.toLowerCase(),
+          icon: n.icon,
+        },
       }
     })
   }
@@ -445,11 +447,13 @@ export class YamlParser {
               rankSpacing: s.style.rankSpacing,
             }
           : undefined,
-        vendor: s.vendor?.toLowerCase(),
-        service: s.service?.toLowerCase(),
-        model: s.model?.toLowerCase(),
-        resource: s.resource?.toLowerCase(),
-        icon: s.icon,
+        device: {
+          vendor: s.vendor?.toLowerCase(),
+          service: s.service?.toLowerCase(),
+          model: s.model?.toLowerCase(),
+          resource: s.resource?.toLowerCase(),
+          icon: s.icon,
+        },
         file: s.file,
         pins: s.pins ? this.parsePins(s.pins, warnings) : undefined,
       }

--- a/libs/@shumoku/core/src/parser/parser.ts
+++ b/libs/@shumoku/core/src/parser/parser.ts
@@ -16,6 +16,7 @@ import type {
   NetworkGraph,
   Node,
   NodeShape,
+  NodeSpec,
   PaperOrientation,
   PaperSize,
   Pin,
@@ -286,14 +287,7 @@ export class YamlParser {
             }
           : undefined,
         metadata: n.metadata,
-        device: {
-          type: this.parseDeviceType(n.type),
-          vendor: n.vendor?.toLowerCase(),
-          service: n.service?.toLowerCase(),
-          model: n.model?.toLowerCase(),
-          resource: n.resource?.toLowerCase(),
-          icon: n.icon,
-        },
+        spec: this.buildNodeSpec(n),
       }
     })
   }
@@ -447,17 +441,66 @@ export class YamlParser {
               rankSpacing: s.style.rankSpacing,
             }
           : undefined,
-        device: {
-          vendor: s.vendor?.toLowerCase(),
-          service: s.service?.toLowerCase(),
-          model: s.model?.toLowerCase(),
-          resource: s.resource?.toLowerCase(),
-          icon: s.icon,
-        },
+        spec: this.buildSubgraphSpec(s),
         file: s.file,
         pins: s.pins ? this.parsePins(s.pins, warnings) : undefined,
       }
     })
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: YAML input is untyped
+  private buildNodeSpec(n: any): NodeSpec | undefined {
+    const hasService = !!n.service
+    const hasType = !!n.type
+    const hasModel = !!n.model
+    const hasVendor = !!n.vendor
+    const hasIcon = !!n.icon
+
+    if (!hasService && !hasType && !hasModel && !hasVendor && !hasIcon) return undefined
+
+    if (hasService) {
+      return {
+        kind: 'service' as const,
+        vendor: n.vendor?.toLowerCase(),
+        service: n.service.toLowerCase(),
+        resource: n.resource?.toLowerCase(),
+        icon: n.icon,
+      }
+    }
+
+    return {
+      kind: 'hardware' as const,
+      type: this.parseDeviceType(n.type),
+      vendor: n.vendor?.toLowerCase(),
+      model: n.model?.toLowerCase(),
+      icon: n.icon,
+    }
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: YAML input is untyped
+  private buildSubgraphSpec(s: any): NodeSpec | undefined {
+    const hasService = !!s.service
+    const hasVendor = !!s.vendor
+    const hasIcon = !!s.icon
+
+    if (!hasService && !hasVendor && !hasIcon) return undefined
+
+    if (hasService) {
+      return {
+        kind: 'service' as const,
+        vendor: s.vendor?.toLowerCase(),
+        service: s.service.toLowerCase(),
+        resource: s.resource?.toLowerCase(),
+        icon: s.icon,
+      }
+    }
+
+    return {
+      kind: 'hardware' as const,
+      vendor: s.vendor?.toLowerCase(),
+      model: s.model?.toLowerCase(),
+      icon: s.icon,
+    }
   }
 
   private parseSettings(settings?: YamlGraphSettings): GraphSettings | undefined {

--- a/libs/@shumoku/renderer-png/src/png.ts
+++ b/libs/@shumoku/renderer-png/src/png.ts
@@ -9,6 +9,7 @@
 
 import { Resvg } from '@resvg/resvg-js'
 import type { LayoutResult, NetworkGraph } from '@shumoku/core'
+import { specIconKey } from '@shumoku/core'
 import {
   type CDNConfig,
   fetchCDNIcon,
@@ -72,15 +73,14 @@ function collectIconUrls(graph: NetworkGraph): string[] {
 
   // Collect from nodes
   for (const node of graph.nodes) {
-    const dev = node.device
-    if (dev?.icon) {
-      urls.add(dev.icon)
-    } else if (dev?.vendor && hasCDNIcons(dev.vendor)) {
+    const spec = node.spec
+    if (spec?.icon) {
+      urls.add(spec.icon)
+    } else if (spec?.vendor && hasCDNIcons(spec.vendor)) {
       // Match the same logic as calculateIconInfo in svg.ts
-      const iconKey =
-        dev.service && dev.resource ? `${dev.service}/${dev.resource}` : dev.service || dev.model
+      const iconKey = specIconKey(spec)
       if (iconKey) {
-        urls.add(getCDNIconUrl(dev.vendor, iconKey))
+        urls.add(getCDNIconUrl(spec.vendor, iconKey))
       }
     }
   }
@@ -88,8 +88,8 @@ function collectIconUrls(graph: NetworkGraph): string[] {
   // Collect from subgraphs (flat structure)
   if (graph.subgraphs) {
     for (const sg of graph.subgraphs) {
-      if (sg.device?.icon) {
-        urls.add(sg.device.icon)
+      if (sg.spec?.icon) {
+        urls.add(sg.spec.icon)
       }
     }
   }

--- a/libs/@shumoku/renderer-png/src/png.ts
+++ b/libs/@shumoku/renderer-png/src/png.ts
@@ -72,16 +72,15 @@ function collectIconUrls(graph: NetworkGraph): string[] {
 
   // Collect from nodes
   for (const node of graph.nodes) {
-    if (node.icon) {
-      urls.add(node.icon)
-    } else if (node.vendor && hasCDNIcons(node.vendor)) {
+    const dev = node.device
+    if (dev?.icon) {
+      urls.add(dev.icon)
+    } else if (dev?.vendor && hasCDNIcons(dev.vendor)) {
       // Match the same logic as calculateIconInfo in svg.ts
       const iconKey =
-        node.service && node.resource
-          ? `${node.service}/${node.resource}`
-          : node.service || node.model
+        dev.service && dev.resource ? `${dev.service}/${dev.resource}` : dev.service || dev.model
       if (iconKey) {
-        urls.add(getCDNIconUrl(node.vendor, iconKey))
+        urls.add(getCDNIconUrl(dev.vendor, iconKey))
       }
     }
   }
@@ -89,8 +88,8 @@ function collectIconUrls(graph: NetworkGraph): string[] {
   // Collect from subgraphs (flat structure)
   if (graph.subgraphs) {
     for (const sg of graph.subgraphs) {
-      if (sg.icon) {
-        urls.add(sg.icon)
+      if (sg.device?.icon) {
+        urls.add(sg.device.icon)
       }
     }
   }

--- a/libs/@shumoku/renderer-svg/src/svg.ts
+++ b/libs/@shumoku/renderer-svg/src/svg.ts
@@ -515,7 +515,7 @@ export class SVGRenderer {
     // Collect used device types
     const usedDeviceTypes = new Set<string>()
     for (const node of graph.nodes) {
-      if (node.type) usedDeviceTypes.add(node.type)
+      if (node.device?.type) usedDeviceTypes.add(node.device.type)
     }
 
     // Build legend items
@@ -660,10 +660,11 @@ export class SVGRenderer {
 
     // Check if subgraph has icon (user-specified or CDN-supported vendor)
     // AWS uses service/resource format (e.g., ec2/instance)
+    const sgDev = subgraph.device
     const iconKey =
-      subgraph.service && subgraph.resource
-        ? `${subgraph.service}/${subgraph.resource}`
-        : subgraph.service || subgraph.model
+      sgDev?.service && sgDev.resource
+        ? `${sgDev.service}/${sgDev.resource}`
+        : sgDev?.service || sgDev?.model
     let hasIcon = false
     const defaultIconSize = 24
     const iconPadding = 8
@@ -673,10 +674,10 @@ export class SVGRenderer {
     let iconWidth = defaultIconSize
     let iconHeight = defaultIconSize
 
-    if (subgraph.icon) {
+    if (sgDev?.icon) {
       hasIcon = true
-      iconUrl = subgraph.icon
-      const dims = this.options.iconDimensions.get(subgraph.icon)
+      iconUrl = sgDev.icon
+      const dims = this.options.iconDimensions.get(sgDev.icon)
       if (dims) {
         const aspectRatio = dims.width / dims.height
         if (aspectRatio >= 1) {
@@ -687,8 +688,8 @@ export class SVGRenderer {
           iconWidth = Math.round(defaultIconSize * aspectRatio)
         }
       }
-    } else if (subgraph.vendor && iconKey && hasCDNIcons(subgraph.vendor)) {
-      const cdnUrl = getCDNIconUrl(subgraph.vendor, iconKey)
+    } else if (sgDev?.vendor && iconKey && hasCDNIcons(sgDev.vendor)) {
+      const cdnUrl = getCDNIconUrl(sgDev.vendor, iconKey)
       const dims = this.options.iconDimensions.get(cdnUrl)
       if (dims) {
         hasIcon = true
@@ -881,11 +882,12 @@ ${fg}
 
     const attrs: string[] = []
 
-    if (node.type) attrs.push(`data-device-type="${this.escapeXml(node.type)}"`)
-    if (node.vendor) attrs.push(`data-device-vendor="${this.escapeXml(node.vendor)}"`)
-    if (node.model) attrs.push(`data-device-model="${this.escapeXml(node.model)}"`)
-    if (node.service) attrs.push(`data-device-service="${this.escapeXml(node.service)}"`)
-    if (node.resource) attrs.push(`data-device-resource="${this.escapeXml(node.resource)}"`)
+    const dev = node.device
+    if (dev?.type) attrs.push(`data-device-type="${this.escapeXml(dev.type)}"`)
+    if (dev?.vendor) attrs.push(`data-device-vendor="${this.escapeXml(dev.vendor)}"`)
+    if (dev?.model) attrs.push(`data-device-model="${this.escapeXml(dev.model)}"`)
+    if (dev?.service) attrs.push(`data-device-service="${this.escapeXml(dev.service)}"`)
+    if (dev?.resource) attrs.push(`data-device-resource="${this.escapeXml(dev.resource)}"`)
 
     return attrs.length > 0 ? ` ${attrs.join(' ')}` : ''
   }
@@ -1071,26 +1073,26 @@ ${fg}
     // Use full node width as max; layout engine already calculated appropriate size
     const maxIconWidth = w
 
+    const dev = node.device
+
     // User-specified icon URL takes highest priority
-    if (node.icon) {
-      const dims = this.options.iconDimensions.get(node.icon)
+    if (dev?.icon) {
+      const dims = this.options.iconDimensions.get(dev.icon)
       const { width, height } = this.calculateIconSize(dims, maxIconWidth)
       return {
         width,
         height,
-        svg: `<image href="${node.icon}" width="${width}" height="${height}" preserveAspectRatio="xMidYMid meet" />`,
+        svg: `<image href="${dev.icon}" width="${width}" height="${height}" preserveAspectRatio="xMidYMid meet" />`,
       }
     }
 
     // Try vendor-specific icon first (service for cloud, model for hardware)
     // AWS uses service/resource format (e.g., ec2/instance)
     const iconKey =
-      node.service && node.resource
-        ? `${node.service}/${node.resource}`
-        : node.service || node.model
+      dev?.service && dev.resource ? `${dev.service}/${dev.resource}` : dev?.service || dev?.model
     // Use CDN icons for supported vendors (only if dimensions were resolved, i.e. icon exists)
-    if (node.vendor && iconKey && hasCDNIcons(node.vendor)) {
-      const cdnUrl = getCDNIconUrl(node.vendor, iconKey)
+    if (dev?.vendor && iconKey && hasCDNIcons(dev.vendor)) {
+      const cdnUrl = getCDNIconUrl(dev.vendor, iconKey)
       const dims = this.options.iconDimensions.get(cdnUrl)
       if (dims) {
         const { width, height } = this.calculateIconSize(dims, maxIconWidth)
@@ -1104,7 +1106,7 @@ ${fg}
     }
 
     // Fall back to device type icon
-    const iconPath = getDeviceIcon(node.type)
+    const iconPath = getDeviceIcon(dev?.type)
     if (!iconPath) return null
 
     return {
@@ -1855,23 +1857,22 @@ export function collectIconUrls(graph: NetworkGraph): string[] {
   const urls = new Set<string>()
 
   for (const node of graph.nodes) {
-    if (node.icon) {
-      urls.add(node.icon)
-    } else if (node.vendor && hasCDNIcons(node.vendor)) {
+    const dev = node.device
+    if (dev?.icon) {
+      urls.add(dev.icon)
+    } else if (dev?.vendor && hasCDNIcons(dev.vendor)) {
       const iconKey =
-        node.service && node.resource
-          ? `${node.service}/${node.resource}`
-          : node.service || node.model
+        dev.service && dev.resource ? `${dev.service}/${dev.resource}` : dev.service || dev.model
       if (iconKey) {
-        urls.add(getCDNIconUrl(node.vendor, iconKey))
+        urls.add(getCDNIconUrl(dev.vendor, iconKey))
       }
     }
   }
 
   if (graph.subgraphs) {
     for (const sg of graph.subgraphs) {
-      if (sg.icon) {
-        urls.add(sg.icon)
+      if (sg.device?.icon) {
+        urls.add(sg.device.icon)
       }
     }
   }

--- a/libs/@shumoku/renderer-svg/src/svg.ts
+++ b/libs/@shumoku/renderer-svg/src/svg.ts
@@ -32,6 +32,8 @@ import {
   lightTheme,
   SMALL_LABEL_CHAR_WIDTH,
   type SurfaceToken,
+  specDeviceType,
+  specIconKey,
   type Theme,
 } from '@shumoku/core'
 
@@ -515,7 +517,8 @@ export class SVGRenderer {
     // Collect used device types
     const usedDeviceTypes = new Set<string>()
     for (const node of graph.nodes) {
-      if (node.device?.type) usedDeviceTypes.add(node.device.type)
+      const dt = specDeviceType(node.spec)
+      if (dt) usedDeviceTypes.add(dt)
     }
 
     // Build legend items
@@ -660,11 +663,8 @@ export class SVGRenderer {
 
     // Check if subgraph has icon (user-specified or CDN-supported vendor)
     // AWS uses service/resource format (e.g., ec2/instance)
-    const sgDev = subgraph.device
-    const iconKey =
-      sgDev?.service && sgDev.resource
-        ? `${sgDev.service}/${sgDev.resource}`
-        : sgDev?.service || sgDev?.model
+    const sgSpec = subgraph.spec
+    const iconKey = specIconKey(sgSpec)
     let hasIcon = false
     const defaultIconSize = 24
     const iconPadding = 8
@@ -674,10 +674,10 @@ export class SVGRenderer {
     let iconWidth = defaultIconSize
     let iconHeight = defaultIconSize
 
-    if (sgDev?.icon) {
+    if (sgSpec?.icon) {
       hasIcon = true
-      iconUrl = sgDev.icon
-      const dims = this.options.iconDimensions.get(sgDev.icon)
+      iconUrl = sgSpec.icon
+      const dims = this.options.iconDimensions.get(sgSpec.icon)
       if (dims) {
         const aspectRatio = dims.width / dims.height
         if (aspectRatio >= 1) {
@@ -688,8 +688,8 @@ export class SVGRenderer {
           iconWidth = Math.round(defaultIconSize * aspectRatio)
         }
       }
-    } else if (sgDev?.vendor && iconKey && hasCDNIcons(sgDev.vendor)) {
-      const cdnUrl = getCDNIconUrl(sgDev.vendor, iconKey)
+    } else if (sgSpec?.vendor && iconKey && hasCDNIcons(sgSpec.vendor)) {
+      const cdnUrl = getCDNIconUrl(sgSpec.vendor, iconKey)
       const dims = this.options.iconDimensions.get(cdnUrl)
       if (dims) {
         hasIcon = true
@@ -882,12 +882,16 @@ ${fg}
 
     const attrs: string[] = []
 
-    const dev = node.device
-    if (dev?.type) attrs.push(`data-device-type="${this.escapeXml(dev.type)}"`)
-    if (dev?.vendor) attrs.push(`data-device-vendor="${this.escapeXml(dev.vendor)}"`)
-    if (dev?.model) attrs.push(`data-device-model="${this.escapeXml(dev.model)}"`)
-    if (dev?.service) attrs.push(`data-device-service="${this.escapeXml(dev.service)}"`)
-    if (dev?.resource) attrs.push(`data-device-resource="${this.escapeXml(dev.resource)}"`)
+    const spec = node.spec
+    const dt = specDeviceType(spec)
+    if (dt) attrs.push(`data-device-type="${this.escapeXml(dt)}"`)
+    if (spec?.vendor) attrs.push(`data-device-vendor="${this.escapeXml(spec.vendor)}"`)
+    if (spec?.kind === 'hardware' && spec.model)
+      attrs.push(`data-device-model="${this.escapeXml(spec.model)}"`)
+    if (spec?.kind === 'service') {
+      if (spec.service) attrs.push(`data-device-service="${this.escapeXml(spec.service)}"`)
+      if (spec.resource) attrs.push(`data-device-resource="${this.escapeXml(spec.resource)}"`)
+    }
 
     return attrs.length > 0 ? ` ${attrs.join(' ')}` : ''
   }
@@ -1073,26 +1077,25 @@ ${fg}
     // Use full node width as max; layout engine already calculated appropriate size
     const maxIconWidth = w
 
-    const dev = node.device
+    const spec = node.spec
 
     // User-specified icon URL takes highest priority
-    if (dev?.icon) {
-      const dims = this.options.iconDimensions.get(dev.icon)
+    if (spec?.icon) {
+      const dims = this.options.iconDimensions.get(spec.icon)
       const { width, height } = this.calculateIconSize(dims, maxIconWidth)
       return {
         width,
         height,
-        svg: `<image href="${dev.icon}" width="${width}" height="${height}" preserveAspectRatio="xMidYMid meet" />`,
+        svg: `<image href="${spec.icon}" width="${width}" height="${height}" preserveAspectRatio="xMidYMid meet" />`,
       }
     }
 
     // Try vendor-specific icon first (service for cloud, model for hardware)
     // AWS uses service/resource format (e.g., ec2/instance)
-    const iconKey =
-      dev?.service && dev.resource ? `${dev.service}/${dev.resource}` : dev?.service || dev?.model
+    const iconKey = specIconKey(spec)
     // Use CDN icons for supported vendors (only if dimensions were resolved, i.e. icon exists)
-    if (dev?.vendor && iconKey && hasCDNIcons(dev.vendor)) {
-      const cdnUrl = getCDNIconUrl(dev.vendor, iconKey)
+    if (spec?.vendor && iconKey && hasCDNIcons(spec.vendor)) {
+      const cdnUrl = getCDNIconUrl(spec.vendor, iconKey)
       const dims = this.options.iconDimensions.get(cdnUrl)
       if (dims) {
         const { width, height } = this.calculateIconSize(dims, maxIconWidth)
@@ -1106,7 +1109,7 @@ ${fg}
     }
 
     // Fall back to device type icon
-    const iconPath = getDeviceIcon(dev?.type)
+    const iconPath = getDeviceIcon(specDeviceType(spec))
     if (!iconPath) return null
 
     return {
@@ -1857,22 +1860,21 @@ export function collectIconUrls(graph: NetworkGraph): string[] {
   const urls = new Set<string>()
 
   for (const node of graph.nodes) {
-    const dev = node.device
-    if (dev?.icon) {
-      urls.add(dev.icon)
-    } else if (dev?.vendor && hasCDNIcons(dev.vendor)) {
-      const iconKey =
-        dev.service && dev.resource ? `${dev.service}/${dev.resource}` : dev.service || dev.model
+    const spec = node.spec
+    if (spec?.icon) {
+      urls.add(spec.icon)
+    } else if (spec?.vendor && hasCDNIcons(spec.vendor)) {
+      const iconKey = specIconKey(spec)
       if (iconKey) {
-        urls.add(getCDNIconUrl(dev.vendor, iconKey))
+        urls.add(getCDNIconUrl(spec.vendor, iconKey))
       }
     }
   }
 
   if (graph.subgraphs) {
     for (const sg of graph.subgraphs) {
-      if (sg.device?.icon) {
-        urls.add(sg.device.icon)
+      if (sg.spec?.icon) {
+        urls.add(sg.spec.icon)
       }
     }
   }

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -227,7 +227,8 @@
   }) {
     const id = `node-${Date.now()}`
     const label = opts?.label ?? 'New Node'
-    const { width: w, height: h } = computeNodeSize({ label, type: opts?.type })
+    const device = opts?.type ? { type: opts.type } : undefined
+    const { width: w, height: h } = computeNodeSize({ label, device })
     const { parent, initial } = resolveParentAndPosition(opts?.position, w)
     const obstacles = collectObstacles(id, parent, nodes, subgraphs)
     const pos = resolvePosition({ x: initial.x, y: initial.y, w, h }, obstacles)
@@ -237,7 +238,7 @@
       id,
       position: pos,
       size: { width: w, height: h },
-      node: { id, label, type: opts?.type, shape: opts?.shape ?? 'rounded', parent },
+      node: { id, label, device, shape: opts?.shape ?? 'rounded', parent },
     })
     nodes = n
     finalizeAdd(id, new Map(subgraphs))
@@ -345,7 +346,7 @@
         kind: 'node' as const,
         label: node.node.label ?? 'Node',
         shape: node.node.shape,
-        type: node.node.type,
+        type: node.node.device?.type,
       }
     }
     const sg = subgraphs.get(id)

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -21,6 +21,7 @@
     removePort,
     resolvePosition,
     routeEdges,
+    specDeviceType,
   } from '@shumoku/core'
   import { themeToColors } from '../lib/render-colors'
   import SvgCanvas from './svg/SvgCanvas.svelte'
@@ -227,8 +228,8 @@
   }) {
     const id = `node-${Date.now()}`
     const label = opts?.label ?? 'New Node'
-    const device = opts?.type ? { type: opts.type } : undefined
-    const { width: w, height: h } = computeNodeSize({ label, device })
+    const spec = opts?.type ? { kind: 'hardware' as const, type: opts.type } : undefined
+    const { width: w, height: h } = computeNodeSize({ label, spec })
     const { parent, initial } = resolveParentAndPosition(opts?.position, w)
     const obstacles = collectObstacles(id, parent, nodes, subgraphs)
     const pos = resolvePosition({ x: initial.x, y: initial.y, w, h }, obstacles)
@@ -238,7 +239,7 @@
       id,
       position: pos,
       size: { width: w, height: h },
-      node: { id, label, device, shape: opts?.shape ?? 'rounded', parent },
+      node: { id, label, spec, shape: opts?.shape ?? 'rounded', parent },
     })
     nodes = n
     finalizeAdd(id, new Map(subgraphs))
@@ -346,7 +347,7 @@
         kind: 'node' as const,
         label: node.node.label ?? 'Node',
         shape: node.node.shape,
-        type: node.node.device?.type,
+        type: specDeviceType(node.node.spec),
       }
     }
     const sg = subgraphs.get(id)

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -51,7 +51,7 @@
   const strokeDasharray = $derived(node.node.style?.strokeDasharray ?? '')
 
   // Icon
-  const iconPath = $derived(getDeviceIcon(node.node.type))
+  const iconPath = $derived(getDeviceIcon(node.node.device?.type))
   const iconSize = DEFAULT_ICON_SIZE
 
   // Labels
@@ -121,7 +121,7 @@
 <g
   class="node"
   data-id={node.id}
-  data-device-type={node.node.type ?? ''}
+  data-device-type={node.node.device?.type ?? ''}
   filter="url(#{shadowFilterId})"
   use:elementDrag={() => ({
     filter: (e) => {
@@ -269,7 +269,7 @@
           viewBox="0 0 24 24"
           fill="currentColor"
           role="img"
-          aria-label={node.node.type ?? 'icon'}
+          aria-label={node.node.device?.type ?? 'icon'}
         >
           {@html iconPath}
         </svg>

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -5,6 +5,7 @@
     getDeviceIcon,
     ICON_LABEL_GAP,
     LABEL_LINE_HEIGHT,
+    specDeviceType,
   } from '@shumoku/core'
   import type { RenderColors } from '../../lib/render-colors'
   import { elementDrag } from '../../lib/use-drag'
@@ -51,7 +52,7 @@
   const strokeDasharray = $derived(node.node.style?.strokeDasharray ?? '')
 
   // Icon
-  const iconPath = $derived(getDeviceIcon(node.node.device?.type))
+  const iconPath = $derived(getDeviceIcon(specDeviceType(node.node.spec)))
   const iconSize = DEFAULT_ICON_SIZE
 
   // Labels
@@ -121,7 +122,7 @@
 <g
   class="node"
   data-id={node.id}
-  data-device-type={node.node.device?.type ?? ''}
+  data-device-type={specDeviceType(node.node.spec) ?? ''}
   filter="url(#{shadowFilterId})"
   use:elementDrag={() => ({
     filter: (e) => {
@@ -269,7 +270,7 @@
           viewBox="0 0 24 24"
           fill="currentColor"
           role="img"
-          aria-label={node.node.device?.type ?? 'icon'}
+          aria-label={specDeviceType(node.node.spec) ?? 'icon'}
         >
           {@html iconPath}
         </svg>

--- a/libs/@shumoku/renderer/src/static.ts
+++ b/libs/@shumoku/renderer/src/static.ts
@@ -25,6 +25,7 @@ import {
   lightTheme,
   SMALL_LABEL_CHAR_WIDTH,
   type SurfaceToken,
+  specDeviceType,
 } from '@shumoku/core'
 import { type RenderColors, themeToColors } from './lib/render-colors'
 import { computePortLabelPosition, getVlanStroke, pointsToPathD } from './lib/svg-coords'
@@ -154,7 +155,7 @@ function renderNode(node: ResolvedNode, colors: RenderColors): string {
   )
 
   // Icon
-  const iconPath = getDeviceIcon(n.device?.type)
+  const iconPath = getDeviceIcon(specDeviceType(n.spec))
   const iconSize = DEFAULT_ICON_SIZE
   const iconHeight = iconPath ? iconSize : 0
   const gap = iconHeight > 0 ? ICON_LABEL_GAP : 0

--- a/libs/@shumoku/renderer/src/static.ts
+++ b/libs/@shumoku/renderer/src/static.ts
@@ -154,7 +154,7 @@ function renderNode(node: ResolvedNode, colors: RenderColors): string {
   )
 
   // Icon
-  const iconPath = getDeviceIcon(n.type)
+  const iconPath = getDeviceIcon(n.device?.type)
   const iconSize = DEFAULT_ICON_SIZE
   const iconHeight = iconPath ? iconSize : 0
   const gap = iconHeight > 0 ? ICON_LABEL_GAP : 0

--- a/libs/plugins/netbox/src/converter.ts
+++ b/libs/plugins/netbox/src/converter.ts
@@ -591,10 +591,12 @@ function buildNodes(
       id: device.name,
       label: labelLines,
       shape: 'rounded',
-      type: deviceType as DeviceType,
       rank: tagConfig?.level,
-      model: device.model?.toLowerCase(),
-      vendor: device.manufacturer?.toLowerCase(),
+      device: {
+        type: deviceType as DeviceType,
+        model: device.model?.toLowerCase(),
+        vendor: device.manufacturer?.toLowerCase(),
+      },
     }
 
     if (colorByStatus && device.status) {
@@ -777,7 +779,7 @@ function buildVMNodes(
       id: `vm-${vm.name}`,
       label: labelLines,
       shape: 'rounded',
-      type: 'server' as DeviceType,
+      device: { type: 'server' as DeviceType },
       style: { ...VM_NODE_STYLE },
       metadata: {
         isVirtualMachine: true,
@@ -900,9 +902,9 @@ function serializeNode(lines: string[], node: Node): void {
     lines.push(`    label: "${node.label}"`)
   }
 
-  if (node.type) lines.push(`    type: ${node.type}`)
-  if (node.vendor) lines.push(`    vendor: ${node.vendor}`)
-  if (node.model) lines.push(`    model: ${node.model}`)
+  if (node.device?.type) lines.push(`    type: ${node.device.type}`)
+  if (node.device?.vendor) lines.push(`    vendor: ${node.device.vendor}`)
+  if (node.device?.model) lines.push(`    model: ${node.device.model}`)
   if (node.parent) lines.push(`    parent: ${node.parent}`)
   if (node.rank !== undefined) lines.push(`    rank: ${node.rank}`)
 }
@@ -1133,10 +1135,12 @@ function buildLocationGraph(
       id: info.name,
       label: labelLines,
       shape: 'rounded',
-      type: deviceType as DeviceType,
       rank: tagConfig?.level,
-      model: info.model?.toLowerCase(),
-      vendor: info.manufacturer?.toLowerCase(),
+      device: {
+        type: deviceType as DeviceType,
+        model: info.model?.toLowerCase(),
+        vendor: info.manufacturer?.toLowerCase(),
+      },
     }
 
     if (colorByStatus && info.status) {

--- a/libs/plugins/netbox/src/converter.ts
+++ b/libs/plugins/netbox/src/converter.ts
@@ -15,6 +15,7 @@ import type {
   Node,
   Subgraph,
 } from '@shumoku/core/models'
+import { specDeviceType } from '@shumoku/core/models'
 
 import type {
   ConnectionData,
@@ -592,7 +593,8 @@ function buildNodes(
       label: labelLines,
       shape: 'rounded',
       rank: tagConfig?.level,
-      device: {
+      spec: {
+        kind: 'hardware' as const,
         type: deviceType as DeviceType,
         model: device.model?.toLowerCase(),
         vendor: device.manufacturer?.toLowerCase(),
@@ -779,7 +781,7 @@ function buildVMNodes(
       id: `vm-${vm.name}`,
       label: labelLines,
       shape: 'rounded',
-      device: { type: 'server' as DeviceType },
+      spec: { kind: 'hardware' as const, type: 'server' as DeviceType },
       style: { ...VM_NODE_STYLE },
       metadata: {
         isVirtualMachine: true,
@@ -902,9 +904,10 @@ function serializeNode(lines: string[], node: Node): void {
     lines.push(`    label: "${node.label}"`)
   }
 
-  if (node.device?.type) lines.push(`    type: ${node.device.type}`)
-  if (node.device?.vendor) lines.push(`    vendor: ${node.device.vendor}`)
-  if (node.device?.model) lines.push(`    model: ${node.device.model}`)
+  const dt = specDeviceType(node.spec)
+  if (dt) lines.push(`    type: ${dt}`)
+  if (node.spec?.vendor) lines.push(`    vendor: ${node.spec.vendor}`)
+  if (node.spec?.kind === 'hardware' && node.spec.model) lines.push(`    model: ${node.spec.model}`)
   if (node.parent) lines.push(`    parent: ${node.parent}`)
   if (node.rank !== undefined) lines.push(`    rank: ${node.rank}`)
 }
@@ -1136,7 +1139,8 @@ function buildLocationGraph(
       label: labelLines,
       shape: 'rounded',
       rank: tagConfig?.level,
-      device: {
+      spec: {
+        kind: 'hardware' as const,
         type: deviceType as DeviceType,
         model: info.model?.toLowerCase(),
         vendor: info.manufacturer?.toLowerCase(),


### PR DESCRIPTION
## Summary

### 1. Show all settable fields in Information dialog
- Rewrite `getDisplayFields()` in `DetailPanel.svelte` to show complete field sets per element kind (node, subgraph, edge, port)
- Empty editable fields are displayed so users can populate them in edit mode

### 2. Nest device fields into `DeviceInfo` object
- Move type, vendor, model, service, resource, icon from flat Node/Subgraph properties into a nested `device: DeviceInfo` object
- Separates graph-structural fields from device/resource identification

### 3. Replace DeviceInfo with `NodeSpec` discriminated union
- Rename `device` → `spec` on Node/Subgraph
- Replace flat `DeviceInfo` with discriminated union: `HardwareSpec | ComputeSpec | ServiceSpec`
- Each kind carries only relevant fields:
  - `hardware`: type, vendor, model
  - `compute`: type, vendor, platform
  - `service`: vendor, service, resource
- Add `specDeviceType()` and `specIconKey()` helpers for safe field extraction

## BREAKING CHANGES
- `Node.type/vendor/model/...` → `Node.spec.type/vendor/model/...`
- `DeviceInfo` type removed in favor of `NodeSpec` union
- All consumers (renderers, plugins, editor, server) updated

## Test plan
- [ ] Nodes render with correct icons (hardware type → built-in icon)
- [ ] CDN vendor icons still resolve (vendor + model/service)
- [ ] Information dialog shows all fields per element kind
- [ ] Edit mode: fields are editable
- [ ] Parser correctly infers `kind` from YAML fields
- [ ] All packages pass typecheck, lint, and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)