### PR TITLE
feat: device catalog with PoE analysis and spec dialog

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -12,6 +12,7 @@
     "format": "biome check --write ."
   },
   "dependencies": {
+    "@shumoku/catalog": "workspace:*",
     "@shumoku/core": "workspace:*",
     "@shumoku/renderer": "workspace:*",
     "bits-ui": "^2.15.4",

--- a/apps/editor/src/lib/components/DetailPanel.svelte
+++ b/apps/editor/src/lib/components/DetailPanel.svelte
@@ -2,11 +2,13 @@
   import { getDeviceIcon } from '@shumoku/core'
   import { Dialog, ScrollArea, Tabs } from 'bits-ui'
   import { X } from 'phosphor-svelte'
+  import type { PoEBudget } from '$lib/poe-analysis'
 
   let {
     open = false,
     data,
     mode = 'view',
+    poeBudget,
     onclose,
     onupdate,
   }: {
@@ -14,6 +16,7 @@
     // biome-ignore lint/suspicious/noExplicitAny: mixed element data
     data: Record<string, any> | null
     mode?: 'edit' | 'view'
+    poeBudget?: PoEBudget
     onclose?: () => void
     onupdate?: (id: string, field: string, value: string) => void
   } = $props()
@@ -282,6 +285,44 @@
                           >
                             <span class="text-blue-500 font-semibold">{port.label}</span>
                             <span class="text-neutral-400">{port.side}</span>
+                          </div>
+                        {/each}
+                      </div>
+                    </div>
+                  {/if}
+                  {#if poeBudget}
+                    <div
+                      class="mt-3 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/40"
+                    >
+                      <div class="flex items-center justify-between mb-2">
+                        <span
+                          class="text-[11px] font-bold uppercase tracking-wider text-amber-700 dark:text-amber-400"
+                          >PoE Budget</span
+                        >
+                        <span class="text-[11px] font-mono text-amber-600 dark:text-amber-300"
+                          >{poeBudget.used_w}W / {poeBudget.budget_w}W</span
+                        >
+                      </div>
+                      <div
+                        class="w-full h-2 rounded-full bg-amber-200 dark:bg-amber-900/40 overflow-hidden mb-2"
+                      >
+                        <div
+                          class="h-full rounded-full transition-all {poeBudget.utilization_pct > 80 ? 'bg-red-500' : poeBudget.utilization_pct > 50 ? 'bg-amber-500' : 'bg-green-500'}"
+                          style="width: {Math.min(100, poeBudget.utilization_pct)}%"
+                        ></div>
+                      </div>
+                      <div class="text-[10px] text-amber-600 dark:text-amber-400 mb-2">
+                        {poeBudget.remaining_w}W remaining ({poeBudget.utilization_pct}%)
+                      </div>
+                      <div class="space-y-1">
+                        {#each poeBudget.links as link}
+                          <div class="flex justify-between text-[10px]">
+                            <span class="text-neutral-600 dark:text-neutral-300"
+                              >{link.toNodeLabel}</span
+                            >
+                            <span class="font-mono text-amber-700 dark:text-amber-300"
+                              >{link.draw_w}W</span
+                            >
                           </div>
                         {/each}
                       </div>

--- a/apps/editor/src/lib/components/DetailPanel.svelte
+++ b/apps/editor/src/lib/components/DetailPanel.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
-  import { getDeviceIcon } from '@shumoku/core'
-  import { Dialog, ScrollArea, Tabs } from 'bits-ui'
-  import { X } from 'phosphor-svelte'
+  import type { Catalog, CatalogEntry, HardwareProperties } from '@shumoku/catalog'
+  import { getDeviceIcon, type Link } from '@shumoku/core'
+  import { Combobox, Dialog, ScrollArea, Tabs } from 'bits-ui'
+  import { ArrowSquareOut, CaretUpDown, X } from 'phosphor-svelte'
   import type { PoEBudget } from '$lib/poe-analysis'
+  import SpecCatalogDialog from './SpecCatalogDialog.svelte'
 
   let {
     open = false,
     data,
     mode = 'view',
     poeBudget,
+    catalog,
+    links = [],
     onclose,
     onupdate,
   }: {
@@ -17,9 +21,48 @@
     data: Record<string, any> | null
     mode?: 'edit' | 'view'
     poeBudget?: PoEBudget
+    catalog?: Catalog
+    links?: Link[]
     onclose?: () => void
     onupdate?: (id: string, field: string, value: string) => void
   } = $props()
+
+  let specDialogOpen = $state(false)
+  let comboSearchValue = $state('')
+
+  const comboResults = $derived.by(() => {
+    if (!catalog) return []
+    if (!comboSearchValue.trim()) return catalog.list().slice(0, 10)
+    return catalog.search(comboSearchValue).slice(0, 10)
+  })
+
+  function handleComboSelect(entryId: string) {
+    if (!catalog || !data?.id) return
+    const entry = catalog.lookup(entryId)
+    if (!entry) return
+    const spec: Record<string, string> = { kind: entry.spec.kind }
+    if (entry.spec.vendor) spec.vendor = entry.spec.vendor
+    if ('type' in entry.spec && entry.spec.type) spec.type = String(entry.spec.type)
+    if ('model' in entry.spec && entry.spec.model) spec.model = entry.spec.model
+    if ('service' in entry.spec && entry.spec.service) spec.service = entry.spec.service
+    if ('resource' in entry.spec && entry.spec.resource) spec.resource = entry.spec.resource
+    if (entry.spec.icon) spec.icon = entry.spec.icon
+    for (const [key, value] of Object.entries(spec)) {
+      onupdate?.(data.id, `spec.${key}`, value)
+    }
+  }
+
+  const catalogEntry = $derived.by<CatalogEntry | null>(() => {
+    if (!catalog || !data?.spec) return null
+    const spec = data.spec
+    if (spec.kind !== 'hardware' && spec.kind !== 'compute') return null
+    if (!spec.vendor || !spec.model) return null
+    return catalog.lookup(`${spec.vendor}/${spec.model}`) ?? null
+  })
+
+  const hwProps = $derived(
+    catalogEntry?.spec.kind === 'hardware' ? (catalogEntry.properties as HardwareProperties) : null,
+  )
 
   const kind = $derived((data?.kind as string) ?? 'unknown')
   const editing = $derived(mode === 'edit')
@@ -37,17 +80,104 @@
   }
 
   const iconPath = $derived(data?.spec?.type ? getDeviceIcon(data.spec.type) : undefined)
+  const nodeLabel = $derived(
+    data?.label
+      ? Array.isArray(data.label)
+        ? data.label.map(stripHtml).join(' / ')
+        : stripHtml(String(data.label))
+      : '',
+  )
+  const ports = $derived(data?.ports ?? [])
 
-  function getDisplayFields(
+  interface PortConnection {
+    portLabel: string
+    side: string
+    peerNode: string
+    peerPort: string
+    ip?: string
+    peerIp?: string
+    bandwidth?: string
+    vlan?: string
+    linkLabel?: string
+    direction: 'out' | 'in'
+  }
+
+  // Derive port connections from links
+  const portConnections = $derived.by<PortConnection[]>(() => {
+    if (!data?.id || !links?.length || !ports?.length) return []
+    const nodeId = data.id as string
+    const conns: PortConnection[] = []
+
+    // biome-ignore lint/suspicious/noExplicitAny: port data is untyped
+    const portMap = new Map<string, any>()
+    // biome-ignore lint/suspicious/noExplicitAny: port data is untyped
+    for (const p of ports) portMap.set((p as any).label, p)
+
+    for (const link of links) {
+      const fromNode = typeof link.from === 'string' ? link.from : link.from.node
+      const toNode = typeof link.to === 'string' ? link.to : link.to.node
+      const fromPort = typeof link.from === 'object' ? link.from.port : undefined
+      const toPort = typeof link.to === 'object' ? link.to.port : undefined
+      const rawFromIp = typeof link.from === 'object' ? link.from.ip : undefined
+      const rawToIp = typeof link.to === 'object' ? link.to.ip : undefined
+      const fromIp = Array.isArray(rawFromIp) ? rawFromIp.join(', ') : rawFromIp
+      const toIp = Array.isArray(rawToIp) ? rawToIp.join(', ') : rawToIp
+      const vlan = link.vlan
+        ? Array.isArray(link.vlan)
+          ? link.vlan.join(', ')
+          : String(link.vlan)
+        : undefined
+
+      const bw = link.bandwidth ?? undefined
+      const label = Array.isArray(link.label) ? link.label.join(', ') : link.label
+
+      if (fromNode === nodeId && fromPort) {
+        const port = portMap.get(fromPort)
+        conns.push({
+          portLabel: fromPort,
+          side: port?.side ?? '',
+          peerNode: toNode,
+          peerPort: toPort ?? '',
+          ip: fromIp,
+          peerIp: toIp,
+          bandwidth: bw,
+          vlan,
+          linkLabel: label,
+          direction: 'out',
+        })
+      } else if (toNode === nodeId && toPort) {
+        const port = portMap.get(toPort)
+        conns.push({
+          portLabel: toPort,
+          side: port?.side ?? '',
+          peerNode: fromNode,
+          peerPort: fromPort ?? '',
+          ip: toIp,
+          peerIp: fromIp,
+          bandwidth: bw,
+          vlan,
+          linkLabel: label,
+          direction: 'in',
+        })
+      }
+    }
+    return conns
+  })
+
+  function handleFieldChange(key: string, value: string) {
+    if (!data?.id) return
+    onupdate?.(data.id, key, value)
+  }
+
+  // Properties tab: non-spec editable fields
+  function getEditableFields(
     // biome-ignore lint/suspicious/noExplicitAny: mixed element data
     d: Record<string, any>,
   ): { key: string; label: string; value: string; editable: boolean }[] {
     const fields: { key: string; label: string; value: string; editable: boolean }[] = []
     const k = d.kind as string
-    const dev = d.spec ?? {}
 
     if (k === 'node') {
-      // All Node fields
       const raw = d.label
         ? Array.isArray(d.label)
           ? d.label.map(stripHtml).join('\n')
@@ -55,27 +185,6 @@
         : ''
       fields.push({ key: 'label', label: 'Label', value: raw, editable: true })
       fields.push({ key: 'shape', label: 'Shape', value: d.shape ?? '', editable: true })
-      fields.push({ key: 'spec.type', label: 'Type', value: dev.type ?? '', editable: true })
-      fields.push({
-        key: 'spec.vendor',
-        label: 'Vendor',
-        value: dev.vendor ?? '',
-        editable: true,
-      })
-      fields.push({ key: 'spec.model', label: 'Model', value: dev.model ?? '', editable: true })
-      fields.push({
-        key: 'spec.service',
-        label: 'Service',
-        value: dev.service ?? '',
-        editable: true,
-      })
-      fields.push({
-        key: 'spec.resource',
-        label: 'Resource',
-        value: dev.resource ?? '',
-        editable: true,
-      })
-      fields.push({ key: 'spec.icon', label: 'Icon URL', value: dev.icon ?? '', editable: true })
       fields.push({ key: 'parent', label: 'Parent', value: d.parent ?? '', editable: false })
       fields.push({
         key: 'rank',
@@ -98,27 +207,7 @@
           editable: false,
         })
     } else if (k === 'subgraph') {
-      // All Subgraph fields
       fields.push({ key: 'label', label: 'Label', value: d.label ?? '', editable: true })
-      fields.push({
-        key: 'spec.vendor',
-        label: 'Vendor',
-        value: dev.vendor ?? '',
-        editable: true,
-      })
-      fields.push({
-        key: 'spec.service',
-        label: 'Service',
-        value: dev.service ?? '',
-        editable: true,
-      })
-      fields.push({
-        key: 'spec.resource',
-        label: 'Resource',
-        value: dev.resource ?? '',
-        editable: true,
-      })
-      fields.push({ key: 'spec.icon', label: 'Icon URL', value: dev.icon ?? '', editable: true })
       fields.push({
         key: 'direction',
         label: 'Direction',
@@ -130,7 +219,7 @@
         fields.push({
           key: 'bounds',
           label: 'Bounds',
-          value: `${d.bounds.width.toFixed(0)} × ${d.bounds.height.toFixed(0)} at (${d.bounds.x.toFixed(0)}, ${d.bounds.y.toFixed(0)})`,
+          value: `${d.bounds.width.toFixed(0)} × ${d.bounds.height.toFixed(0)}`,
           editable: false,
         })
       if (d.children)
@@ -149,39 +238,29 @@
           editable: false,
         })
       if (d.to)
-        fields.push({ key: 'to', label: 'To', value: `${d.to.node}:${d.to.port}`, editable: false })
-      if (d.width)
-        fields.push({ key: 'width', label: 'Width', value: String(d.width), editable: false })
-      if (d.points)
         fields.push({
-          key: 'points',
-          label: 'Points',
-          value: `${d.points} waypoints`,
+          key: 'to',
+          label: 'To',
+          value: `${d.to.node}:${d.to.port}`,
           editable: false,
         })
     } else if (k === 'port') {
       fields.push({ key: 'label', label: 'Label', value: d.label ?? '', editable: true })
       if (d.nodeId) fields.push({ key: 'nodeId', label: 'Node', value: d.nodeId, editable: false })
       if (d.side) fields.push({ key: 'side', label: 'Side', value: d.side, editable: false })
-      if (d.position)
-        fields.push({
-          key: 'position',
-          label: 'Position',
-          value: `${d.position.x.toFixed(1)}, ${d.position.y.toFixed(1)}`,
-          editable: false,
-        })
     }
 
     return fields
   }
 
-  const displayFields = $derived(data ? getDisplayFields(data) : [])
-  const ports = $derived(data?.ports ?? [])
+  const editableFields = $derived(data ? getEditableFields(data) : [])
 
-  function handleFieldChange(key: string, value: string) {
-    if (!data?.id) return
-    onupdate?.(data.id, key, value)
-  }
+  // Ports not in any connection
+  const unconnectedPorts = $derived.by(() => {
+    const connectedLabels = new Set(portConnections.map((c) => c.portLabel))
+    // biome-ignore lint/suspicious/noExplicitAny: port data untyped
+    return ports.filter((p: any) => !connectedLabels.has(p.label))
+  })
 
   const inputClass =
     'w-full px-1.5 py-0.5 text-[12px] font-mono bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded outline-none focus:ring-1 focus:ring-blue-400 text-neutral-700 dark:text-neutral-200'
@@ -222,27 +301,263 @@
         </Dialog.Description>
 
         <Tabs.Root value="overview">
-          <!-- Overview tab -->
+          <!-- ============ Overview tab ============ -->
           <Tabs.Content value="overview">
             <ScrollArea.Root style="height: 45vh;">
               <ScrollArea.Viewport style="height: 100%;">
-                <div class="px-5 py-4 space-y-3 text-xs">
-                  {#if iconPath}
-                    <div class="flex justify-center py-2">
-                      <svg
-                        width="40"
-                        height="40"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                        role="img"
-                        aria-label={data?.type ?? 'icon'}
-                        class="text-neutral-500 dark:text-neutral-400"
+                <div class="px-5 py-4 text-xs space-y-3">
+                  <!-- Node identity + device block -->
+                  <div class="flex items-center gap-3">
+                    {#if iconPath}
+                      <div class="shrink-0 p-2 rounded-lg bg-neutral-100 dark:bg-neutral-700">
+                        <svg
+                          width="32"
+                          height="32"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                          role="img"
+                          aria-label={data?.spec?.type ?? 'icon'}
+                          class="text-neutral-500 dark:text-neutral-400"
+                        >
+                          {@html iconPath}
+                        </svg>
+                      </div>
+                    {/if}
+                    <div class="min-w-0 flex-1">
+                      <div
+                        class="text-sm font-semibold text-neutral-800 dark:text-neutral-100 truncate"
                       >
-                        {@html iconPath}
-                      </svg>
+                        {nodeLabel || data.id}
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Device selector / info -->
+                  {#if kind === 'node' || kind === 'subgraph'}
+                    {#if editing}
+                      <div class="flex items-center gap-2">
+                        <Combobox.Root
+                          type="single"
+                          onValueChange={(v) => { if (v) handleComboSelect(v) }}
+                        >
+                          <div class="relative flex-1">
+                            <Combobox.Input
+                              placeholder="Search products..."
+                              defaultValue={catalogEntry?.label ?? ''}
+                              class="w-full pl-3 pr-8 py-1.5 text-[11px] bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-lg outline-none focus:ring-1 focus:ring-blue-400 text-neutral-700 dark:text-neutral-200"
+                              oninput={(e) => { comboSearchValue = (e.target as HTMLInputElement).value }}
+                            />
+                            <CaretUpDown
+                              class="absolute right-2 top-1/2 -translate-y-1/2 w-3 h-3 text-neutral-400"
+                            />
+                          </div>
+                          <Combobox.Content
+                            class="z-[70] mt-1 max-h-48 w-full overflow-auto rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 shadow-lg"
+                          >
+                            {#each comboResults as entry}
+                              <Combobox.Item
+                                value={entry.id}
+                                label={entry.label}
+                                class="px-3 py-1.5 text-[11px] cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-700/50 data-[highlighted]:bg-neutral-50 dark:data-[highlighted]:bg-neutral-700/50"
+                              >
+                                <div class="font-medium text-neutral-800 dark:text-neutral-100">
+                                  {entry.label}
+                                </div>
+                                <div class="text-[9px] font-mono text-neutral-400">{entry.id}</div>
+                              </Combobox.Item>
+                            {/each}
+                          </Combobox.Content>
+                        </Combobox.Root>
+                        <button
+                          type="button"
+                          class="shrink-0 p-1.5 rounded-lg text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
+                          title="Spec Details"
+                          onclick={() => { specDialogOpen = true }}
+                        >
+                          <ArrowSquareOut class="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    {:else if catalogEntry}
+                      <button
+                        type="button"
+                        class="flex items-center gap-2 w-full px-2.5 py-1.5 text-left rounded-lg bg-neutral-50 dark:bg-neutral-700/50 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+                        onclick={() => { specDialogOpen = true }}
+                      >
+                        <div class="flex-1 min-w-0">
+                          <div
+                            class="text-[10px] uppercase tracking-wider text-neutral-400 dark:text-neutral-500"
+                          >
+                            {catalogEntry.spec.vendor}
+                          </div>
+                          <div
+                            class="text-[11px] font-medium text-neutral-700 dark:text-neutral-200 truncate"
+                          >
+                            {catalogEntry.label}
+                          </div>
+                        </div>
+                        <ArrowSquareOut class="shrink-0 w-3.5 h-3.5 text-neutral-400" />
+                      </button>
+                    {/if}
+                  {/if}
+
+                  <!-- Connections -->
+                  {#if portConnections.length > 0}
+                    <div>
+                      <div
+                        class="text-[10px] font-bold uppercase tracking-wider text-neutral-400 dark:text-neutral-500 mb-1.5"
+                      >
+                        Connections
+                      </div>
+                      <div class="space-y-1">
+                        {#each portConnections as conn}
+                          <div
+                            class="px-2.5 py-1.5 rounded-lg bg-neutral-50 dark:bg-neutral-700/30 text-[10px]"
+                          >
+                            <div class="flex items-center gap-1.5">
+                              <span class="font-mono font-semibold text-blue-600 dark:text-blue-400"
+                                >{conn.portLabel}</span
+                              >
+                              <span class="text-neutral-300 dark:text-neutral-600"
+                                >{conn.direction === 'out' ? '→' : '←'}</span
+                              >
+                              <span class="font-mono text-neutral-700 dark:text-neutral-200"
+                                >{conn.peerNode}</span
+                              >
+                              {#if conn.peerPort}
+                                <span class="text-neutral-400">:{conn.peerPort}</span>
+                              {/if}
+                              {#if conn.bandwidth}
+                                <span
+                                  class="ml-auto px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 font-mono text-[9px]"
+                                  >{conn.bandwidth}</span
+                                >
+                              {/if}
+                            </div>
+                            {#if conn.ip || conn.vlan || conn.linkLabel}
+                              <div
+                                class="flex gap-2 mt-0.5 text-[9px] text-neutral-400 dark:text-neutral-500"
+                              >
+                                {#if conn.ip}
+                                  <span>{conn.ip}</span>
+                                {/if}
+                                {#if conn.vlan}
+                                  <span>VLAN {conn.vlan}</span>
+                                {/if}
+                                {#if conn.linkLabel}
+                                  <span>{conn.linkLabel}</span>
+                                {/if}
+                              </div>
+                            {/if}
+                          </div>
+                        {/each}
+                      </div>
                     </div>
                   {/if}
-                  {#each displayFields as field}
+
+                  <!-- Unconnected ports -->
+                  {#if unconnectedPorts.length > 0}
+                    <div>
+                      <div
+                        class="text-[10px] font-bold uppercase tracking-wider text-neutral-400 dark:text-neutral-500 mb-1.5"
+                      >
+                        Ports
+                      </div>
+                      <div class="flex flex-wrap gap-1">
+                        {#each unconnectedPorts as port}
+                          <span
+                            class="px-1.5 py-0.5 rounded text-[9px] font-mono bg-neutral-100 dark:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
+                            >{port.label}
+                            <span class="text-neutral-300 dark:text-neutral-600"
+                              >({port.side})</span
+                            ></span
+                          >
+                        {/each}
+                      </div>
+                    </div>
+                  {/if}
+
+                  <!-- PoE Budget -->
+                  {#if poeBudget}
+                    <div>
+                      <div class="flex items-center justify-between mb-1.5">
+                        <span
+                          class="text-[10px] font-bold uppercase tracking-wider text-neutral-400 dark:text-neutral-500"
+                          >PoE Budget</span
+                        >
+                        <span class="text-[10px] font-mono text-amber-600 dark:text-amber-300"
+                          >{poeBudget.used_w}W / {poeBudget.budget_w}W</span
+                        >
+                      </div>
+                      <div
+                        class="w-full h-2 rounded-full bg-neutral-200 dark:bg-neutral-700 overflow-hidden mb-1.5"
+                        role="meter"
+                        aria-valuenow={poeBudget.used_w}
+                        aria-valuemax={poeBudget.budget_w}
+                      >
+                        <div
+                          class="h-full rounded-full transition-all {poeBudget.utilization_pct > 80 ? 'bg-red-500' : poeBudget.utilization_pct > 50 ? 'bg-amber-500' : 'bg-green-500'}"
+                          style="width: {Math.min(100, poeBudget.utilization_pct)}%"
+                        ></div>
+                      </div>
+                      <div class="text-[9px] text-neutral-400 dark:text-neutral-500 mb-2">
+                        {poeBudget.remaining_w}W remaining ({poeBudget.utilization_pct}%)
+                      </div>
+                      <div class="space-y-1">
+                        {#each poeBudget.links as link}
+                          <div
+                            class="px-2.5 py-1.5 rounded-lg bg-neutral-50 dark:bg-neutral-700/30 text-[10px]"
+                          >
+                            <div class="flex items-center justify-between">
+                              <span class="text-neutral-700 dark:text-neutral-200">
+                                {#if link.fromPort}
+                                  <span class="font-mono text-blue-500 dark:text-blue-400"
+                                    >{link.fromPort}</span
+                                  >
+                                  →
+                                {/if}
+                                {link.toNodeLabel}
+                                {#if link.toPort}
+                                  <span class="text-neutral-400">:{link.toPort}</span>
+                                {/if}
+                              </span>
+                              <span class="font-mono text-amber-600 dark:text-amber-400"
+                                >{link.draw_w}W</span
+                              >
+                            </div>
+                            {#if link.passthrough}
+                              {#each link.passthrough as pt}
+                                <div
+                                  class="flex justify-between mt-0.5 pl-3 border-l border-neutral-200 dark:border-neutral-600 ml-1 text-[9px] text-neutral-400 dark:text-neutral-500"
+                                >
+                                  <span>{pt.nodeLabel}</span>
+                                  <span class="font-mono">{pt.draw_w}W</span>
+                                </div>
+                              {/each}
+                            {/if}
+                          </div>
+                        {/each}
+                      </div>
+                    </div>
+                  {/if}
+                </div>
+              </ScrollArea.Viewport>
+              <ScrollArea.Scrollbar
+                orientation="vertical"
+                class="flex w-2 touch-none select-none rounded-full bg-neutral-100 dark:bg-neutral-700/50 p-px"
+              >
+                <ScrollArea.Thumb
+                  class="flex-1 rounded-full bg-neutral-300 dark:bg-neutral-500 hover:bg-neutral-400 dark:hover:bg-neutral-400 transition-colors"
+                />
+              </ScrollArea.Scrollbar>
+            </ScrollArea.Root>
+          </Tabs.Content>
+
+          <!-- ============ Properties tab (editable) ============ -->
+          <Tabs.Content value="properties">
+            <ScrollArea.Root style="height: 45vh;">
+              <ScrollArea.Viewport style="height: 100%;">
+                <div class="px-5 py-4 space-y-3 text-xs">
+                  {#each editableFields as field}
                     <div class="flex gap-3 items-start">
                       <span
                         class="shrink-0 w-16 text-right text-neutral-400 dark:text-neutral-500 font-medium pt-1"
@@ -261,87 +576,11 @@
                         <span
                           class="text-neutral-700 dark:text-neutral-200 font-mono break-all leading-relaxed pt-0.5"
                         >
-                          {#if typeof field.value === 'string' && field.value.includes('\n')}
-                            {#each field.value.split('\n') as line}
-                              <div>{line}</div>
-                            {/each}
-                          {:else}
-                            {field.value}
-                          {/if}
+                          {field.value}
                         </span>
                       {/if}
                     </div>
                   {/each}
-                  {#if ports.length > 0}
-                    <div class="flex gap-3 items-start">
-                      <span
-                        class="shrink-0 w-16 text-right text-neutral-400 dark:text-neutral-500 font-medium pt-0.5"
-                        >Ports</span
-                      >
-                      <div class="space-y-1.5">
-                        {#each ports as port}
-                          <div
-                            class="flex items-center gap-2 pl-2 border-l-2 border-blue-200 dark:border-blue-800 text-[11px]"
-                          >
-                            <span class="text-blue-500 font-semibold">{port.label}</span>
-                            <span class="text-neutral-400">{port.side}</span>
-                          </div>
-                        {/each}
-                      </div>
-                    </div>
-                  {/if}
-                  {#if poeBudget}
-                    <div
-                      class="mt-3 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/40"
-                    >
-                      <div class="flex items-center justify-between mb-2">
-                        <span
-                          class="text-[11px] font-bold uppercase tracking-wider text-amber-700 dark:text-amber-400"
-                          >PoE Budget</span
-                        >
-                        <span class="text-[11px] font-mono text-amber-600 dark:text-amber-300"
-                          >{poeBudget.used_w}W / {poeBudget.budget_w}W</span
-                        >
-                      </div>
-                      <div
-                        class="w-full h-2 rounded-full bg-amber-200 dark:bg-amber-900/40 overflow-hidden mb-2"
-                      >
-                        <div
-                          class="h-full rounded-full transition-all {poeBudget.utilization_pct > 80 ? 'bg-red-500' : poeBudget.utilization_pct > 50 ? 'bg-amber-500' : 'bg-green-500'}"
-                          style="width: {Math.min(100, poeBudget.utilization_pct)}%"
-                        ></div>
-                      </div>
-                      <div class="text-[10px] text-amber-600 dark:text-amber-400 mb-2">
-                        {poeBudget.remaining_w}W remaining ({poeBudget.utilization_pct}%)
-                      </div>
-                      <div class="space-y-1">
-                        {#each poeBudget.links as link}
-                          <div class="flex justify-between text-[10px]">
-                            <span class="text-neutral-600 dark:text-neutral-300"
-                              >{link.toNodeLabel}</span
-                            >
-                            <span class="font-mono text-amber-700 dark:text-amber-300"
-                              >{link.draw_w}W</span
-                            >
-                          </div>
-                          {#if link.passthrough}
-                            {#each link.passthrough as pt}
-                              <div
-                                class="flex justify-between text-[10px] pl-3 border-l border-amber-300 dark:border-amber-700 ml-1"
-                              >
-                                <span class="text-neutral-400 dark:text-neutral-500"
-                                  >{pt.nodeLabel}</span
-                                >
-                                <span class="font-mono text-neutral-400 dark:text-neutral-500"
-                                  >{pt.draw_w}W</span
-                                >
-                              </div>
-                            {/each}
-                          {/if}
-                        {/each}
-                      </div>
-                    </div>
-                  {/if}
                 </div>
               </ScrollArea.Viewport>
               <ScrollArea.Scrollbar
@@ -355,7 +594,7 @@
             </ScrollArea.Root>
           </Tabs.Content>
 
-          <!-- Raw tab -->
+          <!-- ============ Raw tab ============ -->
           <Tabs.Content value="raw">
             <ScrollArea.Root style="height: 45vh;">
               <ScrollArea.Viewport style="height: 100%;">
@@ -384,6 +623,12 @@
               Overview
             </Tabs.Trigger>
             <Tabs.Trigger
+              value="properties"
+              class="px-3 py-2 text-xs font-medium border-t-2 -mt-px transition-colors data-[state=active]:border-blue-500 data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400 border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200"
+            >
+              Properties
+            </Tabs.Trigger>
+            <Tabs.Trigger
               value="raw"
               class="px-3 py-2 text-xs font-medium border-t-2 -mt-px transition-colors data-[state=active]:border-blue-500 data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400 border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200"
             >
@@ -395,3 +640,17 @@
     </Dialog.Content>
   </Dialog.Portal>
 </Dialog.Root>
+
+<SpecCatalogDialog
+  open={specDialogOpen}
+  {mode}
+  {catalog}
+  currentSpec={data?.spec}
+  onclose={() => { specDialogOpen = false }}
+  onselect={(spec) => {
+    if (!data?.id) return
+    for (const [key, value] of Object.entries(spec)) {
+      onupdate?.(data.id, `spec.${key}`, value)
+    }
+  }}
+/>

--- a/apps/editor/src/lib/components/DetailPanel.svelte
+++ b/apps/editor/src/lib/components/DetailPanel.svelte
@@ -324,6 +324,20 @@
                               >{link.draw_w}W</span
                             >
                           </div>
+                          {#if link.passthrough}
+                            {#each link.passthrough as pt}
+                              <div
+                                class="flex justify-between text-[10px] pl-3 border-l border-amber-300 dark:border-amber-700 ml-1"
+                              >
+                                <span class="text-neutral-400 dark:text-neutral-500"
+                                  >{pt.nodeLabel}</span
+                                >
+                                <span class="font-mono text-neutral-400 dark:text-neutral-500"
+                                  >{pt.draw_w}W</span
+                                >
+                              </div>
+                            {/each}
+                          {/if}
                         {/each}
                       </div>
                     </div>

--- a/apps/editor/src/lib/components/SpecCatalogDialog.svelte
+++ b/apps/editor/src/lib/components/SpecCatalogDialog.svelte
@@ -1,0 +1,599 @@
+<script lang="ts">
+  import type { Catalog, CatalogEntry, HardwareProperties } from '@shumoku/catalog'
+  import { Dialog, ScrollArea, Tabs } from 'bits-ui'
+  import { ArrowLeft } from 'phosphor-svelte'
+
+  let {
+    open = false,
+    mode = 'view',
+    catalog,
+    currentSpec,
+    onclose,
+    onselect,
+  }: {
+    open?: boolean
+    mode?: 'edit' | 'view'
+    catalog?: Catalog
+    // biome-ignore lint/suspicious/noExplicitAny: mixed spec data
+    currentSpec?: Record<string, any> | null
+    onclose?: () => void
+    onselect?: (spec: Record<string, string>) => void
+  } = $props()
+
+  const editing = $derived(mode === 'edit')
+
+  // Cascade select state
+  let selectedKind = $state<string>('hardware')
+  let selectedVendor = $state('')
+  let selectedSeries = $state('')
+  let selectedModelId = $state('')
+
+  // Derive vendors filtered by kind
+  const vendors = $derived.by(() => {
+    if (!catalog) return []
+    const set = new Set<string>()
+    for (const e of catalog.listByKind(selectedKind as 'hardware' | 'compute' | 'service')) {
+      if (e.spec.vendor) set.add(e.spec.vendor)
+    }
+    return [...set].sort()
+  })
+
+  // All entries for selected vendor+kind
+  const vendorEntries = $derived.by(() => {
+    if (!catalog || !selectedVendor) return []
+    return catalog.listByVendor(selectedVendor).filter((e) => e.spec.kind === selectedKind)
+  })
+
+  // Series = entries that have children (other entries extend them)
+  const seriesEntries = $derived.by(() => {
+    const allIds = new Set(vendorEntries.map((e) => e.id))
+    const parentIds = new Set(vendorEntries.filter((e) => e.extends).map((e) => e.extends))
+    return vendorEntries.filter((e) => parentIds.has(e.id))
+  })
+
+  // Has series?
+  const hasSeries = $derived(seriesEntries.length > 0)
+
+  // Models = entries under selected series, or standalone entries (no extends, no children)
+  const modelEntries = $derived.by(() => {
+    if (hasSeries && selectedSeries) {
+      return vendorEntries.filter((e) => e.extends === selectedSeries)
+    }
+    if (!hasSeries) {
+      // No series — all vendor entries are directly selectable
+      return vendorEntries
+    }
+    return []
+  })
+
+  // Resolved entry
+  const resolvedEntry = $derived.by<CatalogEntry | null>(() => {
+    if (!catalog) return null
+    if (selectedModelId) return catalog.lookup(selectedModelId) ?? null
+    if (selectedSeries) return catalog.lookup(selectedSeries) ?? null
+    return null
+  })
+
+  const hwProps = $derived(
+    resolvedEntry?.spec.kind === 'hardware'
+      ? (resolvedEntry.properties as HardwareProperties)
+      : null,
+  )
+
+  // Sync from currentSpec when dialog opens
+  $effect(() => {
+    if (open && catalog && currentSpec) {
+      selectedKind = currentSpec.kind ?? 'hardware'
+      if (currentSpec.vendor && currentSpec.model) {
+        const entry = catalog.lookup(`${currentSpec.vendor}/${currentSpec.model}`)
+        if (entry) {
+          selectedVendor = entry.spec.vendor ?? ''
+          selectedModelId = entry.id
+          selectedSeries = entry.extends ?? ''
+          return
+        }
+      }
+      selectedVendor = currentSpec.vendor ?? ''
+      selectedSeries = ''
+      selectedModelId = ''
+    }
+  })
+
+  function handleKindChange(kind: string) {
+    selectedKind = kind
+    selectedVendor = ''
+    selectedSeries = ''
+    selectedModelId = ''
+  }
+
+  function handleVendorChange(vendor: string) {
+    selectedVendor = vendor
+    selectedSeries = ''
+    selectedModelId = ''
+  }
+
+  function handleSeriesChange(seriesId: string) {
+    selectedSeries = seriesId
+    selectedModelId = ''
+  }
+
+  function handleModelChange(modelId: string) {
+    selectedModelId = modelId
+  }
+
+  function apply() {
+    const entry = resolvedEntry
+    if (!entry) return
+    const spec: Record<string, string> = { kind: entry.spec.kind }
+    if (entry.spec.vendor) spec.vendor = entry.spec.vendor
+    if ('type' in entry.spec && entry.spec.type) spec.type = String(entry.spec.type)
+    if ('model' in entry.spec && entry.spec.model) spec.model = entry.spec.model
+    if ('service' in entry.spec && entry.spec.service) spec.service = entry.spec.service
+    if ('resource' in entry.spec && entry.spec.resource) spec.resource = entry.spec.resource
+    if (entry.spec.icon) spec.icon = entry.spec.icon
+    onselect?.(spec)
+    onclose?.()
+  }
+
+  // Custom tab
+  let customKind = $state('hardware')
+  let customType = $state('')
+  let customVendor = $state('')
+  let customModel = $state('')
+  let customService = $state('')
+  let customResource = $state('')
+  let customIcon = $state('')
+
+  $effect(() => {
+    if (open && currentSpec) {
+      customKind = currentSpec.kind ?? 'hardware'
+      customType = currentSpec.type ?? ''
+      customVendor = currentSpec.vendor ?? ''
+      customModel = currentSpec.model ?? ''
+      customService = currentSpec.service ?? ''
+      customResource = currentSpec.resource ?? ''
+      customIcon = currentSpec.icon ?? ''
+    }
+  })
+
+  function applyCustom() {
+    const spec: Record<string, string> = {}
+    if (customKind) spec.kind = customKind
+    if (customType) spec.type = customType
+    if (customVendor) spec.vendor = customVendor
+    if (customModel) spec.model = customModel
+    if (customService) spec.service = customService
+    if (customResource) spec.resource = customResource
+    if (customIcon) spec.icon = customIcon
+    onselect?.(spec)
+    onclose?.()
+  }
+
+  const selectClass =
+    'w-full px-2 py-1.5 text-xs bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-lg outline-none focus:ring-1 focus:ring-blue-400 text-neutral-700 dark:text-neutral-200'
+  const inputClass =
+    'w-full px-2 py-1 text-[12px] font-mono bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded outline-none focus:ring-1 focus:ring-blue-400 text-neutral-700 dark:text-neutral-200'
+  const labelClass =
+    'text-[10px] font-medium text-neutral-400 dark:text-neutral-500 uppercase tracking-wider'
+</script>
+
+<Dialog.Root {open} onOpenChange={(o) => { if (!o) onclose?.() }}>
+  <Dialog.Portal>
+    <Dialog.Overlay class="fixed inset-0 z-50 bg-black/20 dark:bg-black/40 backdrop-blur-[2px]" />
+    <Dialog.Content
+      class="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[60] w-[520px] bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-2xl focus:outline-none"
+    >
+      <div
+        class="flex items-center justify-between px-5 py-4 border-b border-neutral-200 dark:border-neutral-700"
+      >
+        <div class="flex items-center gap-3">
+          <Dialog.Close
+            class="p-1 rounded-lg text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100 dark:hover:text-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+          >
+            <ArrowLeft class="w-4 h-4" />
+          </Dialog.Close>
+          <Dialog.Title class="text-sm font-semibold text-neutral-800 dark:text-neutral-100"
+            >Node Spec</Dialog.Title
+          >
+        </div>
+        {#if editing && resolvedEntry}
+          <button
+            type="button"
+            class="px-3 py-1 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-lg transition-colors"
+            onclick={apply}
+          >
+            Apply
+          </button>
+        {/if}
+      </div>
+      <Dialog.Description class="sr-only"
+        >Select or customize node specification</Dialog.Description
+      >
+
+      <Tabs.Root value="overview">
+        <!-- ============ Overview tab ============ -->
+        <Tabs.Content value="overview">
+          <ScrollArea.Root style="height: 45vh;">
+            <ScrollArea.Viewport style="height: 100%;">
+              <div class="px-5 py-4">
+                <!-- Cascade selects (edit) / text display (view) -->
+                <div class="space-y-2 mb-4">
+                  <div>
+                    <div class={labelClass}>Kind</div>
+                    {#if editing}
+                      <select
+                        class={selectClass}
+                        value={selectedKind}
+                        onchange={(e) => handleKindChange((e.target as HTMLSelectElement).value)}
+                      >
+                        <option value="hardware">hardware</option>
+                        <option value="compute">compute</option>
+                        <option value="service">service</option>
+                      </select>
+                    {:else}
+                      <div class="text-xs font-mono text-neutral-700 dark:text-neutral-200 py-1">
+                        {selectedKind}
+                      </div>
+                    {/if}
+                  </div>
+                  <div>
+                    <div class={labelClass}>Vendor</div>
+                    {#if editing}
+                      <select
+                        class={selectClass}
+                        value={selectedVendor}
+                        onchange={(e) => handleVendorChange((e.target as HTMLSelectElement).value)}
+                      >
+                        <option value="">-- select --</option>
+                        {#each vendors as v}
+                          <option value={v}>{v}</option>
+                        {/each}
+                      </select>
+                    {:else}
+                      <div class="text-xs font-mono text-neutral-700 dark:text-neutral-200 py-1">
+                        {selectedVendor || '—'}
+                      </div>
+                    {/if}
+                  </div>
+                  {#if selectedVendor && hasSeries}
+                    <div>
+                      <div class={labelClass}>Series</div>
+                      {#if editing}
+                        <select
+                          class={selectClass}
+                          value={selectedSeries}
+                          onchange={(e) => handleSeriesChange((e.target as HTMLSelectElement).value)}
+                        >
+                          <option value="">-- select --</option>
+                          {#each seriesEntries as s}
+                            <option value={s.id}>{s.label}</option>
+                          {/each}
+                        </select>
+                      {:else}
+                        <div class="text-xs font-mono text-neutral-700 dark:text-neutral-200 py-1">
+                          {catalog?.getRaw(selectedSeries)?.label ?? '—'}
+                        </div>
+                      {/if}
+                    </div>
+                  {/if}
+                  {#if selectedVendor && modelEntries.length > 0}
+                    <div>
+                      <div class={labelClass}>Model</div>
+                      {#if editing}
+                        <select
+                          class={selectClass}
+                          value={selectedModelId}
+                          onchange={(e) => handleModelChange((e.target as HTMLSelectElement).value)}
+                        >
+                          <option value="">-- select --</option>
+                          {#each modelEntries as m}
+                            <option value={m.id}>{m.label}</option>
+                          {/each}
+                        </select>
+                      {:else}
+                        <div class="text-xs font-mono text-neutral-700 dark:text-neutral-200 py-1">
+                          {resolvedEntry?.label ?? '—'}
+                        </div>
+                      {/if}
+                    </div>
+                  {/if}
+                </div>
+
+                <!-- Product overview -->
+                {#if resolvedEntry}
+                  <div class="text-base font-semibold text-neutral-800 dark:text-neutral-100 mb-1">
+                    {resolvedEntry.label}
+                  </div>
+                  <div class="text-[10px] font-mono text-neutral-400 dark:text-neutral-500 mb-3">
+                    {resolvedEntry.id}
+                  </div>
+
+                  {#if resolvedEntry.tags.length > 0}
+                    <div class="flex flex-wrap gap-1 mb-3">
+                      {#each resolvedEntry.tags as tag}
+                        <span
+                          class="px-1.5 py-0.5 text-[9px] font-medium rounded bg-neutral-100 dark:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
+                          >{tag}</span
+                        >
+                      {/each}
+                    </div>
+                  {/if}
+
+                  {#if hwProps}
+                    <!-- Summary line -->
+                    <div
+                      class="text-[11px] text-neutral-500 dark:text-neutral-400 mb-4 leading-relaxed"
+                    >
+                      {#if resolvedEntry.spec.kind === 'hardware' && 'type' in resolvedEntry.spec && resolvedEntry.spec.type}
+                        <span class="capitalize">{resolvedEntry.spec.type}</span>
+                      {/if}
+                      {#if hwProps.power?.poe_out}
+                        <span>
+                          · PoE {hwProps.power.poe_out.standard} {hwProps.power.poe_out.budget_w}W ({hwProps.power.poe_out.ports}
+                          ports)</span
+                        >
+                      {/if}
+                      {#if hwProps.power?.poe_in}
+                        <span> · PoE consumer class {hwProps.power.poe_in.class}</span>
+                      {/if}
+                      {#if hwProps.power?.max_draw_w}
+                        <span> · {hwProps.power.max_draw_w}W max</span>
+                      {/if}
+                      {#if hwProps.switching?.capacity_gbps}
+                        <span> · {hwProps.switching.capacity_gbps} Gbps</span>
+                      {/if}
+                      {#if hwProps.wireless?.standard}
+                        <span> · {hwProps.wireless.standard} {hwProps.wireless.mimo ?? ''}</span>
+                      {/if}
+                      {#if hwProps.physical?.form_factor}
+                        <span> · {hwProps.physical.form_factor}</span>
+                      {/if}
+                      {#if hwProps.physical?.fanless}
+                        <span> · fanless</span>
+                      {/if}
+                    </div>
+
+                    <!-- Spec cards -->
+                    <div class="grid grid-cols-3 gap-2 mb-4">
+                      {#if hwProps.power?.max_draw_w}
+                        <div
+                          class="p-2 rounded-lg bg-neutral-50 dark:bg-neutral-700/50 text-center"
+                        >
+                          <div class="text-[8px] uppercase tracking-wider text-neutral-400">
+                            Power
+                          </div>
+                          <div
+                            class="text-xs font-mono font-semibold text-neutral-700 dark:text-neutral-200"
+                          >
+                            {hwProps.power.max_draw_w}W
+                          </div>
+                        </div>
+                      {/if}
+                      {#if hwProps.switching?.capacity_gbps}
+                        <div
+                          class="p-2 rounded-lg bg-neutral-50 dark:bg-neutral-700/50 text-center"
+                        >
+                          <div class="text-[8px] uppercase tracking-wider text-neutral-400">
+                            Switch
+                          </div>
+                          <div
+                            class="text-xs font-mono font-semibold text-neutral-700 dark:text-neutral-200"
+                          >
+                            {hwProps.switching.capacity_gbps}G
+                          </div>
+                        </div>
+                      {/if}
+                      {#if hwProps.wireless?.standard}
+                        <div
+                          class="p-2 rounded-lg bg-neutral-50 dark:bg-neutral-700/50 text-center"
+                        >
+                          <div class="text-[8px] uppercase tracking-wider text-neutral-400">
+                            WiFi
+                          </div>
+                          <div
+                            class="text-xs font-mono font-semibold text-neutral-700 dark:text-neutral-200"
+                          >
+                            {hwProps.wireless.standard}
+                          </div>
+                        </div>
+                      {/if}
+                      {#if hwProps.ports?.downlink}
+                        <div
+                          class="p-2 rounded-lg bg-neutral-50 dark:bg-neutral-700/50 text-center"
+                        >
+                          <div class="text-[8px] uppercase tracking-wider text-neutral-400">
+                            Ports
+                          </div>
+                          <div
+                            class="text-xs font-mono font-semibold text-neutral-700 dark:text-neutral-200"
+                          >
+                            {hwProps.ports.downlink.reduce((s, p) => s + p.count, 0)}
+                          </div>
+                        </div>
+                      {/if}
+                      {#if hwProps.physical?.weight_g}
+                        <div
+                          class="p-2 rounded-lg bg-neutral-50 dark:bg-neutral-700/50 text-center"
+                        >
+                          <div class="text-[8px] uppercase tracking-wider text-neutral-400">
+                            Weight
+                          </div>
+                          <div
+                            class="text-xs font-mono font-semibold text-neutral-700 dark:text-neutral-200"
+                          >
+                            {hwProps.physical.weight_g}g
+                          </div>
+                        </div>
+                      {/if}
+                    </div>
+
+                    <!-- Ports -->
+                    {#if hwProps.ports}
+                      <div class="text-[10px] mb-3">
+                        {#if hwProps.ports.downlink}
+                          {#each hwProps.ports.downlink as pg}
+                            <div class="flex justify-between py-0.5">
+                              <span class="text-neutral-500">Downlink</span>
+                              <span class="font-mono text-neutral-700 dark:text-neutral-200"
+                                >{pg.count}× {pg.speed}
+                                {pg.media}
+                                {#if pg.poe}
+                                  (PoE)
+                                {/if}</span
+                              >
+                            </div>
+                          {/each}
+                        {/if}
+                        {#if hwProps.ports.uplink}
+                          {#each hwProps.ports.uplink as pg}
+                            <div class="flex justify-between py-0.5">
+                              <span class="text-neutral-500">Uplink</span>
+                              <span class="font-mono text-neutral-700 dark:text-neutral-200"
+                                >{pg.count}× {pg.speed} {pg.media}</span
+                              >
+                            </div>
+                          {/each}
+                        {/if}
+                      </div>
+                    {/if}
+                  {/if}
+                {:else if !selectedVendor}
+                  <p class="text-xs text-neutral-400 dark:text-neutral-500 italic text-center py-8">
+                    {editing ? 'Select a vendor to browse products' : 'No catalog match for this node'}
+                  </p>
+                {/if}
+              </div>
+            </ScrollArea.Viewport>
+            <ScrollArea.Scrollbar
+              orientation="vertical"
+              class="flex w-2 touch-none select-none rounded-full bg-neutral-100 dark:bg-neutral-700/50 p-px"
+            >
+              <ScrollArea.Thumb
+                class="flex-1 rounded-full bg-neutral-300 dark:bg-neutral-500 hover:bg-neutral-400 dark:hover:bg-neutral-400 transition-colors"
+              />
+            </ScrollArea.Scrollbar>
+          </ScrollArea.Root>
+        </Tabs.Content>
+
+        <!-- ============ Custom tab ============ -->
+        <Tabs.Content value="custom">
+          <ScrollArea.Root style="height: 45vh;">
+            <ScrollArea.Viewport style="height: 100%;">
+              <div class="px-5 py-4 space-y-3">
+                <div>
+                  <label class={labelClass}>Kind</label>
+                  <select class={inputClass} bind:value={customKind}>
+                    <option value="hardware">hardware</option>
+                    <option value="compute">compute</option>
+                    <option value="service">service</option>
+                  </select>
+                </div>
+                {#if customKind === 'hardware' || customKind === 'compute'}
+                  <div>
+                    <label class={labelClass}>Type</label>
+                    <input
+                      type="text"
+                      class={inputClass}
+                      bind:value={customType}
+                      placeholder="switch, router, access-point..."
+                    >
+                  </div>
+                {/if}
+                <div>
+                  <label class={labelClass}>Vendor</label>
+                  <input
+                    type="text"
+                    class={inputClass}
+                    bind:value={customVendor}
+                    placeholder="cisco, hpe..."
+                  >
+                </div>
+                {#if customKind === 'hardware'}
+                  <div>
+                    <label class={labelClass}>Model</label>
+                    <input
+                      type="text"
+                      class={inputClass}
+                      bind:value={customModel}
+                      placeholder="ws-c3560cx-8pc-s..."
+                    >
+                  </div>
+                {/if}
+                {#if customKind === 'compute'}
+                  <div>
+                    <label class={labelClass}>Platform</label>
+                    <input
+                      type="text"
+                      class={inputClass}
+                      bind:value={customModel}
+                      placeholder="ec2, esxi..."
+                    >
+                  </div>
+                {/if}
+                {#if customKind === 'service'}
+                  <div>
+                    <label class={labelClass}>Service</label>
+                    <input
+                      type="text"
+                      class={inputClass}
+                      bind:value={customService}
+                      placeholder="lambda, s3..."
+                    >
+                  </div>
+                  <div>
+                    <label class={labelClass}>Resource</label>
+                    <input
+                      type="text"
+                      class={inputClass}
+                      bind:value={customResource}
+                      placeholder="function, bucket..."
+                    >
+                  </div>
+                {/if}
+                <div>
+                  <label class={labelClass}>Icon URL</label>
+                  <input
+                    type="text"
+                    class={inputClass}
+                    bind:value={customIcon}
+                    placeholder="https://..."
+                  >
+                </div>
+                <button
+                  type="button"
+                  class="w-full py-2 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-lg transition-colors"
+                  onclick={applyCustom}
+                >
+                  Apply
+                </button>
+              </div>
+            </ScrollArea.Viewport>
+            <ScrollArea.Scrollbar
+              orientation="vertical"
+              class="flex w-2 touch-none select-none rounded-full bg-neutral-100 dark:bg-neutral-700/50 p-px"
+            >
+              <ScrollArea.Thumb
+                class="flex-1 rounded-full bg-neutral-300 dark:bg-neutral-500 hover:bg-neutral-400 dark:hover:bg-neutral-400 transition-colors"
+              />
+            </ScrollArea.Scrollbar>
+          </ScrollArea.Root>
+        </Tabs.Content>
+
+        <Tabs.List class="flex border-t border-neutral-200 dark:border-neutral-700">
+          <Tabs.Trigger
+            value="overview"
+            class="px-3 py-2 text-xs font-medium border-t-2 -mt-px transition-colors data-[state=active]:border-blue-500 data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400 border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200"
+          >
+            Overview
+          </Tabs.Trigger>
+          <Tabs.Trigger
+            value="custom"
+            class="px-3 py-2 text-xs font-medium border-t-2 -mt-px transition-colors data-[state=active]:border-blue-500 data-[state=active]:text-blue-600 dark:data-[state=active]:text-blue-400 border-transparent text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200"
+          >
+            Custom
+          </Tabs.Trigger>
+        </Tabs.List>
+      </Tabs.Root>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>

--- a/apps/editor/src/lib/poe-analysis.ts
+++ b/apps/editor/src/lib/poe-analysis.ts
@@ -17,8 +17,10 @@ export interface PoEPassthrough {
 
 export interface PoELinkDraw {
   linkId: string
+  fromPort: string
   toNodeId: string
   toNodeLabel: string
+  toPort: string
   draw_w: number
   /** Downstream devices powered via passthrough */
   passthrough?: PoEPassthrough[]
@@ -59,19 +61,27 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
   const nodeMap = new Map<string, Node>()
   for (const node of nodes) nodeMap.set(node.id, node)
 
-  // Build adjacency: nodeId → [{ peerId, linkId }]
-  const adj = new Map<string, { peerId: string; linkId: string }[]>()
+  // Build adjacency: nodeId → [{ peerId, linkId, localPort, peerPort }]
+  interface AdjEntry {
+    peerId: string
+    linkId: string
+    localPort: string
+    peerPort: string
+  }
+  const adj = new Map<string, AdjEntry[]>()
   for (const link of links) {
     const from = linkEndpointNode(link.from)
     const to = linkEndpointNode(link.to)
     const id = link.id ?? `${from}-${to}`
+    const fromPort = typeof link.from === 'object' ? (link.from.port ?? '') : ''
+    const toPort = typeof link.to === 'object' ? (link.to.port ?? '') : ''
 
     const fl = adj.get(from) ?? []
-    fl.push({ peerId: to, linkId: id })
+    fl.push({ peerId: to, linkId: id, localPort: fromPort, peerPort: toPort })
     adj.set(from, fl)
 
     const tl = adj.get(to) ?? []
-    tl.push({ peerId: from, linkId: id })
+    tl.push({ peerId: from, linkId: id, localPort: toPort, peerPort: fromPort })
     adj.set(to, tl)
   }
 
@@ -85,7 +95,7 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
     const poeLinks: PoELinkDraw[] = []
     let totalUsed = 0
 
-    for (const { peerId, linkId } of neighbors) {
+    for (const { peerId, linkId, localPort, peerPort } of neighbors) {
       const peer = nodeMap.get(peerId)
       if (!peer) continue
 
@@ -117,8 +127,10 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
       const peerLabel = Array.isArray(peer.label) ? peer.label[0] : peer.label
       poeLinks.push({
         linkId,
+        fromPort: localPort,
         toNodeId: peerId,
         toNodeLabel: peerLabel,
+        toPort: peerPort,
         draw_w: totalDraw,
         passthrough: passthroughDevices.length > 0 ? passthroughDevices : undefined,
       })

--- a/apps/editor/src/lib/poe-analysis.ts
+++ b/apps/editor/src/lib/poe-analysis.ts
@@ -82,10 +82,9 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
       if (!peer) continue
 
       const peerPower = getPower(peer, catalog)
-      if (!peerPower) continue
-      if (!peerPower.poe_in && !peerPower.max_draw_w) continue
+      if (!peerPower?.poe_in) continue // only PoE consumers (PD with poe_in)
 
-      const ownDraw = peerPower.poe_in?.max_draw_w ?? peerPower.max_draw_w ?? 0
+      const ownDraw = peerPower.poe_in.max_draw_w ?? peerPower.max_draw_w ?? 0
       if (ownDraw <= 0) continue
 
       // Passthrough: if peer also has poe_out, add its downstream consumption
@@ -96,8 +95,8 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
           const ds = nodeMap.get(dsId)
           if (!ds) continue
           const dsPower = getPower(ds, catalog)
-          if (dsPower?.poe_in?.max_draw_w ?? dsPower?.max_draw_w) {
-            passthroughDraw += dsPower?.poe_in?.max_draw_w ?? dsPower?.max_draw_w ?? 0
+          if (dsPower?.poe_in) {
+            passthroughDraw += dsPower.poe_in.max_draw_w ?? dsPower.max_draw_w ?? 0
           }
         }
       }

--- a/apps/editor/src/lib/poe-analysis.ts
+++ b/apps/editor/src/lib/poe-analysis.ts
@@ -1,0 +1,127 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * PoE budget analysis for the editor.
+ * Uses @shumoku/catalog to resolve device specs and compute power budgets.
+ */
+
+import type { Catalog, HardwareProperties, PowerProperties } from '@shumoku/catalog'
+import type { Link, Node } from '@shumoku/core'
+
+export interface PoELinkDraw {
+  linkId: string
+  toNodeId: string
+  toNodeLabel: string
+  draw_w: number
+}
+
+export interface PoEBudget {
+  nodeId: string
+  nodeLabel: string
+  budget_w: number
+  used_w: number
+  remaining_w: number
+  utilization_pct: number
+  links: PoELinkDraw[]
+}
+
+function catalogId(node: Node): string | undefined {
+  const s = node.spec
+  if (!s || s.kind !== 'hardware' || !s.vendor || !s.model) return undefined
+  return `${s.vendor}/${s.model}`
+}
+
+function getPower(node: Node, catalog: Catalog): PowerProperties | undefined {
+  const id = catalogId(node)
+  if (!id) return undefined
+  const entry = catalog.lookup(id)
+  if (!entry || entry.spec.kind !== 'hardware') return undefined
+  return (entry.properties as HardwareProperties).power
+}
+
+function linkEndpointNode(ep: string | { node: string }): string {
+  return typeof ep === 'string' ? ep : ep.node
+}
+
+/**
+ * Compute PoE budgets for all PoE source (PSE) nodes in the network.
+ */
+export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEBudget[] {
+  const nodeMap = new Map<string, Node>()
+  for (const node of nodes) nodeMap.set(node.id, node)
+
+  // Build adjacency: nodeId → [{ peerId, linkId }]
+  const adj = new Map<string, { peerId: string; linkId: string }[]>()
+  for (const link of links) {
+    const from = linkEndpointNode(link.from)
+    const to = linkEndpointNode(link.to)
+    const id = link.id ?? `${from}-${to}`
+
+    const fl = adj.get(from) ?? []
+    fl.push({ peerId: to, linkId: id })
+    adj.set(from, fl)
+
+    const tl = adj.get(to) ?? []
+    tl.push({ peerId: from, linkId: id })
+    adj.set(to, tl)
+  }
+
+  const budgets: PoEBudget[] = []
+
+  for (const node of nodes) {
+    const power = getPower(node, catalog)
+    if (!power?.poe_out?.budget_w) continue
+
+    const neighbors = adj.get(node.id) ?? []
+    const poeLinks: PoELinkDraw[] = []
+    let totalUsed = 0
+
+    for (const { peerId, linkId } of neighbors) {
+      const peer = nodeMap.get(peerId)
+      if (!peer) continue
+
+      const peerPower = getPower(peer, catalog)
+      if (!peerPower) continue
+      if (!peerPower.poe_in && !peerPower.max_draw_w) continue
+
+      const ownDraw = peerPower.poe_in?.max_draw_w ?? peerPower.max_draw_w ?? 0
+      if (ownDraw <= 0) continue
+
+      // Passthrough: if peer also has poe_out, add its downstream consumption
+      let passthroughDraw = 0
+      if (peerPower.poe_out) {
+        for (const { peerId: dsId } of adj.get(peerId) ?? []) {
+          if (dsId === node.id) continue
+          const ds = nodeMap.get(dsId)
+          if (!ds) continue
+          const dsPower = getPower(ds, catalog)
+          if (dsPower?.poe_in?.max_draw_w ?? dsPower?.max_draw_w) {
+            passthroughDraw += dsPower?.poe_in?.max_draw_w ?? dsPower?.max_draw_w ?? 0
+          }
+        }
+      }
+
+      const totalDraw = ownDraw + passthroughDraw
+      const peerLabel = Array.isArray(peer.label) ? peer.label[0] : peer.label
+      poeLinks.push({ linkId, toNodeId: peerId, toNodeLabel: peerLabel, draw_w: totalDraw })
+      totalUsed += totalDraw
+    }
+
+    if (poeLinks.length > 0) {
+      const budget = power.poe_out.budget_w
+      const label = Array.isArray(node.label) ? node.label[0] : node.label
+      budgets.push({
+        nodeId: node.id,
+        nodeLabel: label,
+        budget_w: budget,
+        used_w: Math.round(totalUsed * 10) / 10,
+        remaining_w: Math.round((budget - totalUsed) * 10) / 10,
+        utilization_pct: Math.round((totalUsed / budget) * 1000) / 10,
+        links: poeLinks,
+      })
+    }
+  }
+
+  return budgets
+}

--- a/apps/editor/src/lib/poe-analysis.ts
+++ b/apps/editor/src/lib/poe-analysis.ts
@@ -9,11 +9,19 @@
 import type { Catalog, HardwareProperties, PowerProperties } from '@shumoku/catalog'
 import type { Link, Node } from '@shumoku/core'
 
+export interface PoEPassthrough {
+  nodeId: string
+  nodeLabel: string
+  draw_w: number
+}
+
 export interface PoELinkDraw {
   linkId: string
   toNodeId: string
   toNodeLabel: string
   draw_w: number
+  /** Downstream devices powered via passthrough */
+  passthrough?: PoEPassthrough[]
 }
 
 export interface PoEBudget {
@@ -87,8 +95,9 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
       const ownDraw = peerPower.poe_in.max_draw_w ?? peerPower.max_draw_w ?? 0
       if (ownDraw <= 0) continue
 
-      // Passthrough: if peer also has poe_out, add its downstream consumption
+      // Passthrough: if peer also has poe_out, collect downstream consumption
       let passthroughDraw = 0
+      const passthroughDevices: PoEPassthrough[] = []
       if (peerPower.poe_out) {
         for (const { peerId: dsId } of adj.get(peerId) ?? []) {
           if (dsId === node.id) continue
@@ -96,14 +105,23 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
           if (!ds) continue
           const dsPower = getPower(ds, catalog)
           if (dsPower?.poe_in) {
-            passthroughDraw += dsPower.poe_in.max_draw_w ?? dsPower.max_draw_w ?? 0
+            const dsDraw = dsPower.poe_in.max_draw_w ?? dsPower.max_draw_w ?? 0
+            passthroughDraw += dsDraw
+            const dsLabel = Array.isArray(ds.label) ? ds.label[0] : ds.label
+            passthroughDevices.push({ nodeId: dsId, nodeLabel: dsLabel, draw_w: dsDraw })
           }
         }
       }
 
       const totalDraw = ownDraw + passthroughDraw
       const peerLabel = Array.isArray(peer.label) ? peer.label[0] : peer.label
-      poeLinks.push({ linkId, toNodeId: peerId, toNodeLabel: peerLabel, draw_w: totalDraw })
+      poeLinks.push({
+        linkId,
+        toNodeId: peerId,
+        toNodeLabel: peerLabel,
+        draw_w: totalDraw,
+        passthrough: passthroughDevices.length > 0 ? passthroughDevices : undefined,
+      })
       totalUsed += totalDraw
     }
 

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { builtinEntries, Catalog } from '@shumoku/catalog'
   import {
     computeNetworkLayout,
     createMemoryFileResolver,
@@ -23,6 +24,7 @@
   import SideToolbar from '$lib/components/SideToolbar.svelte'
   import StatusBadge from '$lib/components/StatusBadge.svelte'
   import { editorState, initDarkMode } from '$lib/context.svelte'
+  import { analyzePoE, type PoEBudget } from '$lib/poe-analysis'
 
   // =========================================================================
   // Layout state — THE source of truth
@@ -54,6 +56,11 @@
   // biome-ignore lint/suspicious/noExplicitAny: mixed element detail data
   let detailData = $state<Record<string, any> | null>(null)
   let labelEdit = $state<{ portId: string; label: string; x: number; y: number } | null>(null)
+
+  // PoE analysis
+  const catalog = new Catalog()
+  catalog.registerAll(builtinEntries)
+  let poeBudgets = $state<PoEBudget[]>([])
 
   // =========================================================================
   // Derived
@@ -138,6 +145,7 @@
         status = 'Computing layout...'
         const { resolved } = await computeNetworkLayout(g)
         loadFromResolved(resolved, g.links)
+        poeBudgets = analyzePoE(g.nodes, g.links, catalog)
         const mainFile = sampleNetwork.find((f) => f.name === 'main.yaml')
         if (mainFile) yamlSource = mainFile.content
         status = 'Ready'
@@ -315,6 +323,7 @@
     open={detailData !== null}
     data={detailData}
     mode={editorState.mode}
+    poeBudget={poeBudgets.find((b) => b.nodeId === detailData?.id)}
     onclose={() => { detailData = null }}
     onupdate={(id, field, value) => {
       // Update node properties in state

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -324,6 +324,8 @@
     data={detailData}
     mode={editorState.mode}
     poeBudget={poeBudgets.find((b) => b.nodeId === detailData?.id)}
+    {catalog}
+    {links}
     onclose={() => { detailData = null }}
     onupdate={(id, field, value) => {
       // Update node properties in state

--- a/bun.lock
+++ b/bun.lock
@@ -160,6 +160,20 @@
         "vite": "^6.0.7",
       },
     },
+    "libs/@shumoku/catalog": {
+      "name": "@shumoku/catalog",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shumoku/core": "workspace:*",
+        "js-yaml": "^4.1.0",
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^25.0.7",
+        "typescript": "^5.6.3",
+        "vitest": "^4.0.17",
+      },
+    },
     "libs/@shumoku/core": {
       "name": "@shumoku/core",
       "version": "0.2.23",
@@ -726,6 +740,8 @@
     "@shikijs/types": ["@shikijs/types@3.21.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@shumoku/catalog": ["@shumoku/catalog@workspace:libs/@shumoku/catalog"],
 
     "@shumoku/cli": ["@shumoku/cli@workspace:apps/cli"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
       "name": "@shumoku/editor",
       "version": "0.1.0",
       "dependencies": {
+        "@shumoku/catalog": "workspace:*",
         "@shumoku/core": "workspace:*",
         "@shumoku/renderer": "workspace:*",
         "bits-ui": "^2.15.4",

--- a/libs/@shumoku/catalog/data/hardware/cisco/catalyst-3560cx/_series.yaml
+++ b/libs/@shumoku/catalog/data/hardware/cisco/catalyst-3560cx/_series.yaml
@@ -1,0 +1,25 @@
+# Cisco Catalyst 3560-CX Series Compact Switches
+# Source: https://www.cisco.com/c/en/us/products/switches/catalyst-3560-cx-series-switches/
+# Note: End-of-Sale 2022, successor is Catalyst 9200CX
+id: cisco/catalyst-3560cx
+label: Catalyst 3560-CX Series
+spec:
+  kind: hardware
+  type: l3-switch
+  vendor: cisco
+tags: [l3-switch, compact, fanless, campus]
+properties:
+  switching:
+    mac_table_size: 16000
+    vlan_count: 1023
+    jumbo_frame_bytes: 9198
+  physical:
+    form_factor: compact
+    fanless: true
+    operating_temp_c: { min: 0, max: 45 }
+    mounting: [desk, wall, rack]
+  management:
+    stackable: false
+    protocols: [snmp-v1, snmp-v2c, snmp-v3, ssh, cli, web]
+    dram_mb: 512
+    flash_mb: 256

--- a/libs/@shumoku/catalog/data/hardware/cisco/catalyst-3560cx/ws-c3560cx-12pc-s.yaml
+++ b/libs/@shumoku/catalog/data/hardware/cisco/catalyst-3560cx/ws-c3560cx-12pc-s.yaml
@@ -1,0 +1,30 @@
+# Cisco WS-C3560CX-12PC-S — 12-port PoE+ compact switch
+id: cisco/catalyst-3560cx/ws-c3560cx-12pc-s
+label: WS-C3560CX-12PC-S
+extends: cisco/catalyst-3560cx
+spec:
+  kind: hardware
+  type: l3-switch
+  vendor: cisco
+  model: ws-c3560cx-12pc-s
+tags: [poe-source]
+properties:
+  power:
+    max_draw_w: 310
+    poe_out:
+      standard: "802.3at"
+      budget_w: 240
+      max_per_port_w: 30
+      ports: 12
+  switching:
+    capacity_gbps: 28
+    forwarding_rate_mpps: 20.83
+  ports:
+    downlink:
+      - { count: 12, speed: "1g", media: copper, poe: true }
+    uplink:
+      - { count: 2, speed: "1g", media: sfp }
+      - { count: 2, speed: "1g", media: copper }
+  management:
+    layer: 2
+    image: lan-base

--- a/libs/@shumoku/catalog/data/hardware/cisco/catalyst-3560cx/ws-c3560cx-8pc-s.yaml
+++ b/libs/@shumoku/catalog/data/hardware/cisco/catalyst-3560cx/ws-c3560cx-8pc-s.yaml
@@ -1,0 +1,30 @@
+# Cisco WS-C3560CX-8PC-S — 8-port PoE+ compact switch
+id: cisco/catalyst-3560cx/ws-c3560cx-8pc-s
+label: WS-C3560CX-8PC-S
+extends: cisco/catalyst-3560cx
+spec:
+  kind: hardware
+  type: l3-switch
+  vendor: cisco
+  model: ws-c3560cx-8pc-s
+tags: [poe-source]
+properties:
+  power:
+    max_draw_w: 300
+    poe_out:
+      standard: "802.3at"
+      budget_w: 240
+      max_per_port_w: 30
+      ports: 8
+  switching:
+    capacity_gbps: 22
+    forwarding_rate_mpps: 16.07
+  ports:
+    downlink:
+      - { count: 8, speed: "1g", media: copper, poe: true }
+    uplink:
+      - { count: 2, speed: "1g", media: sfp }
+      - { count: 2, speed: "1g", media: copper }
+  management:
+    layer: 2
+    image: lan-base

--- a/libs/@shumoku/catalog/data/hardware/cisco/catalyst-3560cx/ws-c3560cx-8tc-s.yaml
+++ b/libs/@shumoku/catalog/data/hardware/cisco/catalyst-3560cx/ws-c3560cx-8tc-s.yaml
@@ -1,0 +1,25 @@
+# Cisco WS-C3560CX-8TC-S — 8-port non-PoE compact switch
+id: cisco/catalyst-3560cx/ws-c3560cx-8tc-s
+label: WS-C3560CX-8TC-S
+extends: cisco/catalyst-3560cx
+spec:
+  kind: hardware
+  type: l3-switch
+  vendor: cisco
+  model: ws-c3560cx-8tc-s
+tags: []
+properties:
+  power:
+    max_draw_w: 24
+  switching:
+    capacity_gbps: 22
+    forwarding_rate_mpps: 16.07
+  ports:
+    downlink:
+      - { count: 8, speed: "1g", media: copper }
+    uplink:
+      - { count: 2, speed: "1g", media: sfp }
+      - { count: 2, speed: "1g", media: copper }
+  management:
+    layer: 2
+    image: lan-base

--- a/libs/@shumoku/catalog/data/hardware/generic/ip-phone.yaml
+++ b/libs/@shumoku/catalog/data/hardware/generic/ip-phone.yaml
@@ -1,0 +1,16 @@
+# Generic IP Phone — PoE-powered VoIP endpoint
+id: generic/ip-phone
+label: IP Phone
+spec:
+  kind: hardware
+  type: cpe
+  vendor: generic
+  model: ip-phone
+tags: [poe-consumer, voip]
+properties:
+  power:
+    max_draw_w: 5
+    poe_in:
+      standard: "802.3af"
+      class: 1
+      max_draw_w: 5

--- a/libs/@shumoku/catalog/data/hardware/hpe/aruba-ap-505.yaml
+++ b/libs/@shumoku/catalog/data/hardware/hpe/aruba-ap-505.yaml
@@ -1,0 +1,28 @@
+# HPE Aruba AP-505 — WiFi 6 indoor access point
+# Source: https://www.arubanetworks.com/products/wireless/access-points/indoor-access-points/500-series/
+id: hpe/aruba-ap-505
+label: Aruba AP-505
+spec:
+  kind: hardware
+  type: access-point
+  vendor: hpe
+  model: aruba-ap-505
+tags: [wifi-6, indoor, ceiling-mount, poe-consumer]
+properties:
+  power:
+    max_draw_w: 11
+    poe_in:
+      standard: "802.3af"
+      class: 3
+      max_draw_w: 16.5  # with USB device attached
+  wireless:
+    standard: wifi-6
+    radios: 2
+    mimo: "2x2"
+    bands: ["2.4ghz", "5ghz"]
+    antenna_type: internal
+  physical:
+    form_factor: ceiling
+    dimensions_mm: { w: 160, d: 161, h: 37 }
+    weight_g: 500
+    mounting: [ceiling, wall]

--- a/libs/@shumoku/catalog/data/hardware/hpe/aruba-instant-on-ap11d.yaml
+++ b/libs/@shumoku/catalog/data/hardware/hpe/aruba-instant-on-ap11d.yaml
@@ -1,0 +1,38 @@
+# Aruba Instant On AP11D — WiFi 5 desk/wall AP with PoE passthrough
+# Source: https://www.arubainstanton.com/products/access-points/ap11d/
+# Note: E3 port provides PoE-out (802.3af, 15.4W) only when powered via 802.3at
+id: hpe/aruba-instant-on-ap11d
+label: Aruba Instant On AP11D
+spec:
+  kind: hardware
+  type: access-point
+  vendor: hpe
+  model: aruba-instant-on-ap11d
+tags: [wifi-5, desk, poe-consumer, poe-passthrough]
+properties:
+  power:
+    max_draw_w: 12
+    poe_in:
+      standard: "802.3af"
+      class: 3
+    poe_out:
+      standard: "802.3af"
+      budget_w: 15.4
+      max_per_port_w: 15.4
+      ports: 1  # E3 only
+  wireless:
+    standard: wifi-5
+    radios: 2
+    mimo: "2x2"
+    bands: ["2.4ghz", "5ghz"]
+    antenna_type: internal
+  ports:
+    downlink:
+      - { count: 3, speed: "1g", media: copper }
+    uplink:
+      - { count: 1, speed: "1g", media: copper }
+  physical:
+    form_factor: desktop
+    dimensions_mm: { w: 86, d: 150, h: 40 }
+    weight_g: 313
+    mounting: [desk, wall]

--- a/libs/@shumoku/catalog/data/hardware/panasonic/switch-m8egpwr-plus.yaml
+++ b/libs/@shumoku/catalog/data/hardware/panasonic/switch-m8egpwr-plus.yaml
@@ -1,0 +1,36 @@
+# Panasonic Switch-M8eGPWR+ (PN28089K) — 8-port Gigabit PoE+ managed switch
+# Source: https://panasonic.co.jp/ew/pewnw/product/lan/m8egpwr_new.html
+id: panasonic/switch-m8egpwr-plus
+label: Switch-M8eGPWR+ (PN28089K)
+spec:
+  kind: hardware
+  type: l2-switch
+  vendor: panasonic
+  model: switch-m8egpwr-plus
+tags: [poe-source, l2-switch, managed, poe-plus]
+properties:
+  power:
+    max_draw_w: 310
+    idle_draw_w: 17
+    poe_out:
+      standard: "802.3at"
+      budget_w: 240
+      max_per_port_w: 30
+      ports: 8
+  switching:
+    capacity_gbps: 20
+    forwarding_rate_mpps: 14.8
+    mac_table_size: 8000
+  ports:
+    downlink:
+      - { count: 8, speed: "1g", media: copper, poe: true }
+    uplink:
+      - { count: 2, speed: "1g", media: sfp }
+  physical:
+    form_factor: "1U"
+    dimensions_mm: { w: 330, d: 250, h: 44 }
+    weight_g: 3000
+    mounting: [rack]
+  management:
+    layer: 2
+    protocols: [snmp-v1, snmp-v2c, ssh, cli, web]

--- a/libs/@shumoku/catalog/data/hardware/panasonic/switch-m8epwr.yaml
+++ b/libs/@shumoku/catalog/data/hardware/panasonic/switch-m8epwr.yaml
@@ -1,0 +1,39 @@
+# Panasonic Switch-M8ePWR (PN27089K) — 8-port PoE managed switch
+# Source: https://panasonic.co.jp/ew/pewnw/product/lan/m8epwr_new.html
+# Note: 10/100BASE-TX downlink ports (not Gigabit)
+id: panasonic/switch-m8epwr
+label: Switch-M8ePWR (PN27089K)
+spec:
+  kind: hardware
+  type: l2-switch
+  vendor: panasonic
+  model: switch-m8epwr
+tags: [poe-source, l2-switch, managed]
+properties:
+  power:
+    max_draw_w: 161
+    idle_draw_w: 10.6
+    poe_out:
+      standard: "802.3af"
+      budget_w: 124
+      max_per_port_w: 15.4
+      ports: 8
+  switching:
+    capacity_gbps: 5.6
+    forwarding_rate_mpps: 4.1
+    mac_table_size: 16000
+    buffer_mb: 1.5
+  ports:
+    downlink:
+      - { count: 8, speed: "100m", media: copper, poe: true }
+    uplink:
+      - { count: 2, speed: "1g", media: copper }
+      - { count: 2, speed: "1g", media: sfp }
+  physical:
+    form_factor: "1U"
+    dimensions_mm: { w: 210, d: 280, h: 44 }
+    weight_g: 2300
+    mounting: [rack]
+  management:
+    layer: 2
+    protocols: [snmp-v1, snmp-v2c, ssh, cli, web]

--- a/libs/@shumoku/catalog/package.json
+++ b/libs/@shumoku/catalog/package.json
@@ -26,6 +26,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "build:data": "bun src/build-data.ts",
     "dev": "tsc --watch",
     "test": "vitest --passWithNoTests",
     "typecheck": "tsc --noEmit",

--- a/libs/@shumoku/catalog/package.json
+++ b/libs/@shumoku/catalog/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@shumoku/catalog",
+  "version": "0.1.0",
+  "description": "Device and service catalog for shumoku network diagrams",
+  "license": "AGPL-3.0-only",
+  "author": "konoe-akitoshi",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
+    "directory": "libs/@shumoku/catalog"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "data"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "format": "biome check --write ."
+  },
+  "dependencies": {
+    "@shumoku/core": "workspace:*",
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^25.0.7",
+    "typescript": "^5.6.3",
+    "vitest": "^4.0.17"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libs/@shumoku/catalog/package.json
+++ b/libs/@shumoku/catalog/package.json
@@ -25,7 +25,7 @@
     "data"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --build --force",
     "build:data": "bun src/build-data.ts",
     "dev": "tsc --watch",
     "test": "vitest --passWithNoTests",

--- a/libs/@shumoku/catalog/src/build-data.ts
+++ b/libs/@shumoku/catalog/src/build-data.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Build script: reads YAML data files and generates builtin-data.ts
+ * Run: bun src/build-data.ts
+ */
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parseCatalogYaml } from './loader.js'
+
+const dataDir = join(import.meta.dirname, '../data')
+const outFile = join(import.meta.dirname, 'builtin-data.ts')
+
+function collectYamlFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      files.push(...collectYamlFiles(full))
+    } else if (entry.endsWith('.yaml') || entry.endsWith('.yml')) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+const files = collectYamlFiles(dataDir)
+const entries = files.map((f) => parseCatalogYaml(readFileSync(f, 'utf-8')))
+
+const code = `// Auto-generated from YAML data files — do not edit manually
+// Run: bun src/build-data.ts
+
+import type { CatalogEntry } from './types.js'
+
+export const builtinData = ${JSON.stringify(entries, null, 2)} as unknown as CatalogEntry[]
+`
+
+writeFileSync(outFile, code, 'utf-8')
+console.log(`Generated ${outFile} with ${entries.length} entries`)

--- a/libs/@shumoku/catalog/src/builtin-data.ts
+++ b/libs/@shumoku/catalog/src/builtin-data.ts
@@ -1,0 +1,433 @@
+// Auto-generated from YAML data files — do not edit manually
+// Run: bun src/build-data.ts
+
+import type { CatalogEntry } from './types.js'
+
+export const builtinData = [
+  {
+    id: 'cisco/catalyst-3560cx/ws-c3560cx-12pc-s',
+    label: 'WS-C3560CX-12PC-S',
+    spec: {
+      kind: 'hardware',
+      type: 'l3-switch',
+      vendor: 'cisco',
+      model: 'ws-c3560cx-12pc-s',
+    },
+    extends: 'cisco/catalyst-3560cx',
+    tags: ['poe-source'],
+    properties: {
+      power: {
+        max_draw_w: 310,
+        poe_out: {
+          standard: '802.3at',
+          budget_w: 240,
+          max_per_port_w: 30,
+          ports: 12,
+        },
+      },
+      switching: {
+        capacity_gbps: 28,
+        forwarding_rate_mpps: 20.83,
+      },
+      ports: {
+        downlink: [
+          {
+            count: 12,
+            speed: '1g',
+            media: 'copper',
+            poe: true,
+          },
+        ],
+        uplink: [
+          {
+            count: 2,
+            speed: '1g',
+            media: 'sfp',
+          },
+          {
+            count: 2,
+            speed: '1g',
+            media: 'copper',
+          },
+        ],
+      },
+      management: {
+        layer: 2,
+        image: 'lan-base',
+      },
+    },
+  },
+  {
+    id: 'cisco/catalyst-3560cx/ws-c3560cx-8pc-s',
+    label: 'WS-C3560CX-8PC-S',
+    spec: {
+      kind: 'hardware',
+      type: 'l3-switch',
+      vendor: 'cisco',
+      model: 'ws-c3560cx-8pc-s',
+    },
+    extends: 'cisco/catalyst-3560cx',
+    tags: ['poe-source'],
+    properties: {
+      power: {
+        max_draw_w: 300,
+        poe_out: {
+          standard: '802.3at',
+          budget_w: 240,
+          max_per_port_w: 30,
+          ports: 8,
+        },
+      },
+      switching: {
+        capacity_gbps: 22,
+        forwarding_rate_mpps: 16.07,
+      },
+      ports: {
+        downlink: [
+          {
+            count: 8,
+            speed: '1g',
+            media: 'copper',
+            poe: true,
+          },
+        ],
+        uplink: [
+          {
+            count: 2,
+            speed: '1g',
+            media: 'sfp',
+          },
+          {
+            count: 2,
+            speed: '1g',
+            media: 'copper',
+          },
+        ],
+      },
+      management: {
+        layer: 2,
+        image: 'lan-base',
+      },
+    },
+  },
+  {
+    id: 'cisco/catalyst-3560cx/ws-c3560cx-8tc-s',
+    label: 'WS-C3560CX-8TC-S',
+    spec: {
+      kind: 'hardware',
+      type: 'l3-switch',
+      vendor: 'cisco',
+      model: 'ws-c3560cx-8tc-s',
+    },
+    extends: 'cisco/catalyst-3560cx',
+    tags: [],
+    properties: {
+      power: {
+        max_draw_w: 24,
+      },
+      switching: {
+        capacity_gbps: 22,
+        forwarding_rate_mpps: 16.07,
+      },
+      ports: {
+        downlink: [
+          {
+            count: 8,
+            speed: '1g',
+            media: 'copper',
+          },
+        ],
+        uplink: [
+          {
+            count: 2,
+            speed: '1g',
+            media: 'sfp',
+          },
+          {
+            count: 2,
+            speed: '1g',
+            media: 'copper',
+          },
+        ],
+      },
+      management: {
+        layer: 2,
+        image: 'lan-base',
+      },
+    },
+  },
+  {
+    id: 'cisco/catalyst-3560cx',
+    label: 'Catalyst 3560-CX Series',
+    spec: {
+      kind: 'hardware',
+      type: 'l3-switch',
+      vendor: 'cisco',
+    },
+    tags: ['l3-switch', 'compact', 'fanless', 'campus'],
+    properties: {
+      switching: {
+        mac_table_size: 16000,
+        vlan_count: 1023,
+        jumbo_frame_bytes: 9198,
+      },
+      physical: {
+        form_factor: 'compact',
+        fanless: true,
+        operating_temp_c: {
+          min: 0,
+          max: 45,
+        },
+        mounting: ['desk', 'wall', 'rack'],
+      },
+      management: {
+        stackable: false,
+        protocols: ['snmp-v1', 'snmp-v2c', 'snmp-v3', 'ssh', 'cli', 'web'],
+        dram_mb: 512,
+        flash_mb: 256,
+      },
+    },
+  },
+  {
+    id: 'generic/ip-phone',
+    label: 'IP Phone',
+    spec: {
+      kind: 'hardware',
+      type: 'cpe',
+      vendor: 'generic',
+      model: 'ip-phone',
+    },
+    tags: ['poe-consumer', 'voip'],
+    properties: {
+      power: {
+        max_draw_w: 5,
+        poe_in: {
+          standard: '802.3af',
+          class: 1,
+          max_draw_w: 5,
+        },
+      },
+    },
+  },
+  {
+    id: 'hpe/aruba-ap-505',
+    label: 'Aruba AP-505',
+    spec: {
+      kind: 'hardware',
+      type: 'access-point',
+      vendor: 'hpe',
+      model: 'aruba-ap-505',
+    },
+    tags: ['wifi-6', 'indoor', 'ceiling-mount', 'poe-consumer'],
+    properties: {
+      power: {
+        max_draw_w: 11,
+        poe_in: {
+          standard: '802.3af',
+          class: 3,
+          max_draw_w: 16.5,
+        },
+      },
+      wireless: {
+        standard: 'wifi-6',
+        radios: 2,
+        mimo: '2x2',
+        bands: ['2.4ghz', '5ghz'],
+        antenna_type: 'internal',
+      },
+      physical: {
+        form_factor: 'ceiling',
+        dimensions_mm: {
+          w: 160,
+          d: 161,
+          h: 37,
+        },
+        weight_g: 500,
+        mounting: ['ceiling', 'wall'],
+      },
+    },
+  },
+  {
+    id: 'hpe/aruba-instant-on-ap11d',
+    label: 'Aruba Instant On AP11D',
+    spec: {
+      kind: 'hardware',
+      type: 'access-point',
+      vendor: 'hpe',
+      model: 'aruba-instant-on-ap11d',
+    },
+    tags: ['wifi-5', 'desk', 'poe-consumer', 'poe-passthrough'],
+    properties: {
+      power: {
+        max_draw_w: 12,
+        poe_in: {
+          standard: '802.3af',
+          class: 3,
+        },
+        poe_out: {
+          standard: '802.3af',
+          budget_w: 15.4,
+          max_per_port_w: 15.4,
+          ports: 1,
+        },
+      },
+      wireless: {
+        standard: 'wifi-5',
+        radios: 2,
+        mimo: '2x2',
+        bands: ['2.4ghz', '5ghz'],
+        antenna_type: 'internal',
+      },
+      ports: {
+        downlink: [
+          {
+            count: 3,
+            speed: '1g',
+            media: 'copper',
+          },
+        ],
+        uplink: [
+          {
+            count: 1,
+            speed: '1g',
+            media: 'copper',
+          },
+        ],
+      },
+      physical: {
+        form_factor: 'desktop',
+        dimensions_mm: {
+          w: 86,
+          d: 150,
+          h: 40,
+        },
+        weight_g: 313,
+        mounting: ['desk', 'wall'],
+      },
+    },
+  },
+  {
+    id: 'panasonic/switch-m8egpwr-plus',
+    label: 'Switch-M8eGPWR+ (PN28089K)',
+    spec: {
+      kind: 'hardware',
+      type: 'l2-switch',
+      vendor: 'panasonic',
+      model: 'switch-m8egpwr-plus',
+    },
+    tags: ['poe-source', 'l2-switch', 'managed', 'poe-plus'],
+    properties: {
+      power: {
+        max_draw_w: 310,
+        idle_draw_w: 17,
+        poe_out: {
+          standard: '802.3at',
+          budget_w: 240,
+          max_per_port_w: 30,
+          ports: 8,
+        },
+      },
+      switching: {
+        capacity_gbps: 20,
+        forwarding_rate_mpps: 14.8,
+        mac_table_size: 8000,
+      },
+      ports: {
+        downlink: [
+          {
+            count: 8,
+            speed: '1g',
+            media: 'copper',
+            poe: true,
+          },
+        ],
+        uplink: [
+          {
+            count: 2,
+            speed: '1g',
+            media: 'sfp',
+          },
+        ],
+      },
+      physical: {
+        form_factor: '1U',
+        dimensions_mm: {
+          w: 330,
+          d: 250,
+          h: 44,
+        },
+        weight_g: 3000,
+        mounting: ['rack'],
+      },
+      management: {
+        layer: 2,
+        protocols: ['snmp-v1', 'snmp-v2c', 'ssh', 'cli', 'web'],
+      },
+    },
+  },
+  {
+    id: 'panasonic/switch-m8epwr',
+    label: 'Switch-M8ePWR (PN27089K)',
+    spec: {
+      kind: 'hardware',
+      type: 'l2-switch',
+      vendor: 'panasonic',
+      model: 'switch-m8epwr',
+    },
+    tags: ['poe-source', 'l2-switch', 'managed'],
+    properties: {
+      power: {
+        max_draw_w: 161,
+        idle_draw_w: 10.6,
+        poe_out: {
+          standard: '802.3af',
+          budget_w: 124,
+          max_per_port_w: 15.4,
+          ports: 8,
+        },
+      },
+      switching: {
+        capacity_gbps: 5.6,
+        forwarding_rate_mpps: 4.1,
+        mac_table_size: 16000,
+        buffer_mb: 1.5,
+      },
+      ports: {
+        downlink: [
+          {
+            count: 8,
+            speed: '100m',
+            media: 'copper',
+            poe: true,
+          },
+        ],
+        uplink: [
+          {
+            count: 2,
+            speed: '1g',
+            media: 'copper',
+          },
+          {
+            count: 2,
+            speed: '1g',
+            media: 'sfp',
+          },
+        ],
+      },
+      physical: {
+        form_factor: '1U',
+        dimensions_mm: {
+          w: 210,
+          d: 280,
+          h: 44,
+        },
+        weight_g: 2300,
+        mounting: ['rack'],
+      },
+      management: {
+        layer: 2,
+        protocols: ['snmp-v1', 'snmp-v2c', 'ssh', 'cli', 'web'],
+      },
+    },
+  },
+] as unknown as CatalogEntry[]

--- a/libs/@shumoku/catalog/src/builtin.ts
+++ b/libs/@shumoku/catalog/src/builtin.ts
@@ -1,0 +1,285 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Built-in catalog entries for common network devices.
+ * These serve as the initial dataset — community contributions welcome.
+ */
+
+import { DeviceType } from '@shumoku/core'
+import type { HardwareCatalogEntry } from './types.js'
+
+// ============================================
+// Cisco Catalyst 3560-CX Series
+// ============================================
+
+const catalyst3560cx: HardwareCatalogEntry = {
+  id: 'cisco/catalyst-3560cx',
+  label: 'Catalyst 3560-CX Series',
+  spec: { kind: 'hardware', type: DeviceType.L3Switch, vendor: 'cisco' },
+  tags: ['l3-switch', 'compact', 'fanless', 'campus'],
+  properties: {
+    switching: {
+      mac_table_size: 16000,
+      vlan_count: 1023,
+      jumbo_frame_bytes: 9198,
+    },
+    physical: {
+      form_factor: 'compact',
+      fanless: true,
+      operating_temp_c: { min: 0, max: 45 },
+      mounting: ['desk', 'wall', 'rack'],
+    },
+    management: {
+      stackable: false,
+      protocols: ['snmp-v1', 'snmp-v2c', 'snmp-v3', 'ssh', 'cli', 'web'],
+      dram_mb: 512,
+      flash_mb: 256,
+    },
+  },
+}
+
+const c3560cx8tcS: HardwareCatalogEntry = {
+  id: 'cisco/catalyst-3560cx/ws-c3560cx-8tc-s',
+  label: 'WS-C3560CX-8TC-S',
+  extends: 'cisco/catalyst-3560cx',
+  spec: { kind: 'hardware', type: DeviceType.L3Switch, vendor: 'cisco', model: 'ws-c3560cx-8tc-s' },
+  tags: [],
+  properties: {
+    power: { max_draw_w: 24 },
+    switching: { capacity_gbps: 22, forwarding_rate_mpps: 16.07 },
+    ports: {
+      downlink: [{ count: 8, speed: '1g', media: 'copper' }],
+      uplink: [
+        { count: 2, speed: '1g', media: 'sfp' },
+        { count: 2, speed: '1g', media: 'copper' },
+      ],
+    },
+    management: { layer: 2, image: 'lan-base' },
+  },
+}
+
+const c3560cx8pcS: HardwareCatalogEntry = {
+  id: 'cisco/catalyst-3560cx/ws-c3560cx-8pc-s',
+  label: 'WS-C3560CX-8PC-S',
+  extends: 'cisco/catalyst-3560cx',
+  spec: { kind: 'hardware', type: DeviceType.L3Switch, vendor: 'cisco', model: 'ws-c3560cx-8pc-s' },
+  tags: ['poe-source'],
+  properties: {
+    power: {
+      max_draw_w: 300,
+      poe_out: { standard: '802.3at', budget_w: 240, max_per_port_w: 30, ports: 8 },
+    },
+    switching: { capacity_gbps: 22, forwarding_rate_mpps: 16.07 },
+    ports: {
+      downlink: [{ count: 8, speed: '1g', media: 'copper', poe: true }],
+      uplink: [
+        { count: 2, speed: '1g', media: 'sfp' },
+        { count: 2, speed: '1g', media: 'copper' },
+      ],
+    },
+    management: { layer: 2, image: 'lan-base' },
+  },
+}
+
+const c3560cx12pcS: HardwareCatalogEntry = {
+  id: 'cisco/catalyst-3560cx/ws-c3560cx-12pc-s',
+  label: 'WS-C3560CX-12PC-S',
+  extends: 'cisco/catalyst-3560cx',
+  spec: {
+    kind: 'hardware',
+    type: DeviceType.L3Switch,
+    vendor: 'cisco',
+    model: 'ws-c3560cx-12pc-s',
+  },
+  tags: ['poe-source'],
+  properties: {
+    power: {
+      max_draw_w: 310,
+      poe_out: { standard: '802.3at', budget_w: 240, max_per_port_w: 30, ports: 12 },
+    },
+    switching: { capacity_gbps: 28, forwarding_rate_mpps: 20.83 },
+    ports: {
+      downlink: [{ count: 12, speed: '1g', media: 'copper', poe: true }],
+      uplink: [
+        { count: 2, speed: '1g', media: 'sfp' },
+        { count: 2, speed: '1g', media: 'copper' },
+      ],
+    },
+    management: { layer: 2, image: 'lan-base' },
+  },
+}
+
+// ============================================
+// HPE Aruba AP-505
+// ============================================
+
+const arubaAp505: HardwareCatalogEntry = {
+  id: 'hpe/aruba-ap-505',
+  label: 'Aruba AP-505',
+  spec: { kind: 'hardware', type: DeviceType.AccessPoint, vendor: 'hpe', model: 'aruba-ap-505' },
+  tags: ['wifi-6', 'indoor', 'ceiling-mount', 'poe-consumer'],
+  properties: {
+    power: {
+      max_draw_w: 11,
+      poe_in: { standard: '802.3af', class: 3, max_draw_w: 16.5 },
+    },
+    wireless: {
+      standard: 'wifi-6',
+      radios: 2,
+      mimo: '2x2',
+      bands: ['2.4ghz', '5ghz'],
+      antenna_type: 'internal',
+    },
+    physical: {
+      form_factor: 'ceiling',
+      dimensions_mm: { w: 160, d: 161, h: 37 },
+      weight_g: 500,
+      mounting: ['ceiling', 'wall'],
+    },
+  },
+}
+
+// ============================================
+// Aruba Instant On AP11D
+// ============================================
+
+const arubaInstantOnAp11d: HardwareCatalogEntry = {
+  id: 'hpe/aruba-instant-on-ap11d',
+  label: 'Aruba Instant On AP11D',
+  spec: {
+    kind: 'hardware',
+    type: DeviceType.AccessPoint,
+    vendor: 'hpe',
+    model: 'aruba-instant-on-ap11d',
+  },
+  tags: ['wifi-5', 'desk', 'poe-consumer', 'poe-passthrough'],
+  properties: {
+    power: {
+      max_draw_w: 12,
+      poe_in: { standard: '802.3af', class: 3 },
+      poe_out: { standard: '802.3af', budget_w: 15.4, max_per_port_w: 15.4, ports: 1 },
+    },
+    wireless: {
+      standard: 'wifi-5',
+      radios: 2,
+      mimo: '2x2',
+      bands: ['2.4ghz', '5ghz'],
+      antenna_type: 'internal',
+    },
+    ports: {
+      downlink: [{ count: 3, speed: '1g', media: 'copper' }],
+      uplink: [{ count: 1, speed: '1g', media: 'copper' }],
+    },
+    physical: {
+      form_factor: 'desktop',
+      dimensions_mm: { w: 86, d: 150, h: 40 },
+      weight_g: 313,
+      mounting: ['desk', 'wall'],
+    },
+  },
+}
+
+// ============================================
+// Panasonic Switch-M8ePWR (PN27089K)
+// ============================================
+
+const switchM8ePwr: HardwareCatalogEntry = {
+  id: 'panasonic/switch-m8epwr',
+  label: 'Switch-M8ePWR (PN27089K)',
+  spec: {
+    kind: 'hardware',
+    type: DeviceType.L2Switch,
+    vendor: 'panasonic',
+    model: 'switch-m8epwr',
+  },
+  tags: ['poe-source', 'l2-switch', 'managed'],
+  properties: {
+    power: {
+      max_draw_w: 161,
+      idle_draw_w: 10.6,
+      poe_out: { standard: '802.3af', budget_w: 124, max_per_port_w: 15.4, ports: 8 },
+    },
+    switching: {
+      capacity_gbps: 5.6,
+      forwarding_rate_mpps: 4.1,
+      mac_table_size: 16000,
+      buffer_mb: 1.5,
+    },
+    ports: {
+      downlink: [{ count: 8, speed: '100m', media: 'copper', poe: true }],
+      uplink: [
+        { count: 2, speed: '1g', media: 'copper' },
+        { count: 2, speed: '1g', media: 'sfp' },
+      ],
+    },
+    physical: {
+      form_factor: '1U',
+      dimensions_mm: { w: 210, d: 280, h: 44 },
+      weight_g: 2300,
+      mounting: ['rack'],
+    },
+    management: {
+      layer: 2,
+      protocols: ['snmp-v1', 'snmp-v2c', 'ssh', 'cli', 'web'],
+    },
+  },
+}
+
+// ============================================
+// Panasonic Switch-M8eGPWR+ (PN28089K)
+// ============================================
+
+const switchM8eGpwrPlus: HardwareCatalogEntry = {
+  id: 'panasonic/switch-m8egpwr-plus',
+  label: 'Switch-M8eGPWR+ (PN28089K)',
+  spec: {
+    kind: 'hardware',
+    type: DeviceType.L2Switch,
+    vendor: 'panasonic',
+    model: 'switch-m8egpwr-plus',
+  },
+  tags: ['poe-source', 'l2-switch', 'managed', 'poe-plus'],
+  properties: {
+    power: {
+      max_draw_w: 310,
+      idle_draw_w: 17,
+      poe_out: { standard: '802.3at', budget_w: 240, max_per_port_w: 30, ports: 8 },
+    },
+    switching: {
+      capacity_gbps: 20,
+      forwarding_rate_mpps: 14.8,
+      mac_table_size: 8000,
+    },
+    ports: {
+      downlink: [{ count: 8, speed: '1g', media: 'copper', poe: true }],
+      uplink: [{ count: 2, speed: '1g', media: 'sfp' }],
+    },
+    physical: {
+      form_factor: '1U',
+      dimensions_mm: { w: 330, d: 250, h: 44 },
+      weight_g: 3000,
+      mounting: ['rack'],
+    },
+    management: {
+      layer: 2,
+      protocols: ['snmp-v1', 'snmp-v2c', 'ssh', 'cli', 'web'],
+    },
+  },
+}
+
+// ============================================
+// Export all built-in entries
+// ============================================
+
+export const builtinEntries: HardwareCatalogEntry[] = [
+  catalyst3560cx,
+  c3560cx8tcS,
+  c3560cx8pcS,
+  c3560cx12pcS,
+  arubaAp505,
+  arubaInstantOnAp11d,
+  switchM8ePwr,
+  switchM8eGpwrPlus,
+]

--- a/libs/@shumoku/catalog/src/builtin.ts
+++ b/libs/@shumoku/catalog/src/builtin.ts
@@ -3,283 +3,39 @@
 // For commercial licensing, contact: contact@shumoku.dev
 
 /**
- * Built-in catalog entries for common network devices.
+ * Built-in catalog entries loaded from YAML data files.
  * These serve as the initial dataset — community contributions welcome.
  */
 
-import { DeviceType } from '@shumoku/core'
-import type { HardwareCatalogEntry } from './types.js'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parseCatalogYaml } from './loader.js'
+import type { CatalogEntry } from './types.js'
 
-// ============================================
-// Cisco Catalyst 3560-CX Series
-// ============================================
+const dataDir = join(fileURLToPath(import.meta.url), '../../data')
 
-const catalyst3560cx: HardwareCatalogEntry = {
-  id: 'cisco/catalyst-3560cx',
-  label: 'Catalyst 3560-CX Series',
-  spec: { kind: 'hardware', type: DeviceType.L3Switch, vendor: 'cisco' },
-  tags: ['l3-switch', 'compact', 'fanless', 'campus'],
-  properties: {
-    switching: {
-      mac_table_size: 16000,
-      vlan_count: 1023,
-      jumbo_frame_bytes: 9198,
-    },
-    physical: {
-      form_factor: 'compact',
-      fanless: true,
-      operating_temp_c: { min: 0, max: 45 },
-      mounting: ['desk', 'wall', 'rack'],
-    },
-    management: {
-      stackable: false,
-      protocols: ['snmp-v1', 'snmp-v2c', 'snmp-v3', 'ssh', 'cli', 'web'],
-      dram_mb: 512,
-      flash_mb: 256,
-    },
-  },
+function collectYamlFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      files.push(...collectYamlFiles(full))
+    } else if (entry.endsWith('.yaml') || entry.endsWith('.yml')) {
+      files.push(full)
+    }
+  }
+  return files
 }
 
-const c3560cx8tcS: HardwareCatalogEntry = {
-  id: 'cisco/catalyst-3560cx/ws-c3560cx-8tc-s',
-  label: 'WS-C3560CX-8TC-S',
-  extends: 'cisco/catalyst-3560cx',
-  spec: { kind: 'hardware', type: DeviceType.L3Switch, vendor: 'cisco', model: 'ws-c3560cx-8tc-s' },
-  tags: [],
-  properties: {
-    power: { max_draw_w: 24 },
-    switching: { capacity_gbps: 22, forwarding_rate_mpps: 16.07 },
-    ports: {
-      downlink: [{ count: 8, speed: '1g', media: 'copper' }],
-      uplink: [
-        { count: 2, speed: '1g', media: 'sfp' },
-        { count: 2, speed: '1g', media: 'copper' },
-      ],
-    },
-    management: { layer: 2, image: 'lan-base' },
-  },
+function loadBuiltinEntries(): CatalogEntry[] {
+  const files = collectYamlFiles(dataDir)
+  const entries: CatalogEntry[] = []
+  for (const file of files) {
+    const content = readFileSync(file, 'utf-8')
+    entries.push(parseCatalogYaml(content))
+  }
+  return entries
 }
 
-const c3560cx8pcS: HardwareCatalogEntry = {
-  id: 'cisco/catalyst-3560cx/ws-c3560cx-8pc-s',
-  label: 'WS-C3560CX-8PC-S',
-  extends: 'cisco/catalyst-3560cx',
-  spec: { kind: 'hardware', type: DeviceType.L3Switch, vendor: 'cisco', model: 'ws-c3560cx-8pc-s' },
-  tags: ['poe-source'],
-  properties: {
-    power: {
-      max_draw_w: 300,
-      poe_out: { standard: '802.3at', budget_w: 240, max_per_port_w: 30, ports: 8 },
-    },
-    switching: { capacity_gbps: 22, forwarding_rate_mpps: 16.07 },
-    ports: {
-      downlink: [{ count: 8, speed: '1g', media: 'copper', poe: true }],
-      uplink: [
-        { count: 2, speed: '1g', media: 'sfp' },
-        { count: 2, speed: '1g', media: 'copper' },
-      ],
-    },
-    management: { layer: 2, image: 'lan-base' },
-  },
-}
-
-const c3560cx12pcS: HardwareCatalogEntry = {
-  id: 'cisco/catalyst-3560cx/ws-c3560cx-12pc-s',
-  label: 'WS-C3560CX-12PC-S',
-  extends: 'cisco/catalyst-3560cx',
-  spec: {
-    kind: 'hardware',
-    type: DeviceType.L3Switch,
-    vendor: 'cisco',
-    model: 'ws-c3560cx-12pc-s',
-  },
-  tags: ['poe-source'],
-  properties: {
-    power: {
-      max_draw_w: 310,
-      poe_out: { standard: '802.3at', budget_w: 240, max_per_port_w: 30, ports: 12 },
-    },
-    switching: { capacity_gbps: 28, forwarding_rate_mpps: 20.83 },
-    ports: {
-      downlink: [{ count: 12, speed: '1g', media: 'copper', poe: true }],
-      uplink: [
-        { count: 2, speed: '1g', media: 'sfp' },
-        { count: 2, speed: '1g', media: 'copper' },
-      ],
-    },
-    management: { layer: 2, image: 'lan-base' },
-  },
-}
-
-// ============================================
-// HPE Aruba AP-505
-// ============================================
-
-const arubaAp505: HardwareCatalogEntry = {
-  id: 'hpe/aruba-ap-505',
-  label: 'Aruba AP-505',
-  spec: { kind: 'hardware', type: DeviceType.AccessPoint, vendor: 'hpe', model: 'aruba-ap-505' },
-  tags: ['wifi-6', 'indoor', 'ceiling-mount', 'poe-consumer'],
-  properties: {
-    power: {
-      max_draw_w: 11,
-      poe_in: { standard: '802.3af', class: 3, max_draw_w: 16.5 },
-    },
-    wireless: {
-      standard: 'wifi-6',
-      radios: 2,
-      mimo: '2x2',
-      bands: ['2.4ghz', '5ghz'],
-      antenna_type: 'internal',
-    },
-    physical: {
-      form_factor: 'ceiling',
-      dimensions_mm: { w: 160, d: 161, h: 37 },
-      weight_g: 500,
-      mounting: ['ceiling', 'wall'],
-    },
-  },
-}
-
-// ============================================
-// Aruba Instant On AP11D
-// ============================================
-
-const arubaInstantOnAp11d: HardwareCatalogEntry = {
-  id: 'hpe/aruba-instant-on-ap11d',
-  label: 'Aruba Instant On AP11D',
-  spec: {
-    kind: 'hardware',
-    type: DeviceType.AccessPoint,
-    vendor: 'hpe',
-    model: 'aruba-instant-on-ap11d',
-  },
-  tags: ['wifi-5', 'desk', 'poe-consumer', 'poe-passthrough'],
-  properties: {
-    power: {
-      max_draw_w: 12,
-      poe_in: { standard: '802.3af', class: 3 },
-      poe_out: { standard: '802.3af', budget_w: 15.4, max_per_port_w: 15.4, ports: 1 },
-    },
-    wireless: {
-      standard: 'wifi-5',
-      radios: 2,
-      mimo: '2x2',
-      bands: ['2.4ghz', '5ghz'],
-      antenna_type: 'internal',
-    },
-    ports: {
-      downlink: [{ count: 3, speed: '1g', media: 'copper' }],
-      uplink: [{ count: 1, speed: '1g', media: 'copper' }],
-    },
-    physical: {
-      form_factor: 'desktop',
-      dimensions_mm: { w: 86, d: 150, h: 40 },
-      weight_g: 313,
-      mounting: ['desk', 'wall'],
-    },
-  },
-}
-
-// ============================================
-// Panasonic Switch-M8ePWR (PN27089K)
-// ============================================
-
-const switchM8ePwr: HardwareCatalogEntry = {
-  id: 'panasonic/switch-m8epwr',
-  label: 'Switch-M8ePWR (PN27089K)',
-  spec: {
-    kind: 'hardware',
-    type: DeviceType.L2Switch,
-    vendor: 'panasonic',
-    model: 'switch-m8epwr',
-  },
-  tags: ['poe-source', 'l2-switch', 'managed'],
-  properties: {
-    power: {
-      max_draw_w: 161,
-      idle_draw_w: 10.6,
-      poe_out: { standard: '802.3af', budget_w: 124, max_per_port_w: 15.4, ports: 8 },
-    },
-    switching: {
-      capacity_gbps: 5.6,
-      forwarding_rate_mpps: 4.1,
-      mac_table_size: 16000,
-      buffer_mb: 1.5,
-    },
-    ports: {
-      downlink: [{ count: 8, speed: '100m', media: 'copper', poe: true }],
-      uplink: [
-        { count: 2, speed: '1g', media: 'copper' },
-        { count: 2, speed: '1g', media: 'sfp' },
-      ],
-    },
-    physical: {
-      form_factor: '1U',
-      dimensions_mm: { w: 210, d: 280, h: 44 },
-      weight_g: 2300,
-      mounting: ['rack'],
-    },
-    management: {
-      layer: 2,
-      protocols: ['snmp-v1', 'snmp-v2c', 'ssh', 'cli', 'web'],
-    },
-  },
-}
-
-// ============================================
-// Panasonic Switch-M8eGPWR+ (PN28089K)
-// ============================================
-
-const switchM8eGpwrPlus: HardwareCatalogEntry = {
-  id: 'panasonic/switch-m8egpwr-plus',
-  label: 'Switch-M8eGPWR+ (PN28089K)',
-  spec: {
-    kind: 'hardware',
-    type: DeviceType.L2Switch,
-    vendor: 'panasonic',
-    model: 'switch-m8egpwr-plus',
-  },
-  tags: ['poe-source', 'l2-switch', 'managed', 'poe-plus'],
-  properties: {
-    power: {
-      max_draw_w: 310,
-      idle_draw_w: 17,
-      poe_out: { standard: '802.3at', budget_w: 240, max_per_port_w: 30, ports: 8 },
-    },
-    switching: {
-      capacity_gbps: 20,
-      forwarding_rate_mpps: 14.8,
-      mac_table_size: 8000,
-    },
-    ports: {
-      downlink: [{ count: 8, speed: '1g', media: 'copper', poe: true }],
-      uplink: [{ count: 2, speed: '1g', media: 'sfp' }],
-    },
-    physical: {
-      form_factor: '1U',
-      dimensions_mm: { w: 330, d: 250, h: 44 },
-      weight_g: 3000,
-      mounting: ['rack'],
-    },
-    management: {
-      layer: 2,
-      protocols: ['snmp-v1', 'snmp-v2c', 'ssh', 'cli', 'web'],
-    },
-  },
-}
-
-// ============================================
-// Export all built-in entries
-// ============================================
-
-export const builtinEntries: HardwareCatalogEntry[] = [
-  catalyst3560cx,
-  c3560cx8tcS,
-  c3560cx8pcS,
-  c3560cx12pcS,
-  arubaAp505,
-  arubaInstantOnAp11d,
-  switchM8ePwr,
-  switchM8eGpwrPlus,
-]
+export const builtinEntries: CatalogEntry[] = loadBuiltinEntries()

--- a/libs/@shumoku/catalog/src/builtin.ts
+++ b/libs/@shumoku/catalog/src/builtin.ts
@@ -3,39 +3,8 @@
 // For commercial licensing, contact: contact@shumoku.dev
 
 /**
- * Built-in catalog entries loaded from YAML data files.
- * These serve as the initial dataset — community contributions welcome.
+ * Built-in catalog entries — re-exports auto-generated data from YAML files.
+ * To regenerate: bun src/build-data.ts
  */
 
-import { readdirSync, readFileSync, statSync } from 'node:fs'
-import { join } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { parseCatalogYaml } from './loader.js'
-import type { CatalogEntry } from './types.js'
-
-const dataDir = join(fileURLToPath(import.meta.url), '../../data')
-
-function collectYamlFiles(dir: string): string[] {
-  const files: string[] = []
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry)
-    if (statSync(full).isDirectory()) {
-      files.push(...collectYamlFiles(full))
-    } else if (entry.endsWith('.yaml') || entry.endsWith('.yml')) {
-      files.push(full)
-    }
-  }
-  return files
-}
-
-function loadBuiltinEntries(): CatalogEntry[] {
-  const files = collectYamlFiles(dataDir)
-  const entries: CatalogEntry[] = []
-  for (const file of files) {
-    const content = readFileSync(file, 'utf-8')
-    entries.push(parseCatalogYaml(content))
-  }
-  return entries
-}
-
-export const builtinEntries: CatalogEntry[] = loadBuiltinEntries()
+export { builtinData as builtinEntries } from './builtin-data.js'

--- a/libs/@shumoku/catalog/src/catalog.ts
+++ b/libs/@shumoku/catalog/src/catalog.ts
@@ -1,0 +1,136 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import type { NodeSpec } from '@shumoku/core'
+import type { CatalogEntry } from './types.js'
+
+/**
+ * Device and service catalog.
+ *
+ * Supports:
+ * - Registration and lookup by ID
+ * - Property inheritance via `extends`
+ * - Search by query string, kind, vendor, or tag
+ */
+export class Catalog {
+  private entries = new Map<string, CatalogEntry>()
+
+  /** Register a catalog entry. */
+  register(entry: CatalogEntry): void {
+    this.entries.set(entry.id, entry)
+  }
+
+  /** Register multiple entries at once. */
+  registerAll(entries: CatalogEntry[]): void {
+    for (const entry of entries) {
+      this.register(entry)
+    }
+  }
+
+  /** Look up an entry by ID, resolving `extends` inheritance. */
+  lookup(id: string): CatalogEntry | undefined {
+    const entry = this.entries.get(id)
+    if (!entry) return undefined
+    if (!entry.extends) return entry
+    return this.resolve(entry)
+  }
+
+  /** Get raw entry without inheritance resolution. */
+  getRaw(id: string): CatalogEntry | undefined {
+    return this.entries.get(id)
+  }
+
+  /** List all entries. */
+  list(): CatalogEntry[] {
+    return [...this.entries.values()]
+  }
+
+  /** Filter entries by kind. */
+  listByKind(kind: NodeSpec['kind']): CatalogEntry[] {
+    return this.list().filter((e) => e.spec.kind === kind)
+  }
+
+  /** Filter entries by vendor. */
+  listByVendor(vendor: string): CatalogEntry[] {
+    const v = vendor.toLowerCase()
+    return this.list().filter((e) => e.spec.vendor?.toLowerCase() === v)
+  }
+
+  /** Filter entries that have a specific tag. */
+  listByTag(tag: string): CatalogEntry[] {
+    const t = tag.toLowerCase()
+    return this.list().filter((e) => e.tags.some((et) => et.toLowerCase() === t))
+  }
+
+  /** Search entries by query string (matches id, label, tags, vendor). */
+  search(query: string): CatalogEntry[] {
+    const q = query.toLowerCase()
+    return this.list().filter(
+      (e) =>
+        e.id.toLowerCase().includes(q) ||
+        e.label.toLowerCase().includes(q) ||
+        e.tags.some((t) => t.toLowerCase().includes(q)) ||
+        (e.spec.vendor?.toLowerCase().includes(q) ?? false),
+    )
+  }
+
+  /** Number of registered entries. */
+  get size(): number {
+    return this.entries.size
+  }
+
+  /**
+   * Resolve an entry by merging parent properties via `extends` chain.
+   * Protects against circular references.
+   */
+  private resolve(entry: CatalogEntry): CatalogEntry {
+    const chain: CatalogEntry[] = [entry]
+    const visited = new Set<string>([entry.id])
+
+    let current = entry
+    while (current.extends) {
+      if (visited.has(current.extends)) break // circular guard
+      const parent = this.entries.get(current.extends)
+      if (!parent) break
+      visited.add(current.extends)
+      chain.push(parent)
+      current = parent
+    }
+
+    // Merge from root to leaf (parent first, child overrides)
+    chain.reverse()
+    let merged = chain[0] as CatalogEntry
+    for (const item of chain.slice(1)) {
+      merged = mergeEntries(merged, item)
+    }
+    return merged
+  }
+}
+
+/** Deep merge two catalog entries (parent + child). Child wins on conflict. */
+function mergeEntries(parent: CatalogEntry, child: CatalogEntry): CatalogEntry {
+  return {
+    id: child.id,
+    label: child.label,
+    spec: child.spec.kind === parent.spec.kind ? { ...parent.spec, ...child.spec } : child.spec,
+    extends: child.extends,
+    tags: [...new Set([...parent.tags, ...child.tags])],
+    properties: deepMerge(parent.properties, child.properties),
+  }
+}
+
+/** Recursive shallow merge for plain objects. Arrays are replaced, not merged. */
+// biome-ignore lint/suspicious/noExplicitAny: recursive merge over unknown shapes
+function deepMerge(a: any, b: any): any {
+  if (b === undefined || b === null) return a
+  if (a === undefined || a === null) return b
+  if (typeof a !== 'object' || typeof b !== 'object') return b
+  if (Array.isArray(a) || Array.isArray(b)) return b
+
+  const result = { ...a }
+  for (const key of Object.keys(b)) {
+    result[key] = deepMerge(a[key], b[key])
+  }
+  return result
+}

--- a/libs/@shumoku/catalog/src/catalog.ts
+++ b/libs/@shumoku/catalog/src/catalog.ts
@@ -15,10 +15,20 @@ import type { CatalogEntry } from './types.js'
  */
 export class Catalog {
   private entries = new Map<string, CatalogEntry>()
+  /** Reverse index: "vendor/model" → entry ID (for shorthand lookup) */
+  private byVendorModel = new Map<string, string>()
 
   /** Register a catalog entry. */
   register(entry: CatalogEntry): void {
     this.entries.set(entry.id, entry)
+    // Build reverse index from vendor+model for shorthand lookup
+    const spec = entry.spec
+    if (spec.kind === 'hardware' || spec.kind === 'compute') {
+      const model = 'model' in spec ? spec.model : 'platform' in spec ? spec.platform : undefined
+      if (spec.vendor && model) {
+        this.byVendorModel.set(`${spec.vendor}/${model}`, entry.id)
+      }
+    }
   }
 
   /** Register multiple entries at once. */
@@ -28,9 +38,14 @@ export class Catalog {
     }
   }
 
-  /** Look up an entry by ID, resolving `extends` inheritance. */
+  /** Look up by ID or vendor/model shorthand, resolving `extends` inheritance. */
   lookup(id: string): CatalogEntry | undefined {
-    const entry = this.entries.get(id)
+    let entry = this.entries.get(id)
+    // Fallback: try vendor/model reverse index (handles 3-level IDs like cisco/catalyst-3560cx/ws-...)
+    if (!entry) {
+      const fullId = this.byVendorModel.get(id)
+      if (fullId) entry = this.entries.get(fullId)
+    }
     if (!entry) return undefined
     if (!entry.extends) return entry
     return this.resolve(entry)

--- a/libs/@shumoku/catalog/src/index.ts
+++ b/libs/@shumoku/catalog/src/index.ts
@@ -4,6 +4,7 @@
 
 export { builtinEntries } from './builtin.js'
 export { Catalog } from './catalog.js'
+export { parseCatalogYaml, parseCatalogYamlMulti } from './loader.js'
 export type {
   CatalogEntry,
   ComputeCatalogEntry,

--- a/libs/@shumoku/catalog/src/index.ts
+++ b/libs/@shumoku/catalog/src/index.ts
@@ -1,0 +1,25 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+export { builtinEntries } from './builtin.js'
+export { Catalog } from './catalog.js'
+export type {
+  CatalogEntry,
+  ComputeCatalogEntry,
+  ComputeProperties,
+  HardwareCatalogEntry,
+  HardwareProperties,
+  ManagementProperties,
+  PhysicalProperties,
+  PoEIn,
+  PoEOut,
+  PortGroup,
+  PortProperties,
+  PowerProperties,
+  PropertiesFor,
+  ServiceCatalogEntry,
+  ServiceProperties,
+  SwitchingProperties,
+  WirelessProperties,
+} from './types.js'

--- a/libs/@shumoku/catalog/src/loader.ts
+++ b/libs/@shumoku/catalog/src/loader.ts
@@ -1,0 +1,51 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * YAML catalog loader — reads .yaml files from a directory tree
+ * and converts them into CatalogEntry objects.
+ */
+
+import yaml from 'js-yaml'
+import type { CatalogEntry } from './types.js'
+
+/**
+ * Parse a single YAML string into a CatalogEntry.
+ * Performs minimal validation (id and spec.kind are required).
+ */
+export function parseCatalogYaml(content: string): CatalogEntry {
+  // biome-ignore lint/suspicious/noExplicitAny: YAML parse returns unknown shape
+  const raw = yaml.load(content) as any
+  if (!raw?.id) throw new Error('Catalog entry missing "id"')
+  if (!raw?.spec?.kind) throw new Error(`Catalog entry "${raw.id}" missing "spec.kind"`)
+
+  return {
+    id: raw.id,
+    label: raw.label ?? raw.id,
+    spec: raw.spec,
+    extends: raw.extends,
+    tags: raw.tags ?? [],
+    properties: raw.properties ?? {},
+  }
+}
+
+/**
+ * Parse multiple YAML documents (separated by ---) from a single string.
+ */
+export function parseCatalogYamlMulti(content: string): CatalogEntry[] {
+  // biome-ignore lint/suspicious/noExplicitAny: YAML parse returns unknown shape
+  const docs = yaml.loadAll(content) as any[]
+  return docs.filter(Boolean).map((raw) => {
+    if (!raw?.id) throw new Error('Catalog entry missing "id"')
+    if (!raw?.spec?.kind) throw new Error(`Catalog entry "${raw.id}" missing "spec.kind"`)
+    return {
+      id: raw.id,
+      label: raw.label ?? raw.id,
+      spec: raw.spec,
+      extends: raw.extends,
+      tags: raw.tags ?? [],
+      properties: raw.properties ?? {},
+    }
+  })
+}

--- a/libs/@shumoku/catalog/src/types.ts
+++ b/libs/@shumoku/catalog/src/types.ts
@@ -1,0 +1,198 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import type { NodeSpec } from '@shumoku/core'
+
+// ============================================
+// Properties — grouped by concern
+// ============================================
+
+/** PoE consumer (Powered Device) */
+export interface PoEIn {
+  /** PoE standard: "802.3af", "802.3at", "802.3bt" */
+  standard?: string
+  /** PoE class (0–8) */
+  class?: number
+  /** Max power draw via PoE (watts) */
+  max_draw_w?: number
+}
+
+/** PoE source (Power Sourcing Equipment) */
+export interface PoEOut {
+  /** PoE standard */
+  standard?: string
+  /** Total PoE power budget (watts) */
+  budget_w?: number
+  /** Max PoE per port (watts) */
+  max_per_port_w?: number
+  /** Number of PoE-capable ports */
+  ports?: number
+}
+
+export interface PowerProperties {
+  /** Maximum device power consumption (watts, including PoE delivery) */
+  max_draw_w?: number
+  /** Idle power consumption (watts) */
+  idle_draw_w?: number
+  /** PoE consumer capabilities */
+  poe_in?: PoEIn
+  /** PoE source capabilities */
+  poe_out?: PoEOut
+}
+
+export interface PortGroup {
+  count: number
+  /** Port speed: "100m", "1g", "2.5g", "5g", "10g", "25g", "40g", "100g" */
+  speed: string
+  /** Media type: "copper", "sfp", "sfp+", "qsfp+", "qsfp28" */
+  media: string
+  /** Whether these ports support PoE */
+  poe?: boolean
+}
+
+export interface PortProperties {
+  downlink?: PortGroup[]
+  uplink?: PortGroup[]
+}
+
+export interface SwitchingProperties {
+  /** Switching capacity (Gbps) */
+  capacity_gbps?: number
+  /** Forwarding rate (Mpps) */
+  forwarding_rate_mpps?: number
+  /** MAC address table size */
+  mac_table_size?: number
+  /** Number of VLANs supported */
+  vlan_count?: number
+  /** Maximum jumbo frame size (bytes) */
+  jumbo_frame_bytes?: number
+  /** Packet buffer memory (MB) */
+  buffer_mb?: number
+}
+
+export interface WirelessProperties {
+  /** WiFi standard: "wifi-4", "wifi-5", "wifi-6", "wifi-6e", "wifi-7" */
+  standard?: string
+  /** Number of radios */
+  radios?: number
+  /** MIMO configuration: "2x2", "4x4", "8x8" */
+  mimo?: string
+  /** Supported frequency bands */
+  bands?: string[]
+  /** Maximum concurrent clients */
+  max_clients?: number
+  /** Antenna type: "internal", "external" */
+  antenna_type?: string
+  /** Maximum data rate (Mbps) */
+  max_data_rate_mbps?: number
+}
+
+export interface PhysicalProperties {
+  /** Form factor: "desktop", "1U", "2U", "wall-mount", "ceiling", "compact" */
+  form_factor?: string
+  /** Dimensions in mm */
+  dimensions_mm?: { w: number; d: number; h: number }
+  /** Weight in grams */
+  weight_g?: number
+  /** Fanless operation */
+  fanless?: boolean
+  /** Operating temperature range (Celsius) */
+  operating_temp_c?: { min: number; max: number }
+  /** Supported mounting options */
+  mounting?: string[]
+  /** IP rating (e.g., "IP41") */
+  ip_rating?: string
+}
+
+export interface ManagementProperties {
+  /** Network layer: 2 or 3 */
+  layer?: number
+  /** Stacking support */
+  stackable?: boolean
+  /** Maximum stack members */
+  stack_members_max?: number
+  /** Management protocols */
+  protocols?: string[]
+  /** Software image / license tier */
+  image?: string
+  /** DRAM (MB) */
+  dram_mb?: number
+  /** Flash storage (MB) */
+  flash_mb?: number
+}
+
+// ============================================
+// Hardware Properties (aggregate)
+// ============================================
+
+export interface HardwareProperties {
+  power?: PowerProperties
+  ports?: PortProperties
+  switching?: SwitchingProperties
+  wireless?: WirelessProperties
+  physical?: PhysicalProperties
+  management?: ManagementProperties
+}
+
+// ============================================
+// Compute Properties
+// ============================================
+
+export interface ComputeProperties {
+  vcpu?: number
+  memory_gb?: number
+  storage_gb?: number
+  network_gbps?: number
+  os?: string
+  hypervisor?: string
+}
+
+// ============================================
+// Service Properties
+// ============================================
+
+export interface ServiceProperties {
+  pricing_model?: string
+  region?: string
+  max_memory_mb?: number
+  max_timeout_s?: number
+}
+
+// ============================================
+// Kind → Properties type mapping
+// ============================================
+
+export type PropertiesFor<K extends NodeSpec['kind']> = K extends 'hardware'
+  ? HardwareProperties
+  : K extends 'compute'
+    ? ComputeProperties
+    : K extends 'service'
+      ? ServiceProperties
+      : never
+
+// ============================================
+// Catalog Entry
+// ============================================
+
+export interface CatalogEntry<K extends NodeSpec['kind'] = NodeSpec['kind']> {
+  /** Unique ID: "vendor/series/model" or "vendor/model" */
+  id: string
+  /** Human-readable label */
+  label: string
+  /** Node specification (identity) */
+  spec: Extract<NodeSpec, { kind: K }>
+  /** Parent entry ID for property inheritance */
+  extends?: string
+  /** Tags for search and filtering */
+  tags: string[]
+  /** Detailed properties (type-safe per kind) */
+  properties: PropertiesFor<K>
+}
+
+/** Type-narrowed entry for hardware */
+export type HardwareCatalogEntry = CatalogEntry<'hardware'>
+/** Type-narrowed entry for compute */
+export type ComputeCatalogEntry = CatalogEntry<'compute'>
+/** Type-narrowed entry for service */
+export type ServiceCatalogEntry = CatalogEntry<'service'>

--- a/libs/@shumoku/catalog/src/types.ts
+++ b/libs/@shumoku/catalog/src/types.ts
@@ -175,24 +175,33 @@ export type PropertiesFor<K extends NodeSpec['kind']> = K extends 'hardware'
 // Catalog Entry
 // ============================================
 
-export interface CatalogEntry<K extends NodeSpec['kind'] = NodeSpec['kind']> {
+export interface CatalogEntry {
   /** Unique ID: "vendor/series/model" or "vendor/model" */
   id: string
   /** Human-readable label */
   label: string
   /** Node specification (identity) */
-  spec: Extract<NodeSpec, { kind: K }>
+  spec: NodeSpec
   /** Parent entry ID for property inheritance */
   extends?: string
   /** Tags for search and filtering */
   tags: string[]
-  /** Detailed properties (type-safe per kind) */
-  properties: PropertiesFor<K>
+  /** Detailed properties — use kind to narrow */
+  properties: HardwareProperties | ComputeProperties | ServiceProperties
 }
 
 /** Type-narrowed entry for hardware */
-export type HardwareCatalogEntry = CatalogEntry<'hardware'>
+export type HardwareCatalogEntry = CatalogEntry & {
+  spec: Extract<NodeSpec, { kind: 'hardware' }>
+  properties: HardwareProperties
+}
 /** Type-narrowed entry for compute */
-export type ComputeCatalogEntry = CatalogEntry<'compute'>
+export type ComputeCatalogEntry = CatalogEntry & {
+  spec: Extract<NodeSpec, { kind: 'compute' }>
+  properties: ComputeProperties
+}
 /** Type-narrowed entry for service */
-export type ServiceCatalogEntry = CatalogEntry<'service'>
+export type ServiceCatalogEntry = CatalogEntry & {
+  spec: Extract<NodeSpec, { kind: 'service' }>
+  properties: ServiceProperties
+}

--- a/libs/@shumoku/catalog/tsconfig.json
+++ b/libs/@shumoku/catalog/tsconfig.json
@@ -6,6 +6,6 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/build-data.ts"],
   "references": [{ "path": "../core" }]
 }

--- a/libs/@shumoku/catalog/tsconfig.json
+++ b/libs/@shumoku/catalog/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"],
+  "references": [{ "path": "../core" }]
+}

--- a/libs/@shumoku/core/src/fixtures/index.ts
+++ b/libs/@shumoku/core/src/fixtures/index.ts
@@ -347,62 +347,53 @@ nodes:
     model: EX4400-48T
     parent: noc
 
-  # ========== Building A ==========
+  # ========== Building A (Cisco PoE switch + Aruba APs) ==========
   - id: sw-a1
     label: "SW-A1 (Floor 1)"
-    type: l2-switch
-    vendor: juniper
-    model: EX2300-24P
-    parent: building-a
-
-  - id: sw-a2
-    label: "SW-A2 (Floor 2)"
-    type: l2-switch
-    vendor: juniper
-    model: EX2300-24P
+    type: l3-switch
+    vendor: cisco
+    model: ws-c3560cx-8pc-s
     parent: building-a
 
   - id: ap-a1
     label: "AP-A1"
     type: access-point
-    vendor: aruba
-    model: ap500-series
+    vendor: hpe
+    model: aruba-ap-505
     parent: building-a
 
   - id: ap-a2
     label: "AP-A2"
     type: access-point
-    vendor: aruba
-    model: ap500-series
+    vendor: hpe
+    model: aruba-ap-505
     parent: building-a
 
-  # ========== Building B ==========
+  # ========== Building B (Panasonic PoE switch + AP11D passthrough) ==========
   - id: sw-b1
-    label: "SW-B1 (Floor 1)"
+    label: "SW-B1"
     type: l2-switch
-    vendor: yamaha
-    model: swx2310_28gt
-    parent: building-b
-
-  - id: sw-b2
-    label: "SW-B2 (Floor 2)"
-    type: l2-switch
-    vendor: yamaha
-    model: swx2310_28gt
+    vendor: panasonic
+    model: switch-m8egpwr-plus
     parent: building-b
 
   - id: ap-b1
     label: "AP-B1"
     type: access-point
-    vendor: aruba
-    model: ap500-series
+    vendor: hpe
+    model: aruba-ap-505
     parent: building-b
 
   - id: ap-b2
-    label: "AP-B2"
+    label: "AP-B2 (Desk)"
     type: access-point
-    vendor: aruba
-    model: ap500-series
+    vendor: hpe
+    model: aruba-instant-on-ap11d
+    parent: building-b
+
+  - id: ip-phone
+    label: "IP Phone"
+    type: cpe
     parent: building-b
 
 links:
@@ -443,19 +434,7 @@ links:
     vlan: [10, 30]
     bandwidth: 10G
 
-  # Building A cascade
-  - from:
-      node: sw-a1
-      port: eth24
-      ip: 10.10.1.1/30
-    to:
-      node: sw-a2
-      port: uplink
-      ip: 10.10.1.2/30
-    label: "Cascade"
-    vlan: [10, 20]
-    bandwidth: 10G
-
+  # Building A: PoE switch → APs
   - from:
       node: sw-a1
       port: eth1
@@ -466,27 +445,15 @@ links:
     bandwidth: 1G
 
   - from:
-      node: sw-a2
-      port: eth1
+      node: sw-a1
+      port: eth2
     to:
       node: ap-a2
       port: eth0
     vlan: 20
     bandwidth: 1G
 
-  # Building B cascade
-  - from:
-      node: sw-b1
-      port: eth24
-      ip: 10.20.1.1/30
-    to:
-      node: sw-b2
-      port: uplink
-      ip: 10.20.1.2/30
-    label: "Cascade"
-    vlan: [10, 30]
-    bandwidth: 10G
-
+  # Building B: PoE switch → AP + AP11D passthrough → IP Phone
   - from:
       node: sw-b1
       port: eth1
@@ -497,12 +464,20 @@ links:
     bandwidth: 1G
 
   - from:
-      node: sw-b2
-      port: eth1
+      node: sw-b1
+      port: eth2
     to:
       node: ap-b2
-      port: eth0
+      port: e0
     vlan: 30
+    bandwidth: 1G
+
+  - from:
+      node: ap-b2
+      port: e3
+    to:
+      node: ip-phone
+      port: eth0
     bandwidth: 1G
 `,
   },

--- a/libs/@shumoku/core/src/fixtures/index.ts
+++ b/libs/@shumoku/core/src/fixtures/index.ts
@@ -394,6 +394,8 @@ nodes:
   - id: ip-phone
     label: "IP Phone"
     type: cpe
+    vendor: generic
+    model: ip-phone
     parent: building-b
 
 links:


### PR DESCRIPTION
## Summary

### @shumoku/catalog package
- New package for device/service catalog with typed properties
- Discriminated union: HardwareSpec | ComputeSpec | ServiceSpec
- Series→model inheritance via `extends` field
- YAML data files as source, pre-generated TS for browser compat
- Built-in entries: Cisco Catalyst 3560-CX (series + 3 models), Aruba AP-505, Aruba Instant On AP11D, Panasonic Switch-M8ePWR/M8eGPWR+, Generic IP Phone
- Catalog class with lookup, search, vendor/model reverse index

### PoE budget analysis
- Compute PoE budgets from network topology + catalog data
- Support PoE passthrough (AP11D → IP Phone cascade)
- Per-link port info (fromPort → toNodeLabel:toPort)

### Detail panel overhaul
- **Overview tab**: node identity, device Combobox (edit) / product block (view), connections with bandwidth/VLAN/IP, unconnected ports, PoE budget meter
- **Properties tab**: editable fields (label, shape, parent, rank)
- **Raw tab**: JSON dump
- **Spec Dialog**: cascade Kind→Vendor→Series→Model selects, product overview with summary/spec cards/port detail, Custom tab for manual entry

### Sample data update
- Building A: Cisco 3560-CX 8PC → AP-505 ×2
- Building B: Panasonic M8eGPWR+ → AP-505 + AP11D → IP Phone (PoE passthrough)

## Test plan
- [ ] Select SW-B1 → Overview shows connections with bandwidth, PoE budget with port info
- [ ] Select AP-B2 → Shows PoE passthrough to IP Phone
- [ ] Click product block → Spec Dialog opens with cascade selects
- [ ] Edit mode: Combobox product selection works
- [ ] Spec Dialog: Kind→Vendor→Series→Model cascade filters correctly
- [ ] Panasonic products selectable without Series step

🤖 Generated with [Claude Code](https://claude.com/claude-code)