### PR TITLE
feat(editor): .neted.json project file format

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -16,7 +16,7 @@ import {
 } from '@shumoku/core'
 import { analyzePoE, type PoEBudget } from './poe-analysis'
 import { sampleBomItems, samplePalette } from './sample-project'
-import type { BomItem, SpecPaletteEntry } from './types'
+import type { BomItem, NetedProject, SpecPaletteEntry } from './types'
 
 // =========================================================================
 // Editor UI state — mode, theme
@@ -200,35 +200,61 @@ export const diagramState = {
       .map((i) => i.nodeId as string)
   },
 
-  // Serialization
-  stateToJson(): string {
-    return JSON.stringify(
-      {
-        layout: {
-          nodes: Object.fromEntries(new Map(nodes)),
-          ports: Object.fromEntries(new Map(ports)),
-          edges: Object.fromEntries(new Map(edges)),
-          subgraphs: Object.fromEntries(new Map(subgraphs)),
-          bounds: { ...bounds },
-        },
-        links: [...links],
+  // Serialization — .neted.json format
+  /** Export project as NetedProject JSON string */
+  exportProject(name = 'Untitled'): string {
+    const project: NetedProject = {
+      version: 1,
+      name,
+      palette: [...palette],
+      bom: [...bomItems],
+      connections: [...links],
+      diagram: {
+        nodes: Object.fromEntries(new Map(nodes)),
+        ports: Object.fromEntries(new Map(ports)),
+        edges: Object.fromEntries(new Map(edges)),
+        subgraphs: Object.fromEntries(new Map(subgraphs)),
+        bounds: { ...bounds },
       },
-      null,
-      2,
-    )
+    }
+    return JSON.stringify(project, null, 2)
   },
 
-  loadFromJson(jsonStr: string) {
+  /** Import project from NetedProject JSON string */
+  importProject(jsonStr: string) {
     const data = JSON.parse(jsonStr)
-    nodes = new Map(Object.entries(data.layout?.nodes ?? {})) as Map<string, ResolvedNode>
-    ports = new Map(Object.entries(data.layout?.ports ?? {})) as Map<string, ResolvedPort>
-    edges = new Map(Object.entries(data.layout?.edges ?? {})) as Map<string, ResolvedEdge>
-    subgraphs = new Map(Object.entries(data.layout?.subgraphs ?? {})) as Map<
-      string,
-      ResolvedSubgraph
-    >
-    bounds = data.layout?.bounds ?? { x: 0, y: 0, width: 800, height: 600 }
-    links = data.links ?? []
+
+    // Support both .neted.json (v1) and legacy diagram.json
+    if (data.version === 1) {
+      // NetedProject format
+      palette = data.palette ?? []
+      bomItems = data.bom ?? []
+      links = data.connections ?? []
+      const d = data.diagram ?? {}
+      nodes = new Map(Object.entries(d.nodes ?? {})) as Map<string, ResolvedNode>
+      ports = new Map(Object.entries(d.ports ?? {})) as Map<string, ResolvedPort>
+      edges = new Map(Object.entries(d.edges ?? {})) as Map<string, ResolvedEdge>
+      subgraphs = new Map(Object.entries(d.subgraphs ?? {})) as Map<string, ResolvedSubgraph>
+      bounds = d.bounds ?? { x: 0, y: 0, width: 800, height: 600 }
+    } else {
+      // Legacy format: { layout: {...}, links: [...] }
+      const layout = data.layout ?? data.diagram ?? {}
+      nodes = new Map(Object.entries(layout.nodes ?? {})) as Map<string, ResolvedNode>
+      ports = new Map(Object.entries(layout.ports ?? {})) as Map<string, ResolvedPort>
+      edges = new Map(Object.entries(layout.edges ?? {})) as Map<string, ResolvedEdge>
+      subgraphs = new Map(Object.entries(layout.subgraphs ?? {})) as Map<string, ResolvedSubgraph>
+      bounds = layout.bounds ?? { x: 0, y: 0, width: 800, height: 600 }
+      links = data.links ?? data.connections ?? []
+      // Legacy: no palette/bom
+      palette = []
+      bomItems = []
+    }
+    poeBudgets = analyzePoE(
+      [...nodes.values()].map((rn) => rn.node),
+      links,
+      catalog,
+    )
+    status = 'Ready'
   },
 
   loadFromResolved(resolved: ResolvedLayout, graphLinks: Link[]) {

--- a/apps/editor/src/lib/types.ts
+++ b/apps/editor/src/lib/types.ts
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import type { ComputeProperties, HardwareProperties, ServiceProperties } from '@shumoku/catalog'
-import type { NodeSpec } from '@shumoku/core'
+import type {
+  Link,
+  NodeSpec,
+  ResolvedEdge,
+  ResolvedNode,
+  ResolvedPort,
+  ResolvedSubgraph,
+} from '@shumoku/core'
 
 // =========================================================================
 // Spec Palette — product definitions
@@ -39,6 +46,46 @@ export interface BomItem {
   /** User notes for this specific instance */
   notes?: string
 }
+
+// =========================================================================
+// Diagram — layout data for a single sheet
+// =========================================================================
+
+/** Serialized diagram data (JSON-safe) */
+export interface DiagramData {
+  nodes: Record<string, ResolvedNode>
+  ports: Record<string, ResolvedPort>
+  edges: Record<string, ResolvedEdge>
+  subgraphs: Record<string, ResolvedSubgraph>
+  bounds: { x: number; y: number; width: number; height: number }
+}
+
+// =========================================================================
+// Project file — .neted.json
+// =========================================================================
+
+/** neted project file format */
+export interface NetedProject {
+  /** Format version */
+  version: 1
+  /** Project name */
+  name: string
+  /** Project settings */
+  settings?: {
+    theme?: 'light' | 'dark'
+  }
+  /** Spec Palette — product definitions */
+  palette: SpecPaletteEntry[]
+  /** BOM — device instances with node bindings */
+  bom: BomItem[]
+  /** Connection definitions (logical) */
+  connections: Link[]
+  /** Diagram layout (physical placement) */
+  diagram: DiagramData
+}
+
+/** File extension for neted projects */
+export const NETED_FILE_EXTENSION = '.neted.json'
 
 // =========================================================================
 // Display helpers

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -36,12 +36,8 @@
 
   let jsonSource = $state('{}')
   $effect(() => {
-    jsonSource = diagramState.stateToJson()
+    jsonSource = diagramState.exportProject('Sample Network')
   })
-
-  // =========================================================================
-  // Init — trigger shared state initialization
-  // =========================================================================
 
   // =========================================================================
   // Apply
@@ -49,7 +45,7 @@
 
   function applyJson(jsonStr: string) {
     try {
-      diagramState.loadFromJson(jsonStr)
+      diagramState.importProject(jsonStr)
     } catch (_e) {
       // JSON parse error
     }
@@ -60,11 +56,13 @@
   // =========================================================================
 
   function handleSave() {
-    const blob = new Blob([diagramState.stateToJson()], { type: 'application/json' })
+    const blob = new Blob([diagramState.exportProject('Sample Network')], {
+      type: 'application/json',
+    })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = 'network-diagram.json'
+    a.download = 'project.neted.json'
     a.click()
     URL.revokeObjectURL(url)
   }
@@ -72,7 +70,7 @@
   function handleLoad() {
     const input = document.createElement('input')
     input.type = 'file'
-    input.accept = '.json'
+    input.accept = '.json,.neted.json'
     input.onchange = async () => {
       const file = input.files?.[0]
       if (!file) return


### PR DESCRIPTION
## Summary
- Add `NetedProject` type and `DiagramData` type in `types.ts` — versioned project file format (`.neted.json`) containing palette, BOM, connections, and diagram layout
- Replace `stateToJson()`/`loadFromJson()` with `exportProject()`/`importProject()` in context — supports both `.neted.json` (v1) and legacy `diagram.json` formats
- Update diagram page: export as `project.neted.json`, accept both `.json` and `.neted.json` on import

## Test plan
- [ ] Export project → verify file is `project.neted.json` with correct structure (version, palette, bom, connections, diagram)
- [ ] Import exported `.neted.json` → verify all state restored (palette, BOM, diagram, connections)
- [ ] Import legacy `diagram.json` → verify diagram loads with empty palette/bom
- [ ] Typecheck passes (`bun run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)