### PR TITLE
feat(editor): Diagram ↔ BOM sync + DetailPanel improvements

### DIFF
--- a/apps/editor/src/lib/components/DetailPanel.svelte
+++ b/apps/editor/src/lib/components/DetailPanel.svelte
@@ -12,6 +12,7 @@
     data,
     mode = 'view',
     poeBudget,
+    boundPaletteId,
     palette = [],
     links = [],
     onclose,
@@ -23,6 +24,7 @@
     data: Record<string, any> | null
     mode?: 'edit' | 'view'
     poeBudget?: PoEBudget
+    boundPaletteId?: string
     palette?: SpecPaletteEntry[]
     links?: Link[]
     onclose?: () => void
@@ -45,37 +47,10 @@
     onbindpalette?.(data.id, paletteId)
   }
 
-  // Bound palette entry for this node (via BOM — single source of truth)
-  const boundPalette = $derived.by<SpecPaletteEntry | null>(() => {
-    if (!data?.id || !palette.length) return null
-    // BOM-based lookup: find BomItem with this nodeId → get paletteId → find palette entry
-    // The parent passes `boundPaletteId` via the palette list; here we match by node spec
-    // since the spec is now propagated from palette via BOM binding
-    const spec = data.spec
-    if (!spec) return null
-    for (const pal of palette) {
-      const ps = pal.spec
-      if (ps.kind === spec.kind && ps.vendor === spec.vendor) {
-        if (ps.kind === 'hardware' && 'model' in ps && 'model' in spec && ps.model === spec.model)
-          return pal
-        if (
-          ps.kind === 'service' &&
-          'service' in ps &&
-          'service' in spec &&
-          ps.service === spec.service
-        )
-          return pal
-        if (
-          ps.kind === 'compute' &&
-          'platform' in ps &&
-          'platform' in spec &&
-          ps.platform === spec.platform
-        )
-          return pal
-      }
-    }
-    return null
-  })
+  // Bound palette entry — looked up via BomItem binding (parent passes boundPaletteId)
+  const boundPalette = $derived(
+    boundPaletteId ? (palette.find((e) => e.id === boundPaletteId) ?? null) : null,
+  )
 
   const hwProps = $derived(
     boundPalette?.spec.kind === 'hardware' && boundPalette.properties
@@ -325,13 +300,15 @@
             <ScrollArea.Root style="height: 45vh;">
               <ScrollArea.Viewport style="height: 100%;">
                 <div class="px-5 py-4 text-xs space-y-3">
-                  <!-- Node identity + device block -->
-                  <div class="flex items-center gap-3">
-                    {#if iconPath}
-                      <div class="shrink-0 p-2 rounded-lg bg-neutral-100 dark:bg-neutral-700">
+                  <!-- Node identity: icon + label + spec -->
+                  <div class="flex items-start gap-3">
+                    <div
+                      class="shrink-0 w-12 h-12 rounded-lg bg-neutral-100 dark:bg-neutral-700 flex items-center justify-center"
+                    >
+                      {#if iconPath}
                         <svg
-                          width="32"
-                          height="32"
+                          width="28"
+                          height="28"
                           viewBox="0 0 24 24"
                           fill="currentColor"
                           role="img"
@@ -340,78 +317,87 @@
                         >
                           {@html iconPath}
                         </svg>
-                      </div>
-                    {/if}
-                    <div class="min-w-0 flex-1">
-                      <div
-                        class="text-sm font-semibold text-neutral-800 dark:text-neutral-100 truncate"
-                      >
-                        {nodeLabel || data.id}
-                      </div>
+                      {:else}
+                        <div
+                          class="w-5 h-5 rounded border-2 border-dashed border-neutral-300 dark:border-neutral-600"
+                        ></div>
+                      {/if}
+                    </div>
+                    <div class="min-w-0 flex-1 space-y-1.5">
+                      <!-- Label -->
+                      {#if editing && (kind === 'node' || kind === 'subgraph')}
+                        <input
+                          type="text"
+                          class="w-full text-sm font-semibold px-2 py-0.5 -ml-2 bg-transparent border border-transparent hover:border-neutral-200 focus:border-neutral-300 dark:hover:border-neutral-600 dark:focus:border-neutral-500 rounded outline-none focus:ring-1 focus:ring-blue-400 text-neutral-800 dark:text-neutral-100"
+                          value={nodeLabel || ''}
+                          placeholder="Label"
+                          onblur={(e) => { if (data?.id) onupdate?.(data.id, 'label', (e.target as HTMLInputElement).value) }}
+                          onkeydown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+                        >
+                      {:else}
+                        <div
+                          class="text-sm font-semibold text-neutral-800 dark:text-neutral-100 truncate"
+                        >
+                          {nodeLabel || data.id}
+                        </div>
+                      {/if}
+
+                      <!-- Spec binding -->
+                      {#if kind === 'node' || kind === 'subgraph'}
+                        {#if editing}
+                          <Combobox.Root
+                            type="single"
+                            onValueChange={(v) => { if (v) handleComboSelect(v) }}
+                          >
+                            <div class="relative">
+                              <Combobox.Input
+                                placeholder="Assign spec..."
+                                defaultValue={boundPalette ? paletteEntryLabel(boundPalette) : ''}
+                                class="w-full pl-2 pr-7 py-0.5 -ml-2 text-[11px] bg-transparent border border-transparent hover:border-neutral-200 focus:border-neutral-300 dark:hover:border-neutral-600 dark:focus:border-neutral-500 rounded outline-none focus:ring-1 focus:ring-blue-400 text-neutral-600 dark:text-neutral-300"
+                                oninput={(e) => { comboSearchValue = (e.target as HTMLInputElement).value }}
+                              />
+                              <CaretUpDown
+                                class="absolute right-1 top-1/2 -translate-y-1/2 w-3 h-3 text-neutral-400"
+                              />
+                            </div>
+                            <Combobox.Content
+                              class="z-[70] mt-1 max-h-48 w-full overflow-auto rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 shadow-lg"
+                            >
+                              {#each comboResults as palEntry}
+                                <Combobox.Item
+                                  value={palEntry.id}
+                                  label={paletteEntryLabel(palEntry)}
+                                  class="px-3 py-1.5 text-[11px] cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-700/50 data-[highlighted]:bg-neutral-50 dark:data-[highlighted]:bg-neutral-700/50"
+                                >
+                                  <div class="font-medium text-neutral-800 dark:text-neutral-100">
+                                    {paletteEntryLabel(palEntry)}
+                                  </div>
+                                  <div class="text-[9px] font-mono text-neutral-400">
+                                    {palEntry.spec.kind}
+                                    / {palEntry.spec.vendor ?? ''}
+                                  </div>
+                                </Combobox.Item>
+                              {/each}
+                            </Combobox.Content>
+                          </Combobox.Root>
+                        {:else if boundPalette}
+                          <div class="flex items-center gap-1.5 text-[11px]">
+                            <span
+                              class="px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-neutral-700 text-[9px] font-medium uppercase text-neutral-500 dark:text-neutral-400"
+                              >{boundPalette.spec.kind}</span
+                            >
+                            <span class="text-neutral-600 dark:text-neutral-300"
+                              >{paletteEntryLabel(boundPalette)}</span
+                            >
+                          </div>
+                        {:else}
+                          <div class="text-[11px] text-neutral-400 dark:text-neutral-500 italic">
+                            No spec assigned
+                          </div>
+                        {/if}
+                      {/if}
                     </div>
                   </div>
-
-                  <!-- Spec binding (from project Palette) -->
-                  {#if kind === 'node' || kind === 'subgraph'}
-                    {#if editing}
-                      <div>
-                        <Combobox.Root
-                          type="single"
-                          onValueChange={(v) => { if (v) handleComboSelect(v) }}
-                        >
-                          <div class="relative">
-                            <Combobox.Input
-                              placeholder="Search Spec Palette..."
-                              defaultValue={boundPalette ? paletteEntryLabel(boundPalette) : ''}
-                              class="w-full pl-3 pr-8 py-1.5 text-[11px] bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-lg outline-none focus:ring-1 focus:ring-blue-400 text-neutral-700 dark:text-neutral-200"
-                              oninput={(e) => { comboSearchValue = (e.target as HTMLInputElement).value }}
-                            />
-                            <CaretUpDown
-                              class="absolute right-2 top-1/2 -translate-y-1/2 w-3 h-3 text-neutral-400"
-                            />
-                          </div>
-                          <Combobox.Content
-                            class="z-[70] mt-1 max-h-48 w-full overflow-auto rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 shadow-lg"
-                          >
-                            {#each comboResults as palEntry}
-                              <Combobox.Item
-                                value={palEntry.id}
-                                label={paletteEntryLabel(palEntry)}
-                                class="px-3 py-1.5 text-[11px] cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-700/50 data-[highlighted]:bg-neutral-50 dark:data-[highlighted]:bg-neutral-700/50"
-                              >
-                                <div class="font-medium text-neutral-800 dark:text-neutral-100">
-                                  {paletteEntryLabel(palEntry)}
-                                </div>
-                                <div class="text-[9px] font-mono text-neutral-400">
-                                  {palEntry.spec.kind}
-                                  / {palEntry.spec.vendor ?? ''}
-                                </div>
-                              </Combobox.Item>
-                            {/each}
-                          </Combobox.Content>
-                        </Combobox.Root>
-                      </div>
-                    {:else if boundPalette}
-                      <div class="px-2.5 py-1.5 rounded-lg bg-neutral-50 dark:bg-neutral-700/50">
-                        <div
-                          class="text-[10px] uppercase tracking-wider text-neutral-400 dark:text-neutral-500"
-                        >
-                          {boundPalette.spec.vendor}
-                        </div>
-                        <div
-                          class="text-[11px] font-medium text-neutral-700 dark:text-neutral-200 truncate"
-                        >
-                          {paletteEntryLabel(boundPalette)}
-                        </div>
-                      </div>
-                    {:else}
-                      <div
-                        class="px-2.5 py-1.5 rounded-lg bg-neutral-50 dark:bg-neutral-700/30 text-[11px] text-neutral-400 dark:text-neutral-500 italic"
-                      >
-                        No spec bound — assign via Edit mode or BOM page
-                      </div>
-                    {/if}
-                  {/if}
 
                   <!-- Connections -->
                   {#if portConnections.length > 0}

--- a/apps/editor/src/lib/components/DetailPanel.svelte
+++ b/apps/editor/src/lib/components/DetailPanel.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
-  import type { Catalog, CatalogEntry, HardwareProperties } from '@shumoku/catalog'
+  import type { HardwareProperties } from '@shumoku/catalog'
   import { getDeviceIcon, type Link } from '@shumoku/core'
   import { Combobox, Dialog, ScrollArea, Tabs } from 'bits-ui'
-  import { ArrowSquareOut, CaretUpDown, X } from 'phosphor-svelte'
+  import { CaretUpDown, X } from 'phosphor-svelte'
   import type { PoEBudget } from '$lib/poe-analysis'
   import type { SpecPaletteEntry } from '$lib/types'
   import { paletteEntryLabel } from '$lib/types'
-  import SpecCatalogDialog from './SpecCatalogDialog.svelte'
 
   let {
     open = false,
     data,
     mode = 'view',
     poeBudget,
-    catalog,
     palette = [],
     links = [],
     onclose,
@@ -25,7 +23,6 @@
     data: Record<string, any> | null
     mode?: 'edit' | 'view'
     poeBudget?: PoEBudget
-    catalog?: Catalog
     palette?: SpecPaletteEntry[]
     links?: Link[]
     onclose?: () => void
@@ -33,7 +30,6 @@
     onbindpalette?: (nodeId: string, paletteId: string) => void
   } = $props()
 
-  let specDialogOpen = $state(false)
   let comboSearchValue = $state('')
 
   const comboResults = $derived.by(() => {
@@ -45,28 +41,16 @@
 
   function handleComboSelect(paletteId: string) {
     if (!data?.id) return
-    const entry = palette.find((e) => e.id === paletteId)
-    if (!entry) return
-    // Update node spec from palette entry
-    const spec = entry.spec
-    const fields: Record<string, string> = { kind: spec.kind }
-    if (spec.vendor) fields.vendor = spec.vendor
-    if ('type' in spec && spec.type) fields.type = String(spec.type)
-    if ('model' in spec && spec.model) fields.model = spec.model
-    if ('service' in spec && spec.service) fields.service = spec.service
-    if ('resource' in spec && spec.resource) fields.resource = spec.resource
-    if (spec.icon) fields.icon = spec.icon
-    for (const [key, value] of Object.entries(fields)) {
-      onupdate?.(data.id, `spec.${key}`, value)
-    }
-    // Bind node to palette via BOM
+    // Bind node to palette via BOM — spec propagation happens in context
     onbindpalette?.(data.id, paletteId)
   }
 
-  // Find bound palette entry for this node (via BOM or direct match)
+  // Bound palette entry for this node (via BOM — single source of truth)
   const boundPalette = $derived.by<SpecPaletteEntry | null>(() => {
     if (!data?.id || !palette.length) return null
-    // Match by spec fingerprint (palette → node spec)
+    // BOM-based lookup: find BomItem with this nodeId → get paletteId → find palette entry
+    // The parent passes `boundPaletteId` via the palette list; here we match by node spec
+    // since the spec is now propagated from palette via BOM binding
     const spec = data.spec
     if (!spec) return null
     for (const pal of palette) {
@@ -93,20 +77,10 @@
     return null
   })
 
-  const catalogEntry = $derived.by<CatalogEntry | null>(() => {
-    if (!catalog || !data?.spec) return null
-    const spec = data.spec
-    if (spec.kind !== 'hardware' && spec.kind !== 'compute') return null
-    if (!spec.vendor || !spec.model) return null
-    return catalog.lookup(`${spec.vendor}/${spec.model}`) ?? null
-  })
-
   const hwProps = $derived(
     boundPalette?.spec.kind === 'hardware' && boundPalette.properties
       ? (boundPalette.properties as HardwareProperties)
-      : catalogEntry?.spec.kind === 'hardware'
-        ? (catalogEntry.properties as HardwareProperties)
-        : null,
+      : null,
   )
 
   const kind = $derived((data?.kind as string) ?? 'unknown')
@@ -377,17 +351,17 @@
                     </div>
                   </div>
 
-                  <!-- Device selector / info -->
+                  <!-- Spec binding (from project Palette) -->
                   {#if kind === 'node' || kind === 'subgraph'}
                     {#if editing}
-                      <div class="flex items-center gap-2">
+                      <div>
                         <Combobox.Root
                           type="single"
                           onValueChange={(v) => { if (v) handleComboSelect(v) }}
                         >
-                          <div class="relative flex-1">
+                          <div class="relative">
                             <Combobox.Input
-                              placeholder="Search products..."
+                              placeholder="Search Spec Palette..."
                               defaultValue={boundPalette ? paletteEntryLabel(boundPalette) : ''}
                               class="w-full pl-3 pr-8 py-1.5 text-[11px] bg-neutral-50 dark:bg-neutral-700 border border-neutral-200 dark:border-neutral-600 rounded-lg outline-none focus:ring-1 focus:ring-blue-400 text-neutral-700 dark:text-neutral-200"
                               oninput={(e) => { comboSearchValue = (e.target as HTMLInputElement).value }}
@@ -416,35 +390,26 @@
                             {/each}
                           </Combobox.Content>
                         </Combobox.Root>
-                        <button
-                          type="button"
-                          class="shrink-0 p-1.5 rounded-lg text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors"
-                          title="Spec Details"
-                          onclick={() => { specDialogOpen = true }}
-                        >
-                          <ArrowSquareOut class="w-3.5 h-3.5" />
-                        </button>
                       </div>
                     {:else if boundPalette}
-                      <button
-                        type="button"
-                        class="flex items-center gap-2 w-full px-2.5 py-1.5 text-left rounded-lg bg-neutral-50 dark:bg-neutral-700/50 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
-                        onclick={() => { specDialogOpen = true }}
-                      >
-                        <div class="flex-1 min-w-0">
-                          <div
-                            class="text-[10px] uppercase tracking-wider text-neutral-400 dark:text-neutral-500"
-                          >
-                            {boundPalette.spec.vendor}
-                          </div>
-                          <div
-                            class="text-[11px] font-medium text-neutral-700 dark:text-neutral-200 truncate"
-                          >
-                            {paletteEntryLabel(boundPalette)}
-                          </div>
+                      <div class="px-2.5 py-1.5 rounded-lg bg-neutral-50 dark:bg-neutral-700/50">
+                        <div
+                          class="text-[10px] uppercase tracking-wider text-neutral-400 dark:text-neutral-500"
+                        >
+                          {boundPalette.spec.vendor}
                         </div>
-                        <ArrowSquareOut class="shrink-0 w-3.5 h-3.5 text-neutral-400" />
-                      </button>
+                        <div
+                          class="text-[11px] font-medium text-neutral-700 dark:text-neutral-200 truncate"
+                        >
+                          {paletteEntryLabel(boundPalette)}
+                        </div>
+                      </div>
+                    {:else}
+                      <div
+                        class="px-2.5 py-1.5 rounded-lg bg-neutral-50 dark:bg-neutral-700/30 text-[11px] text-neutral-400 dark:text-neutral-500 italic"
+                      >
+                        No spec bound — assign via Edit mode or BOM page
+                      </div>
                     {/if}
                   {/if}
 
@@ -688,17 +653,3 @@
     </Dialog.Content>
   </Dialog.Portal>
 </Dialog.Root>
-
-<SpecCatalogDialog
-  open={specDialogOpen}
-  {mode}
-  {catalog}
-  currentSpec={data?.spec}
-  onclose={() => { specDialogOpen = false }}
-  onselect={(spec) => {
-    if (!data?.id) return
-    for (const [key, value] of Object.entries(spec)) {
-      onupdate?.(data.id, `spec.${key}`, value)
-    }
-  }}
-/>

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -208,6 +208,24 @@ export const diagramState = {
     bomItems = [...bomItems, item]
   },
   removeBomItem(id: string) {
+    const item = bomItems.find((i) => i.id === id)
+    if (item?.nodeId) {
+      // Remove diagram node + its ports + connected links
+      const nodeId = item.nodeId
+      const n = new Map(nodes)
+      const p = new Map(ports)
+      n.delete(nodeId)
+      for (const [portId, port] of p) {
+        if (port.nodeId === nodeId) p.delete(portId)
+      }
+      nodes = n
+      ports = p
+      links = links.filter((l) => {
+        const from = typeof l.from === 'string' ? l.from : l.from.node
+        const to = typeof l.to === 'string' ? l.to : l.to.node
+        return from !== nodeId && to !== nodeId
+      })
+    }
     bomItems = bomItems.filter((i) => i.id !== id)
   },
   updateBomItem(id: string, updates: Partial<BomItem>) {

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1,22 +1,28 @@
 import { builtinEntries, Catalog } from '@shumoku/catalog'
 import {
+  collectObstacles,
   computeNetworkLayout,
+  computeNodeSize,
   createMemoryFileResolver,
   darkTheme,
   HierarchicalParser,
   type Link,
   lightTheme,
+  type NodeSpec,
   type ResolvedEdge,
   type ResolvedLayout,
   type ResolvedNode,
   type ResolvedPort,
   type ResolvedSubgraph,
+  resolvePosition,
   sampleNetwork,
   type Theme,
 } from '@shumoku/core'
+import { nanoid } from 'nanoid'
 import { analyzePoE, type PoEBudget } from './poe-analysis'
 import { sampleBomItems, samplePalette } from './sample-project'
 import type { BomItem, NetedProject, SpecPaletteEntry } from './types'
+import { paletteEntryLabel } from './types'
 
 // =========================================================================
 // Editor UI state — mode, theme
@@ -90,6 +96,21 @@ let initialized = $state(false)
 const catalog = new Catalog()
 catalog.registerAll(builtinEntries)
 
+/** Update spec on multiple nodes at once (Palette → Node propagation) */
+function setNodeSpecs(nodeIds: string[], spec: NodeSpec | undefined) {
+  const ids = new Set(nodeIds)
+  const n = new Map(nodes)
+  let changed = false
+  for (const id of ids) {
+    const rn = n.get(id)
+    if (rn) {
+      n.set(id, { ...rn, node: { ...rn.node, spec } })
+      changed = true
+    }
+  }
+  if (changed) nodes = n
+}
+
 export const diagramState = {
   get nodes() {
     return nodes
@@ -157,11 +178,26 @@ export const diagramState = {
     palette = [...palette, entry]
   },
   removeFromPalette(id: string) {
+    // Clear spec on bound nodes before removing
+    const boundNodeIds = bomItems
+      .filter((i) => i.paletteId === id && i.nodeId)
+      .map((i) => i.nodeId as string)
+    if (boundNodeIds.length > 0) setNodeSpecs(boundNodeIds, undefined)
     palette = palette.filter((e) => e.id !== id)
     bomItems = bomItems.filter((i) => i.paletteId !== id)
   },
   updatePaletteEntry(id: string, updates: Partial<SpecPaletteEntry>) {
     palette = palette.map((e) => (e.id === id ? { ...e, ...updates } : e))
+    // Propagate spec change to all bound nodes (Figma-style)
+    if (updates.spec) {
+      const entry = palette.find((e) => e.id === id)
+      if (entry) {
+        const boundNodeIds = bomItems
+          .filter((i) => i.paletteId === id && i.nodeId)
+          .map((i) => i.nodeId as string)
+        if (boundNodeIds.length > 0) setNodeSpecs(boundNodeIds, entry.spec)
+      }
+    }
   },
 
   // BOM items (device instances — master for qty management)
@@ -184,6 +220,12 @@ export const diagramState = {
       bomItems = bomItems.map((i) => (i.nodeId === nodeId ? { ...i, nodeId: undefined } : i))
     }
     bomItems = bomItems.map((i) => (i.id === bomId ? { ...i, nodeId } : i))
+    // Propagate palette spec to node
+    if (nodeId) {
+      const bom = bomItems.find((i) => i.id === bomId)
+      const entry = bom ? palette.find((e) => e.id === bom.paletteId) : undefined
+      setNodeSpecs([nodeId], entry?.spec)
+    }
   },
   /** Get BOM items for a palette entry */
   getBomItemsForPalette(paletteId: string): BomItem[] {
@@ -198,6 +240,70 @@ export const diagramState = {
     return bomItems
       .filter((i) => i.paletteId === paletteId && i.nodeId)
       .map((i) => i.nodeId as string)
+  },
+  /** Unbind node(s) from BOM — sets nodeId to undefined, keeps the BomItem */
+  unbindNodes(nodeIds: string[]) {
+    const ids = new Set(nodeIds)
+    bomItems = bomItems.map((i) =>
+      i.nodeId && ids.has(i.nodeId) ? { ...i, nodeId: undefined } : i,
+    )
+    // Clear spec on unbound nodes
+    setNodeSpecs(nodeIds, undefined)
+  },
+  /** Remove BomItems for deleted diagram nodes */
+  removeNodeBomItems(nodeIds: string[]) {
+    const ids = new Set(nodeIds)
+    bomItems = bomItems.filter((i) => !i.nodeId || !ids.has(i.nodeId))
+  },
+  /** High-level: bind a diagram node to a palette entry (finds/creates BomItem + propagates spec) */
+  bindNodeToPalette(nodeId: string, paletteId: string) {
+    const existing = bomItems.find((i) => i.nodeId === nodeId)
+    if (existing) {
+      // Already bound — re-bind to different palette
+      diagramState.updateBomItem(existing.id, { paletteId })
+      const entry = palette.find((e) => e.id === paletteId)
+      if (entry) setNodeSpecs([nodeId], entry.spec)
+    } else {
+      // Find unplaced BOM item for this palette entry, or create new
+      const unplaced = bomItems.find((i) => i.paletteId === paletteId && !i.nodeId)
+      if (unplaced) {
+        diagramState.bindNodeToBom(unplaced.id, nodeId)
+      } else {
+        const id = nanoid()
+        diagramState.addBomItem({ id, paletteId, nodeId })
+        const entry = palette.find((e) => e.id === paletteId)
+        if (entry) setNodeSpecs([nodeId], entry.spec)
+      }
+    }
+  },
+  /** Create a diagram node for an unplaced BomItem and bind it */
+  placeNodeForBom(bomId: string): string | undefined {
+    const bom = bomItems.find((i) => i.id === bomId)
+    if (!bom || bom.nodeId) return undefined
+    const entry = palette.find((e) => e.id === bom.paletteId)
+    if (!entry) return undefined
+
+    const id = `node-${Date.now()}`
+    const label = paletteEntryLabel(entry)
+    const spec = entry.spec
+    const { width: w, height: h } = computeNodeSize({ label, spec })
+    const obstacles = collectObstacles(id, undefined, nodes, subgraphs)
+    const pos = resolvePosition(
+      { x: bounds.x + bounds.width + 40 + w / 2, y: bounds.y + bounds.height / 2, w, h },
+      obstacles,
+    )
+
+    const n = new Map(nodes)
+    n.set(id, {
+      id,
+      position: pos,
+      size: { width: w, height: h },
+      node: { id, label, spec, shape: 'rounded' },
+    })
+    nodes = n
+    // Bind BomItem to the new node
+    bomItems = bomItems.map((i) => (i.id === bomId ? { ...i, nodeId: id } : i))
+    return id
   },
 
   // Serialization — .neted.json format

--- a/apps/editor/src/lib/types.ts
+++ b/apps/editor/src/lib/types.ts
@@ -39,8 +39,8 @@ export interface SpecPaletteEntry {
 export interface BomItem {
   /** Stable unique ID (nanoid) */
   id: string
-  /** Reference to Spec Palette entry */
-  paletteId: string
+  /** Reference to Spec Palette entry (undefined = not yet assigned) */
+  paletteId?: string
   /** Bound diagram node ID (undefined = not yet placed) */
   nodeId?: string
   /** User notes for this specific instance */

--- a/apps/editor/src/routes/project/[id]/(content)/bom/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/bom/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { DropdownMenu } from 'bits-ui'
   import { nanoid } from 'nanoid'
-  import { CaretDown, Plus, Trash } from 'phosphor-svelte'
+  import { CaretDown, MapPin, Plus, Trash } from 'phosphor-svelte'
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
   import { Badge } from '$lib/components/ui/badge'
@@ -29,10 +29,11 @@
       })),
   )
 
-  // Spec summary
+  // Spec summary (only items with a paletteId)
   const specSummary = $derived.by(() => {
     const groups = new Map<string, { total: number; placed: number }>()
     for (const item of items) {
+      if (!item.paletteId) continue
       const g = groups.get(item.paletteId) ?? { total: 0, placed: 0 }
       g.total++
       if (item.nodeId) g.placed++
@@ -147,8 +148,10 @@
       </Table.Header>
       <Table.Body>
         {#each items as item (item.id)}
-          {@const pal = paletteById.get(item.paletteId)}
-          <Table.Row class={!item.nodeId ? 'bg-amber-50/50 dark:bg-amber-900/5' : ''}>
+          {@const pal = item.paletteId ? paletteById.get(item.paletteId) : undefined}
+          {@const needsSpec = !item.paletteId}
+          {@const needsNode = item.paletteId && !item.nodeId}
+          <Table.Row class={needsSpec || needsNode ? 'bg-amber-50/50 dark:bg-amber-900/5' : ''}>
             <Table.Cell>
               {#if pal}
                 <button
@@ -159,31 +162,61 @@
                   {paletteEntryLabel(pal)}
                 </button>
               {:else}
-                <span class="text-xs text-muted-foreground italic">unknown</span>
-              {/if}
-            </Table.Cell>
-            <Table.Cell>
-              {#if item.nodeId}
-                <span class="font-mono text-xs">{item.nodeId}</span>
-              {:else}
                 <select
                   class="px-2 py-1 text-xs bg-background border border-input rounded-lg outline-none focus:ring-1 focus:ring-ring"
                   value=""
                   onchange={(e) => {
                     const val = (e.target as HTMLSelectElement).value
-                    if (val) diagramState.bindNodeToBom(item.id, val)
+                    if (val) diagramState.bindNodeToPalette(item.nodeId ?? '', val)
                   }}
                 >
-                  <option value="">-- assign node --</option>
-                  {#each unboundNodes as node}
-                    <option value={node.id}>{node.id} ({node.label})</option>
+                  <option value="">-- assign spec --</option>
+                  {#each diagramState.palette as palEntry}
+                    <option value={palEntry.id}>{paletteEntryLabel(palEntry)}</option>
                   {/each}
                 </select>
               {/if}
             </Table.Cell>
             <Table.Cell>
               {#if item.nodeId}
-                <Badge variant="default">placed</Badge>
+                <span class="font-mono text-xs">{item.nodeId}</span>
+              {:else if item.paletteId}
+                <div class="flex items-center gap-1.5">
+                  <select
+                    class="px-2 py-1 text-xs bg-background border border-input rounded-lg outline-none focus:ring-1 focus:ring-ring"
+                    value=""
+                    onchange={(e) => {
+                      const val = (e.target as HTMLSelectElement).value
+                      if (val) diagramState.bindNodeToBom(item.id, val)
+                    }}
+                  >
+                    <option value="">-- assign node --</option>
+                    {#each unboundNodes as node}
+                      <option value={node.id}>{node.id} ({node.label})</option>
+                    {/each}
+                  </select>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    class="h-7 px-2 text-[11px]"
+                    onclick={() => {
+                      diagramState.placeNodeForBom(item.id)
+                      goto(`/project/${$page.params.id}/diagram`)
+                    }}
+                  >
+                    <MapPin class="w-3 h-3 mr-1" />
+                    Place
+                  </Button>
+                </div>
+              {:else}
+                <span class="text-xs text-muted-foreground italic">—</span>
+              {/if}
+            </Table.Cell>
+            <Table.Cell>
+              {#if item.paletteId && item.nodeId}
+                <Badge variant="default">bound</Badge>
+              {:else if !item.paletteId}
+                <Badge variant="outline">unassigned</Badge>
               {:else}
                 <Badge variant="secondary">unplaced</Badge>
               {/if}

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -98,6 +98,11 @@
         onchange={() => {}}
         onlabeledit={(portId: string, label: string, screenX: number, screenY: number) => { labelEdit = { portId, label, x: screenX, y: screenY } }}
         oncontextmenu={(id: string, type: string, screenX: number, screenY: number) => { contextMenu = { id, type, x: screenX, y: screenY } }}
+        onnodeadd={(id: string) => {
+          diagramState.addBomItem({ id: nanoid(), nodeId: id })
+          detailData = renderer?.getElementDetails(id) ?? null
+        }}
+        onnodedelete={(ids: string[]) => { diagramState.unbindNodes(ids) }}
       />
     {:else}
       <div class="flex items-center justify-center h-full text-neutral-400 dark:text-neutral-500">
@@ -185,25 +190,12 @@
     data={detailData}
     mode={editorState.mode}
     poeBudget={diagramState.poeBudgets.find((b) => b.nodeId === detailData?.id)}
-    catalog={diagramState.catalog}
     palette={diagramState.palette}
     links={diagramState.links}
     onclose={() => { detailData = null }}
     onbindpalette={(nodeId, paletteId) => {
-      // Find or create BOM item for this binding
-      const existing = diagramState.bomItems.find((i) => i.nodeId === nodeId)
-      if (existing) {
-        // Re-bind to different palette entry
-        diagramState.updateBomItem(existing.id, { paletteId })
-      } else {
-        // Find unplaced BOM item for this palette entry, or create new
-        const unplaced = diagramState.bomItems.find((i) => i.paletteId === paletteId && !i.nodeId)
-        if (unplaced) {
-          diagramState.bindNodeToBom(unplaced.id, nodeId)
-        } else {
-          diagramState.addBomItem({ id: nanoid(), paletteId, nodeId })
-        }
-      }
+      diagramState.bindNodeToPalette(nodeId, paletteId)
+      detailData = renderer?.getElementDetails(nodeId) ?? null
     }}
     onupdate={(id, field, value) => {
       const node = diagramState.nodes.get(id)

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -190,6 +190,7 @@
     data={detailData}
     mode={editorState.mode}
     poeBudget={diagramState.poeBudgets.find((b) => b.nodeId === detailData?.id)}
+    boundPaletteId={detailData?.id ? diagramState.getPaletteIdForNode(detailData.id) : undefined}
     palette={diagramState.palette}
     links={diagramState.links}
     onclose={() => { detailData = null }}

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -43,6 +43,8 @@
     onselect?: (id: string | null, type: string | null) => void
     onlabeledit?: (portId: string, label: string, screenX: number, screenY: number) => void
     oncontextmenu?: (id: string, type: string, screenX: number, screenY: number) => void
+    onnodeadd?: (id: string) => void
+    onnodedelete?: (ids: string[]) => void
   }
 
   let {
@@ -60,6 +62,8 @@
     onselect,
     onlabeledit,
     oncontextmenu: onctx,
+    onnodeadd,
+    onnodedelete,
   }: RendererProps = $props()
 
   const colors = $derived(themeToColors(theme))
@@ -243,6 +247,7 @@
     })
     nodes = n
     finalizeAdd(id, new Map(subgraphs))
+    onnodeadd?.(id)
     return id
   }
 
@@ -270,7 +275,10 @@
   // =========================================================================
 
   export function deleteById(id: string) {
+    const deletedNodeIds: string[] = []
+
     if (nodes.has(id)) {
+      deletedNodeIds.push(id)
       const n = new Map(nodes)
       const p = new Map(ports)
       n.delete(id)
@@ -313,6 +321,7 @@
       const p = new Map(ports)
       const sg = new Map(subgraphs)
       for (const nid of toDeleteNodes) {
+        deletedNodeIds.push(nid)
         n.delete(nid)
         for (const [portId, port] of p) {
           if (port.nodeId === nid) p.delete(portId)
@@ -334,6 +343,7 @@
       edges = e
     })
     onchange?.(links)
+    if (deletedNodeIds.length > 0) onnodedelete?.(deletedNodeIds)
   }
 
   // =========================================================================


### PR DESCRIPTION
## Summary
- Add `onnodeadd`/`onnodedelete` callbacks to ShumokuRenderer for lifecycle tracking
- Auto-create BomItem on diagram node add (unassigned status), unbind on delete
- BomItem deletion cascades to diagram node + ports + links
- Palette → Node spec propagation via `bindNodeToPalette()` and `setNodeSpecs()`
- DetailPanel: replace spec fingerprint matching with `boundPaletteId` prop (BomItem-based lookup)
- DetailPanel: consolidate label + spec editing into Overview tab with persistent icon placeholder
- Remove direct catalog reference from DetailPanel (Spec Palette only)
- BomItem.paletteId now optional (tracks unassigned diagram nodes)
- BOM page: Place button, spec assignment dropdown, 3-state status (bound/unplaced/unassigned)

## Test plan
- [ ] Add node on diagram → appears in BOM as "unassigned"
- [ ] Assign spec via DetailPanel combobox → BOM status changes to "bound"
- [ ] Delete node on diagram → BOM item reverts to "unplaced"
- [ ] Delete BomItem row → diagram node also removed
- [ ] Right-click existing sample node → DetailPanel shows correct palette binding
- [ ] Edit mode: label inline edit + spec combobox on Overview tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)