### PR TITLE
feat(editor): device type picker + role persist on unbind

### DIFF
--- a/apps/editor/src/lib/components/SideToolbar.svelte
+++ b/apps/editor/src/lib/components/SideToolbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { Tooltip } from 'bits-ui'
+  import { DeviceType } from '@shumoku/core'
+  import { DropdownMenu, Tooltip } from 'bits-ui'
   import { Cube, Eye, Moon, Pencil, Plus, SquaresFour, Sun } from 'phosphor-svelte'
 
   let {
@@ -13,12 +14,28 @@
     mode: 'edit' | 'view'
     isDark?: boolean
     onmodechange?: (mode: 'edit' | 'view') => void
-    onaddnode?: () => void
+    onaddnode?: (spec?: { kind: string; type?: string }) => void
     onaddsubgraph?: () => void
     onthemetoggle?: () => void
   } = $props()
 
   const editing = $derived(mode === 'edit')
+
+  const nodeTypes = [
+    { label: 'Generic Node', spec: undefined },
+    { label: '---' },
+    { label: 'Router', spec: { kind: 'hardware', type: DeviceType.Router } },
+    { label: 'Firewall', spec: { kind: 'hardware', type: DeviceType.Firewall } },
+    { label: 'L2 Switch', spec: { kind: 'hardware', type: DeviceType.L2Switch } },
+    { label: 'L3 Switch', spec: { kind: 'hardware', type: DeviceType.L3Switch } },
+    { label: 'Server', spec: { kind: 'hardware', type: DeviceType.Server } },
+    { label: 'Access Point', spec: { kind: 'hardware', type: DeviceType.AccessPoint } },
+    { label: 'CPE / Phone', spec: { kind: 'hardware', type: DeviceType.CPE } },
+    { label: 'Internet', spec: { kind: 'hardware', type: DeviceType.Internet } },
+    { label: '---' },
+    { label: 'VM / Compute', spec: { kind: 'compute' } },
+    { label: 'Cloud Service', spec: { kind: 'service' } },
+  ] as const
 </script>
 
 <div
@@ -26,26 +43,52 @@
 >
   <!-- Edit tools (show when editing) -->
   {#if editing}
-    <Tooltip.Root>
-      <Tooltip.Trigger>
-        <button
-          type="button"
-          class="flex items-center justify-center w-9 h-9 rounded-lg text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
-          onclick={() => onaddnode?.()}
+    <DropdownMenu.Root>
+      <Tooltip.Root>
+        <Tooltip.Trigger>
+          <DropdownMenu.Trigger>
+            {#snippet child({ props })}
+              <button
+                type="button"
+                class="flex items-center justify-center w-9 h-9 rounded-lg text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+                {...props}
+              >
+                <div class="relative">
+                  <Cube class="w-4.5 h-4.5" />
+                  <Plus
+                    class="w-2.5 h-2.5 absolute -bottom-0.5 -right-0.5 text-blue-500"
+                    weight="bold"
+                  />
+                </div>
+              </button>
+            {/snippet}
+          </DropdownMenu.Trigger>
+        </Tooltip.Trigger>
+        <Tooltip.Content
+          side="left"
+          class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg"
         >
-          <div class="relative">
-            <Cube class="w-4.5 h-4.5" />
-            <Plus class="w-2.5 h-2.5 absolute -bottom-0.5 -right-0.5 text-blue-500" weight="bold" />
-          </div>
-        </button>
-      </Tooltip.Trigger>
-      <Tooltip.Content
+          Add node
+        </Tooltip.Content>
+      </Tooltip.Root>
+      <DropdownMenu.Content
         side="left"
-        class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg"
+        class="z-50 min-w-40 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-1 shadow-lg"
       >
-        Add node
-      </Tooltip.Content>
-    </Tooltip.Root>
+        {#each nodeTypes as item}
+          {#if item.label === '---'}
+            <DropdownMenu.Separator class="my-1 h-px bg-neutral-200 dark:bg-neutral-700" />
+          {:else}
+            <DropdownMenu.Item
+              class="flex items-center rounded-md px-2.5 py-1.5 text-xs cursor-pointer text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700"
+              onclick={() => onaddnode?.(item.spec)}
+            >
+              {item.label}
+            </DropdownMenu.Item>
+          {/if}
+        {/each}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
 
     <Tooltip.Root>
       <Tooltip.Trigger>

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -111,6 +111,15 @@ function setNodeSpecs(nodeIds: string[], spec: NodeSpec | undefined) {
   if (changed) nodes = n
 }
 
+/** Strip product details from spec, keep kind/type (role) */
+function stripProductFromSpec(spec: NodeSpec | undefined): NodeSpec | undefined {
+  if (!spec) return undefined
+  if (spec.kind === 'hardware') return { kind: 'hardware', type: spec.type }
+  if (spec.kind === 'compute') return { kind: 'compute', type: spec.type }
+  if (spec.kind === 'service') return { kind: 'service', service: spec.service }
+  return undefined
+}
+
 export const diagramState = {
   get nodes() {
     return nodes
@@ -178,11 +187,15 @@ export const diagramState = {
     palette = [...palette, entry]
   },
   removeFromPalette(id: string) {
-    // Clear spec on bound nodes before removing
+    // Strip product details but keep role (kind/type) on bound nodes
+    const entry = palette.find((e) => e.id === id)
     const boundNodeIds = bomItems
       .filter((i) => i.paletteId === id && i.nodeId)
       .map((i) => i.nodeId as string)
-    if (boundNodeIds.length > 0) setNodeSpecs(boundNodeIds, undefined)
+    if (boundNodeIds.length > 0) {
+      const roleSpec = stripProductFromSpec(entry?.spec)
+      setNodeSpecs(boundNodeIds, roleSpec)
+    }
     palette = palette.filter((e) => e.id !== id)
     bomItems = bomItems.filter((i) => i.paletteId !== id)
   },
@@ -262,11 +275,18 @@ export const diagramState = {
   /** Unbind node(s) from BOM — sets nodeId to undefined, keeps the BomItem */
   unbindNodes(nodeIds: string[]) {
     const ids = new Set(nodeIds)
+    // Strip product details but keep role (kind/type)
+    const n = new Map(nodes)
+    for (const nodeId of ids) {
+      const rn = n.get(nodeId)
+      if (rn) {
+        n.set(nodeId, { ...rn, node: { ...rn.node, spec: stripProductFromSpec(rn.node.spec) } })
+      }
+    }
+    nodes = n
     bomItems = bomItems.map((i) =>
       i.nodeId && ids.has(i.nodeId) ? { ...i, nodeId: undefined } : i,
     )
-    // Clear spec on unbound nodes
-    setNodeSpecs(nodeIds, undefined)
   },
   /** Remove BomItems for deleted diagram nodes */
   removeNodeBomItems(nodeIds: string[]) {

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -100,7 +100,6 @@
         oncontextmenu={(id: string, type: string, screenX: number, screenY: number) => { contextMenu = { id, type, x: screenX, y: screenY } }}
         onnodeadd={(id: string) => {
           diagramState.addBomItem({ id: nanoid(), nodeId: id })
-          detailData = renderer?.getElementDetails(id) ?? null
         }}
         onnodedelete={(ids: string[]) => { diagramState.unbindNodes(ids) }}
       />
@@ -134,7 +133,7 @@
       mode={editorState.mode}
       isDark={editorState.isDark}
       onmodechange={(m) => { editorState.mode = m }}
-      onaddnode={() => renderer?.addNewNode()}
+      onaddnode={(spec) => renderer?.addNewNode(spec ? { spec } : undefined)}
       onaddsubgraph={() => renderer?.addNewSubgraph()}
       onthemetoggle={() => editorState.toggleTheme()}
     />

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -227,12 +227,17 @@
   export function addNewNode(opts?: {
     label?: string
     type?: DeviceType
+    spec?: { kind: string; type?: string }
     shape?: NodeShape
     position?: { x: number; y: number }
   }) {
     const id = `node-${Date.now()}`
     const label = opts?.label ?? 'New Node'
-    const spec = opts?.type ? { kind: 'hardware' as const, type: opts.type } : undefined
+    const spec = opts?.spec
+      ? (opts.spec as import('@shumoku/core').NodeSpec)
+      : opts?.type
+        ? { kind: 'hardware' as const, type: opts.type }
+        : undefined
     const { width: w, height: h } = computeNodeSize({ label, spec })
     const { parent, initial } = resolveParentAndPosition(opts?.position, w)
     const obstacles = collectObstacles(id, parent, nodes, subgraphs)


### PR DESCRIPTION
## Summary
- SideToolbar "+" button is now a dropdown with categorized device types (Hardware: Router, Firewall, L2/L3 Switch, Server, AP, etc. / Compute: VM / Service: Cloud Service)
- Nodes created with a device type get the correct icon immediately, without needing Palette binding
- `stripProductFromSpec()` preserves `kind`/`type` when unbinding from Palette — only `vendor`/`model` are cleared
- Remove auto-open DetailPanel on node add (was disruptive)
- `ShumokuRenderer.addNewNode()` accepts `spec` option for kind/type

## Context
Interim solution for #111 (Node.role / Node.spec separation). Full role/spec split deferred until #98 and Node/Subgraph unification design is settled.

## Test plan
- [ ] Edit mode → "+" dropdown shows device type categories
- [ ] Select "L2 Switch" → node appears with L2 Switch icon
- [ ] Bind node to Palette entry → spec updated with vendor/model
- [ ] Unbind (delete BomItem or remove Palette entry) → icon persists, vendor/model cleared
- [ ] "Generic Node" → no icon, no spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)