### PR TITLE
fix(editor): make canvas trackpad-friendly with scroll-to-pan

### DIFF
--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -63,6 +63,7 @@
 
   // --- d3-zoom: pan/zoom on viewport <g> ---
   // d3-zoom: pan/zoom always active
+  // Trackpad-friendly: two-finger scroll → pan, pinch (ctrl+wheel) → zoom
   $effect(() => {
     if (!svgEl || !viewportEl) return
 
@@ -70,8 +71,9 @@
     const zoomBehavior = zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.2, 10])
       .filter((e) => {
-        // Allow wheel zoom always, drag only with middle button or space
-        if (e.type === 'wheel') return true
+        // Wheel: only zoom on pinch (ctrlKey / metaKey)
+        if (e.type === 'wheel') return (e as WheelEvent).ctrlKey || (e as WheelEvent).metaKey
+        // Drag: middle button or Alt+left-click
         if (e.type === 'mousedown' || e.type === 'pointerdown') {
           return (e as MouseEvent).button === 1 || (e as MouseEvent).altKey
         }
@@ -85,11 +87,20 @@
 
     svgSel.call(zoomBehavior)
 
+    // Two-finger scroll (non-ctrl/meta wheel) → pan
+    const handleWheel = (e: WheelEvent) => {
+      if (e.ctrlKey || e.metaKey) return // pinch-to-zoom handled by d3-zoom
+      e.preventDefault()
+      zoomBehavior.translateBy(svgSel, -e.deltaX, -e.deltaY)
+    }
+    svgEl.addEventListener('wheel', handleWheel, { passive: false })
+
     // Prevent default context menu on SVG background only when nothing is targeted
     svgSel.on('contextmenu.zoom', null)
 
     return () => {
       svgSel.on('.zoom', null)
+      svgEl.removeEventListener('wheel', handleWheel)
     }
   })
 


### PR DESCRIPTION
## Summary
- 2本指スクロール(通常のwheel)をズームからパンに変更
- ピンチ(ctrl/cmd+wheel)でのズームは維持
- Figma/Miro等と同じ操作モデルに統一し、Macトラックパッド・Windowsマウス両方で自然に操作可能に

### 操作マッピング

| 操作 | 変更前 | 変更後 |
|---|---|---|
| トラックパッド 2本指スクロール | ズーム | **パン** |
| トラックパッド ピンチ | ズーム | ズーム |
| マウスホイール | ズーム | **パン** |
| Ctrl/Cmd+マウスホイール | ズーム | ズーム |
| 中ボタンドラッグ / Alt+左クリック | パン | パン |

## Test plan
- [ ] Macトラックパッドで2本指スクロール → パンすることを確認
- [ ] Macトラックパッドでピンチ → ズームすることを確認
- [ ] Windowsマウスでホイール → パンすることを確認
- [ ] Windowsマウスで Ctrl+ホイール → ズームすることを確認
- [ ] 中ボタンドラッグ / Alt+左クリックドラッグ → パンすることを確認
- [ ] ノードのドラッグ移動が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)