### PR TITLE
feat(catalog,editor): class-based PoE budget reservation

### DIFF
--- a/apps/editor/src/lib/components/detail/NodeContent.svelte
+++ b/apps/editor/src/lib/components/detail/NodeContent.svelte
@@ -194,30 +194,68 @@
 
 <!-- PoE Budget -->
 {#if poeBudget}
+  {@const drawPct = Math.min(100, Math.round((poeBudget.draw_w / poeBudget.budget_w) * 1000) / 10)}
+  {@const reservedPct = Math.min(100, poeBudget.utilization_pct)}
+  {@const barColor =
+    reservedPct > 100
+      ? 'bg-red-500'
+      : reservedPct > 80
+        ? 'bg-red-500'
+        : reservedPct > 50
+          ? 'bg-amber-500'
+          : 'bg-green-500'}
+  {@const drawColor =
+    reservedPct > 100
+      ? 'bg-red-700'
+      : reservedPct > 80
+        ? 'bg-red-700'
+        : reservedPct > 50
+          ? 'bg-amber-700'
+          : 'bg-green-700'}
   <div>
     <div class="flex items-center justify-between mb-1.5">
       <span
         class="text-[10px] font-bold uppercase tracking-wider text-neutral-400 dark:text-neutral-500"
         >PoE Budget</span
       >
-      <span class="text-[10px] font-mono text-amber-600 dark:text-amber-300"
-        >{poeBudget.used_w}W / {poeBudget.budget_w}W</span
-      >
+      <span class="text-[10px] font-mono text-neutral-600 dark:text-neutral-300">
+        <span class="text-emerald-600 dark:text-emerald-400">{poeBudget.draw_w}W</span>
+        <span class="text-neutral-400 dark:text-neutral-500"> / </span>
+        <span class="text-amber-600 dark:text-amber-300">{poeBudget.reserved_w}W</span>
+        <span class="text-neutral-400 dark:text-neutral-500"> / {poeBudget.budget_w}W</span>
+      </span>
     </div>
     <div
-      class="w-full h-2 rounded-full bg-neutral-200 dark:bg-neutral-700 overflow-hidden mb-1.5"
+      class="relative w-full h-2 rounded-full bg-neutral-200 dark:bg-neutral-700 overflow-hidden mb-1"
       role="meter"
-      aria-valuenow={poeBudget.used_w}
+      aria-valuenow={poeBudget.reserved_w}
       aria-valuemax={poeBudget.budget_w}
     >
       <div
-        class="h-full rounded-full transition-all {poeBudget.utilization_pct > 80 ? 'bg-red-500' : poeBudget.utilization_pct > 50 ? 'bg-amber-500' : 'bg-green-500'}"
-        style="width: {Math.min(100, poeBudget.utilization_pct)}%"
+        class="absolute inset-y-0 left-0 {barColor} opacity-60 transition-all"
+        style="width: {reservedPct}%"
+      ></div>
+      <div
+        class="absolute inset-y-0 left-0 {drawColor} transition-all"
+        style="width: {drawPct}%"
       ></div>
     </div>
-    <div class="text-[9px] text-neutral-400 dark:text-neutral-500 mb-2">
-      {poeBudget.remaining_w}W remaining ({poeBudget.utilization_pct}%)
+    <div class="flex justify-between text-[9px] text-neutral-400 dark:text-neutral-500 mb-2">
+      <span>draw · reserved · budget</span>
+      <span>{poeBudget.remaining_w}W free ({reservedPct}%)</span>
     </div>
+    {#if poeBudget.violations.length > 0}
+      <div class="space-y-0.5 mb-2">
+        {#each poeBudget.violations as v}
+          <div
+            class="flex items-start gap-1 text-[10px] text-red-600 dark:text-red-400 px-2 py-1 rounded bg-red-50 dark:bg-red-950/30"
+          >
+            <span class="font-bold">!</span>
+            <span>{v.message}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
     <div class="space-y-1">
       {#each poeBudget.links as link}
         <div class="px-2.5 py-1.5 rounded-lg bg-neutral-50 dark:bg-neutral-700/30 text-[10px]">
@@ -231,16 +269,35 @@
               {#if link.toPort}
                 <span class="text-neutral-400">:{link.toPort}</span>
               {/if}
+              {#if link.effective_class !== undefined}
+                <span
+                  class="ml-1 px-1 py-0 rounded bg-neutral-200 dark:bg-neutral-600 text-[8px] text-neutral-600 dark:text-neutral-300"
+                  >C{link.effective_class}</span
+                >
+              {/if}
             </span>
-            <span class="font-mono text-amber-600 dark:text-amber-400">{link.draw_w}W</span>
+            <span class="font-mono">
+              <span class="text-emerald-600 dark:text-emerald-400">{link.draw_w}W</span>
+              <span class="text-neutral-400"> / </span>
+              <span class="text-amber-600 dark:text-amber-400">{link.reserved_w}W</span>
+            </span>
           </div>
+          {#if link.violations}
+            {#each link.violations as v}
+              <div class="mt-0.5 text-[9px] text-red-500 dark:text-red-400">! {v.message}</div>
+            {/each}
+          {/if}
           {#if link.passthrough}
             {#each link.passthrough as pt}
               <div
                 class="flex justify-between mt-0.5 pl-3 border-l border-neutral-200 dark:border-neutral-600 ml-1 text-[9px] text-neutral-400 dark:text-neutral-500"
               >
                 <span>{pt.nodeLabel}</span>
-                <span class="font-mono">{pt.draw_w}W</span>
+                <span class="font-mono">
+                  <span class="text-emerald-500 dark:text-emerald-500">{pt.draw_w}W</span>
+                  <span> / </span>
+                  <span>{pt.reserved_w}W</span>
+                </span>
               </div>
             {/each}
           {/if}

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -21,7 +21,7 @@ import {
   type Theme,
 } from '@shumoku/core'
 import { nanoid } from 'nanoid'
-import { analyzePoE, type PoEBudget } from './poe-analysis'
+import { analyzePoE } from './poe-analysis'
 import { sampleBomItems, samplePalette } from './sample-project'
 import type { BomItem, NetedProject, SpecPaletteEntry } from './types'
 import { paletteEntryLabel } from './types'
@@ -92,7 +92,6 @@ const diagram = $state({
   links: [] as Link[],
 })
 
-let poeBudgets = $state<PoEBudget[]>([])
 let palette = $state<SpecPaletteEntry[]>([])
 let bomItems = $state<BomItem[]>([])
 let status = $state('Loading...')
@@ -113,6 +112,10 @@ async function rerouteEdges() {
 
 const catalog = new Catalog()
 catalog.registerAll(builtinEntries)
+
+// Reactive: recompute whenever nodes or links change. Avoids stale budget
+// display when users add/remove nodes, rebind specs, or edit links.
+const poeBudgets = $derived(analyzePoE([...diagram.nodes.values()], diagram.links, catalog))
 
 /** Update spec on multiple nodes at once (Palette → Node propagation) */
 function setNodeSpecs(nodeIds: string[], spec: NodeSpec | undefined) {
@@ -424,7 +427,6 @@ export const diagramState = {
     palette = data.palette ?? []
     bomItems = data.bom ?? []
     await diagramState.importGraph(data.diagram ?? { version: '1', nodes: [], links: [] })
-    poeBudgets = analyzePoE([...diagram.nodes.values()], diagram.links, catalog)
     status = 'Ready'
   },
 
@@ -448,7 +450,6 @@ export const diagramState = {
     diagram.subgraphs = new Map()
     diagram.bounds = { x: 0, y: 0, width: 800, height: 600 }
     diagram.links = []
-    poeBudgets = []
     yamlSource = ''
     initialized = false
 
@@ -473,7 +474,6 @@ export const diagramState = {
 
         const { resolved } = await computeNetworkLayout(g)
         diagramState.loadFromResolved(resolved, g.links)
-        poeBudgets = analyzePoE(g.nodes, g.links, catalog)
         const mf = sampleNetwork.find((f) => f.name === 'main.yaml')
         if (mf) yamlSource = mf.content
         status = 'Ready'
@@ -500,7 +500,6 @@ export const diagramState = {
       const g = (await hp.parse(yamlStr, '/main.yaml')).graph
       const { resolved } = await computeNetworkLayout(g)
       diagramState.loadFromResolved(resolved, g.links)
-      poeBudgets = analyzePoE(g.nodes, g.links, catalog)
       yamlSource = yamlStr
       status = 'Ready'
     } catch (e) {

--- a/apps/editor/src/lib/poe-analysis.ts
+++ b/apps/editor/src/lib/poe-analysis.ts
@@ -3,16 +3,48 @@
 
 /**
  * PoE budget analysis for the editor.
- * Uses @shumoku/catalog to resolve device specs and compute power budgets.
+ *
+ * Calculation is based on IEEE 802.3 class-based reservation (the conservative
+ * design default): a PSE reserves a fixed wattage per port based on the PD's
+ * classification — regardless of the PD's actual instantaneous draw. Planning
+ * against `max_draw_w` alone understates the PSE's consumption and can cause
+ * PoE negotiation to fail in practice.
+ *
+ * Each link yields two values:
+ *   - `reserved_w` — watts the PSE commits to the port (the budget accounting value)
+ *   - `draw_w`    — catalog's informational max_draw_w (what the PD actually draws)
+ *
+ * Limitations (tracked in GH issue #119):
+ *   - Static class-based only. LLDP dynamic allocation and UPOE are not modeled.
+ *   - PSE budget is treated as a single value per entry. Conditional budgets
+ *     (PSU model / PSU count / external adapter) are represented by picking
+ *     the conservative (smallest) value in the catalog.
+ *   - PD per-class draw matrix (`poe_in.by_class`) is captured but not yet used
+ *     in draw_w reporting; draw_w uses `poe_in.max_draw_w` (the max-class value).
  */
 
-import type { Catalog, HardwareProperties, PowerProperties } from '@shumoku/catalog'
+import {
+  type Catalog,
+  classReservationW,
+  effectivePoeClass,
+  type HardwareProperties,
+  type PowerProperties,
+} from '@shumoku/catalog'
 import type { Link, Node } from '@shumoku/core'
 
 export interface PoEPassthrough {
   nodeId: string
   nodeLabel: string
   draw_w: number
+  reserved_w: number
+}
+
+export type PoEViolationKind = 'over-budget' | 'over-port-max' | 'min-class-unmet'
+
+export interface PoEViolation {
+  kind: PoEViolationKind
+  message: string
+  linkId?: string
 }
 
 export interface PoELinkDraw {
@@ -21,8 +53,15 @@ export interface PoELinkDraw {
   toNodeId: string
   toNodeLabel: string
   toPort: string
+  /** Watts the PSE reserves for this port (budget accounting). */
+  reserved_w: number
+  /** Watts the PD typically draws (informational, not summed into budget). */
   draw_w: number
-  /** Downstream devices powered via passthrough */
+  /** Effective negotiated PoE class (after min(PD, PSE) downgrade). */
+  effective_class?: number
+  /** Per-link violations (e.g. reservation exceeds PSE max_per_port_w, min_class unmet). */
+  violations?: PoEViolation[]
+  /** Downstream devices powered via passthrough (informational, not summed). */
   passthrough?: PoEPassthrough[]
 }
 
@@ -30,10 +69,24 @@ export interface PoEBudget {
   nodeId: string
   nodeLabel: string
   budget_w: number
-  used_w: number
+  /** Sum of reserved_w across all outgoing PoE links (the budget-accounting value). */
+  reserved_w: number
+  /** Sum of draw_w across all outgoing PoE links (informational, typically < reserved). */
+  draw_w: number
   remaining_w: number
   utilization_pct: number
   links: PoELinkDraw[]
+  violations: PoEViolation[]
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10
+}
+
+function nodeLabelOf(node: Node | undefined, fallbackId: string): string {
+  if (!node) return fallbackId
+  const label = Array.isArray(node.label) ? node.label[0] : node.label
+  return label ?? fallbackId
 }
 
 function catalogId(node: Node): string | undefined {
@@ -54,14 +107,67 @@ function linkEndpointNode(ep: string | { node: string }): string {
   return typeof ep === 'string' ? ep : ep.node
 }
 
+function linkEndpointPort(ep: string | { node: string; port?: string }): string {
+  return typeof ep === 'object' ? (ep.port ?? '') : ''
+}
+
 /**
- * Compute PoE budgets for all PoE source (PSE) nodes in the network.
+ * Compute the watts the PSE reserves for a port given both sides' capabilities,
+ * and the PD's informational draw. Returns undefined if the PD is not a PoE consumer.
+ */
+function computePortPower(
+  pdPower: PowerProperties,
+  psePower: PowerProperties,
+): {
+  reserved_w: number
+  draw_w: number
+  effective_class?: number
+  violations: PoEViolation[]
+} | null {
+  if (!pdPower.poe_in) return null
+  const violations: PoEViolation[] = []
+
+  const effectiveClass = effectivePoeClass(pdPower.poe_in.class, psePower.poe_out?.standard)
+  const classReserved = classReservationW(effectiveClass)
+
+  // Prefer class-based reservation; fall back to PD's declared draw when class unknown.
+  const reserved_w = classReserved ?? pdPower.poe_in.max_draw_w ?? pdPower.max_draw_w ?? 0
+
+  const draw_w = pdPower.poe_in.max_draw_w ?? pdPower.max_draw_w ?? 0
+
+  // Per-port max check: PSE per-port cap vs this reservation.
+  const perPortMax = psePower.poe_out?.max_per_port_w
+  if (perPortMax !== undefined && reserved_w > perPortMax) {
+    violations.push({
+      kind: 'over-port-max',
+      message: `Reserved ${reserved_w}W exceeds PSE per-port max ${perPortMax}W`,
+    })
+  }
+
+  // min_class check: PD may refuse to boot below a required class.
+  const minClass = pdPower.poe_in.min_class
+  if (minClass !== undefined && effectiveClass !== undefined && effectiveClass < minClass) {
+    violations.push({
+      kind: 'min-class-unmet',
+      message: `Device requires Class ${minClass}+ but link negotiates Class ${effectiveClass}`,
+    })
+  }
+
+  return { reserved_w, draw_w, effective_class: effectiveClass, violations }
+}
+
+/**
+ * Compute PoE budgets for every PSE node in the network.
+ *
+ * Each PSE's accounting uses class-based reservation. Passthrough devices (PDs
+ * with both `poe_in` and `poe_out`) are NOT double-counted against the upstream
+ * PSE — they generate their own separate budget entry. Downstream draws from a
+ * passthrough device are surfaced as informational sub-rows.
  */
 export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEBudget[] {
   const nodeMap = new Map<string, Node>()
   for (const node of nodes) nodeMap.set(node.id, node)
 
-  // Build adjacency: nodeId → [{ peerId, linkId, localPort, peerPort }]
   interface AdjEntry {
     peerId: string
     linkId: string
@@ -73,8 +179,8 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
     const from = linkEndpointNode(link.from)
     const to = linkEndpointNode(link.to)
     const id = link.id ?? `${from}-${to}`
-    const fromPort = typeof link.from === 'object' ? (link.from.port ?? '') : ''
-    const toPort = typeof link.to === 'object' ? (link.to.port ?? '') : ''
+    const fromPort = linkEndpointPort(link.from)
+    const toPort = linkEndpointPort(link.to)
 
     const fl = adj.get(from) ?? []
     fl.push({ peerId: to, linkId: id, localPort: fromPort, peerPort: toPort })
@@ -88,68 +194,85 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
   const budgets: PoEBudget[] = []
 
   for (const node of nodes) {
-    const power = getPower(node, catalog)
-    if (!power?.poe_out?.budget_w) continue
+    const pse = getPower(node, catalog)
+    if (!pse?.poe_out?.budget_w) continue
 
     const neighbors = adj.get(node.id) ?? []
     const poeLinks: PoELinkDraw[] = []
-    let totalUsed = 0
+    const nodeViolations: PoEViolation[] = []
+    let totalReserved = 0
+    let totalDraw = 0
 
     for (const { peerId, linkId, localPort, peerPort } of neighbors) {
       const peer = nodeMap.get(peerId)
       if (!peer) continue
 
       const peerPower = getPower(peer, catalog)
-      if (!peerPower?.poe_in) continue // only PoE consumers (PD with poe_in)
+      if (!peerPower) continue
 
-      const ownDraw = peerPower.poe_in.max_draw_w ?? peerPower.max_draw_w ?? 0
-      if (ownDraw <= 0) continue
+      const port = computePortPower(peerPower, pse)
+      if (!port) continue
 
-      // Passthrough: if peer also has poe_out, collect downstream consumption
-      let passthroughDraw = 0
-      const passthroughDevices: PoEPassthrough[] = []
-      if (peerPower.poe_out) {
-        for (const { peerId: dsId } of adj.get(peerId) ?? []) {
-          if (dsId === node.id) continue
-          const ds = nodeMap.get(dsId)
-          if (!ds) continue
-          const dsPower = getPower(ds, catalog)
-          if (dsPower?.poe_in) {
-            const dsDraw = dsPower.poe_in.max_draw_w ?? dsPower.max_draw_w ?? 0
-            passthroughDraw += dsDraw
-            const dsLabel = Array.isArray(ds.label) ? ds.label[0] : ds.label
-            passthroughDevices.push({ nodeId: dsId, nodeLabel: dsLabel, draw_w: dsDraw })
-          }
+      // Informational passthrough: surface what the PD forwards downstream.
+      const passthrough: PoEPassthrough[] = []
+      if (peerPower.poe_out?.budget_w !== undefined) {
+        for (const ds of adj.get(peerId) ?? []) {
+          if (ds.peerId === node.id) continue
+          const dsNode = nodeMap.get(ds.peerId)
+          if (!dsNode) continue
+          const dsPower = getPower(dsNode, catalog)
+          if (!dsPower) continue
+          const dsPort = computePortPower(dsPower, peerPower)
+          if (!dsPort) continue
+          passthrough.push({
+            nodeId: ds.peerId,
+            nodeLabel: nodeLabelOf(dsNode, ds.peerId),
+            draw_w: dsPort.draw_w,
+            reserved_w: dsPort.reserved_w,
+          })
         }
       }
 
-      const totalDraw = ownDraw + passthroughDraw
-      const peerLabel = Array.isArray(peer.label) ? peer.label[0] : peer.label
+      const linkViolations = port.violations.map((v) => ({ ...v, linkId }))
+      nodeViolations.push(...linkViolations)
+
       poeLinks.push({
         linkId,
         fromPort: localPort,
         toNodeId: peerId,
-        toNodeLabel: peerLabel,
+        toNodeLabel: nodeLabelOf(peer, peerId),
         toPort: peerPort,
-        draw_w: totalDraw,
-        passthrough: passthroughDevices.length > 0 ? passthroughDevices : undefined,
+        reserved_w: round1(port.reserved_w),
+        draw_w: round1(port.draw_w),
+        effective_class: port.effective_class,
+        violations: linkViolations.length > 0 ? linkViolations : undefined,
+        passthrough: passthrough.length > 0 ? passthrough : undefined,
       })
-      totalUsed += totalDraw
+      totalReserved += port.reserved_w
+      totalDraw += port.draw_w
     }
 
-    if (poeLinks.length > 0) {
-      const budget = power.poe_out.budget_w
-      const label = Array.isArray(node.label) ? node.label[0] : node.label
-      budgets.push({
-        nodeId: node.id,
-        nodeLabel: label,
-        budget_w: budget,
-        used_w: Math.round(totalUsed * 10) / 10,
-        remaining_w: Math.round((budget - totalUsed) * 10) / 10,
-        utilization_pct: Math.round((totalUsed / budget) * 1000) / 10,
-        links: poeLinks,
+    if (poeLinks.length === 0) continue
+
+    const budget = pse.poe_out.budget_w
+    if (totalReserved > budget) {
+      nodeViolations.push({
+        kind: 'over-budget',
+        message: `Reserved ${round1(totalReserved)}W exceeds PSE budget ${budget}W`,
       })
     }
+
+    budgets.push({
+      nodeId: node.id,
+      nodeLabel: nodeLabelOf(node, node.id),
+      budget_w: budget,
+      reserved_w: round1(totalReserved),
+      draw_w: round1(totalDraw),
+      remaining_w: round1(budget - totalReserved),
+      utilization_pct: Math.round((totalReserved / budget) * 1000) / 10,
+      links: poeLinks,
+      violations: nodeViolations,
+    })
   }
 
   return budgets

--- a/libs/@shumoku/catalog/data/hardware/generic/ip-phone.yaml
+++ b/libs/@shumoku/catalog/data/hardware/generic/ip-phone.yaml
@@ -12,5 +12,5 @@ properties:
     max_draw_w: 5
     poe_in:
       standard: "802.3af"
-      class: 1
+      class: 2
       max_draw_w: 5

--- a/libs/@shumoku/catalog/data/hardware/hpe/aruba-ap-505.yaml
+++ b/libs/@shumoku/catalog/data/hardware/hpe/aruba-ap-505.yaml
@@ -10,11 +10,20 @@ spec:
 tags: [wifi-6, indoor, ceiling-mount, poe-consumer]
 properties:
   power:
-    max_draw_w: 11
+    max_draw_w: 16.5  # worst-case with USB device attached
     poe_in:
-      standard: "802.3af"
-      class: 3
-      max_draw_w: 16.5  # with USB device attached
+      standard: "802.3at"
+      class: 4
+      min_class: 3
+      max_draw_w: 16.5
+      by_class:
+        3:
+          standard: "802.3af"
+          max_draw_w: 11
+          note: "Reduced mode — USB disabled, reduced radio capability"
+        4:
+          standard: "802.3at"
+          max_draw_w: 16.5
   wireless:
     standard: wifi-6
     radios: 2

--- a/libs/@shumoku/catalog/data/hardware/hpe/aruba-instant-on-ap11d.yaml
+++ b/libs/@shumoku/catalog/data/hardware/hpe/aruba-instant-on-ap11d.yaml
@@ -11,10 +11,11 @@ spec:
 tags: [wifi-5, desk, poe-consumer, poe-passthrough]
 properties:
   power:
-    max_draw_w: 12
+    max_draw_w: 27.4  # own 12W + passthrough 15.4W (within 802.3at 30W input)
     poe_in:
-      standard: "802.3af"
-      class: 3
+      standard: "802.3at"  # E3 PoE-out only works when fed 802.3at
+      class: 4
+      max_draw_w: 27.4
     poe_out:
       standard: "802.3af"
       budget_w: 15.4

--- a/libs/@shumoku/catalog/src/builtin-data.ts
+++ b/libs/@shumoku/catalog/src/builtin-data.ts
@@ -203,7 +203,7 @@ export const builtinData = [
         max_draw_w: 5,
         poe_in: {
           standard: '802.3af',
-          class: 1,
+          class: 2,
           max_draw_w: 5,
         },
       },
@@ -221,11 +221,23 @@ export const builtinData = [
     tags: ['wifi-6', 'indoor', 'ceiling-mount', 'poe-consumer'],
     properties: {
       power: {
-        max_draw_w: 11,
+        max_draw_w: 16.5,
         poe_in: {
-          standard: '802.3af',
-          class: 3,
+          standard: '802.3at',
+          class: 4,
+          min_class: 3,
           max_draw_w: 16.5,
+          by_class: {
+            '3': {
+              standard: '802.3af',
+              max_draw_w: 11,
+              note: 'Reduced mode — USB disabled, reduced radio capability',
+            },
+            '4': {
+              standard: '802.3at',
+              max_draw_w: 16.5,
+            },
+          },
         },
       },
       wireless: {
@@ -259,10 +271,11 @@ export const builtinData = [
     tags: ['wifi-5', 'desk', 'poe-consumer', 'poe-passthrough'],
     properties: {
       power: {
-        max_draw_w: 12,
+        max_draw_w: 27.4,
         poe_in: {
-          standard: '802.3af',
-          class: 3,
+          standard: '802.3at',
+          class: 4,
+          max_draw_w: 27.4,
         },
         poe_out: {
           standard: '802.3af',

--- a/libs/@shumoku/catalog/src/index.ts
+++ b/libs/@shumoku/catalog/src/index.ts
@@ -5,6 +5,13 @@
 export { builtinEntries } from './builtin.js'
 export { Catalog } from './catalog.js'
 export { parseCatalogYaml, parseCatalogYamlMulti } from './loader.js'
+export {
+  classReservationW,
+  effectivePoeClass,
+  POE_CLASS_RESERVATION_W,
+  POE_STANDARD_MAX_CLASS,
+  type PoEStandard,
+} from './poe.js'
 export type {
   CatalogEntry,
   ComputeCatalogEntry,
@@ -14,6 +21,7 @@ export type {
   ManagementProperties,
   PhysicalProperties,
   PoEIn,
+  PoEInClassProfile,
   PoEOut,
   PortGroup,
   PortProperties,

--- a/libs/@shumoku/catalog/src/poe.test.ts
+++ b/libs/@shumoku/catalog/src/poe.test.ts
@@ -1,0 +1,55 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import { classReservationW, effectivePoeClass, POE_CLASS_RESERVATION_W } from './poe.js'
+
+describe('effectivePoeClass', () => {
+  it('returns undefined when PD class unknown', () => {
+    expect(effectivePoeClass(undefined, '802.3at')).toBeUndefined()
+  })
+
+  it('returns PD class when PSE standard unknown', () => {
+    expect(effectivePoeClass(5, undefined)).toBe(5)
+    expect(effectivePoeClass(5, 'nonsense')).toBe(5)
+  })
+
+  it('downgrades PD when PSE supports only lower standard', () => {
+    // Class 5 (bt) PD on an at-only PSE → Class 4
+    expect(effectivePoeClass(5, '802.3at')).toBe(4)
+    // Class 5 PD on an af-only PSE → Class 3
+    expect(effectivePoeClass(5, '802.3af')).toBe(3)
+  })
+
+  it('uses PD class when PSE supports higher', () => {
+    // Class 3 PD on a bt PSE stays Class 3 (not upgraded)
+    expect(effectivePoeClass(3, '802.3bt')).toBe(3)
+  })
+
+  it('preserves PD class at the PSE max', () => {
+    expect(effectivePoeClass(4, '802.3at')).toBe(4)
+    expect(effectivePoeClass(8, '802.3bt')).toBe(8)
+  })
+})
+
+describe('classReservationW', () => {
+  it('returns IEEE reservation for each class', () => {
+    expect(classReservationW(0)).toBe(15.4)
+    expect(classReservationW(3)).toBe(15.4)
+    expect(classReservationW(4)).toBe(30)
+    expect(classReservationW(5)).toBe(45)
+    expect(classReservationW(8)).toBe(90)
+  })
+
+  it('returns undefined for unknown class', () => {
+    expect(classReservationW(undefined)).toBeUndefined()
+    expect(classReservationW(99)).toBeUndefined()
+  })
+
+  it('has a full table from 0 to 8', () => {
+    for (let c = 0; c <= 8; c++) {
+      expect(POE_CLASS_RESERVATION_W[c]).toBeDefined()
+    }
+  })
+})

--- a/libs/@shumoku/catalog/src/poe.ts
+++ b/libs/@shumoku/catalog/src/poe.ts
@@ -1,0 +1,71 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * IEEE 802.3 PoE reservation constants.
+ *
+ * A PSE reserves a fixed amount of power per port based on the PD's classification,
+ * regardless of the PD's actual instantaneous draw. Using the catalog `max_draw_w`
+ * for budget planning underestimates PSE consumption; engineers must size against
+ * class-based reservation.
+ */
+
+/** PoE standards recognized by the catalog. */
+export type PoEStandard = '802.3af' | '802.3at' | '802.3bt'
+
+/**
+ * Per-port watts reserved by a PSE when the PD classifies at the given class.
+ *
+ * Values follow the IEEE 802.3 standard worst-case power each class may draw at the
+ * PSE (PI) side. A PSE that sees a Class 4 PD reserves 30 W even if the device
+ * actually draws 12 W.
+ *
+ * Class 0 is treated as Class 3 (15.4 W) per historical convention — an unclassified
+ * device may draw up to Class 3's limit.
+ */
+export const POE_CLASS_RESERVATION_W: Record<number, number> = {
+  0: 15.4,
+  1: 4,
+  2: 7,
+  3: 15.4,
+  4: 30,
+  5: 45,
+  6: 60,
+  7: 75,
+  8: 90,
+}
+
+/** Highest class each PoE standard natively supports. */
+export const POE_STANDARD_MAX_CLASS: Record<PoEStandard, number> = {
+  '802.3af': 3,
+  '802.3at': 4,
+  '802.3bt': 8,
+}
+
+/**
+ * Resolve the effective class negotiated between a PD and a PSE.
+ *
+ * A PD may support up to `pdClass` (under `pdStandard`), but the PSE may only
+ * power up to `pseStandard`'s max class. The actual reservation uses whichever
+ * is lower. Undefined inputs fall back to the best information available.
+ */
+export function effectivePoeClass(
+  pdClass: number | undefined,
+  pseStandard: string | undefined,
+): number | undefined {
+  if (pdClass === undefined) return undefined
+  if (pseStandard === undefined) return pdClass
+  const pseMax = POE_STANDARD_MAX_CLASS[pseStandard as PoEStandard]
+  if (pseMax === undefined) return pdClass
+  return Math.min(pdClass, pseMax)
+}
+
+/**
+ * Watts a PSE reserves for a port given the effective class.
+ * Returns undefined when the class is unknown (caller falls back to `max_draw_w`).
+ */
+export function classReservationW(effectiveClass: number | undefined): number | undefined {
+  if (effectiveClass === undefined) return undefined
+  return POE_CLASS_RESERVATION_W[effectiveClass]
+}

--- a/libs/@shumoku/catalog/src/types.ts
+++ b/libs/@shumoku/catalog/src/types.ts
@@ -8,14 +8,35 @@ import type { NodeSpec } from '@shumoku/core'
 // Properties — grouped by concern
 // ============================================
 
+/** Per-class profile for a multi-class PD (e.g. AP that runs degraded on lower classes). */
+export interface PoEInClassProfile {
+  /** PoE standard at this class ("802.3af" | "802.3at" | "802.3bt") */
+  standard?: string
+  /** Actual device power consumption when operating at this class (watts) */
+  max_draw_w?: number
+  /** Human-readable note (e.g. "1x1 radio, no USB/LLDP") */
+  note?: string
+}
+
 /** PoE consumer (Powered Device) */
 export interface PoEIn {
-  /** PoE standard: "802.3af", "802.3at", "802.3bt" */
+  /** Highest PoE standard supported ("802.3af" | "802.3at" | "802.3bt") */
   standard?: string
-  /** PoE class (0–8) */
+  /** Highest PoE class the device can negotiate (0–8) */
   class?: number
-  /** Max power draw via PoE (watts) */
+  /**
+   * Minimum PoE class required to boot. If omitted, the device is assumed to
+   * gracefully degrade on any lower class it negotiates.
+   */
+  min_class?: number
+  /** Max power draw via PoE at the highest class (watts, informational) */
   max_draw_w?: number
+  /**
+   * Per-class capability matrix for multi-class devices. Optional.
+   * Keyed by class number. Used when a device draws materially different power
+   * and exposes different features at each class it supports.
+   */
+  by_class?: Record<number, PoEInClassProfile>
 }
 
 /** PoE source (Power Sourcing Equipment) */

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -66,8 +66,9 @@
   // Trackpad-friendly: two-finger scroll → pan, pinch (ctrl+wheel) → zoom
   $effect(() => {
     if (!svgEl || !viewportEl) return
+    const svg = svgEl
 
-    const svgSel = select(svgEl)
+    const svgSel = select(svg)
     const zoomBehavior = zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.2, 10])
       .filter((e) => {
@@ -93,14 +94,14 @@
       e.preventDefault()
       zoomBehavior.translateBy(svgSel, -e.deltaX, -e.deltaY)
     }
-    svgEl.addEventListener('wheel', handleWheel, { passive: false })
+    svg.addEventListener('wheel', handleWheel, { passive: false })
 
     // Prevent default context menu on SVG background only when nothing is targeted
     svgSel.on('contextmenu.zoom', null)
 
     return () => {
       svgSel.on('.zoom', null)
-      svgEl.removeEventListener('wheel', handleWheel)
+      svg.removeEventListener('wheel', handleWheel)
     }
   })
 


### PR DESCRIPTION
## Summary

- Replace naive `max_draw_w` summation with IEEE 802.3 class-based reservation in the editor PoE analysis — matches how PSEs actually commit power per port
- Extend `@shumoku/catalog` `PoEIn` schema with `min_class` (boot requirement) and `by_class` matrix; add `POE_CLASS_RESERVATION_W` / `POE_STANDARD_MAX_CLASS` tables and helpers
- NodeContent 3-layer progress bar (draw / reserved / budget) with effective-class badges and per-link violation surfacing (`over-port-max`, `min-class-unmet`, `over-budget`)
- Fix `poeBudgets` reactivity (was only recomputing on project load, now `$derived` — updates on node/link mutations)
- Correct catalog data inconsistencies where declared `max_draw_w` was physically impossible under the declared class/standard:
  - AP-505: class 3/af → class 4/at (+ `by_class[3]` capturing af reduced-feature mode)
  - AP11D: passthrough power now reflected in `max_draw_w` (12 → 27.4), af → at
  - IP Phone: class 1 → class 2 (5W draw exceeds class 1's 3.84W max)

## Why

Planning PoE against `max_draw_w` alone understates what the PSE commits: a class 4 PD reserves 30W on the switch even if it draws 16W. Designs passing validation on raw draw sums can still fail at negotiation time. This PR switches the accounting to the conservative class-based value, surfaces both numbers in the UI, and flags physically-impossible catalog entries.

## Out of scope

- LLDP dynamic allocation / UPOE — static class-based only (tracked in #119)
- Conditional budgets (PSU variant, external adapter) use the smallest declared budget_w in YAML

## Test plan

- [x] `libs/@shumoku/catalog` — 8/8 `poe.test.ts` tests pass (`effectivePoeClass` downgrade, class reservation table)
- [x] `apps/editor` — svelte-check 0 errors
- [x] Repo-wide typecheck passes (pre-commit hook green)
- [x] Manual browser verification: 3-layer bar renders, per-link `{draw}W / {reserved}W` + class badge, passthrough rows inherit correct class reservation
- [ ] Reviewer: sanity-check `by_class` YAML schema before it ossifies

🤖 Generated with [Claude Code](https://claude.com/claude-code)