### PR TITLE
fix(editor): preserve vendor/model + palette binding on node copy-paste

### DIFF
--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { NodeSpec } from '@shumoku/core'
   // @ts-expect-error — SvelteKit resolves the svelte condition from package.json exports
   import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
   import { renderGraphToSvg } from '@shumoku/renderer-svg'
@@ -22,7 +23,8 @@
   let clipboard = $state<{
     label: string
     shape?: string
-    type?: string
+    spec?: NodeSpec
+    paletteId?: string
     elementKind: 'node' | 'subgraph'
   } | null>(null)
   let detailTarget = $state<{ id: string; type: 'node' | 'link' | 'subgraph' } | null>(null)
@@ -158,13 +160,34 @@
       currentParent={contextMenu.type === 'node' ? diagramState.nodes.get(contextMenu.id)?.parent : undefined}
       oncopy={(id) => {
         const info = renderer?.getElementInfo(id)
-        clipboard = info ? { label: info.label, shape: info.kind === 'node' ? info.shape : undefined, type: info.kind === 'node' ? info.type : undefined, elementKind: info.kind } : null
+        if (!info) { clipboard = null; return }
+        const paletteId = info.kind === 'node'
+          ? diagramState.bomItems.find((b) => b.nodeId === id)?.paletteId
+          : undefined
+        clipboard = {
+          label: info.label,
+          shape: info.kind === 'node' ? info.shape : undefined,
+          spec: info.kind === 'node' ? info.spec : undefined,
+          paletteId,
+          elementKind: info.kind,
+        }
       }}
       onpaste={() => {
         if (!clipboard || !contextMenu) return
         const svgPos = renderer?.screenToSvg(contextMenu.x, contextMenu.y)
-        if (clipboard.elementKind === 'subgraph') renderer?.addNewSubgraph({ label: clipboard.label, position: svgPos })
-        else renderer?.addNewNode({ label: clipboard.label, type: clipboard.type, shape: clipboard.shape, position: svgPos })
+        if (clipboard.elementKind === 'subgraph') {
+          renderer?.addNewSubgraph({ label: clipboard.label, position: svgPos })
+        } else {
+          const newId = renderer?.addNewNode({
+            label: clipboard.label,
+            spec: clipboard.spec,
+            shape: clipboard.shape,
+            position: svgPos,
+          })
+          if (newId && clipboard.paletteId) {
+            diagramState.bindNodeToPalette(newId, clipboard.paletteId)
+          }
+        }
       }}
       ondetails={(id) => openDetail(id, contextMenu?.type ?? 'node')}
       onmovetogroup={(nodeId, groupId) => {

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -4,6 +4,7 @@
     Link,
     Node,
     NodeShape,
+    NodeSpec,
     ResolvedEdge,
     ResolvedLayout,
     ResolvedPort,
@@ -227,16 +228,16 @@
   export function addNewNode(opts?: {
     label?: string
     type?: DeviceType
-    spec?: { kind: string; type?: string }
+    spec?: NodeSpec
     shape?: NodeShape
     position?: { x: number; y: number }
   }) {
     const id = `node-${Date.now()}`
     const label = opts?.label ?? 'New Node'
     const spec = opts?.spec
-      ? (opts.spec as import('@shumoku/core').NodeSpec)
+      ? opts.spec
       : opts?.type
-        ? { kind: 'hardware' as const, type: opts.type }
+        ? ({ kind: 'hardware' as const, type: opts.type } satisfies NodeSpec)
         : undefined
     const { width: w, height: h } = computeNodeSize({ label, spec })
     const { parent, initial } = resolveParentAndPosition(opts?.position, w)
@@ -365,6 +366,7 @@
         kind: 'node' as const,
         label: node.label ?? 'Node',
         shape: node.shape,
+        spec: node.spec,
         type: specDeviceType(node.spec),
       }
     }


### PR DESCRIPTION
## Summary

- Copying a node stripped `vendor`/`model` from the spec and dropped the BomItem palette binding, leaving the paste with only a bare `type` role
- Pasted nodes had `spec.kind='hardware'` without `vendor`/`model`, so `catalogId()` in `poe-analysis` returned undefined and the node was invisible to PoE budget accounting
- Users duplicating a PoE AP and wiring it to a PSE saw no budget change until they manually re-bound the palette entry

## Fix

1. `getElementInfo` returns the full `spec` (not just the `type` role via `specDeviceType`)
2. Copy handler also captures the source node's `paletteId` via BomItem lookup
3. Paste passes the full `spec` to `addNewNode` and calls `bindNodeToPalette(newId, paletteId)` — which reuses the BomItem that `onnodeadd` already created for the new node
4. Widen `addNewNode`'s `spec` parameter to `NodeSpec` instead of the narrower `{kind, type}` shape, removing an `as NodeSpec` cast

## Test plan

- [x] Typecheck: renderer + editor, 0 errors
- [x] Biome clean on modified files
- [x] Pre-commit hook (full repo typecheck) passes
- [ ] Manual: copy a palette-bound PoE AP, paste, wire to PSE, confirm PoE budget reflects the new link
- [ ] Manual: copy a bare node (no spec, no palette), paste, confirm behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)