### PR TITLE
fix(renderer): auto-detect mouse wheel vs trackpad for zoom/pan

### DIFF
--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -88,11 +88,20 @@
 
     svgSel.call(zoomBehavior)
 
-    // Two-finger scroll (non-ctrl/meta wheel) → pan
+    // Auto-detect input device (Miro-style):
+    // - deltaX !== 0 → trackpad two-finger scroll → pan
+    // - deltaX === 0 → mouse wheel → zoom at cursor
+    // - Ctrl/Cmd+wheel / pinch → zoom (d3-zoom filter above)
     const handleWheel = (e: WheelEvent) => {
       if (e.ctrlKey || e.metaKey) return // pinch-to-zoom handled by d3-zoom
       e.preventDefault()
-      zoomBehavior.translateBy(svgSel, -e.deltaX, -e.deltaY)
+      if (e.deltaX !== 0) {
+        zoomBehavior.translateBy(svgSel, -e.deltaX, -e.deltaY)
+      } else {
+        const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
+        const rect = svg.getBoundingClientRect()
+        zoomBehavior.scaleBy(svgSel, factor, [e.clientX - rect.left, e.clientY - rect.top])
+      }
     }
     svg.addEventListener('wheel', handleWheel, { passive: false })
 


### PR DESCRIPTION
## Summary
- Mouse wheel (deltaX === 0) now zooms at cursor position instead of vertical-only panning
- Trackpad two-finger scroll (deltaX !== 0) continues to pan as before
- Ctrl/Cmd+wheel and pinch-to-zoom unchanged
- Matches Miro-style auto-detect behavior

## Test plan
- [ ] Mouse wheel: scroll up/down zooms in/out at cursor position
- [ ] Trackpad: two-finger scroll pans the canvas
- [ ] Trackpad: pinch zooms in/out
- [ ] Ctrl+wheel: zooms on both platforms
- [ ] Alt+left-drag / middle-click drag: still pans

🤖 Generated with [Claude Code](https://claude.com/claude-code)