### PR TITLE
feat(editor): open detail panel on double-click

### DIFF
--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -81,7 +81,11 @@
 
 <div class="relative h-screen w-screen overflow-hidden bg-neutral-50 dark:bg-neutral-950">
   <!-- Canvas (full screen, z-0) -->
-  <div class="absolute inset-0">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="absolute inset-0"
+    ondblclick={() => { if (selected) openDetail(selected.id, selected.type) }}
+  >
     {#if diagramState.nodes.size > 0 || diagramState.status !== 'Loading...'}
       <ShumokuRenderer
         bind:this={renderer}


### PR DESCRIPTION
## Summary
- Double-clicking a selected element opens its Information panel
- Uses existing `onselect` state — no renderer changes needed
- Works for nodes, edges, ports, and subgraphs

## Test plan
- [ ] Double-click node → Information panel opens
- [ ] Double-click edge → Link information opens
- [ ] Double-click subgraph → Subgraph information opens
- [ ] Single click still selects without opening panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)