### PR TITLE
feat(editor): project import/export UI

### DIFF
--- a/apps/editor/src/lib/components/NavBar.svelte
+++ b/apps/editor/src/lib/components/NavBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Cube, ListBullets, PlugsConnected, Table } from 'phosphor-svelte'
+  import { Cube, GearSix, ListBullets, PlugsConnected, Table } from 'phosphor-svelte'
   import { page } from '$app/stores'
 
   // Extract project ID from URL
@@ -10,6 +10,7 @@
     { href: `/project/${projectId}/specs`, label: 'Specs', icon: ListBullets },
     { href: `/project/${projectId}/bom`, label: 'BOM', icon: Table },
     { href: `/project/${projectId}/connections`, label: 'Connections', icon: PlugsConnected },
+    { href: `/project/${projectId}/settings`, label: 'Settings', icon: GearSix },
   ])
 </script>
 

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -647,6 +647,9 @@ export const diagramState = {
 
   /** Load a project by ID. Resets all state first. */
   async loadProject(projectId: string) {
+    // Skip load if project was imported via importProject()
+    if (projectId === 'imported' && initialized) return
+
     // Reset all state
     palette = []
     bomItems = []

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -1,13 +1,32 @@
 <script lang="ts">
-  import { Cube, Plus } from 'phosphor-svelte'
+  import { DropdownMenu } from 'bits-ui'
+  import { CaretDown, Cube, FolderOpen, Plus } from 'phosphor-svelte'
   import { goto } from '$app/navigation'
   import { Button } from '$lib/components/ui/button'
   import * as Card from '$lib/components/ui/card'
+  import { diagramState } from '$lib/context.svelte'
 
   const projects = [
     { id: 'sample', name: 'Sample Network', description: 'Multi-site campus network with PoE' },
     { id: 'empty', name: 'Empty Project', description: 'Start from scratch' },
   ]
+
+  function handleImport() {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.json,.neted.json'
+    input.onchange = async () => {
+      const file = input.files?.[0]
+      if (!file) return
+      const text = await file.text()
+      await diagramState.importProject(text)
+      goto('/project/sample/diagram')
+    }
+    input.click()
+  }
+
+  const itemClass =
+    'flex items-center gap-2 w-full px-3 py-2 text-sm text-neutral-700 dark:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 cursor-pointer transition-colors'
 </script>
 
 <div class="min-h-screen bg-background px-6 py-8 max-w-4xl mx-auto">
@@ -16,10 +35,31 @@
       <h1 class="text-2xl font-bold">shumoku</h1>
       <p class="text-sm text-muted-foreground">Network Topology Editor</p>
     </div>
-    <Button disabled title="Requires database (coming soon)">
-      <Plus class="w-4 h-4 mr-1" />
-      New Project
-    </Button>
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        {#snippet child({ props })}
+          <Button {...props}>
+            <Plus class="w-4 h-4 mr-1" />
+            New
+            <CaretDown class="w-3 h-3 ml-1" />
+          </Button>
+        {/snippet}
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content
+        class="min-w-[180px] bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-lg py-1 z-50"
+        sideOffset={4}
+        align="end"
+      >
+        <DropdownMenu.Item class="{itemClass} opacity-50 cursor-not-allowed" disabled>
+          <Plus class="w-4 h-4 text-neutral-400" />
+          New Project
+        </DropdownMenu.Item>
+        <DropdownMenu.Item class={itemClass} onSelect={handleImport}>
+          <FolderOpen class="w-4 h-4 text-neutral-400" />
+          Import .neted.json
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
   </div>
 
   <div class="grid gap-4">

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -20,7 +20,7 @@
       if (!file) return
       const text = await file.text()
       await diagramState.importProject(text)
-      goto('/project/sample/diagram')
+      goto('/project/imported/diagram')
     }
     input.click()
   }

--- a/apps/editor/src/routes/project/[id]/(content)/settings/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/settings/+page.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { DownloadSimple } from 'phosphor-svelte'
+  import { Button } from '$lib/components/ui/button'
+  import { diagramState } from '$lib/context.svelte'
+
+  function handleExportProject() {
+    const json = diagramState.exportProject('Project')
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'project.neted.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+</script>
+
+<div class="max-w-2xl mx-auto space-y-8">
+  <h1 class="text-lg font-bold">Settings</h1>
+
+  <!-- Export -->
+  <section class="space-y-3">
+    <h2
+      class="text-sm font-semibold text-neutral-500 dark:text-neutral-400 uppercase tracking-wider"
+    >
+      Export
+    </h2>
+    <div
+      class="flex items-center justify-between p-4 rounded-xl border border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900"
+    >
+      <div>
+        <div class="text-sm font-medium">Project file</div>
+        <div class="text-xs text-muted-foreground">
+          Download as .neted.json (includes palette, BOM, and diagram)
+        </div>
+      </div>
+      <Button variant="outline" size="sm" onclick={handleExportProject}>
+        <DownloadSimple class="w-4 h-4 mr-1" />
+        Export
+      </Button>
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
## Summary
- Home page: "New Project" button → dropdown with "New Project" + "Import .neted.json"
- New Settings page (`/project/[id]/settings`) with project export (.neted.json download)
- NavBar: add Settings tab with gear icon

Backend logic (`exportProject` / `importProject`) was already implemented — this adds the UI.

## Test plan
- [ ] Home: dropdown opens with New Project (disabled) and Import
- [ ] Import: file picker opens, accepts .json/.neted.json, loads project
- [ ] Settings: Export button downloads project.neted.json
- [ ] NavBar: Settings tab visible and navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)