### PR TITLE
feat(docs): add Editor link to header navigation

### DIFF
--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -22,6 +22,10 @@ export function baseOptions(locale: string): BaseLayoutProps {
         text: 'Playground',
         url: `/${locale}/playground`,
       },
+      {
+        text: 'Editor',
+        url: `/${locale}/editor`,
+      },
     ],
     githubUrl: 'https://github.com/konoe-akitoshi/shumoku',
     i18n: true,


### PR DESCRIPTION
## Summary
- Add "Editor" link to docs header navigation (Docs / Playground / **Editor**)
- Points to existing `/{locale}/editor` page

## Test plan
- [ ] Header shows Editor link on home, playground, and docs pages
- [ ] Link navigates to editor page

🤖 Generated with [Claude Code](https://claude.com/claude-code)