### PR TITLE
feat(editor): load sample from JSON + fix importGraph port placement

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "lint": "biome check .",
-    "format": "biome check --write ."
+    "format": "biome check --write .",
+    "gen:sample": "bun scripts/generate-sample-diagram.ts"
   },
   "dependencies": {
     "@shumoku/catalog": "workspace:*",

--- a/apps/editor/scripts/generate-sample-diagram.ts
+++ b/apps/editor/scripts/generate-sample-diagram.ts
@@ -1,0 +1,92 @@
+/**
+ * One-off generator: parse the sample YAML fixtures, run layout, and emit
+ * a positioned NetworkGraph as a TS const. Output is checked in so runtime
+ * sample load no longer needs to go through the YAML parser.
+ *
+ * Run: `bun apps/editor/scripts/generate-sample-diagram.ts`
+ */
+
+import { spawnSync } from 'node:child_process'
+import { writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  computeNetworkLayout,
+  createMemoryFileResolver,
+  HierarchicalParser,
+  sampleNetwork,
+} from '@shumoku/core'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const OUT_PATH = resolve(SCRIPT_DIR, '../src/lib/sample-diagram.ts')
+
+async function main() {
+  const fileMap = new Map<string, string>()
+  for (const f of sampleNetwork) {
+    fileMap.set(f.name, f.content)
+    fileMap.set(`./${f.name}`, f.content)
+    fileMap.set(`/${f.name}`, f.content)
+  }
+  const resolver = createMemoryFileResolver(fileMap, '/')
+  const hp = new HierarchicalParser(resolver)
+  const mainFile = sampleNetwork.find((f) => f.name === 'main.yaml')
+  if (!mainFile) throw new Error('main.yaml not found')
+  const { graph } = await hp.parse(mainFile.content, '/main.yaml')
+  const { resolved } = await computeNetworkLayout(graph)
+
+  // Copy computed positions back onto Node/Subgraph records.
+  const positionedNodes = [...resolved.nodes.values()]
+  const positionedSubgraphs = [...resolved.subgraphs.values()]
+
+  const diagram = {
+    version: graph.version,
+    name: graph.name,
+    description: graph.description,
+    settings: graph.settings,
+    nodes: positionedNodes,
+    links: graph.links,
+    subgraphs: positionedSubgraphs,
+  }
+
+  const out = `// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Positioned NetworkGraph for the sample project.
+ * Generated from sampleNetwork YAML by scripts/generate-sample-diagram.ts —
+ * run that script to regenerate after editing the YAML fixtures.
+ *
+ * Cast via \`as unknown as NetworkGraph\`: DeviceType is a string enum and
+ * the serialized JSON has raw string literals where the type wants enum
+ * references. The runtime values match — the cast only papers over the
+ * nominal type check.
+ */
+
+import type { NetworkGraph } from '@shumoku/core'
+
+export const sampleDiagram = ${JSON.stringify(diagram, null, 2)} as unknown as NetworkGraph
+`
+
+  writeFileSync(OUT_PATH, out)
+
+  // Let biome format the generated file so it matches repo style (single
+  // quotes, no-quote keys, trailing commas). Otherwise `bun run lint` trips
+  // on the JSON-shaped output.
+  const fmt = spawnSync('bun', ['x', 'biome', 'check', '--write', OUT_PATH], {
+    stdio: 'inherit',
+    shell: true,
+  })
+  if (fmt.status !== 0) {
+    throw new Error(`biome check --write failed on ${OUT_PATH}`)
+  }
+
+  console.log(`wrote ${OUT_PATH}`)
+  console.log(`  nodes: ${positionedNodes.length}`)
+  console.log(`  subgraphs: ${positionedSubgraphs.length}`)
+  console.log(`  links: ${graph.links.length}`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -14,6 +14,7 @@ import {
   type Node,
   type NodeSpec,
   newId,
+  placePorts,
   type ResolvedEdge,
   type ResolvedLayout,
   type ResolvedPort,
@@ -21,12 +22,11 @@ import {
   resolvePosition,
   routeEdges,
   type Subgraph,
-  sampleNetwork,
   type Theme,
 } from '@shumoku/core'
 import { SvelteMap } from 'svelte/reactivity'
 import { analyzePoE } from './poe-analysis'
-import { sampleBomItems, samplePalette } from './sample-project'
+import { sampleProject } from './sample-project'
 import type { BomItem, NetedProject, SpecPaletteEntry } from './types'
 import { paletteEntryLabel } from './types'
 
@@ -603,7 +603,12 @@ export const diagramState = {
     replaceMap(diagram.nodes, nodes)
     replaceMap(diagram.subgraphs, subgraphs)
     diagram.links = links
-    diagram.ports.clear()
+    // Ports are derived from node positions + link endpoints. placePorts is
+    // what YAML/sample loads get via computeNetworkLayout; without it,
+    // rerouteEdges runs on an empty ports map and the diagram renders with
+    // no ports or edges.
+    const direction = graph.settings?.direction ?? 'TB'
+    replaceMap(diagram.ports, placePorts(nodes, links, direction))
     await rerouteEdges()
   },
 
@@ -622,7 +627,11 @@ export const diagramState = {
 
   /** Import project from NetedProject JSON string */
   async importProject(jsonStr: string) {
-    const data = JSON.parse(jsonStr)
+    await diagramState.loadProjectData(JSON.parse(jsonStr))
+  },
+
+  /** Load a NetedProject object directly (shared impl for JSON import + sample) */
+  async loadProjectData(data: Partial<NetedProject>) {
     // Load graph first so we know which node IDs exist, then clean up
     // palette/bom references against that.
     await diagramState.importGraph(data.diagram ?? { version: '1', nodes: [], links: [] })
@@ -663,29 +672,9 @@ export const diagramState = {
     initialized = false
 
     if (projectId === 'sample') {
-      // Load sample project data
-      palette = [...samplePalette]
-      bomItems = [...sampleBomItems]
-
       try {
         status = 'Loading sample...'
-        const fileMap = new Map<string, string>()
-        for (const f of sampleNetwork) {
-          fileMap.set(f.name, f.content)
-          fileMap.set(`./${f.name}`, f.content)
-          fileMap.set(`/${f.name}`, f.content)
-        }
-        const resolver = createMemoryFileResolver(fileMap, '/')
-        const hp = new HierarchicalParser(resolver)
-        const mainFile = sampleNetwork.find((f) => f.name === 'main.yaml')
-        if (!mainFile) throw new Error('main.yaml not found')
-        const g = (await hp.parse(mainFile.content, '/main.yaml')).graph
-
-        const { resolved } = await computeNetworkLayout(g)
-        diagramState.loadFromResolved(resolved, g.links)
-        const mf = sampleNetwork.find((f) => f.name === 'main.yaml')
-        if (mf) yamlSource = mf.content
-        status = 'Ready'
+        await diagramState.loadProjectData(sampleProject)
       } catch (e) {
         status = `Error: ${e instanceof Error ? e.message : String(e)}`
       }

--- a/apps/editor/src/lib/sample-diagram.ts
+++ b/apps/editor/src/lib/sample-diagram.ts
@@ -1,0 +1,819 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Positioned NetworkGraph for the sample project.
+ * Generated from sampleNetwork YAML by scripts/generate-sample-diagram.ts —
+ * run that script to regenerate after editing the YAML fixtures.
+ *
+ * Cast via `as unknown as NetworkGraph`: DeviceType is a string enum and
+ * the serialized JSON has raw string literals where the type wants enum
+ * references. The runtime values match — the cast only papers over the
+ * nominal type check.
+ */
+
+import type { NetworkGraph } from '@shumoku/core'
+
+export const sampleDiagram = {
+  version: '2.0.0',
+  name: 'Sample Network',
+  description: 'Sample network with HA routers, firewall, DMZ and campus',
+  settings: {
+    theme: 'light',
+  },
+  nodes: [
+    {
+      id: 'cloud-services',
+      label: 'Services VPC',
+      shape: 'rounded',
+      parent: 'cloud',
+      spec: {
+        kind: 'service',
+        vendor: 'aws',
+        service: 'ec2',
+        resource: 'instances',
+      },
+      position: {
+        x: 695,
+        y: 78,
+      },
+    },
+    {
+      id: 'vgw',
+      label: 'VPN Gateway',
+      shape: 'rounded',
+      parent: 'cloud',
+      spec: {
+        kind: 'service',
+        vendor: 'aws',
+        service: 'vpc',
+        resource: 'vpn-gateway',
+      },
+      position: {
+        x: 695,
+        y: 278,
+      },
+    },
+    {
+      id: 'isp1',
+      label: 'ISP Line #1 (Primary)',
+      shape: 'rounded',
+      parent: 'perimeter/edge',
+      spec: {
+        kind: 'hardware',
+        type: 'internet',
+      },
+      position: {
+        x: 575,
+        y: 574,
+      },
+    },
+    {
+      id: 'rt1',
+      label: 'Edge-RT-1 (Master)',
+      shape: 'rounded',
+      parent: 'perimeter/edge',
+      spec: {
+        kind: 'hardware',
+        type: 'router',
+        vendor: 'yamaha',
+        model: 'rtx3510',
+      },
+      position: {
+        x: 575,
+        y: 794,
+      },
+    },
+    {
+      id: 'isp2',
+      label: 'ISP Line #2 (Secondary)',
+      shape: 'rounded',
+      parent: 'perimeter/edge',
+      spec: {
+        kind: 'hardware',
+        type: 'internet',
+      },
+      position: {
+        x: 815,
+        y: 574,
+      },
+    },
+    {
+      id: 'rt2',
+      label: 'Edge-RT-2 (Backup)',
+      shape: 'rounded',
+      parent: 'perimeter/edge',
+      spec: {
+        kind: 'hardware',
+        type: 'router',
+        vendor: 'yamaha',
+        model: 'rtx3510',
+      },
+      position: {
+        x: 815,
+        y: 794,
+      },
+    },
+    {
+      id: 'fw1',
+      label: 'FW-1 (Active)',
+      shape: 'rounded',
+      parent: 'perimeter/security',
+      spec: {
+        kind: 'hardware',
+        type: 'firewall',
+        vendor: 'juniper',
+        model: 'srx4100',
+      },
+      position: {
+        x: 566.75,
+        y: 1098.5,
+      },
+    },
+    {
+      id: 'fw2',
+      label: 'FW-2 (Standby)',
+      shape: 'rounded',
+      parent: 'perimeter/security',
+      spec: {
+        kind: 'hardware',
+        type: 'firewall',
+        vendor: 'juniper',
+        model: 'srx4100',
+      },
+      position: {
+        x: 823.25,
+        y: 1098.5,
+      },
+    },
+    {
+      id: 'dmz-sw',
+      label: 'DMZ-SW',
+      shape: 'rounded',
+      parent: 'dmz',
+      spec: {
+        kind: 'hardware',
+        type: 'l2-switch',
+      },
+      position: {
+        x: 215,
+        y: 1434,
+      },
+    },
+    {
+      id: 'web-srv',
+      label: 'Web Server',
+      shape: 'rounded',
+      parent: 'dmz',
+      spec: {
+        kind: 'hardware',
+        type: 'server',
+      },
+      position: {
+        x: 110,
+        y: 1665,
+      },
+    },
+    {
+      id: 'mail-srv',
+      label: 'Mail Server',
+      shape: 'rounded',
+      parent: 'dmz',
+      spec: {
+        kind: 'hardware',
+        type: 'server',
+      },
+      position: {
+        x: 320,
+        y: 1665,
+      },
+    },
+    {
+      id: 'core-sw',
+      label: 'Core-SW',
+      shape: 'rounded',
+      parent: 'campus/noc',
+      spec: {
+        kind: 'hardware',
+        type: 'l3-switch',
+        vendor: 'juniper',
+        model: 'qfx5120-48t',
+      },
+      position: {
+        x: 925,
+        y: 1471,
+      },
+    },
+    {
+      id: 'dist-sw',
+      label: 'Distribution-SW',
+      shape: 'rounded',
+      parent: 'campus/noc',
+      spec: {
+        kind: 'hardware',
+        type: 'l3-switch',
+        vendor: 'juniper',
+        model: 'ex4400-48t',
+      },
+      position: {
+        x: 925,
+        y: 1696.5,
+      },
+    },
+    {
+      id: 'sw-a1',
+      label: 'SW-A1 (Floor 1)',
+      shape: 'rounded',
+      parent: 'campus/building-a',
+      spec: {
+        kind: 'hardware',
+        type: 'l3-switch',
+        vendor: 'cisco',
+        model: 'ws-c3560cx-8pc-s',
+      },
+      position: {
+        x: 695,
+        y: 2001,
+      },
+    },
+    {
+      id: 'ap-a1',
+      label: 'AP-A1',
+      shape: 'rounded',
+      parent: 'campus/building-a',
+      spec: {
+        kind: 'hardware',
+        type: 'access-point',
+        vendor: 'hpe',
+        model: 'aruba-ap-505',
+      },
+      position: {
+        x: 590,
+        y: 2232,
+      },
+    },
+    {
+      id: 'ap-a2',
+      label: 'AP-A2',
+      shape: 'rounded',
+      parent: 'campus/building-a',
+      spec: {
+        kind: 'hardware',
+        type: 'access-point',
+        vendor: 'hpe',
+        model: 'aruba-ap-505',
+      },
+      position: {
+        x: 800,
+        y: 2232,
+      },
+    },
+    {
+      id: 'sw-b1',
+      label: 'SW-B1',
+      shape: 'rounded',
+      parent: 'campus/building-b',
+      spec: {
+        kind: 'hardware',
+        type: 'l2-switch',
+        vendor: 'panasonic',
+        model: 'switch-m8egpwr-plus',
+      },
+      position: {
+        x: 1155,
+        y: 2001,
+      },
+    },
+    {
+      id: 'ap-b1',
+      label: 'AP-B1',
+      shape: 'rounded',
+      parent: 'campus/building-b',
+      spec: {
+        kind: 'hardware',
+        type: 'access-point',
+        vendor: 'hpe',
+        model: 'aruba-ap-505',
+      },
+      position: {
+        x: 1050,
+        y: 2232,
+      },
+    },
+    {
+      id: 'ap-b2',
+      label: 'AP-B2 (Desk)',
+      shape: 'rounded',
+      parent: 'campus/building-b',
+      spec: {
+        kind: 'hardware',
+        type: 'access-point',
+        vendor: 'hpe',
+        model: 'aruba-instant-on-ap11d',
+      },
+      position: {
+        x: 1260,
+        y: 2221,
+      },
+    },
+    {
+      id: 'ip-phone',
+      label: 'IP Phone',
+      shape: 'rounded',
+      parent: 'campus/building-b',
+      spec: {
+        kind: 'hardware',
+        type: 'cpe',
+        vendor: 'generic',
+        model: 'ip-phone',
+      },
+      position: {
+        x: 1260,
+        y: 2430,
+      },
+    },
+  ],
+  links: [
+    {
+      id: 'link-0',
+      from: {
+        node: 'vgw',
+        port: 'tun0',
+        ip: '169.254.100.1/30',
+      },
+      to: {
+        node: 'rt1',
+        port: 'tun1',
+        ip: '169.254.100.2/30',
+      },
+      label: 'IPsec VPN',
+      type: 'dashed',
+    },
+    {
+      id: 'link-1',
+      from: {
+        node: 'vgw',
+        port: 'tun1',
+        ip: '169.254.101.1/30',
+      },
+      to: {
+        node: 'rt2',
+        port: 'tun1',
+        ip: '169.254.101.2/30',
+      },
+      label: 'IPsec VPN',
+      type: 'dashed',
+    },
+    {
+      id: 'link-2',
+      from: {
+        node: 'fw1',
+        port: 'dmz',
+        ip: '10.100.0.2/24',
+      },
+      to: {
+        node: 'dmz-sw',
+        port: 'uplink',
+        ip: '10.100.0.1/24',
+      },
+      label: 'DMZ',
+      type: 'solid',
+      bandwidth: '10G',
+      vlan: [100],
+    },
+    {
+      id: 'link-3',
+      from: {
+        node: 'fw1',
+        port: 'inside',
+        ip: '10.0.2.1/30',
+      },
+      to: {
+        node: 'core-sw',
+        port: 'eth1',
+        ip: '10.0.2.2/30',
+      },
+      label: 'Active',
+      type: 'solid',
+      bandwidth: '10G',
+    },
+    {
+      id: 'link-4',
+      from: {
+        node: 'fw2',
+        port: 'inside',
+        ip: '10.0.2.5/30',
+      },
+      to: {
+        node: 'core-sw',
+        port: 'eth2',
+        ip: '10.0.2.6/30',
+      },
+      label: 'Standby',
+      type: 'solid',
+      bandwidth: '10G',
+    },
+    {
+      id: 'cloud/link-0',
+      from: {
+        node: 'cloud-services',
+        port: 'eth0',
+      },
+      to: {
+        node: 'vgw',
+        port: 'vpc',
+      },
+      label: 'Internal',
+      type: 'solid',
+    },
+    {
+      id: 'perimeter/link-0',
+      from: {
+        node: 'isp1',
+        port: 'eth0',
+        ip: '203.0.113.2/30',
+      },
+      to: {
+        node: 'rt1',
+        port: 'wan1',
+        ip: '203.0.113.1/30',
+      },
+      type: 'solid',
+      bandwidth: '10G',
+    },
+    {
+      id: 'perimeter/link-1',
+      from: {
+        node: 'isp2',
+        port: 'eth0',
+        ip: '198.51.100.2/30',
+      },
+      to: {
+        node: 'rt2',
+        port: 'wan1',
+        ip: '198.51.100.1/30',
+      },
+      type: 'solid',
+      bandwidth: '10G',
+    },
+    {
+      id: 'perimeter/link-2',
+      from: {
+        node: 'rt1',
+        port: 'ha0',
+        ip: '10.255.0.1/30',
+      },
+      to: {
+        node: 'rt2',
+        port: 'ha0',
+        ip: '10.255.0.2/30',
+      },
+      label: 'Keepalive',
+      type: 'solid',
+      redundancy: 'ha',
+      style: {
+        minLength: 300,
+      },
+    },
+    {
+      id: 'perimeter/link-3',
+      from: {
+        node: 'rt1',
+        port: 'lan1',
+        ip: '10.0.1.1/30',
+      },
+      to: {
+        node: 'fw1',
+        port: 'outside',
+        ip: '10.0.1.2/30',
+      },
+      type: 'solid',
+      bandwidth: '10G',
+    },
+    {
+      id: 'perimeter/link-4',
+      from: {
+        node: 'rt2',
+        port: 'lan1',
+        ip: '10.0.1.5/30',
+      },
+      to: {
+        node: 'fw2',
+        port: 'outside',
+        ip: '10.0.1.6/30',
+      },
+      type: 'solid',
+      bandwidth: '10G',
+    },
+    {
+      id: 'perimeter/link-5',
+      from: {
+        node: 'fw1',
+        port: 'ha',
+      },
+      to: {
+        node: 'fw2',
+        port: 'ha',
+      },
+      label: 'HA Sync',
+      type: 'solid',
+      redundancy: 'ha',
+      style: {
+        minLength: 300,
+      },
+    },
+    {
+      id: 'dmz/link-0',
+      from: {
+        node: 'dmz-sw',
+        port: 'eth1',
+      },
+      to: {
+        node: 'web-srv',
+        port: 'eth0',
+      },
+      type: 'solid',
+      bandwidth: '1G',
+      vlan: [100],
+    },
+    {
+      id: 'dmz/link-1',
+      from: {
+        node: 'dmz-sw',
+        port: 'eth2',
+      },
+      to: {
+        node: 'mail-srv',
+        port: 'eth0',
+      },
+      type: 'solid',
+      bandwidth: '1G',
+      vlan: [100],
+    },
+    {
+      id: 'campus/link-0',
+      from: {
+        node: 'core-sw',
+        port: 'ae0',
+        ip: '10.0.3.1/30',
+      },
+      to: {
+        node: 'dist-sw',
+        port: 'ae0',
+        ip: '10.0.3.2/30',
+      },
+      label: '40G LACP',
+      type: 'solid',
+      bandwidth: '40G',
+    },
+    {
+      id: 'campus/link-1',
+      from: {
+        node: 'dist-sw',
+        port: 'eth10',
+        ip: '10.10.0.254/24',
+      },
+      to: {
+        node: 'sw-a1',
+        port: 'uplink',
+        ip: '10.10.0.1/24',
+      },
+      label: 'Trunk',
+      type: 'solid',
+      bandwidth: '10G',
+      vlan: [10, 20],
+    },
+    {
+      id: 'campus/link-2',
+      from: {
+        node: 'dist-sw',
+        port: 'eth20',
+        ip: '10.20.0.254/24',
+      },
+      to: {
+        node: 'sw-b1',
+        port: 'uplink',
+        ip: '10.20.0.1/24',
+      },
+      label: 'Trunk',
+      type: 'solid',
+      bandwidth: '10G',
+      vlan: [10, 30],
+    },
+    {
+      id: 'campus/link-3',
+      from: {
+        node: 'sw-a1',
+        port: 'eth1',
+      },
+      to: {
+        node: 'ap-a1',
+        port: 'eth0',
+      },
+      type: 'solid',
+      bandwidth: '1G',
+      vlan: [20],
+    },
+    {
+      id: 'campus/link-4',
+      from: {
+        node: 'sw-a1',
+        port: 'eth2',
+      },
+      to: {
+        node: 'ap-a2',
+        port: 'eth0',
+      },
+      type: 'solid',
+      bandwidth: '1G',
+      vlan: [20],
+    },
+    {
+      id: 'campus/link-5',
+      from: {
+        node: 'sw-b1',
+        port: 'eth1',
+      },
+      to: {
+        node: 'ap-b1',
+        port: 'eth0',
+      },
+      type: 'solid',
+      bandwidth: '1G',
+      vlan: [30],
+    },
+    {
+      id: 'campus/link-6',
+      from: {
+        node: 'sw-b1',
+        port: 'eth2',
+      },
+      to: {
+        node: 'ap-b2',
+        port: 'e0',
+      },
+      type: 'solid',
+      bandwidth: '1G',
+      vlan: [30],
+    },
+    {
+      id: 'campus/link-7',
+      from: {
+        node: 'ap-b2',
+        port: 'e3',
+      },
+      to: {
+        node: 'ip-phone',
+        port: 'eth0',
+      },
+      type: 'solid',
+      bandwidth: '1G',
+    },
+  ],
+  subgraphs: [
+    {
+      id: 'cloud',
+      label: 'Cloud Services',
+      children: [],
+      style: {
+        fill: 'accent-blue',
+        strokeDasharray: '5 5',
+      },
+      spec: {
+        kind: 'service',
+        vendor: 'aws',
+        service: 'vpc',
+        resource: 'virtual-private-cloud-vpc',
+      },
+      file: './cloud.yaml',
+      bounds: {
+        x: 585,
+        y: 0,
+        width: 220,
+        height: 358,
+      },
+    },
+    {
+      id: 'perimeter',
+      label: 'Perimeter (Edge + Security)',
+      children: [],
+      style: {
+        fill: 'accent-red',
+      },
+      file: './perimeter.yaml',
+      bounds: {
+        x: 413.5,
+        y: 438,
+        width: 563,
+        height: 787,
+      },
+    },
+    {
+      id: 'perimeter/edge',
+      label: 'Edge (HA Routers)',
+      children: [],
+      parent: 'perimeter',
+      style: {
+        fill: 'surface-2',
+      },
+      bounds: {
+        x: 450,
+        y: 486,
+        width: 490,
+        height: 398,
+      },
+    },
+    {
+      id: 'perimeter/security',
+      label: 'Security',
+      children: [],
+      parent: 'perimeter',
+      style: {
+        fill: 'accent-red',
+      },
+      bounds: {
+        x: 433.5,
+        y: 964,
+        width: 523,
+        height: 241,
+      },
+    },
+    {
+      id: 'dmz',
+      label: 'DMZ',
+      children: [],
+      style: {
+        fill: 'accent-amber',
+      },
+      file: './dmz.yaml',
+      bounds: {
+        x: 0,
+        y: 1305,
+        width: 430,
+        height: 420,
+      },
+    },
+    {
+      id: 'campus',
+      label: 'Campus',
+      children: [],
+      style: {
+        fill: 'surface-2',
+      },
+      file: './campus.yaml',
+      bounds: {
+        x: 460,
+        y: 1305,
+        width: 930,
+        height: 1205,
+      },
+    },
+    {
+      id: 'campus/noc',
+      label: 'NOC',
+      children: [],
+      parent: 'campus',
+      style: {
+        fill: 'accent-blue',
+      },
+      bounds: {
+        x: 815,
+        y: 1353,
+        width: 220,
+        height: 439,
+      },
+    },
+    {
+      id: 'campus/building-a',
+      label: 'Building A',
+      children: [],
+      parent: 'campus',
+      direction: 'TB',
+      style: {
+        fill: 'accent-green',
+      },
+      bounds: {
+        x: 480,
+        y: 1872,
+        width: 430,
+        height: 420,
+      },
+    },
+    {
+      id: 'campus/building-b',
+      label: 'Building B',
+      children: [],
+      parent: 'campus',
+      direction: 'TB',
+      style: {
+        fill: 'accent-amber',
+      },
+      bounds: {
+        x: 940,
+        y: 1872,
+        width: 430,
+        height: 618,
+      },
+    },
+  ],
+} as unknown as NetworkGraph

--- a/apps/editor/src/lib/sample-project.ts
+++ b/apps/editor/src/lib/sample-project.ts
@@ -9,7 +9,8 @@
 
 import type { HardwareProperties } from '@shumoku/catalog'
 import { DeviceType } from '@shumoku/core'
-import type { BomItem, SpecPaletteEntry } from './types'
+import { sampleDiagram } from './sample-diagram'
+import type { BomItem, NetedProject, SpecPaletteEntry } from './types'
 
 export const samplePalette: SpecPaletteEntry[] = [
   // ========== Cloud ==========
@@ -188,3 +189,12 @@ export const sampleBomItems: BomItem[] = [
   { id: 'bom-ap-b2', paletteId: 'pal-aruba-ap11d', nodeId: 'ap-b2' },
   { id: 'bom-ip-phone', paletteId: 'pal-generic-ip-phone', nodeId: 'ip-phone' },
 ]
+
+/** Sample project — bundled palette, bom, and positioned diagram */
+export const sampleProject: NetedProject = {
+  version: 1,
+  name: 'Sample Network',
+  palette: samplePalette,
+  bom: sampleBomItems,
+  diagram: sampleDiagram,
+}


### PR DESCRIPTION
## Summary
- サンプルプロジェクトを YAML parse 経由から pre-positioned な NetworkGraph JSON fixture に移行。エディタ内のすべての load path が JSON 経由に統一される。
- その過程で `importGraph` が `diagram.ports.clear()` した後に regenerate していなかったバグ（JSON save/load で ports/edges が消える）を修正。

## What changed
- `apps/editor/scripts/generate-sample-diagram.ts` 追加 — YAML fixture をパース→ layout 実行→ positioned NetworkGraph を `src/lib/sample-diagram.ts` に吐き出す one-off generator。`bun run gen:sample` で再生成可能
- `sample-project.ts` に `sampleProject: NetedProject` を export（palette + bom + positioned diagram を束ねる）
- `importGraph` に `placePorts(nodes, links, direction)` 呼び出しを追加。ports を再構築してから `rerouteEdges` に渡す
- `loadProjectData(NetedProject)` を追加、`importProject(jsonStr)` はこれに delegate
- `loadProject('sample')` は `loadProjectData(sampleProject)` を通るように変更。エディタ側の `HierarchicalParser` 利用は `applyYaml`（ユーザー向け YAML import）のみに縮小

## Test plan
- [ ] `loadProject('sample')` でサンプルがこれまでと同じ見た目で描画される（ports / edges / subgraph bounds すべて揃っている）
- [ ] 一度エクスポート→インポートしたプロジェクトが同じ見た目で再現される（以前は ports/edges が消えていた）
- [ ] YAML import（`applyYaml`）が引き続き動作する
- [ ] `bun run typecheck` / `bun run lint` 通過（ローカルで確認済み）

## 関連
#113 の save/load surface cleanup の一部。続編で `rerouteEdges` の自動導出 / `loadFromResolved` と `importGraph` の統合 / `placeNode` プリミティブ化を別 PR 予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)