### PR TITLE
refactor(editor,core): unify load path around importGraph + export placeNode

### DIFF
--- a/apps/editor/DATA_MODEL.md
+++ b/apps/editor/DATA_MODEL.md
@@ -16,37 +16,39 @@ NetedProject
 ├── bom: BomItem[]
 │   └── { id, paletteId?, nodeId?, notes? }
 └── diagram: NetworkGraph                   ← library type directly
-    ├── nodes: Node[]                       ← position? set by editor/engine
+    ├── nodes: Node[]                       ← position set on save
     │   └── { id, label, shape, spec?, position?, parent?, rank?, style? }
     ├── links: Link[]
     │   └── { id, from, to, bandwidth?, type?, vlan?, arrow?, redundancy? }
     │       └── from/to = string | LinkEndpoint { node, port?, ip? }
-    ├── subgraphs?: Subgraph[]              ← bounds derived from children
-    │   └── { id, label, children?, parent?, direction?, pins? }
+    ├── subgraphs?: Subgraph[]              ← bounds set on save
+    │   └── { id, label, children?, parent?, bounds?, direction?, pins? }
     └── settings?: GraphSettings
 ```
 
-Derived values (not stored):
+Derived values (not stored on the NetworkGraph save wire):
 - Node size — computed by `computeNodeSize()` from label/spec/shape
-- Subgraph bounds — computed from child node positions + padding
-- Ports — computed from node positions + link endpoints
-- Edges — computed by `routeEdges()` (libavoid WASM) from nodes/ports/links
+- Ports (`absolutePosition`, `side`) — computed by `placePorts()` from node positions + link endpoints
+- Edges (routed paths) — computed by `routeEdges()` (libavoid WASM) from nodes/ports/links
 
 ## Runtime State (context.svelte.ts)
 
 ```
-diagram ($state, single object)       Map-based (renderer compat)
-├── nodes: Map<id, ResolvedNode>      ← wraps Node with computed position/size
-├── ports: Map<id, ResolvedPort>      ← derived, recomputed on load
-├── edges: Map<id, ResolvedEdge>      ← derived, recomputed via rerouteEdges()
-├── subgraphs: Map<id, ResolvedSubgraph>
-├── bounds: { x, y, width, height }
-└── links: Link[]
+diagram ($state, single object)       SvelteMap-based (reactive)
+├── nodes: SvelteMap<id, Node>        ← positioned, source of truth
+├── subgraphs: SvelteMap<id, Subgraph>
+├── links: Link[]
+├── ports: SvelteMap<id, ResolvedPort>  ← derived, rebuilt by placePorts() on load / rerouteEdges()
+├── edges: SvelteMap<id, ResolvedEdge>  ← derived, rebuilt by routeEdges() via rerouteEdges()
+└── bounds: { x, y, width, height }
 
 palette: SpecPaletteEntry[]           separate $state
 bomItems: BomItem[]                   separate $state
 poeBudgets: PoEBudget[]               derived from nodes + links + catalog
 ```
+
+`ResolvedNode` / `ResolvedSubgraph` wrapper types were removed in #115 —
+the runtime Maps hold `Node` / `Subgraph` directly.
 
 ## Data Flow
 
@@ -61,5 +63,23 @@ BOM page                   SideToolbar
 Specs page                 ContextMenu
 
 save:  exportGraph()  ->  NetworkGraph (Node[] with positions)  ->  JSON
-load:  JSON  ->  importGraph()  ->  Node[] → ResolvedNode Map + recompute ports/edges
+load:  NetworkGraph  ->  importGraph()  ->  state + placePorts + routeEdges
+       └─ if any node lacks position → falls back to computeNetworkLayout (full layoutNetwork pass)
 ```
+
+### Load entry points
+
+All runtime loads go through `diagramState.importGraph(NetworkGraph)`:
+
+- `loadProjectData(NetedProject)` — sample + JSON project import
+- `applyYaml(yaml)` — parses YAML to NetworkGraph, then forwards
+
+The single-entry design means any fix to load-time derivation (port
+placement, edge routing, bounds) benefits every load path.
+
+### Individual node placement
+
+`placeNode(node, graph, initial, gap?)` in `@shumoku/core` is the
+primitive for placing one unpositioned node with collision avoidance
+against the existing graph. It is the lightweight counterpart to
+`layoutNetwork`, which rebuilds the entire layout from scratch.

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -16,7 +16,6 @@ import {
   newId,
   placePorts,
   type ResolvedEdge,
-  type ResolvedLayout,
   type ResolvedPort,
   rebalanceSubgraphs,
   resolvePosition,
@@ -598,16 +597,43 @@ export const diagramState = {
       subgraphs: [...diagram.subgraphs.values()],
     }
   },
+  /**
+   * Single entry point for loading a NetworkGraph into runtime state.
+   * Handles both positioned inputs (saved JSON) and unpositioned ones
+   * (parsed YAML) — the former derives ports/edges directly from saved
+   * positions; the latter falls back to the full layoutNetwork pass.
+   * Replaces the former `loadFromResolved` path.
+   */
   async importGraph(graph: NetworkGraph) {
     const { nodes, subgraphs, links } = sanitizeGraph(graph)
+    const direction = graph.settings?.direction ?? 'TB'
+    const hasAnyNode = nodes.size > 0
+    const allPositioned = hasAnyNode && [...nodes.values()].every((n) => n.position)
+
+    if (hasAnyNode && !allPositioned) {
+      // YAML-shaped (or partially authored) graph — let layoutNetwork
+      // position every node and rebuild subgraph bounds from the result.
+      const reconstructed: NetworkGraph = {
+        ...graph,
+        nodes: [...nodes.values()],
+        subgraphs: [...subgraphs.values()],
+        links,
+      }
+      const { resolved } = await computeNetworkLayout(reconstructed)
+      replaceMap(diagram.nodes, resolved.nodes)
+      replaceMap(diagram.subgraphs, resolved.subgraphs)
+      replaceMap(diagram.ports, resolved.ports)
+      replaceMap(diagram.edges, resolved.edges)
+      diagram.bounds = { ...resolved.bounds }
+      diagram.links = links
+      return
+    }
+
+    // Positioned (saved JSON, sample, or empty graph): derive ports and
+    // edges from positions without touching node placement.
     replaceMap(diagram.nodes, nodes)
     replaceMap(diagram.subgraphs, subgraphs)
     diagram.links = links
-    // Ports are derived from node positions + link endpoints. placePorts is
-    // what YAML/sample loads get via computeNetworkLayout; without it,
-    // rerouteEdges runs on an empty ports map and the diagram renders with
-    // no ports or edges.
-    const direction = graph.settings?.direction ?? 'TB'
     replaceMap(diagram.ports, placePorts(nodes, links, direction))
     await rerouteEdges()
   },
@@ -643,15 +669,6 @@ export const diagramState = {
     palette = cleanPalette
     bomItems = cleanBom
     status = 'Ready'
-  },
-
-  loadFromResolved(resolved: ResolvedLayout, graphLinks: Link[]) {
-    replaceMap(diagram.nodes, resolved.nodes)
-    replaceMap(diagram.ports, resolved.ports)
-    replaceMap(diagram.edges, resolved.edges)
-    replaceMap(diagram.subgraphs, resolved.subgraphs)
-    diagram.bounds = { ...resolved.bounds }
-    diagram.links = [...graphLinks]
   },
 
   /** Load a project by ID. Resets all state first. */
@@ -696,8 +713,7 @@ export const diagramState = {
       const resolver = createMemoryFileResolver(fileMap, '/')
       const hp = new HierarchicalParser(resolver)
       const g = (await hp.parse(yamlStr, '/main.yaml')).graph
-      const { resolved } = await computeNetworkLayout(g)
-      diagramState.loadFromResolved(resolved, g.links)
+      await diagramState.importGraph(g)
       yamlSource = yamlStr
       status = 'Ready'
     } catch (e) {

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -18,6 +18,7 @@ export {
   movePort,
   moveSubgraph,
   nodesOverlap,
+  placeNode,
   rebalanceSubgraphs,
   removePort,
   resolveNodePosition,

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -134,6 +134,27 @@ export function resolveNodePosition(
   return resolvePosition({ x, y, w: size.width, h: size.height }, obstacles, gap)
 }
 
+/**
+ * Place a single unpositioned node into an existing graph with collision
+ * avoidance. Thin wrapper around resolvePosition/collectObstacles — the
+ * primitive used when loading a partially-positioned graph or adding a
+ * node at runtime, without having to re-run the full layout pass.
+ */
+export function placeNode(
+  node: Node,
+  graph: { nodes: Map<string, Node>; subgraphs?: Map<string, Subgraph> },
+  initial: { x: number; y: number },
+  gap = DEFAULT_NODE_GAP,
+): { x: number; y: number } {
+  const size = computeNodeSize(node)
+  const obstacles = collectObstacles(node.id, node.parent, graph.nodes, graph.subgraphs)
+  return resolvePosition(
+    { x: initial.x, y: initial.y, w: size.width, h: size.height },
+    obstacles,
+    gap,
+  )
+}
+
 /** Check if parentId is sgId or a descendant of sgId */
 function isChildOf(
   parentId: string | undefined,


### PR DESCRIPTION
## Summary
- エディタの load path が `importGraph` / `loadFromResolved` の 2 本あったのを `importGraph` 単一に集約。YAML / JSON / sample すべて同じ入口を通るように整理
- `importGraph` は positioned / unpositioned を自動判定: positioned なら `placePorts` + `routeEdges` のみ、unpositioned なら `computeNetworkLayout` に fallback
- `@shumoku/core` から `placeNode(node, graph, initial, gap?)` を export。未配置 node を 1 個だけ既存グラフに配置する collision-aware primitive (layoutNetwork の軽量版)
- `DATA_MODEL.md` を実態に合わせて更新 (ResolvedNode wrapper は #115 で撲滅済み)

## What changed

- `apps/editor/src/lib/context.svelte.ts`:
  - `importGraph` を unified entry に: positioned 判定で分岐 (any-missing → full layout, all-positioned → placePorts + routeEdges)
  - `loadFromResolved` 削除 (唯一の caller だった `applyYaml` は `importGraph` に forward)
  - 未使用 `ResolvedLayout` の import を削除
- `libs/@shumoku/core/src/layout/interaction.ts`:
  - `placeNode(node, graph, initial, gap?)` を追加。`resolvePosition` + `collectObstacles` の薄いラッパーで「1 個の未配置 node を collision 回避しながら置く」primitive
- `libs/@shumoku/core/src/layout/index.ts`: `placeNode` を export
- `apps/editor/DATA_MODEL.md`: runtime state / load flow を現状に合わせて書き直し

## Test plan
- [x] `bun run typecheck` / `bun run lint` 全 workspace で green (ローカル確認済み)
- [ ] sample project (JSON path) が正しく描画される
- [ ] JSON export → import round-trip が崩れないこと
- [ ] YAML import (`applyYaml`) が引き続き動く — 新しく `importGraph` 経由になったので fall back path が正しく発火するか手動確認
- [ ] 空プロジェクト (nodes 0 の NetworkGraph) の import でエラーが出ないこと

## 関連
#113 の save/load surface cleanup として PR 1 (#130) に続く 2 本目。続編で `rerouteEdges` の reactive 化 / 手動呼び出し撲滅は別途検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)