### PR TITLE
feat(editor): Auto-arrange button for layout refresh

### DIFF
--- a/apps/editor/src/lib/components/SideToolbar.svelte
+++ b/apps/editor/src/lib/components/SideToolbar.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
   import { DeviceType } from '@shumoku/core'
   import { DropdownMenu, Tooltip } from 'bits-ui'
-  import { Cube, Eye, Moon, Pencil, Plus, SquaresFour, Sun } from 'phosphor-svelte'
+  import {
+    ArrowsOutCardinal,
+    Cube,
+    Eye,
+    Moon,
+    Pencil,
+    Plus,
+    SquaresFour,
+    Sun,
+  } from 'phosphor-svelte'
 
   let {
     mode = 'view',
@@ -9,6 +18,7 @@
     onmodechange,
     onaddnode,
     onaddsubgraph,
+    onautoarrange,
     onthemetoggle,
   }: {
     mode: 'edit' | 'view'
@@ -16,6 +26,7 @@
     onmodechange?: (mode: 'edit' | 'view') => void
     onaddnode?: (spec?: { kind: string; type?: string }) => void
     onaddsubgraph?: () => void
+    onautoarrange?: () => void
     onthemetoggle?: () => void
   } = $props()
 
@@ -108,6 +119,24 @@
         class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg"
       >
         Add group
+      </Tooltip.Content>
+    </Tooltip.Root>
+
+    <Tooltip.Root>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          class="flex items-center justify-center w-9 h-9 rounded-lg text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+          onclick={() => onautoarrange?.()}
+        >
+          <ArrowsOutCardinal class="w-4.5 h-4.5" />
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content
+        side="left"
+        class="bg-neutral-800 text-white text-xs px-2 py-1 rounded shadow-lg"
+      >
+        Auto-arrange
       </Tooltip.Content>
     </Tooltip.Root>
 

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -597,6 +597,27 @@ export const diagramState = {
       subgraphs: [...diagram.subgraphs.values()],
     }
   },
+  /**
+   * Re-run the layout engine across the whole diagram, discarding every
+   * manual position. Intended for a user-invoked "Auto-arrange" command
+   * after manual edits have left the graph visually messy.
+   *
+   * Stripping positions (not pinning) means the result matches what a
+   * fresh YAML import would produce; palette and BOM are untouched.
+   */
+  async autoArrange() {
+    const graph: NetworkGraph = {
+      ...diagramState.exportGraph(),
+      nodes: [...diagram.nodes.values()].map((n) => ({ ...n, position: undefined })),
+      subgraphs: [...diagram.subgraphs.values()].map((s) => ({ ...s, bounds: undefined })),
+    }
+    const { resolved } = await computeNetworkLayout(graph)
+    replaceMap(diagram.nodes, resolved.nodes)
+    replaceMap(diagram.subgraphs, resolved.subgraphs)
+    replaceMap(diagram.ports, resolved.ports)
+    replaceMap(diagram.edges, resolved.edges)
+    diagram.bounds = { ...resolved.bounds }
+  },
   // Serialization — .neted.json format
   /** Export project as NetedProject JSON string */
   exportProject(name = 'Untitled'): string {

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -129,6 +129,7 @@
       onmodechange={(m) => { editorState.mode = m }}
       onaddnode={(spec) => renderer?.addNewNode({ id: newId('node'), ...(spec ? { spec } : {}) })}
       onaddsubgraph={() => renderer?.addNewSubgraph({ id: newId('sg') })}
+      onautoarrange={() => diagramState.autoArrange()}
       onthemetoggle={() => editorState.toggleTheme()}
     />
   </div>


### PR DESCRIPTION
## Summary
SideToolbar に **Auto-arrange ボタン** を追加。現在のダイアグラム上の全 position を破棄して `layoutNetwork` を走らせる。手で動かしてゴチャゴチャになった時のリセット + 将来の layout-engine 拡張の足場。

## Scope
- `diagramState.autoArrange()` — 現 NetworkGraph から position/bounds を剥がして `computeNetworkLayout` に流し、結果を runtime state に上書き。palette / bom は触らない
- `SideToolbar.svelte` — Edit モード限定で `ArrowsOutCardinal` アイコンのボタンを追加、`onautoarrange` コールバックで発火
- `+page.svelte` — `onautoarrange={() => diagramState.autoArrange()}` を接続

## Test plan
- [x] `bun run typecheck` / `bun run lint` 通過
- [ ] Edit モードで SideToolbar に十字矢印アイコンが出る
- [ ] View モードでは表示されない
- [ ] サンプルを起動 → ノードを数個ドラッグで動かしてゴチャつかせる → Auto-arrange → 元の階層レイアウトに戻る
- [ ] Palette と BOM がリセットされない (手で palette 足してから arrange しても消えない)

## 関連
Layout engine consolidation plan の第 1 歩。次段以降 (`layoutNetwork` の `{fixed, rootContainer}` 対応 → Sugiyama-style 書き換え) は別 PR で段階的に。

🤖 Generated with [Claude Code](https://claude.com/claude-code)