### PR TITLE
feat(core): add `fixed` option to layoutNetwork

### DIFF
--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -31,6 +31,7 @@ import type {
   NodeSpec,
   Subgraph,
 } from '../models/types.js'
+import { rebalanceSubgraphs } from './interaction.js'
 import type { ResolvedPort } from './resolved-types.js'
 
 // ============================================================================
@@ -47,6 +48,15 @@ export interface NetworkLayoutOptions {
   minPortSpacing?: number
   portSize?: number
   portLabelPadding?: number
+  /**
+   * Nodes whose input `position` is a hard constraint. The tree-based
+   * arrangement runs as usual, then each fixed node is snapped back to
+   * its input position (with its ports shifted by the same delta) and
+   * subgraph bounds are recomputed to fit the actual positions.
+   *
+   * Empty set (default) keeps the legacy "re-layout everything" behavior.
+   */
+  fixed?: Set<string>
 }
 
 export interface NetworkLayoutResult {
@@ -66,6 +76,7 @@ const DEFAULTS: Required<NetworkLayoutOptions> = {
   minPortSpacing: 40,
   portSize: 8,
   portLabelPadding: 8,
+  fixed: new Set(),
 }
 
 /**
@@ -695,6 +706,40 @@ export function layoutNetwork(
   const subgraphs = new Map<string, Subgraph>()
   const ports = new Map<string, ResolvedPort>()
   arrangeTrees(trees, 0, 0, opts.topLevelGap, pp, opts, nodes, subgraphs, ports)
+
+  // Fixed-position enforcement: the tree-based pass places every node by
+  // its column; for nodes the caller marked as fixed we snap back to the
+  // input coordinate and shift their ports by the same delta so they
+  // stay stuck to the node. Subgraph bounds are then recomputed from
+  // actual children via rebalanceSubgraphs, which also resolves sibling
+  // collisions introduced by the override.
+  if (opts.fixed.size > 0) {
+    const inputPositions = new Map<string, { x: number; y: number }>()
+    for (const n of graph.nodes) {
+      if (n.position && opts.fixed.has(n.id)) inputPositions.set(n.id, n.position)
+    }
+    let anyMoved = false
+    for (const [id, target] of inputPositions) {
+      const arranged = nodes.get(id)
+      if (!arranged?.position) continue
+      const dx = target.x - arranged.position.x
+      const dy = target.y - arranged.position.y
+      if (dx === 0 && dy === 0) continue
+      anyMoved = true
+      nodes.set(id, { ...arranged, position: { x: target.x, y: target.y } })
+      for (const [pid, port] of ports) {
+        if (port.nodeId !== id) continue
+        ports.set(pid, {
+          ...port,
+          absolutePosition: {
+            x: port.absolutePosition.x + dx,
+            y: port.absolutePosition.y + dy,
+          },
+        })
+      }
+    }
+    if (anyMoved) rebalanceSubgraphs(nodes, subgraphs, ports)
+  }
 
   // Bounds
   let minX = Infinity,


### PR DESCRIPTION
## Summary
`layoutNetwork` に `fixed: Set<string>` オプションを追加。**既存 position を尊重しつつ他を layout し直す** ユースケースを可能にする (「新しい node を 1 個足したい、既存は動かさないで」等)。

## How it works
- 現行 tree-based 配置をそのまま実行
- その後、`fixed` に含まれる node id で入力 `position` が与えられているものを**取得し座標を上書き**
- 同時に、その node に属する **port も同じ delta だけシフト** (ports が node に張り付いたまま動く)
- 最後に `rebalanceSubgraphs` を呼んで:
  - subgraph bounds を子の実位置から再計算
  - sibling subgraph 衝突を解決

`fixed` 空 (default) なら従来挙動そのまま。既存呼び出しは無影響。

## Not in this PR
- rootContainer オプション (partial arrange) — 別 PR で
- `placeNode` を `layoutNetwork({fixed: existing})` の wrapper に降格 — まず本 PR が動くことを確認してから
- fixed node/subgraph のハード衝突耐性向上 — 当面は rebalance 任せ

## Test plan
- [x] `bun test` in core 66/66 pass (regression)
- [x] `bun run build` in core (tsc)
- [x] `bun run typecheck` 全 workspace 30/30
- [ ] 手動: Auto-arrange ボタン(PR #133)と組み合わせて、ノード A を手で動かして固定扱いに近い振る舞いが作れるか確認 (将来 PR で editor 側に fixed 渡す入口を作った際の接続確認用)
- [ ] 手動: fixed 指定無しで sample が今まで通り見えるか

## 関連
Layout engine consolidation plan の Step 1。続いて `placeNode` の統合 (PR C)、必要なら Sugiyama-style 書き換え (Step 2)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)