### PR TITLE
feat(core): Sugiyama foundation — cycles + layers

### DIFF
--- a/libs/@shumoku/core/src/layout/sugiyama/cycles.test.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/cycles.test.ts
@@ -1,0 +1,125 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest'
+import { removeCycles } from './cycles.js'
+import type { Edge } from './types.js'
+
+/** Build a small edge list tersely: `[['a','b','e1'], ...]` → Edge[]. */
+function edges(pairs: [string, string, string][]): Edge[] {
+  return pairs.map(([s, t, id]) => ({ id, source: s, target: t }))
+}
+
+/** Find the (possibly reversed) edge by its original id. */
+function edgeById(dag: Edge[], id: string): Edge | undefined {
+  return dag.find((e) => e.id === id)
+}
+
+describe('removeCycles', () => {
+  it('leaves a DAG untouched', () => {
+    // a → b → c (already acyclic)
+    const nodes = ['a', 'b', 'c']
+    const input = edges([
+      ['a', 'b', 'e1'],
+      ['b', 'c', 'e2'],
+    ])
+    const { dag, reversed } = removeCycles(nodes, input)
+    expect(reversed.size).toBe(0)
+    expect(dag.map((e) => [e.source, e.target])).toEqual([
+      ['a', 'b'],
+      ['b', 'c'],
+    ])
+  })
+
+  it('reverses a back edge in a simple cycle', () => {
+    // a → b → c → a  (back edge is the one that closes the loop)
+    const nodes = ['a', 'b', 'c']
+    const input = edges([
+      ['a', 'b', 'e1'],
+      ['b', 'c', 'e2'],
+      ['c', 'a', 'e3'],
+    ])
+    const { dag, reversed } = removeCycles(nodes, input)
+    expect(reversed.size).toBe(1)
+    expect(reversed.has('e3')).toBe(true)
+
+    const e3 = edgeById(dag, 'e3')
+    expect(e3?.source).toBe('a')
+    expect(e3?.target).toBe('c')
+    expect(e3?.reversed).toBe(true)
+  })
+
+  it('handles two-node cycle (bidirectional edge)', () => {
+    const nodes = ['a', 'b']
+    const input = edges([
+      ['a', 'b', 'e1'],
+      ['b', 'a', 'e2'],
+    ])
+    const { reversed } = removeCycles(nodes, input)
+    expect(reversed.size).toBe(1)
+    // Either e1 or e2 gets reversed; we don't overspecify which.
+    expect(reversed.has('e1') || reversed.has('e2')).toBe(true)
+  })
+
+  it('drops self loops from adjacency without flagging them', () => {
+    // a → a should not be treated as a back edge
+    const nodes = ['a']
+    const input = edges([['a', 'a', 'self']])
+    const { dag, reversed } = removeCycles(nodes, input)
+    expect(reversed.size).toBe(0)
+    expect(edgeById(dag, 'self')?.reversed).toBeUndefined()
+  })
+
+  it('handles disconnected components independently', () => {
+    // a→b→a (cycle) and c→d (not)
+    const nodes = ['a', 'b', 'c', 'd']
+    const input = edges([
+      ['a', 'b', 'e1'],
+      ['b', 'a', 'e2'],
+      ['c', 'd', 'e3'],
+    ])
+    const { reversed } = removeCycles(nodes, input)
+    expect(reversed.size).toBe(1)
+    expect(reversed.has('e3')).toBe(false)
+  })
+
+  it('produces a DAG on deeply nested cycles', () => {
+    // Ring: a→b→c→d→a
+    const nodes = ['a', 'b', 'c', 'd']
+    const input = edges([
+      ['a', 'b', 'e1'],
+      ['b', 'c', 'e2'],
+      ['c', 'd', 'e3'],
+      ['d', 'a', 'e4'],
+    ])
+    const { dag, reversed } = removeCycles(nodes, input)
+    expect(reversed.size).toBe(1)
+
+    // Topo-sort-able → DAG check. If there's a cycle, no topological
+    // order exists, so Kahn's algorithm produces fewer than |V| nodes.
+    const inDeg = new Map(nodes.map((n) => [n, 0]))
+    for (const e of dag) {
+      if (e.source === e.target) continue
+      inDeg.set(e.target, (inDeg.get(e.target) ?? 0) + 1)
+    }
+    const queue = [...inDeg.entries()].filter(([_, d]) => d === 0).map(([n]) => n)
+    let popped = 0
+    const succ = new Map<string, string[]>()
+    for (const n of nodes) succ.set(n, [])
+    for (const e of dag) {
+      if (e.source === e.target) continue
+      succ.get(e.source)?.push(e.target)
+    }
+    while (queue.length > 0) {
+      const u = queue.shift()
+      if (u === undefined) break
+      popped++
+      for (const v of succ.get(u) ?? []) {
+        const d = (inDeg.get(v) ?? 0) - 1
+        inDeg.set(v, d)
+        if (d === 0) queue.push(v)
+      }
+    }
+    expect(popped).toBe(nodes.length)
+  })
+})

--- a/libs/@shumoku/core/src/layout/sugiyama/cycles.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/cycles.ts
@@ -1,0 +1,90 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Cycle removal for Sugiyama-style layered layout.
+ *
+ * Layered layout needs a DAG: every edge must go from a lower layer to a
+ * higher one. Real graphs have cycles (e.g. redundant links between two
+ * routers), so we reverse a minimal set of edges before layer assignment
+ * and mark them `reversed` so downstream code can still draw them with
+ * the original direction.
+ *
+ * We use a DFS-based heuristic (not Greedy FAS): pick back edges —
+ * edges whose target is an ancestor of the source in the current DFS
+ * tree — and reverse them. This is O(V + E) and produces a close-to-
+ * optimal feedback arc set for sparse graphs, which is the common case.
+ */
+
+import type { CycleRemovalResult, Edge, EdgeId, NodeId } from './types.js'
+
+/**
+ * Remove cycles by reversing back edges discovered during DFS. The
+ * returned `dag` has the same edges (with the reversed ones flipped and
+ * marked); the caller decides how to present reversed edges in output
+ * (renderers usually draw them the original way).
+ */
+export function removeCycles(nodes: NodeId[], edges: Edge[]): CycleRemovalResult {
+  // Build adjacency. A single node can appear multiple times in
+  // `nodes`; dedupe via the map keys.
+  const outgoing = new Map<NodeId, { edgeId: EdgeId; target: NodeId }[]>()
+  for (const n of nodes) {
+    if (!outgoing.has(n)) outgoing.set(n, [])
+  }
+  for (const e of edges) {
+    // Self loops can never be drawn as DAG edges; just drop them from
+    // the adjacency and keep them in the output unchanged.
+    if (e.source === e.target) continue
+    outgoing.get(e.source)?.push({ edgeId: e.id, target: e.target })
+  }
+
+  // DFS state
+  const WHITE = 0
+  const GRAY = 1 // on the current DFS stack
+  const BLACK = 2 // fully explored
+  const color = new Map<NodeId, number>()
+  for (const n of outgoing.keys()) color.set(n, WHITE)
+
+  const reversed = new Set<EdgeId>()
+
+  function visit(start: NodeId) {
+    // Iterative DFS so deep graphs don't blow the call stack. We keep a
+    // stack of (node, outgoingIndex) frames; incrementing the index
+    // before visiting mirrors the recursive "visit next child, then
+    // backtrack" pattern.
+    const stack: { node: NodeId; idx: number }[] = [{ node: start, idx: 0 }]
+    color.set(start, GRAY)
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1]
+      if (!frame) break
+      const adj = outgoing.get(frame.node) ?? []
+      if (frame.idx >= adj.length) {
+        color.set(frame.node, BLACK)
+        stack.pop()
+        continue
+      }
+      const next = adj[frame.idx++]
+      if (!next) continue
+      const c = color.get(next.target) ?? WHITE
+      if (c === WHITE) {
+        color.set(next.target, GRAY)
+        stack.push({ node: next.target, idx: 0 })
+      } else if (c === GRAY) {
+        // Back edge: reverses the current DFS stack direction, so flip it.
+        reversed.add(next.edgeId)
+      }
+      // c === BLACK → forward/cross edge, leave alone.
+    }
+  }
+
+  for (const n of outgoing.keys()) {
+    if (color.get(n) === WHITE) visit(n)
+  }
+
+  const dag: Edge[] = edges.map((e) => {
+    if (!reversed.has(e.id)) return e
+    return { id: e.id, source: e.target, target: e.source, reversed: true }
+  })
+
+  return { dag, reversed }
+}

--- a/libs/@shumoku/core/src/layout/sugiyama/index.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/index.ts
@@ -1,0 +1,22 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Sugiyama-style layered layout pipeline.
+ *
+ * This module is a parallel implementation of `layoutNetwork`, built out
+ * phase by phase. It is not wired into the public `layoutNetwork` yet —
+ * when the four phases are complete and validated against the existing
+ * tree-based output, we will switch `layoutNetwork` to delegate here
+ * and remove the legacy implementation.
+ */
+
+export { removeCycles } from './cycles.js'
+export { assignLayers } from './layers.js'
+export type {
+  CycleRemovalResult,
+  Edge,
+  EdgeId,
+  LayerAssignment,
+  NodeId,
+} from './types.js'

--- a/libs/@shumoku/core/src/layout/sugiyama/layers.test.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/layers.test.ts
@@ -1,0 +1,126 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest'
+import { assignLayers } from './layers.js'
+import type { Edge } from './types.js'
+
+function edges(pairs: [string, string, string][]): Edge[] {
+  return pairs.map(([s, t, id]) => ({ id, source: s, target: t }))
+}
+
+describe('assignLayers', () => {
+  it('places an isolated node at layer 0', () => {
+    const { layers, layerOf } = assignLayers(['a'], [])
+    expect(layers).toEqual([['a']])
+    expect(layerOf.get('a')).toBe(0)
+  })
+
+  it('lays out a simple chain as consecutive layers', () => {
+    // a → b → c → d
+    const nodes = ['a', 'b', 'c', 'd']
+    const e = edges([
+      ['a', 'b', 'e1'],
+      ['b', 'c', 'e2'],
+      ['c', 'd', 'e3'],
+    ])
+    const { layers, layerOf } = assignLayers(nodes, e)
+    expect(layerOf.get('a')).toBe(0)
+    expect(layerOf.get('b')).toBe(1)
+    expect(layerOf.get('c')).toBe(2)
+    expect(layerOf.get('d')).toBe(3)
+    expect(layers.length).toBe(4)
+  })
+
+  it('uses longest path — ties broken by longest predecessor chain', () => {
+    // a → b → d
+    //  \     ↗
+    //   ─ c ─
+    // b and c both reach d; d's layer should be max(layer(b), layer(c)) + 1 = 2.
+    const nodes = ['a', 'b', 'c', 'd']
+    const e = edges([
+      ['a', 'b', 'e1'],
+      ['a', 'c', 'e2'],
+      ['b', 'd', 'e3'],
+      ['c', 'd', 'e4'],
+    ])
+    const { layerOf } = assignLayers(nodes, e)
+    expect(layerOf.get('a')).toBe(0)
+    expect(layerOf.get('b')).toBe(1)
+    expect(layerOf.get('c')).toBe(1)
+    expect(layerOf.get('d')).toBe(2)
+  })
+
+  it('extends layer to accommodate a long-path dependency', () => {
+    // a → b → c → e
+    //          ↗
+    //     a → d
+    // e's layer = max(layer(c)=2, layer(d)=1) + 1 = 3
+    const nodes = ['a', 'b', 'c', 'd', 'e']
+    const es = edges([
+      ['a', 'b', 'e1'],
+      ['b', 'c', 'e2'],
+      ['c', 'e', 'e3'],
+      ['a', 'd', 'e4'],
+      ['d', 'e', 'e5'],
+    ])
+    const { layerOf } = assignLayers(nodes, es)
+    expect(layerOf.get('e')).toBe(3)
+  })
+
+  it('treats disconnected components independently, both starting at 0', () => {
+    // a → b   and   c → d
+    const nodes = ['a', 'b', 'c', 'd']
+    const e = edges([
+      ['a', 'b', 'e1'],
+      ['c', 'd', 'e2'],
+    ])
+    const { layerOf } = assignLayers(nodes, e)
+    expect(layerOf.get('a')).toBe(0)
+    expect(layerOf.get('c')).toBe(0)
+    expect(layerOf.get('b')).toBe(1)
+    expect(layerOf.get('d')).toBe(1)
+  })
+
+  it('bucketizes nodes into layers[i] arrays matching layerOf', () => {
+    const nodes = ['a', 'b', 'c', 'd']
+    const e = edges([
+      ['a', 'b', 'e1'],
+      ['a', 'c', 'e2'],
+      ['b', 'd', 'e3'],
+      ['c', 'd', 'e4'],
+    ])
+    const { layers, layerOf } = assignLayers(nodes, e)
+    for (const [i, layer] of layers.entries()) {
+      for (const n of layer) expect(layerOf.get(n)).toBe(i)
+    }
+    const totalInLayers = layers.reduce((s, l) => s + l.length, 0)
+    expect(totalInLayers).toBe(nodes.length)
+  })
+
+  it('preserves input order for nodes at the same layer (stable output)', () => {
+    // a, b, c are all sources (no preds), all layer 0
+    const nodes = ['a', 'b', 'c']
+    const { layers } = assignLayers(nodes, [])
+    expect(layers[0]).toEqual(['a', 'b', 'c'])
+  })
+
+  it('tolerates residual cycles by placing stuck nodes at layer 0', () => {
+    // a → b, and a cycle b → c → b (caller forgot to removeCycles first)
+    // The non-cyclic path gives a=0, b=1; c is stuck (not reachable by topo
+    // sort because it's in a cycle with b) — we place it at layer 0 rather
+    // than crash.
+    const nodes = ['a', 'b', 'c']
+    const e = edges([
+      ['a', 'b', 'e1'],
+      ['b', 'c', 'e2'],
+      ['c', 'b', 'e3'],
+    ])
+    const { layerOf } = assignLayers(nodes, e)
+    // We don't over-specify which layer c ends up at, just that it
+    // doesn't throw and every node has a layer.
+    expect(layerOf.get('a')).toBeDefined()
+    expect(layerOf.get('b')).toBeDefined()
+    expect(layerOf.get('c')).toBeDefined()
+  })
+})

--- a/libs/@shumoku/core/src/layout/sugiyama/layers.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/layers.ts
@@ -1,0 +1,93 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Layer assignment for Sugiyama-style layered layout.
+ *
+ * Given a DAG, assign each node an integer layer index so every edge
+ * goes from a lower layer to a higher one. We use the longest-path
+ * method: layer(v) = max over all predecessors u of layer(u) + 1.
+ *
+ * Longest-path is O(V + E), trivially correct, and produces
+ * layer-compact layouts for the small-to-medium graphs typical of
+ * network topologies. Coffman-Graham or network-simplex would give
+ * tighter width bounds but aren't justified here.
+ *
+ * Disconnected components are all laid out with their longest-path
+ * layers starting at 0; the caller can shift or pack them in a later
+ * step if needed.
+ */
+
+import type { Edge, LayerAssignment, NodeId } from './types.js'
+
+export function assignLayers(nodes: NodeId[], dag: Edge[]): LayerAssignment {
+  // Build predecessor list. In a DAG this lets us compute
+  // layer(v) = 1 + max(layer(u) for u in preds(v)) via topological order.
+  const preds = new Map<NodeId, NodeId[]>()
+  for (const n of nodes) preds.set(n, [])
+  for (const e of dag) {
+    if (e.source === e.target) continue // self loop — skip
+    const list = preds.get(e.target)
+    if (list) list.push(e.source)
+  }
+
+  // Build successor list for topological sort.
+  const succ = new Map<NodeId, NodeId[]>()
+  const inDegree = new Map<NodeId, number>()
+  for (const n of nodes) {
+    succ.set(n, [])
+    inDegree.set(n, 0)
+  }
+  for (const e of dag) {
+    if (e.source === e.target) continue
+    succ.get(e.source)?.push(e.target)
+    inDegree.set(e.target, (inDegree.get(e.target) ?? 0) + 1)
+  }
+
+  // Kahn-style topological sort. We iterate nodes in a stable order (the
+  // input order of `nodes`) so the output is deterministic for equal
+  // graphs — important for testability and diff-friendly output.
+  const queue: NodeId[] = []
+  for (const n of nodes) {
+    if ((inDegree.get(n) ?? 0) === 0) queue.push(n)
+  }
+  const topo: NodeId[] = []
+  const queueHead = { i: 0 }
+  while (queueHead.i < queue.length) {
+    const u = queue[queueHead.i++]
+    if (u === undefined) break
+    topo.push(u)
+    for (const v of succ.get(u) ?? []) {
+      const d = (inDegree.get(v) ?? 0) - 1
+      inDegree.set(v, d)
+      if (d === 0) queue.push(v)
+    }
+  }
+
+  // If topo length < nodes length we have a cycle the caller forgot to
+  // remove — treat remaining nodes as layer 0 rather than crashing.
+  const layerOf = new Map<NodeId, number>()
+  for (const u of topo) {
+    let maxPred = -1
+    for (const p of preds.get(u) ?? []) {
+      const lp = layerOf.get(p)
+      if (lp !== undefined && lp > maxPred) maxPred = lp
+    }
+    layerOf.set(u, maxPred + 1)
+  }
+  for (const n of nodes) {
+    if (!layerOf.has(n)) layerOf.set(n, 0)
+  }
+
+  // Bucket into layers[i].
+  let maxLayer = 0
+  for (const l of layerOf.values()) if (l > maxLayer) maxLayer = l
+  const layers: NodeId[][] = Array.from({ length: maxLayer + 1 }, () => [])
+  for (const n of nodes) {
+    const l = layerOf.get(n) ?? 0
+    const bucket = layers[l]
+    if (bucket) bucket.push(n)
+  }
+
+  return { layers, layerOf }
+}

--- a/libs/@shumoku/core/src/layout/sugiyama/types.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/types.ts
@@ -1,0 +1,51 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Shared types for the Sugiyama-style layered layout pipeline.
+ *
+ * The pipeline runs in four phases:
+ *   1. Cycle removal       — DFS back edges get reversed so the graph is a DAG
+ *   2. Layer assignment    — longest-path ranking gives each node an integer layer
+ *   3. Crossing reduction  — barycenter ordering within each layer
+ *   4. Coordinate assignment — layer + order → absolute x/y
+ *
+ * Each phase operates on the minimal data it needs; phases pass a growing
+ * intermediate structure (Edge[] → LayerAssignment → LayerOrder → Positions).
+ */
+
+export type NodeId = string
+export type EdgeId = string
+
+/**
+ * An edge between two nodes. `reversed` is set by the cycle-removal phase
+ * when a back edge has been flipped so the graph is a DAG — downstream
+ * phases lay out the edge as if it went source→target but renderers can
+ * use the flag to draw it the original direction.
+ */
+export interface Edge {
+  id: EdgeId
+  source: NodeId
+  target: NodeId
+  reversed?: boolean
+}
+
+/**
+ * Output of the cycle-removal phase. `dag` is the edge list with back
+ * edges already reversed (so `source` precedes `target` in any topo
+ * order); `reversed` tracks which original edges were flipped.
+ */
+export interface CycleRemovalResult {
+  dag: Edge[]
+  reversed: Set<EdgeId>
+}
+
+/**
+ * Output of the layer-assignment phase.
+ *   layers[i] = ordered list of node ids at layer i (i=0 is the source layer)
+ *   layerOf maps each node id → layer index
+ */
+export interface LayerAssignment {
+  layers: NodeId[][]
+  layerOf: Map<NodeId, number>
+}


### PR DESCRIPTION
## Summary
Sugiyama-style layered layout pipeline の**第 1 弾**。`libs/@shumoku/core/src/layout/sugiyama/` に独立モジュールとして並行実装中 (既存 tree-based `layoutNetwork` は未変更)。

この PR は **前段 2 フェーズ**:

1. **Cycle removal** (`sugiyama/cycles.ts`)
   - DFS back-edge 検出で循環を一時的に反転 → DAG 化
   - Iterative DFS (深いグラフでスタックオーバーフローしない)
   - Self-loop は adjacency から除外

2. **Layer assignment** (`sugiyama/layers.ts`)
   - Kahn style トポロジカルソート + longest-path rank
   - 各 node の layer = max predecessor layer + 1
   - 非連結コンポーネントはそれぞれ layer 0 から
   - 入力 node 順序を尊重した安定出力

## Scope
- 新ディレクトリ `sugiyama/` — 4 ファイル (cycles, layers, types, index)
- テスト 14 新規ケース (simple / cycle / two-node / self-loop / disconnected / deep ring / stable output / residual cycles)
- 純粋関数、`NetworkGraph` 依存なし (後段フェーズと合成する薄い inner types のみ使用)

## Not in this PR
- Crossing reduction (barycenter) — PR E
- Coordinate assignment — PR E
- Compound subgraph (recursive) — PR F
- `layoutNetwork` との結線 — PR F

## Test plan
- [x] `bun test` in core 80/80 pass (既存 66 + 新規 14)
- [x] `bun run build` in core (tsc)
- [x] `bun x biome check` no fixes

## 関連
Step 2 of layout engine consolidation plan。最終的に `layoutNetwork` 内部を Sugiyama に切り替え、`placeNode` を wrapper に降格予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)