### PR TITLE
feat(core): Sugiyama phases 3-4 — ordering + coords

### DIFF
--- a/libs/@shumoku/core/src/layout/sugiyama/coords.test.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/coords.test.ts
@@ -1,0 +1,129 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest'
+import { assignCoordinates, type NodeSize } from './coords.js'
+import type { LayerAssignment } from './types.js'
+
+function makeLayers(layers: string[][]): LayerAssignment {
+  const layerOf = new Map<string, number>()
+  for (const [i, layer] of layers.entries()) {
+    for (const n of layer) layerOf.set(n, i)
+  }
+  return { layers, layerOf }
+}
+
+const uniformSize: NodeSize = { width: 100, height: 50 }
+
+describe('assignCoordinates', () => {
+  it('places a single node at origin', () => {
+    const layers = makeLayers([['a']])
+    const positions = assignCoordinates(layers, { defaultSize: uniformSize })
+    expect(positions.get('a')).toEqual({ x: 0, y: 25 })
+  })
+
+  it('centers a single layer around x = 0', () => {
+    const layers = makeLayers([['a', 'b', 'c']])
+    const positions = assignCoordinates(layers, {
+      defaultSize: uniformSize,
+      nodeGap: 20,
+    })
+    const xs = ['a', 'b', 'c'].map((n) => positions.get(n)?.x ?? 0)
+    // Widths 100, 100, 100 with gap 20 → total 100 + 20 + 100 + 20 + 100 = 340
+    // Centered: first node's centre at -120, then +120 apart
+    expect(xs).toEqual([-120, 0, 120])
+    // Same y (all in one layer)
+    const ys = ['a', 'b', 'c'].map((n) => positions.get(n)?.y ?? 0)
+    expect(new Set(ys).size).toBe(1)
+  })
+
+  it('stacks layers along y with layerGap spacing', () => {
+    const layers = makeLayers([['a'], ['b']])
+    const positions = assignCoordinates(layers, {
+      defaultSize: uniformSize,
+      layerGap: 40,
+    })
+    const ay = positions.get('a')?.y ?? 0
+    const by = positions.get('b')?.y ?? 0
+    // Layer thickness = 50 (height). a centre = 25. b centre = 50 + 40 + 25 = 115.
+    expect(ay).toBe(25)
+    expect(by).toBe(115)
+  })
+
+  it('accommodates nodes of different widths without overlap', () => {
+    const layers = makeLayers([['a', 'b']])
+    const sizes = new Map<string, NodeSize>([
+      ['a', { width: 200, height: 50 }],
+      ['b', { width: 80, height: 50 }],
+    ])
+    const positions = assignCoordinates(layers, {
+      sizes,
+      defaultSize: uniformSize,
+      nodeGap: 20,
+    })
+    const ax = positions.get('a')?.x ?? 0
+    const bx = positions.get('b')?.x ?? 0
+    // a's right edge should not overlap b's left edge
+    const aRight = ax + 200 / 2
+    const bLeft = bx - 80 / 2
+    expect(bLeft).toBeGreaterThanOrEqual(aRight + 20 - 0.001)
+  })
+
+  it('uses the tallest node as layer thickness', () => {
+    const layers = makeLayers([['a', 'b'], ['c']])
+    const sizes = new Map<string, NodeSize>([
+      ['a', { width: 100, height: 100 }],
+      ['b', { width: 100, height: 50 }],
+      ['c', { width: 100, height: 50 }],
+    ])
+    const positions = assignCoordinates(layers, {
+      sizes,
+      defaultSize: uniformSize,
+      layerGap: 20,
+    })
+    // Layer 0 thickness = 100 (tallest), centres at 50.
+    expect(positions.get('a')?.y).toBe(50)
+    expect(positions.get('b')?.y).toBe(50)
+    // Layer 1 starts at 100 + 20 = 120, thickness = 50, centre = 145.
+    expect(positions.get('c')?.y).toBe(145)
+  })
+
+  it('rotates to LR: primary axis becomes x', () => {
+    const layers = makeLayers([['a'], ['b']])
+    const positions = assignCoordinates(layers, {
+      defaultSize: uniformSize,
+      direction: 'LR',
+    })
+    const a = positions.get('a')
+    const b = positions.get('b')
+    // In LR, layer index drives x (not y).
+    expect((a?.x ?? 0) < (b?.x ?? 0)).toBe(true)
+    // Within-layer axis becomes y; single-node layers share x-axis centre.
+    expect(a?.y).toBe(b?.y)
+  })
+
+  it('flips to BT: y negated', () => {
+    const layers = makeLayers([['a'], ['b']])
+    const tb = assignCoordinates(layers, { defaultSize: uniformSize, direction: 'TB' })
+    const bt = assignCoordinates(layers, { defaultSize: uniformSize, direction: 'BT' })
+    expect(bt.get('a')?.y).toBe(-(tb.get('a')?.y ?? 0))
+    expect(bt.get('b')?.y).toBe(-(tb.get('b')?.y ?? 0))
+    // x unchanged
+    expect(bt.get('a')?.x).toBe(tb.get('a')?.x)
+  })
+
+  it('falls back to defaultSize when sizes map is missing a node', () => {
+    const layers = makeLayers([['a', 'b']])
+    const sizes = new Map<string, NodeSize>([['a', { width: 100, height: 50 }]])
+    const positions = assignCoordinates(layers, {
+      sizes,
+      defaultSize: { width: 80, height: 60 },
+      nodeGap: 10,
+    })
+    // b uses defaultSize (80 wide, 60 tall). Layer thickness = max(50, 60) = 60.
+    // Centres: widths 100, 80 → total span 100 + 10 + 80 = 190, centre offset = -95.
+    // a centre x = (0 + 100/2) + (-95) = -45; b centre x = (100 + 10 + 80/2) - 95 = 55.
+    expect(positions.get('a')?.x).toBe(-45)
+    expect(positions.get('b')?.x).toBe(55)
+  })
+})

--- a/libs/@shumoku/core/src/layout/sugiyama/coords.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/coords.ts
@@ -1,0 +1,120 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Coordinate assignment for Sugiyama-style layered layout.
+ *
+ * Given ordered layers (after crossing reduction) and per-node sizes,
+ * compute an absolute (x, y) for each node. We use a simple
+ * center-of-layer approach:
+ *
+ *   - Stack layers along the secondary axis (y for TB/BT, x for LR/RL),
+ *     spaced by `layerGap`. Each layer's thickness matches its tallest
+ *     (or widest, for LR/RL) node.
+ *   - Within each layer, place nodes left-to-right using each node's own
+ *     width + `nodeGap` gaps, then shift the whole layer so it's centred
+ *     around 0 on the primary axis.
+ *
+ * This is cruder than Brandes-Köpf's four-alignment averaging but
+ * produces readable layouts for sparse network topologies and is
+ * O(V + E). Brandes-Köpf can be dropped in later without touching the
+ * callers.
+ *
+ * Direction handling rotates the output after the TB computation —
+ * keeps the core layout code simple and gives identical crossing
+ * metrics across directions.
+ */
+
+import type { LayerAssignment, NodeId } from './types.js'
+
+export type Direction = 'TB' | 'BT' | 'LR' | 'RL'
+
+export interface NodeSize {
+  width: number
+  height: number
+}
+
+export interface AssignCoordinatesOptions {
+  /** Gap between adjacent layers. */
+  layerGap?: number
+  /** Gap between sibling nodes in the same layer. */
+  nodeGap?: number
+  /** Per-node sizes. Missing entries fall back to `defaultSize`. */
+  sizes?: Map<NodeId, NodeSize>
+  /** Fallback size when `sizes` is absent or lacks an entry. */
+  defaultSize?: NodeSize
+  /** Which way the edges flow. Defaults to TB. */
+  direction?: Direction
+}
+
+export interface Position {
+  x: number
+  y: number
+}
+
+/**
+ * Compute absolute centre positions for every node in the layer
+ * assignment. The returned map is keyed by NodeId and independent of
+ * the input (safe to mutate).
+ */
+export function assignCoordinates(
+  layerAssignment: LayerAssignment,
+  options: AssignCoordinatesOptions = {},
+): Map<NodeId, Position> {
+  const layerGap = options.layerGap ?? 60
+  const nodeGap = options.nodeGap ?? 40
+  const sizes = options.sizes ?? new Map<NodeId, NodeSize>()
+  const defaultSize = options.defaultSize ?? { width: 160, height: 60 }
+  const direction: Direction = options.direction ?? 'TB'
+
+  const sizeOf = (n: NodeId) => sizes.get(n) ?? defaultSize
+
+  // First compute TB-style coords (layers stacked top-to-bottom,
+  // nodes within a layer left-to-right). Rotate at the end for other
+  // directions so we keep a single layout path.
+  const tbPositions = new Map<NodeId, Position>()
+
+  let yCursor = 0
+  for (const layer of layerAssignment.layers) {
+    // Lay out nodes in the layer left-to-right, accumulating widths.
+    const xs: number[] = []
+    let xCursor = 0
+    for (const n of layer) {
+      const { width } = sizeOf(n)
+      xs.push(xCursor + width / 2)
+      xCursor += width + nodeGap
+    }
+    // Total span (minus the trailing gap) → shift to centre at 0.
+    const span = layer.length === 0 ? 0 : xCursor - nodeGap
+    const shiftX = -span / 2
+    // Layer thickness = tallest node in the layer.
+    const layerHeight = layer.reduce((h, n) => Math.max(h, sizeOf(n).height), 0)
+
+    for (const [i, n] of layer.entries()) {
+      const x = (xs[i] ?? 0) + shiftX
+      const y = yCursor + layerHeight / 2
+      tbPositions.set(n, { x, y })
+    }
+
+    yCursor += layerHeight + layerGap
+  }
+
+  if (direction === 'TB') return tbPositions
+
+  // Rotate / flip.
+  const result = new Map<NodeId, Position>()
+  for (const [id, { x, y }] of tbPositions) {
+    switch (direction) {
+      case 'BT':
+        result.set(id, { x, y: -y })
+        break
+      case 'LR':
+        result.set(id, { x: y, y: x })
+        break
+      case 'RL':
+        result.set(id, { x: -y, y: x })
+        break
+    }
+  }
+  return result
+}

--- a/libs/@shumoku/core/src/layout/sugiyama/index.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/index.ts
@@ -11,8 +11,17 @@
  * and remove the legacy implementation.
  */
 
+export type {
+  AssignCoordinatesOptions,
+  Direction,
+  NodeSize,
+  Position,
+} from './coords.js'
+export { assignCoordinates } from './coords.js'
 export { removeCycles } from './cycles.js'
 export { assignLayers } from './layers.js'
+export type { ReduceCrossingsOptions } from './ordering.js'
+export { reduceCrossings } from './ordering.js'
 export type {
   CycleRemovalResult,
   Edge,

--- a/libs/@shumoku/core/src/layout/sugiyama/ordering.test.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/ordering.test.ts
@@ -1,0 +1,172 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, it } from 'vitest'
+import { reduceCrossings } from './ordering.js'
+import type { Edge, LayerAssignment } from './types.js'
+
+function edges(pairs: [string, string, string][]): Edge[] {
+  return pairs.map(([s, t, id]) => ({ id, source: s, target: t }))
+}
+
+function makeLayers(layers: string[][]): LayerAssignment {
+  const layerOf = new Map<string, number>()
+  for (const [i, layer] of layers.entries()) {
+    for (const n of layer) layerOf.set(n, i)
+  }
+  return { layers, layerOf }
+}
+
+/** Count edge crossings between two consecutive layers. */
+function crossings(above: string[], below: string[], es: Edge[]): number {
+  const aboveIdx = new Map(above.map((n, i) => [n, i]))
+  const belowIdx = new Map(below.map((n, i) => [n, i]))
+  const pairs = es
+    .filter((e) => aboveIdx.has(e.source) && belowIdx.has(e.target))
+    .map((e) => [aboveIdx.get(e.source) ?? 0, belowIdx.get(e.target) ?? 0] as const)
+  let count = 0
+  for (let i = 0; i < pairs.length; i++) {
+    for (let j = i + 1; j < pairs.length; j++) {
+      const a = pairs[i]
+      const b = pairs[j]
+      if (!a || !b) continue
+      const [a1, a2] = a
+      const [b1, b2] = b
+      if ((a1 < b1 && a2 > b2) || (a1 > b1 && a2 < b2)) count++
+    }
+  }
+  return count
+}
+
+describe('reduceCrossings', () => {
+  it('leaves an already-optimal order untouched', () => {
+    // a→c, b→d : no crossings already
+    const input = makeLayers([
+      ['a', 'b'],
+      ['c', 'd'],
+    ])
+    const es = edges([
+      ['a', 'c', 'e1'],
+      ['b', 'd', 'e2'],
+    ])
+    const result = reduceCrossings(input, es)
+    expect(result.layers).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ])
+  })
+
+  it('swaps a layer to remove crossings', () => {
+    // a→d, b→c : crossing if [c, d] order
+    const input = makeLayers([
+      ['a', 'b'],
+      ['c', 'd'],
+    ])
+    const es = edges([
+      ['a', 'd', 'e1'],
+      ['b', 'c', 'e2'],
+    ])
+    const before = crossings(input.layers[0] ?? [], input.layers[1] ?? [], es)
+    const result = reduceCrossings(input, es)
+    const after = crossings(result.layers[0] ?? [], result.layers[1] ?? [], es)
+    expect(after).toBeLessThanOrEqual(before)
+    // Specifically, the optimal order is [d, c]
+    expect(result.layers[1]).toEqual(['d', 'c'])
+  })
+
+  it('keeps floating (unlinked) nodes stable', () => {
+    const input = makeLayers([['a', 'b', 'c']])
+    const result = reduceCrossings(input, [])
+    expect(result.layers[0]).toEqual(['a', 'b', 'c'])
+  })
+
+  it('reduces crossings in a 3-layer chain', () => {
+    // Layers: [a,b] → [c,d] → [e,f]
+    // Edges tangle two layers: a→d, b→c, c→f, d→e
+    const input = makeLayers([
+      ['a', 'b'],
+      ['c', 'd'],
+      ['e', 'f'],
+    ])
+    const es = edges([
+      ['a', 'd', 'e1'],
+      ['b', 'c', 'e2'],
+      ['c', 'f', 'e3'],
+      ['d', 'e', 'e4'],
+    ])
+
+    const before =
+      crossings(input.layers[0] ?? [], input.layers[1] ?? [], es) +
+      crossings(input.layers[1] ?? [], input.layers[2] ?? [], es)
+
+    const result = reduceCrossings(input, es)
+    const after =
+      crossings(result.layers[0] ?? [], result.layers[1] ?? [], es) +
+      crossings(result.layers[1] ?? [], result.layers[2] ?? [], es)
+
+    expect(after).toBeLessThanOrEqual(before)
+  })
+
+  it('updates layerOf to match reordered layers', () => {
+    const input = makeLayers([
+      ['a', 'b'],
+      ['c', 'd'],
+    ])
+    const result = reduceCrossings(
+      input,
+      edges([
+        ['a', 'd', 'e1'],
+        ['b', 'c', 'e2'],
+      ]),
+    )
+    for (const [i, layer] of result.layers.entries()) {
+      for (const n of layer) expect(result.layerOf.get(n)).toBe(i)
+    }
+  })
+
+  it('respects `iterations` option (0 iterations = no change)', () => {
+    const input = makeLayers([
+      ['a', 'b'],
+      ['c', 'd'],
+    ])
+    const es = edges([
+      ['a', 'd', 'e1'],
+      ['b', 'c', 'e2'],
+    ])
+    const result = reduceCrossings(input, es, { iterations: 0 })
+    expect(result.layers).toEqual([
+      ['a', 'b'],
+      ['c', 'd'],
+    ])
+  })
+
+  it('is idempotent when re-run on already-reduced output', () => {
+    const input = makeLayers([
+      ['a', 'b'],
+      ['c', 'd'],
+    ])
+    const es = edges([
+      ['a', 'd', 'e1'],
+      ['b', 'c', 'e2'],
+    ])
+    const once = reduceCrossings(input, es)
+    const twice = reduceCrossings(once, es)
+    expect(twice.layers).toEqual(once.layers)
+  })
+
+  it('does not mutate the input layer arrays', () => {
+    const input = makeLayers([
+      ['a', 'b'],
+      ['c', 'd'],
+    ])
+    const snapshot = input.layers.map((l) => [...l])
+    reduceCrossings(
+      input,
+      edges([
+        ['a', 'd', 'e1'],
+        ['b', 'c', 'e2'],
+      ]),
+    )
+    expect(input.layers).toEqual(snapshot)
+  })
+})

--- a/libs/@shumoku/core/src/layout/sugiyama/ordering.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/ordering.ts
@@ -1,0 +1,123 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Crossing reduction for Sugiyama-style layered layout.
+ *
+ * Given a layer assignment, reorder nodes *within* each layer so edges
+ * between adjacent layers cross as little as possible. We use the
+ * **barycenter heuristic** (Sugiyama 1981, Gansner 1993): for each
+ * node, compute the average index of its neighbours in the previous
+ * layer, then sort the current layer by those averages.
+ *
+ * A single downward sweep greatly reduces crossings; alternating with
+ * an upward sweep (and iterating a handful of times) tightens the
+ * result further without getting stuck in cycles. We don't do proper
+ * median or weighted-median sorts — barycenter with ~4 iterations is
+ * good enough for the small-to-medium graphs typical of network
+ * topologies, and keeps the phase readable.
+ *
+ * Nodes with no neighbours in the reference layer keep their current
+ * position (they "float"). Stable sort semantics ensure deterministic
+ * output when multiple nodes share the same barycenter value.
+ */
+
+import type { Edge, LayerAssignment, NodeId } from './types.js'
+
+export interface ReduceCrossingsOptions {
+  /** Down+Up passes to run. 4 converges on most graphs. */
+  iterations?: number
+}
+
+export function reduceCrossings(
+  layerAssignment: LayerAssignment,
+  edges: Edge[],
+  options: ReduceCrossingsOptions = {},
+): LayerAssignment {
+  const iters = options.iterations ?? 4
+  // Work on a copy so we don't mutate the caller's arrays.
+  const layers = layerAssignment.layers.map((l) => [...l])
+
+  // Pre-index adjacency: for each (node, neighbourLayerDirection), the
+  // neighbours. Built once; indices into layers[] are recomputed each
+  // sweep because positions change as we go.
+  const outgoing = new Map<NodeId, NodeId[]>()
+  const incoming = new Map<NodeId, NodeId[]>()
+  for (const layer of layers) {
+    for (const n of layer) {
+      outgoing.set(n, [])
+      incoming.set(n, [])
+    }
+  }
+  for (const e of edges) {
+    if (e.source === e.target) continue
+    outgoing.get(e.source)?.push(e.target)
+    incoming.get(e.target)?.push(e.source)
+  }
+
+  for (let iter = 0; iter < iters; iter++) {
+    // Downward sweep: reorder layer L by barycenter of neighbours in L-1
+    for (let i = 1; i < layers.length; i++) {
+      const above = layers[i - 1]
+      const current = layers[i]
+      if (!above || !current) continue
+      layers[i] = sortByBarycenter(current, above, incoming)
+    }
+    // Upward sweep: reorder layer L by barycenter of neighbours in L+1
+    for (let i = layers.length - 2; i >= 0; i--) {
+      const below = layers[i + 1]
+      const current = layers[i]
+      if (!below || !current) continue
+      layers[i] = sortByBarycenter(current, below, outgoing)
+    }
+  }
+
+  // Rebuild layerOf from the reordered layers so the output is consistent.
+  const layerOf = new Map<NodeId, number>()
+  for (const [i, layer] of layers.entries()) {
+    for (const n of layer) layerOf.set(n, i)
+  }
+  return { layers, layerOf }
+}
+
+/**
+ * Sort `current` by the average index of each node's neighbours in
+ * `reference`, falling back to the node's current position when it has
+ * no neighbours there (keeps floating nodes stable).
+ */
+function sortByBarycenter(
+  current: NodeId[],
+  reference: NodeId[],
+  neighbours: Map<NodeId, NodeId[]>,
+): NodeId[] {
+  const refIndex = new Map<NodeId, number>()
+  for (const [i, n] of reference.entries()) refIndex.set(n, i)
+
+  const originalIndex = new Map<NodeId, number>()
+  for (const [i, n] of current.entries()) originalIndex.set(n, i)
+
+  const bary = new Map<NodeId, number>()
+  for (const n of current) {
+    const ns = neighbours.get(n) ?? []
+    let sum = 0
+    let count = 0
+    for (const m of ns) {
+      const idx = refIndex.get(m)
+      if (idx === undefined) continue
+      sum += idx
+      count++
+    }
+    // No neighbours in reference layer → keep current index so the node
+    // doesn't jump around arbitrarily between sweeps.
+    bary.set(n, count === 0 ? (originalIndex.get(n) ?? 0) : sum / count)
+  }
+
+  // Stable sort: when barycenters tie, preserve original order. JS's
+  // Array.prototype.sort is stable per spec as of ES2019.
+  return [...current].sort((a, b) => {
+    const ba = bary.get(a) ?? 0
+    const bb = bary.get(b) ?? 0
+    if (ba === bb) return (originalIndex.get(a) ?? 0) - (originalIndex.get(b) ?? 0)
+    return ba - bb
+  })
+}


### PR DESCRIPTION
## Summary
Sugiyama-style layered layout pipeline の**第 2 弾**。PR #135 で入れた 前段 2 フェーズ (cycle removal / layer assignment) に続く 後段 2 フェーズ。

1. **Crossing reduction** (`sugiyama/ordering.ts`)
   - Barycenter heuristic (Sugiyama 1981 / Gansner 1993)
   - Downward + Upward sweep を 4 iterations (default)
   - Floating node (隣接 layer に neighbour 無し) は現在位置保持
   - Stable sort (barycenter tie 時に入力順保持)

2. **Coordinate assignment** (`sugiyama/coords.ts`)
   - Layers を secondary 軸に `layerGap` で積む、各 layer 厚は最 tall node
   - Layer 内は width + `nodeGap` で横並び → 中央 0 に shift
   - TB を標準とし、BT/LR/RL は最後に rotation で対応 (core 単一実装)
   - サイズマップ省略時は `defaultSize` fallback

## Scope
- 新ファイル: `ordering.ts`, `ordering.test.ts`, `coords.ts`, `coords.test.ts`
- `sugiyama/index.ts` に export 追加
- 16 新規テストケース

## Not in this PR
- Compound subgraph (recursive) — PR F
- `layoutNetwork` との結線 — PR F
- fixed/hints 対応 — PR F (composed pipeline 層で)

## Test plan
- [x] `bun test` in core 96/96 pass (既存 80 + 新規 16)
- [x] `bun run build` in core (tsc)
- [x] `bun x biome check` no fixes

## 関連
Step 2 of layout engine consolidation plan。次 PR F で 4 フェーズを合成 → compound 対応 → `layoutNetwork` に結線 → 旧 tree-based 削除 + `placeNode` wrapper 化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)