### PR TITLE
refactor(core): consolidate layout geometric types into models

### DIFF
--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -34,6 +34,7 @@ import {
 import { getDeviceIcon } from '../icons/index.js'
 import type {
   Bounds,
+  Direction,
   LinkEndpoint,
   NetworkGraph,
   Node,
@@ -55,7 +56,7 @@ import {
 // ============================================================================
 
 export interface NetworkLayoutOptions {
-  direction?: 'TB' | 'BT' | 'LR' | 'RL'
+  direction?: Direction
   gap?: number
   topLevelGap?: number
   subgraphPadding?: number

--- a/libs/@shumoku/core/src/layout/port-placement.ts
+++ b/libs/@shumoku/core/src/layout/port-placement.ts
@@ -17,7 +17,7 @@
  *   HA → bottom/top
  */
 
-import type { Link, LinkEndpoint, Node, Position } from '../models/types.js'
+import type { Direction, Link, LinkEndpoint, Node, Position } from '../models/types.js'
 import { computeNodeSize } from './network-layout.js'
 import type { ResolvedPort } from './resolved-types.js'
 
@@ -25,7 +25,6 @@ import type { ResolvedPort } from './resolved-types.js'
 const PORT_SIZE = { width: 8, height: 8 }
 
 type Side = 'top' | 'bottom' | 'left' | 'right'
-type Direction = 'TB' | 'BT' | 'LR' | 'RL'
 
 interface PortAssignment {
   nodeId: string

--- a/libs/@shumoku/core/src/layout/sugiyama/compose.test.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/compose.test.ts
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { describe, expect, it } from 'vitest'
+import type { Size } from '../../models/types.js'
 import { layoutFlat } from './compose.js'
-import type { NodeSize } from './coords.js'
 import type { Edge } from './types.js'
 
 function edges(pairs: [string, string, string][]): Edge[] {
   return pairs.map(([s, t, id]) => ({ id, source: s, target: t }))
 }
 
-const uniformSize: NodeSize = { width: 100, height: 50 }
+const uniformSize: Size = { width: 100, height: 50 }
 
 describe('layoutFlat', () => {
   it('lays out a simple chain with each node in its own layer', () => {
@@ -102,7 +102,7 @@ describe('layoutFlat', () => {
   })
 
   it('respects node sizes when assigning coordinates', () => {
-    const sizes = new Map<string, NodeSize>([
+    const sizes = new Map<string, Size>([
       ['a', { width: 200, height: 50 }],
       ['b', { width: 80, height: 50 }],
     ])

--- a/libs/@shumoku/core/src/layout/sugiyama/compose.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/compose.ts
@@ -23,7 +23,8 @@
  * need arises.
  */
 
-import { type AssignCoordinatesOptions, assignCoordinates, type Position } from './coords.js'
+import type { Position } from '../../models/types.js'
+import { type AssignCoordinatesOptions, assignCoordinates } from './coords.js'
 import { removeCycles } from './cycles.js'
 import { assignLayers } from './layers.js'
 import { reduceCrossings } from './ordering.js'

--- a/libs/@shumoku/core/src/layout/sugiyama/compound.test.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/compound.test.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { describe, expect, it } from 'vitest'
+import type { Size } from '../../models/types.js'
 import { type CompoundNode, type CompoundSubgraph, layoutCompound } from './compound.js'
-import type { NodeSize } from './coords.js'
 import type { Edge } from './types.js'
 
-function nodes(ids: [string, string | null, NodeSize?][]): CompoundNode[] {
+function nodes(ids: [string, string | null, Size?][]): CompoundNode[] {
   return ids.map(([id, parent, size]) => ({ id, parent, ...(size && { size }) }))
 }
 
@@ -18,7 +18,7 @@ function edges(pairs: [string, string, string][]): Edge[] {
   return pairs.map(([s, t, id]) => ({ id, source: s, target: t }))
 }
 
-const uniformSize: NodeSize = { width: 100, height: 50 }
+const uniformSize: Size = { width: 100, height: 50 }
 
 describe('layoutCompound', () => {
   it('lays out top-level-only nodes (no subgraphs) like flat layout', () => {

--- a/libs/@shumoku/core/src/layout/sugiyama/compound.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/compound.ts
@@ -29,8 +29,8 @@
  * our stack) after this function returns positioned nodes/subgraphs.
  */
 
+import type { Bounds, Position, Size } from '../../models/types.js'
 import { type LayoutFlatOptions, layoutFlat } from './compose.js'
-import type { NodeSize, Position } from './coords.js'
 import type { Edge, NodeId } from './types.js'
 
 export interface CompoundNode {
@@ -41,7 +41,7 @@ export interface CompoundNode {
    * Intrinsic size for *leaf* nodes. Ignored for subgraphs, which get
    * their size computed from their children's bounds.
    */
-  size?: NodeSize
+  size?: Size
 }
 
 export interface CompoundSubgraph {
@@ -55,7 +55,7 @@ export interface CompoundLayoutOptions extends LayoutFlatOptions {
   /** Extra vertical space reserved for a subgraph's label. */
   subgraphLabelHeight?: number
   /** Default size for leaf nodes without a size entry. */
-  defaultSize?: NodeSize
+  defaultSize?: Size
 }
 
 export interface CompoundLayoutResult {
@@ -65,13 +65,6 @@ export interface CompoundLayoutResult {
   subgraphBounds: Map<NodeId, Bounds>
   /** Overall bounding rectangle containing every element. */
   rootBounds: Bounds
-}
-
-export interface Bounds {
-  x: number
-  y: number
-  width: number
-  height: number
 }
 
 export function layoutCompound(
@@ -111,7 +104,7 @@ export function layoutCompound(
 
   // Per-subgraph computed size (starts as a placeholder, filled in
   // bottom-up). Top-level entry keyed by `null` is ignored.
-  const subgraphSize = new Map<NodeId, NodeSize>()
+  const subgraphSize = new Map<NodeId, Size>()
 
   // Filter edges to only those with both endpoints in the given child set.
   const filterEdges = (childIds: Set<NodeId>) =>
@@ -138,7 +131,7 @@ export function layoutCompound(
 
     // Size map: leaves use their intrinsic size, subgraphs use
     // previously-computed bounds expanded by padding + label.
-    const sizes = new Map<NodeId, NodeSize>()
+    const sizes = new Map<NodeId, Size>()
     for (const c of children) {
       const sg = subgraphById.get(c.id)
       if (sg) {

--- a/libs/@shumoku/core/src/layout/sugiyama/coords.test.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/coords.test.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { describe, expect, it } from 'vitest'
-import { assignCoordinates, type NodeSize } from './coords.js'
+import type { Size } from '../../models/types.js'
+import { assignCoordinates } from './coords.js'
 import type { LayerAssignment } from './types.js'
 
 function makeLayers(layers: string[][]): LayerAssignment {
@@ -13,7 +14,7 @@ function makeLayers(layers: string[][]): LayerAssignment {
   return { layers, layerOf }
 }
 
-const uniformSize: NodeSize = { width: 100, height: 50 }
+const uniformSize: Size = { width: 100, height: 50 }
 
 describe('assignCoordinates', () => {
   it('places a single node at origin', () => {
@@ -52,7 +53,7 @@ describe('assignCoordinates', () => {
 
   it('accommodates nodes of different widths without overlap', () => {
     const layers = makeLayers([['a', 'b']])
-    const sizes = new Map<string, NodeSize>([
+    const sizes = new Map<string, Size>([
       ['a', { width: 200, height: 50 }],
       ['b', { width: 80, height: 50 }],
     ])
@@ -71,7 +72,7 @@ describe('assignCoordinates', () => {
 
   it('uses the tallest node as layer thickness', () => {
     const layers = makeLayers([['a', 'b'], ['c']])
-    const sizes = new Map<string, NodeSize>([
+    const sizes = new Map<string, Size>([
       ['a', { width: 100, height: 100 }],
       ['b', { width: 100, height: 50 }],
       ['c', { width: 100, height: 50 }],
@@ -215,7 +216,7 @@ describe('assignCoordinates', () => {
 
   it('falls back to defaultSize when sizes map is missing a node', () => {
     const layers = makeLayers([['a', 'b']])
-    const sizes = new Map<string, NodeSize>([['a', { width: 100, height: 50 }]])
+    const sizes = new Map<string, Size>([['a', { width: 100, height: 50 }]])
     const positions = assignCoordinates(layers, {
       sizes,
       defaultSize: { width: 80, height: 60 },

--- a/libs/@shumoku/core/src/layout/sugiyama/coords.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/coords.ts
@@ -40,14 +40,8 @@
  * keeps the core layout code as a single implementation.
  */
 
+import type { Direction, Position, Size } from '../../models/types.js'
 import type { Edge, LayerAssignment, NodeId } from './types.js'
-
-export type Direction = 'TB' | 'BT' | 'LR' | 'RL'
-
-export interface NodeSize {
-  width: number
-  height: number
-}
 
 export interface AssignCoordinatesOptions {
   /** Gap between adjacent layers. */
@@ -55,9 +49,9 @@ export interface AssignCoordinatesOptions {
   /** Gap between sibling nodes in the same layer. */
   nodeGap?: number
   /** Per-node sizes. Missing entries fall back to `defaultSize`. */
-  sizes?: Map<NodeId, NodeSize>
+  sizes?: Map<NodeId, Size>
   /** Fallback size when `sizes` is absent or lacks an entry. */
-  defaultSize?: NodeSize
+  defaultSize?: Size
   /** Which way the edges flow. Defaults to TB. */
   direction?: Direction
   /**
@@ -68,11 +62,6 @@ export interface AssignCoordinatesOptions {
    * layer unchanged.
    */
   edges?: Edge[]
-}
-
-export interface Position {
-  x: number
-  y: number
 }
 
 /**
@@ -86,7 +75,7 @@ export function assignCoordinates(
 ): Map<NodeId, Position> {
   const layerGap = options.layerGap ?? 60
   const nodeGap = options.nodeGap ?? 40
-  const sizes = options.sizes ?? new Map<NodeId, NodeSize>()
+  const sizes = options.sizes ?? new Map<NodeId, Size>()
   const defaultSize = options.defaultSize ?? { width: 160, height: 60 }
   const direction: Direction = options.direction ?? 'TB'
   const sizeOf = (n: NodeId) => sizes.get(n) ?? defaultSize
@@ -180,7 +169,7 @@ export function assignCoordinates(
  * centred on x = 0. Returns the per-node centre x, in the same order
  * as `layer`.
  */
-function centredLayer(layer: NodeId[], sizeOf: (n: NodeId) => NodeSize, nodeGap: number): number[] {
+function centredLayer(layer: NodeId[], sizeOf: (n: NodeId) => Size, nodeGap: number): number[] {
   const xs: number[] = []
   let xCursor = 0
   for (const n of layer) {
@@ -232,7 +221,7 @@ function forwardPack(
   layer: NodeId[],
   preds: Map<NodeId, NodeId[]>,
   previousLayers: Map<NodeId, number>[],
-  sizeOf: (n: NodeId) => NodeSize,
+  sizeOf: (n: NodeId) => Size,
   nodeGap: number,
 ): Map<NodeId, number> {
   const out = new Map<NodeId, number>()
@@ -259,7 +248,7 @@ function backwardPack(
   layer: NodeId[],
   preds: Map<NodeId, NodeId[]>,
   previousLayers: Map<NodeId, number>[],
-  sizeOf: (n: NodeId) => NodeSize,
+  sizeOf: (n: NodeId) => Size,
   nodeGap: number,
 ): Map<NodeId, number> {
   const out = new Map<NodeId, number>()

--- a/libs/@shumoku/core/src/layout/sugiyama/index.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/index.ts
@@ -4,29 +4,25 @@
 /**
  * Sugiyama-style layered layout pipeline.
  *
- * This module is a parallel implementation of `layoutNetwork`, built out
- * phase by phase. It is not wired into the public `layoutNetwork` yet —
- * when the four phases are complete and validated against the existing
- * tree-based output, we will switch `layoutNetwork` to delegate here
- * and remove the legacy implementation.
+ * `layoutNetwork` delegates its internals to `layoutCompound` here;
+ * callers outside core rarely need these primitives directly, but they
+ * are exported for testability and so other layout-engine experiments
+ * can reuse the individual phases without vendoring the whole module.
+ *
+ * Shared geometric types (`Position`, `Bounds`, `Size`, `Direction`)
+ * live in `@shumoku/core/models` rather than being redefined here.
  */
 
 export type { LayoutFlatOptions, LayoutFlatResult } from './compose.js'
 export { layoutFlat } from './compose.js'
 export type {
-  Bounds,
   CompoundLayoutOptions,
   CompoundLayoutResult,
   CompoundNode,
   CompoundSubgraph,
 } from './compound.js'
 export { layoutCompound } from './compound.js'
-export type {
-  AssignCoordinatesOptions,
-  Direction,
-  NodeSize,
-  Position,
-} from './coords.js'
+export type { AssignCoordinatesOptions } from './coords.js'
 export { assignCoordinates } from './coords.js'
 export { removeCycles } from './cycles.js'
 export { assignLayers } from './layers.js'

--- a/libs/@shumoku/core/src/layout/sugiyama/types.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/types.ts
@@ -14,6 +14,11 @@
  * intermediate structure (Edge[] → LayerAssignment → LayerOrder → Positions).
  */
 
+/**
+ * String id aliases kept for self-documentation inside the algorithm
+ * modules. Values are plain `string` — callers can pass a raw string
+ * and TypeScript will accept it.
+ */
 export type NodeId = string
 export type EdgeId = string
 

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -295,8 +295,6 @@ export function getNodeId(endpoint: string | LinkEndpoint): string {
 // Subgraph Types
 // ============================================
 
-export type LayoutDirection = 'TB' | 'BT' | 'LR' | 'RL'
-
 export interface SubgraphStyle {
   /**
    * Fill color - can be a hex color or a surface token (e.g., "surface-1", "accent-blue")
@@ -377,7 +375,7 @@ export interface Subgraph {
   /**
    * Layout direction within this subgraph
    */
-  direction?: LayoutDirection
+  direction?: Direction
 
   /**
    * Custom style
@@ -563,7 +561,7 @@ export interface GraphSettings {
   /**
    * Default layout direction
    */
-  direction?: LayoutDirection
+  direction?: Direction
 
   /**
    * Theme for diagram appearance (light or dark)
@@ -706,6 +704,16 @@ export interface Bounds {
   width: number
   height: number
 }
+
+/**
+ * Layout flow direction. Used by every engine and option type that
+ * produces directional diagrams.
+ *   - `TB` top→bottom (default)
+ *   - `BT` bottom→top
+ *   - `LR` left→right
+ *   - `RL` right→left
+ */
+export type Direction = 'TB' | 'BT' | 'LR' | 'RL'
 
 /**
  * Port position on a node edge


### PR DESCRIPTION
## Summary
Layout まわりの型の散らかりを整理。`Position` / `Bounds` / `Direction` / `Size` を `core/models/types.ts` に一本化して、重複定義を削除。

## Before / After

**重複していた型:**
| 型 | 重複箇所 | 解消 |
|---|---|---|
| `Position` | `models/types.ts` + `sugiyama/coords.ts` | `coords.ts` の方を削除 → core から import |
| `Bounds` | `models/types.ts` + `sugiyama/compound.ts` | `compound.ts` の方を削除 → core から import |
| `Direction` | `coords.ts` + `port-placement.ts` + `network-layout.ts` + 孤児 `LayoutDirection` | `core/models/types.ts` に `Direction` を追加、全箇所 import |
| `NodeSize` | `sugiyama/coords.ts` | 既存の `Size` (core) に置き換え |

**Run-time 挙動は変化なし** — 構造的に同じ型なので、型の所在だけを変更。

## Changes
- `core/models/types.ts`:
  - `Direction` export 追加
  - 孤児 `LayoutDirection` 削除 (`Direction` にリネーム、内部 2 箇所の参照は置換)
- `sugiyama/coords.ts`: local `Position` / `NodeSize` / `Direction` 削除、core から import
- `sugiyama/compound.ts`: local `Bounds` 削除、core から import、`NodeSize` → `Size`
- `sugiyama/compose.ts`: `Position` を core から import
- `sugiyama/index.ts`: もう公開しない型の export を削除、docstring 更新
- `sugiyama/types.ts`: `NodeId` / `EdgeId` alias に docstring 追加
- `layout/port-placement.ts`: local `Direction` 削除、core から
- `layout/network-layout.ts`: `'TB' | 'BT' | ...` 書き下ろしを `Direction` import に
- tests: `NodeSize` → `Size`

## Test plan
- [x] `bun test` in core **116/116 pass**
- [x] `bun run typecheck` workspace **30/30 green**
- [x] `bun run build` in core (tsc)

## 関連
API 2 本 (`layoutNetwork` / `placeNode`) の役割明記 + 型整理シリーズの **Step 1 / 3**:
- [x] Step 1: 型統合 ← 本 PR
- [ ] Step 2: オプション型統合 (4 階層 → 2 階層)
- [ ] Step 3: hints option 追加 + 役割ドキュメント

🤖 Generated with [Claude Code](https://claude.com/claude-code)