### PR TITLE
refactor(core): collapse Sugiyama option tower into one shared type

### DIFF
--- a/libs/@shumoku/core/src/layout/sugiyama/compose.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/compose.ts
@@ -30,7 +30,15 @@ import { assignLayers } from './layers.js'
 import { reduceCrossings } from './ordering.js'
 import type { Edge, NodeId } from './types.js'
 
-export interface LayoutFlatOptions extends AssignCoordinatesOptions {
+/**
+ * All Sugiyama-pipeline knobs in one type. `layoutFlat` and
+ * `layoutCompound` both accept this shape; fields only meaningful at
+ * the compound level (`subgraphPadding`, `subgraphLabelHeight`) are
+ * ignored by `layoutFlat`, which keeps the two entry points calling
+ * each other with a single options object rather than shuttling
+ * subsets.
+ */
+export interface SugiyamaOptions extends AssignCoordinatesOptions {
   /** Barycenter iterations for crossing reduction. */
   iterations?: number
   /**
@@ -40,6 +48,10 @@ export interface LayoutFlatOptions extends AssignCoordinatesOptions {
    * repositioned.
    */
   fixed?: Map<NodeId, Position>
+  /** Padding inside a subgraph's border (compound-only). */
+  subgraphPadding?: number
+  /** Vertical space reserved for the subgraph label (compound-only). */
+  subgraphLabelHeight?: number
 }
 
 export interface LayoutFlatResult {
@@ -55,7 +67,7 @@ export interface LayoutFlatResult {
 export function layoutFlat(
   nodes: NodeId[],
   edges: Edge[],
-  options: LayoutFlatOptions = {},
+  options: SugiyamaOptions = {},
 ): LayoutFlatResult {
   // Phase 1: break cycles so subsequent phases can assume a DAG.
   const { dag, reversed } = removeCycles(nodes, edges)

--- a/libs/@shumoku/core/src/layout/sugiyama/compound.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/compound.ts
@@ -30,7 +30,7 @@
  */
 
 import type { Bounds, Position, Size } from '../../models/types.js'
-import { type LayoutFlatOptions, layoutFlat } from './compose.js'
+import { layoutFlat, type SugiyamaOptions } from './compose.js'
 import type { Edge, NodeId } from './types.js'
 
 export interface CompoundNode {
@@ -49,15 +49,6 @@ export interface CompoundSubgraph {
   parent?: NodeId | null
 }
 
-export interface CompoundLayoutOptions extends LayoutFlatOptions {
-  /** Padding around the inside of every subgraph. */
-  subgraphPadding?: number
-  /** Extra vertical space reserved for a subgraph's label. */
-  subgraphLabelHeight?: number
-  /** Default size for leaf nodes without a size entry. */
-  defaultSize?: Size
-}
-
 export interface CompoundLayoutResult {
   /** Centre position of every leaf node, keyed by node id. */
   nodePositions: Map<NodeId, Position>
@@ -71,7 +62,7 @@ export function layoutCompound(
   nodes: CompoundNode[],
   subgraphs: CompoundSubgraph[],
   edges: Edge[],
-  options: CompoundLayoutOptions = {},
+  options: SugiyamaOptions = {},
 ): CompoundLayoutResult {
   const padding = options.subgraphPadding ?? 20
   const labelHeight = options.subgraphLabelHeight ?? 28

--- a/libs/@shumoku/core/src/layout/sugiyama/index.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/index.ts
@@ -13,14 +13,9 @@
  * live in `@shumoku/core/models` rather than being redefined here.
  */
 
-export type { LayoutFlatOptions, LayoutFlatResult } from './compose.js'
+export type { LayoutFlatResult, SugiyamaOptions } from './compose.js'
 export { layoutFlat } from './compose.js'
-export type {
-  CompoundLayoutOptions,
-  CompoundLayoutResult,
-  CompoundNode,
-  CompoundSubgraph,
-} from './compound.js'
+export type { CompoundLayoutResult, CompoundNode, CompoundSubgraph } from './compound.js'
 export { layoutCompound } from './compound.js'
 export type { AssignCoordinatesOptions } from './coords.js'
 export { assignCoordinates } from './coords.js'


### PR DESCRIPTION
## Summary
4 階層のオプション型タワーを 3 階層に圧縮。

**Before (4 types):**
```
AssignCoordinatesOptions
  └── LayoutFlatOptions          (+ iterations, fixed)
        └── CompoundLayoutOptions (+ subgraphPadding, subgraphLabelHeight, defaultSize [重複])
        
+ NetworkLayoutOptions (public、standalone)
```

**After (3 types):**
```
AssignCoordinatesOptions          ← そのまま
  └── SugiyamaOptions            (iterations + fixed + subgraph*)
  
+ NetworkLayoutOptions (public、standalone)
```

- `LayoutFlatOptions` + `CompoundLayoutOptions` → **`SugiyamaOptions`** 1 本に
- `layoutFlat` / `layoutCompound` 両方が `SugiyamaOptions` を受け取る (サブグラフ専用フィールドは flat では無視される)
- `defaultSize` の重複宣言削除 (親から継承済み)
- 公開 API (`NetworkLayoutOptions`) はそのまま

## Changes
- `sugiyama/compose.ts`: `LayoutFlatOptions` → `SugiyamaOptions` にリネーム、subgraph* フィールドを追加
- `sugiyama/compound.ts`: `CompoundLayoutOptions` 削除、`SugiyamaOptions` を使う
- `sugiyama/index.ts`: export 更新

## Test plan
- [x] `bun test` in core **116/116 pass**
- [x] `bun run typecheck` workspace **30/30 green**
- [x] `bun run build` in core (tsc)

## 関連
レイアウト API 整理シリーズの Step 2:
- [x] Step 1: 型統合 (#139)
- [x] Step 2: オプション型統合 ← 本 PR
- [ ] Step 3: hints option 追加 + 2 API 役割ドキュメント

🤖 Generated with [Claude Code](https://claude.com/claude-code)