### PR TITLE
feat(core): hints option for layoutNetwork + document two-API split

### DIFF
--- a/apps/editor/DATA_MODEL.md
+++ b/apps/editor/DATA_MODEL.md
@@ -88,9 +88,31 @@ forward. Private helpers `applyProject` / `applyGraph` live module-scoped
 and handle sanitize + `placePorts` + `routeEdges`. Every load — sample,
 YAML paste, JSON drop — passes through the same terminal.
 
-### Individual node placement
+### Placement APIs — two primitives, two intents
 
-`placeNode(node, graph, initial, gap?)` in `@shumoku/core` is the
-primitive for placing one unpositioned node with collision avoidance
-against the existing graph. It is the lightweight counterpart to
-`layoutNetwork`, which rebuilds the entire layout from scratch.
+`@shumoku/core` exposes two placement functions. They cover different
+use cases and are intentionally kept separate rather than collapsed
+into one:
+
+| | `placeNode` | `layoutNetwork` |
+|---|---|---|
+| Intent | **Geometric** (put it at this point) | **Structural** (arrange by link flow) |
+| Input | One node + initial (x, y) | Whole graph |
+| Algorithm | Collision-avoidance around initial | Sugiyama: cycles → layers → ordering → coords |
+| Honours structure | No — links ignored | Yes — layers follow flow direction |
+| Cost | O(existing obstacles) | O(V + E), libavoid-class |
+| Use for | User drop / paste / "add here" | Auto-arrange / re-layout / YAML import |
+
+`layoutNetwork` accepts two knobs for selective placement:
+
+  - **`fixed: Set<string>`** — hard constraint. Listed nodes are snapped
+    back to their input positions after Sugiyama; their ports shift
+    with them and subgraph bounds are recomputed.
+  - **`hints: Map<string, { x }>`** — soft constraint. Listed nodes
+    use the hint as their preferred x in the coord pass; packing
+    still prevents overlap, so the final x may drift in tight
+    neighbourhoods.
+
+"Arrange selection" = `layoutNetwork({ fixed: nonSelectedIds })`;
+"Nudge these nodes toward this x" = `layoutNetwork({ hints })`.
+Click-to-drop = `placeNode`.

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -135,10 +135,19 @@ export function resolveNodePosition(
 }
 
 /**
- * Place a single unpositioned node into an existing graph with collision
- * avoidance. Thin wrapper around resolvePosition/collectObstacles — the
- * primitive used when loading a partially-positioned graph or adding a
- * node at runtime, without having to re-run the full layout pass.
+ * **Geometric** placement for a single unpositioned node: find the
+ * point nearest `initial` that doesn't overlap any existing node or
+ * subgraph. The graph's link structure is deliberately ignored — this
+ * is the primitive for "drop the node exactly where the user clicked",
+ * "paste at cursor", "convert BOM item to diagram node at the canvas
+ * edge", i.e. user-driven placement where the surrounding topology
+ * should not influence the outcome.
+ *
+ * For **structural** placement (re-layout based on link flow, pin a
+ * set of nodes, arrange a selection), use `layoutNetwork` with its
+ * `fixed` / `hints` options instead. The two APIs stay separate
+ * because their intents differ: `placeNode` is O(existing obstacles)
+ * geometry, `layoutNetwork` is a full Sugiyama run.
  */
 export function placeNode(
   node: Node,

--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -66,14 +66,25 @@ export interface NetworkLayoutOptions {
   portSize?: number
   portLabelPadding?: number
   /**
-   * Nodes whose input `position` is a hard constraint. Sugiyama runs
-   * as usual, then each fixed node is snapped back to its input
+   * Nodes whose input `position` is a **hard constraint**. Sugiyama
+   * runs as usual, then each fixed node is snapped back to its input
    * position (with its ports shifted by the same delta); subgraph
    * bounds are recomputed via rebalanceSubgraphs.
    *
-   * Empty set keeps the legacy "re-layout everything" behavior.
+   * Empty set keeps the legacy "re-layout everything" behaviour.
    */
   fixed?: Set<string>
+  /**
+   * Soft per-node x-coord hints. For any node listed here, the
+   * Sugiyama coordinate pass uses the hint as the preferred x instead
+   * of the barycenter of its predecessors — packing still prevents
+   * overlap, so the final x may drift if the neighbourhood is tight.
+   * y comes from the node's layer as usual (hints are x-only).
+   *
+   * Use hints for "nudge these nodes toward this x" scenarios; use
+   * `fixed` when the position must be exact.
+   */
+  hints?: Map<string, { x: number }>
 }
 
 export interface NetworkLayoutResult {
@@ -94,6 +105,7 @@ const DEFAULTS: Required<NetworkLayoutOptions> = {
   portSize: 8,
   portLabelPadding: 8,
   fixed: new Set(),
+  hints: new Map(),
 }
 
 // ============================================================================
@@ -287,6 +299,23 @@ function applyFixedOverride(
 // Main entry
 // ============================================================================
 
+/**
+ * **Structural** full-graph layout. Runs the Sugiyama pipeline over
+ * the entire `NetworkGraph` (cycle-breaking → layer assignment →
+ * crossing reduction → coordinate assignment), then places ports and
+ * applies `fixed` / `hints` post-processing. Use this for:
+ *
+ *   - initial layout of a freshly-parsed graph (YAML import)
+ *   - "Auto-arrange" / re-layout after heavy editing
+ *   - "Arrange selection": pass `fixed` for the nodes you want kept,
+ *     let the algorithm reposition the rest
+ *   - "Nudge these nodes toward these x values": use `hints`
+ *
+ * For **geometric** placement of one node at a specific point without
+ * disturbing the rest (user drop, paste at cursor), use `placeNode`.
+ * That's deliberately a separate, cheaper primitive — this function
+ * is O(V + E) with libavoid-class constants.
+ */
 export function layoutNetwork(
   graph: NetworkGraph,
   options?: NetworkLayoutOptions,
@@ -314,6 +343,7 @@ export function layoutNetwork(
     layerGap: opts.topLevelGap,
     subgraphPadding: opts.subgraphPadding,
     subgraphLabelHeight: opts.subgraphLabelHeight,
+    hints: opts.hints.size > 0 ? opts.hints : undefined,
   })
 
   // Fold positions back onto Node / Subgraph records.

--- a/libs/@shumoku/core/src/layout/sugiyama/coords.test.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/coords.test.ts
@@ -113,6 +113,52 @@ describe('assignCoordinates', () => {
     expect(bt.get('a')?.x).toBe(tb.get('a')?.x)
   })
 
+  it('honours hints over barycenter', () => {
+    // Without a hint, c would align under its parent b (barycenter).
+    // With a hint, c snaps to the hinted x instead.
+    const layers: LayerAssignment = {
+      layers: [['a', 'b'], ['c']],
+      layerOf: new Map([
+        ['a', 0],
+        ['b', 0],
+        ['c', 1],
+      ]),
+    }
+    const positions = assignCoordinates(layers, {
+      defaultSize: uniformSize,
+      edges: [{ id: 'e1', source: 'b', target: 'c' }],
+      hints: new Map([['c', { x: 999 }]]),
+    })
+    expect(positions.get('c')?.x).toBe(999)
+  })
+
+  it('hint is still packed against siblings', () => {
+    // Two siblings in the same layer: hint on one, barycenter on the
+    // other. The hint wins for its node, packing still prevents overlap.
+    const layers: LayerAssignment = {
+      layers: [['p'], ['a', 'b']],
+      layerOf: new Map([
+        ['p', 0],
+        ['a', 1],
+        ['b', 1],
+      ]),
+    }
+    const positions = assignCoordinates(layers, {
+      defaultSize: uniformSize,
+      nodeGap: 20,
+      edges: [
+        { id: 'e1', source: 'p', target: 'a' },
+        { id: 'e2', source: 'p', target: 'b' },
+      ],
+      // a wants x=1000 (far right); b has no hint so barycenter=p.x
+      hints: new Map([['a', { x: 1000 }]]),
+    })
+    const ax = positions.get('a')?.x ?? 0
+    const bx = positions.get('b')?.x ?? 0
+    // b must not overlap a; the two are at least (width + gap) apart
+    expect(Math.abs(bx - ax)).toBeGreaterThanOrEqual(uniformSize.width + 20 - 0.001)
+  })
+
   it('aligns a single-parent child directly under its parent (barycenter)', () => {
     // a  b            ← layer 0
     //    ↓

--- a/libs/@shumoku/core/src/layout/sugiyama/coords.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/coords.ts
@@ -62,6 +62,20 @@ export interface AssignCoordinatesOptions {
    * layer unchanged.
    */
   edges?: Edge[]
+  /**
+   * Soft per-node x hints. When a node has an entry, the forward and
+   * backward packs both treat it as the node's preferred x — packed
+   * against neighbours in the usual way but anchored at the hint
+   * instead of the barycenter of its parents. Hints win over parent-
+   * derived preferences when both exist. The `y` field of the hint is
+   * **ignored**: layer assignment already owns the secondary axis.
+   *
+   * Hints are interpreted in whatever coordinate system the caller
+   * supplied; inside `layoutCompound` that's each container's local
+   * frame, so global-coord hints for deeply nested nodes won't land
+   * where you'd expect. Use hard-pinning (`fixed`) for that case.
+   */
+  hints?: Map<NodeId, { x: number }>
 }
 
 /**
@@ -132,8 +146,8 @@ export function assignCoordinates(
         continue
       }
 
-      const forwardX = forwardPack(layer, preds, forwardByLayer, sizeOf, nodeGap)
-      const backwardX = backwardPack(layer, preds, backwardByLayer, sizeOf, nodeGap)
+      const forwardX = forwardPack(layer, preds, forwardByLayer, sizeOf, nodeGap, options.hints)
+      const backwardX = backwardPack(layer, preds, backwardByLayer, sizeOf, nodeGap, options.hints)
       forwardByLayer.push(forwardX)
       backwardByLayer.push(backwardX)
       for (const n of layer) {
@@ -182,12 +196,21 @@ function centredLayer(layer: NodeId[], sizeOf: (n: NodeId) => Size, nodeGap: num
   return xs.map((x) => x + shiftX)
 }
 
-/** Mean x of a node's predecessors across a layered pass, or undefined. */
+/**
+ * Preferred x for a node, priority:
+ *   1. Hint (explicit caller override)
+ *   2. Barycenter of its predecessors in the layers above
+ *   3. undefined (packing fallback takes over)
+ */
 function preferredX(
   node: NodeId,
   preds: Map<NodeId, NodeId[]>,
   layerX: Map<NodeId, number>[],
+  hints: Map<NodeId, { x: number }> | undefined,
 ): number | undefined {
+  const hint = hints?.get(node)
+  if (hint !== undefined) return hint.x
+
   const parents = preds.get(node) ?? []
   if (parents.length === 0) return undefined
   let sum = 0
@@ -223,12 +246,13 @@ function forwardPack(
   previousLayers: Map<NodeId, number>[],
   sizeOf: (n: NodeId) => Size,
   nodeGap: number,
+  hints: Map<NodeId, { x: number }> | undefined,
 ): Map<NodeId, number> {
   const out = new Map<NodeId, number>()
   let prevRight = Number.NEGATIVE_INFINITY
   for (const [j, n] of layer.entries()) {
     const { width } = sizeOf(n)
-    const pref = preferredX(n, preds, previousLayers)
+    const pref = preferredX(n, preds, previousLayers, hints)
     const minX = j === 0 ? Number.NEGATIVE_INFINITY : prevRight + nodeGap + width / 2
     const desired = pref ?? minX
     const x = desired < minX ? minX : desired
@@ -250,6 +274,7 @@ function backwardPack(
   previousLayers: Map<NodeId, number>[],
   sizeOf: (n: NodeId) => Size,
   nodeGap: number,
+  hints: Map<NodeId, { x: number }> | undefined,
 ): Map<NodeId, number> {
   const out = new Map<NodeId, number>()
   let nextLeft = Number.POSITIVE_INFINITY
@@ -257,7 +282,7 @@ function backwardPack(
     const n = layer[j]
     if (n === undefined) continue
     const { width } = sizeOf(n)
-    const pref = preferredX(n, preds, previousLayers)
+    const pref = preferredX(n, preds, previousLayers, hints)
     const maxX = j === layer.length - 1 ? Number.POSITIVE_INFINITY : nextLeft - nodeGap - width / 2
     const desired = pref ?? maxX
     const x = desired > maxX ? maxX : desired


### PR DESCRIPTION
## Summary
レイアウト API 整理シリーズの **最終段 (Step 3)**。`layoutNetwork` に `hints` オプションを追加し、`placeNode` と `layoutNetwork` を**別プリミティブとして残す設計判断を明文化**。

## 2 つの配置 API の役割

| | `placeNode` | `layoutNetwork` |
|---|---|---|
| 意図 | **幾何的** (ここに置きたい) | **構造的** (リンク流れに沿って) |
| 入力 | 1 node + initial (x, y) | グラフ全体 |
| アルゴリズム | initial 周辺の collision 回避 | Sugiyama 4 フェーズ |
| 構造尊重 | しない (link 無視) | する (layer = flow) |
| コスト | O(障害物数) | O(V + E) |
| 用途 | Click-to-drop / paste / "add here" | Auto-arrange / re-layout / YAML import |

## Added: `hints` option

```ts
layoutNetwork(graph, {
  hints: new Map([
    ['node-a', { x: 500 }],
  ])
})
```

- Soft 制約: `hint.x` を preferred x として使う
- Barycenter より優先
- Packing は尊重する (overlap しない範囲で)
- `hint.y` は無視 (y は layer が決める)

**Priority順:** hint → parent barycenter → packing fallback

## Changes
- `sugiyama/coords.ts`:
  - `AssignCoordinatesOptions.hints` 追加
  - `preferredX` が hint を最優先
  - `forwardPack` / `backwardPack` 両方に hints を渡す
- `network-layout.ts`:
  - `NetworkLayoutOptions.hints` 追加、`layoutCompound` に forward
  - `layoutNetwork` にトップレベル docstring で役割明記
- `interaction.ts`:
  - `placeNode` docstring で「geometric placement」と明記、`layoutNetwork` との使い分け記載
- `DATA_MODEL.md`:
  - 2 つの API の use-case 表を追加
  - `fixed` / `hints` の違いを記載
- tests: hints 関連 2 ケース追加 (priority-over-barycenter / packed-against-siblings)

## 既知の制約 (ドキュメント済み)
`layoutCompound` 内では hints は **各 container の local 座標系** で解釈される。深い subgraph 内の node に対して global 座標のヒントを渡すと想定外の位置になる。この場合は `fixed` (hard pin with absolute coords) を使うのが正解。将来 compound-aware hints を実装する場合も signature は不変。

## Test plan
- [x] `bun test` in core **118/118 pass** (既存 116 + 新規 2)
- [x] `bun run typecheck` workspace **30/30 green**
- [x] `bun run build` in core (tsc)

## 関連
完了したシリーズ:
- [x] #139 型統合 (Position/Bounds/Direction/Size)
- [x] #140 オプション型 tower 統合
- [x] **本 PR** hints 追加 + 2 API 役割ドキュメント

🤖 Generated with [Claude Code](https://claude.com/claude-code)