### PR TITLE
fix(editor): compute diagram bounds when loading a positioned graph

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1004,5 +1004,56 @@ async function applyGraph(graph: NetworkGraph) {
   replaceMap(diagram.subgraphs, subgraphs)
   diagram.links = links
   replaceMap(diagram.ports, placePorts(nodes, links, direction))
+  // Positioned path skips layoutNetwork, so nobody else computes
+  // bounds from the saved coordinates. Mirror the same union + 50-pad
+  // formula `layoutNetwork` uses internally so the renderer's viewBox
+  // matches the actual extent of the loaded diagram. Without this the
+  // initial viewBox stays at the `loadProject` reset default
+  // (800×600) and large saved diagrams render clipped to the top-left.
+  diagram.bounds = boundsOfPositionedGraph(nodes, subgraphs)
   await rerouteEdges()
+}
+
+/**
+ * Compute a padded bounding box over positioned nodes and subgraphs.
+ * Matches the fallback in `layoutNetwork` (50-unit margin around the
+ * tight union), and falls back to the same empty-graph placeholder so
+ * the runtime `diagram.bounds` shape is consistent whichever path set
+ * it.
+ */
+function boundsOfPositionedGraph(
+  nodes: Map<string, Node>,
+  subgraphs: Map<string, Subgraph>,
+): { x: number; y: number; width: number; height: number } {
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+
+  for (const n of nodes.values()) {
+    if (!n.position) continue
+    const size = computeNodeSize(n)
+    minX = Math.min(minX, n.position.x - size.width / 2)
+    minY = Math.min(minY, n.position.y - size.height / 2)
+    maxX = Math.max(maxX, n.position.x + size.width / 2)
+    maxY = Math.max(maxY, n.position.y + size.height / 2)
+  }
+  for (const sg of subgraphs.values()) {
+    if (!sg.bounds) continue
+    minX = Math.min(minX, sg.bounds.x)
+    minY = Math.min(minY, sg.bounds.y)
+    maxX = Math.max(maxX, sg.bounds.x + sg.bounds.width)
+    maxY = Math.max(maxY, sg.bounds.y + sg.bounds.height)
+  }
+
+  if (minX === Number.POSITIVE_INFINITY) {
+    return { x: 0, y: 0, width: 400, height: 300 }
+  }
+  const pad = 50
+  return {
+    x: minX - pad,
+    y: minY - pad,
+    width: maxX - minX + pad * 2,
+    height: maxY - minY + pad * 2,
+  }
 }


### PR DESCRIPTION
## Summary
リロード時の拡大率が明らかにおかしい & Auto-arrange で「縮む」挙動の根本原因修正。

## 原因
\`applyGraph\` の **positioned (JSON/sample) 分岐は \`layoutNetwork\` を通らない** → bounds 計算も走らない → \`diagram.bounds\` は \`loadProject\` の reset default \`{x:0, y:0, w:800, h:600}\` のまま。

Sample は実際 y=2300 まで伸びてるのに、viewBox は 800×600 相当に貼り付いたまま → **左上しか見えない**状態でユーザーに見えてた。

Auto-arrange 実行すると \`computeNetworkLayout\` が正しく bounds を返すので viewBox が全体に fit → 「急に縮んだ」ように見える。実は autoArrange 後が正しい状態で、**ロード時が壊れてた**だけ。

## Fix
\`applyGraph\` の positioned 分岐で bounds を計算。\`layoutNetwork\` の末尾と同じ union + 50 padding + 空グラフ fallback を \`boundsOfPositionedGraph\` ヘルパーに切り出して両方使う。

## Verified
- ロード時に全体が fit で見える (手動確認済み)
- Auto-arrange しても見た目のサイズが変わらない
- \`bun run typecheck\` editor 通過

## 関連
PR #143 (sheet drill-down) と直交。こちらは load 時の bounds 計算バグで、sheet view には影響しない。