### PR TITLE
feat(editor): JSON-only CodePanel (diagram side-panel)

### DIFF
--- a/apps/editor/src/lib/components/CodePanel.svelte
+++ b/apps/editor/src/lib/components/CodePanel.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { CaretLeft, Code, Play } from 'phosphor-svelte'
+  import { diagramState } from '$lib/context.svelte'
+
+  let {
+    isOpen = $bindable(false),
+  }: {
+    isOpen?: boolean
+  } = $props()
+
+  // Live JSON snapshot of the current diagram. Re-computed from state
+  // every tick so drags / add / delete flow into the textarea. When
+  // the user has the textarea focused we keep their in-progress edit
+  // instead of clobbering it, which matters for multi-line JSON.
+  const liveJson = $derived(JSON.stringify(diagramState.exportGraph(), null, 2))
+
+  let draft = $state('')
+  let dirty = $state(false)
+  let error = $state('')
+
+  // If the state changes and the user hasn't touched the draft, pull
+  // the fresh JSON into the textarea. Once they start typing (`dirty`
+  // flips true) the draft is theirs until they Apply or Revert.
+  $effect(() => {
+    if (!dirty) draft = liveJson
+  })
+
+  function onInput(value: string) {
+    draft = value
+    dirty = true
+    error = ''
+  }
+
+  async function apply() {
+    try {
+      await diagramState.importDiagram(draft)
+      error = ''
+      dirty = false
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e)
+    }
+  }
+
+  function revert() {
+    draft = liveJson
+    dirty = false
+    error = ''
+  }
+</script>
+
+<div class="flex h-full items-stretch gap-1">
+  {#if isOpen}
+    <div
+      class="w-[400px] bg-white/95 dark:bg-neutral-900/95 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-xl flex flex-col overflow-hidden"
+    >
+      <div
+        class="flex items-center justify-between px-3 py-2 border-b border-neutral-200 dark:border-neutral-700 shrink-0"
+      >
+        <span class="text-xs font-semibold text-neutral-700 dark:text-neutral-200">
+          Diagram JSON
+        </span>
+        <span class="text-[10px] font-mono text-neutral-400 dark:text-neutral-500">
+          NetworkGraph
+        </span>
+      </div>
+
+      <textarea
+        class="flex-1 w-full p-3 text-[11px] font-mono leading-relaxed bg-transparent text-neutral-700 dark:text-neutral-200 resize-none outline-none placeholder:text-neutral-400 themed-scrollbar"
+        spellcheck="false"
+        placeholder={'{\n  "version": "1",\n  "nodes": [],\n  "links": []\n}'}
+        value={draft}
+        oninput={(e) => onInput((e.target as HTMLTextAreaElement).value)}
+      ></textarea>
+
+      {#if error}
+        <div
+          class="px-3 py-1.5 text-[11px] font-mono text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-900/30 border-t border-red-200 dark:border-red-900/50 shrink-0 break-all"
+        >
+          {error}
+        </div>
+      {/if}
+
+      <div
+        class="flex items-center justify-between px-3 py-2 border-t border-neutral-200 dark:border-neutral-700 shrink-0"
+      >
+        <span class="text-[10px] text-neutral-400 dark:text-neutral-500">
+          {dirty ? 'Unsaved edits' : 'Live'}
+        </span>
+        <div class="flex items-center gap-1.5">
+          {#if dirty}
+            <button
+              type="button"
+              class="px-2.5 py-1.5 text-xs font-medium text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded-lg transition-colors"
+              onclick={revert}
+            >
+              Revert
+            </button>
+          {/if}
+          <button
+            type="button"
+            class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            disabled={!dirty}
+            onclick={apply}
+          >
+            <Play class="w-3 h-3" weight="fill" />
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <button
+    type="button"
+    class="self-center flex items-center justify-center shrink-0 bg-white/90 dark:bg-neutral-800/90 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-lg shadow-lg text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors {isOpen
+      ? 'w-6 h-10'
+      : 'w-10 h-10'}"
+    title={isOpen ? 'Close code panel' : 'Open code panel'}
+    onclick={() => {
+      isOpen = !isOpen
+    }}
+  >
+    {#if isOpen}
+      <CaretLeft class="w-4 h-4" />
+    {:else}
+      <Code class="w-5 h-5" />
+    {/if}
+  </button>
+</div>
+
+<style>
+  .themed-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: #d4d4d4 transparent;
+  }
+  :global(.dark) .themed-scrollbar {
+    scrollbar-color: #525252 transparent;
+  }
+</style>

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -3,6 +3,7 @@
   // @ts-expect-error — SvelteKit resolves the svelte condition from package.json exports
   import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
   import { renderGraphToSvg } from '@shumoku/renderer-svg'
+  import CodePanel from '$lib/components/CodePanel.svelte'
   import DetailPanel from '$lib/components/DetailPanel.svelte'
   import ExportMenu from '$lib/components/ExportMenu.svelte'
   import LabelEditPopover from '$lib/components/LabelEditPopover.svelte'
@@ -28,6 +29,7 @@
   } | null>(null)
   let detailTarget = $state<{ id: string; type: 'node' | 'link' | 'subgraph' } | null>(null)
   let labelEdit = $state<{ portId: string; label: string; x: number; y: number } | null>(null)
+  let codePanelOpen = $state(false)
 
   // =========================================================================
   // Detail panel — resolve edge/port to their parent types
@@ -143,6 +145,11 @@
   <!-- Bottom-left: Status -->
   <div class="fixed bottom-3 left-3 z-20">
     <StatusBadge status={diagramState.status} stats={diagramState.stats} {selected} />
+  </div>
+
+  <!-- Left side: Code panel (slide-out) -->
+  <div class="fixed left-3 top-1/2 -translate-y-1/2 z-20 h-[80vh] flex">
+    <CodePanel bind:isOpen={codePanelOpen} />
   </div>
 
   <!-- Bottom-center: Sheet bar -->


### PR DESCRIPTION
## Summary
#115 で "broken, will restore later" と消された CodePanel の **JSON 限定版**を復活。旧 CodePanel は YAML 先行で project 全体の書き換えだったが、今回は **diagram JSON (NetworkGraph) 限定**で、最近入った linear load pipeline の \`importDiagram\` に乗る素直な実装。

## 挙動
- 左端にトグルボタン、開くと 400px 幅のスライドパネル (80vh)
- textarea に現在の diagram JSON を pretty-print 表示
- **Live モード**: canvas の編集 (drag / add / delete) が textarea にも即反映
- **Dirty モード**: ユーザが入力始めると "Unsaved edits" 表示、Revert / Apply ボタン出現
- Apply → \`diagramState.importDiagram\` 経由で canvas に反映
- パースエラーは赤帯で textarea 直下に表示 (SvelteKit error route に飛ばない)

## Layout fix (in this branch)
最初 \`max-h-[80vh]\` を使ったら flex の最小高さが確保されず潰れたので \`h-[80vh]\` に。

## Naming
prop 名 \`isOpen\` (\`open\` だと biome の \`noGlobalAssign\` に触れる — DOM \`window.open\` と同じ識別子への代入になる)

## Scope
YAML タブは意図的に切り捨て。\`applyYaml\` 自体は context に残っているので、後で YAML タブを足したくなったらこのパネルに追加するだけ。

## Test plan
- [x] \`bun run typecheck\` 0 errors
- [x] \`bun x biome check\` clean
- [ ] 手動: トグル → パネル展開、JSON 表示、canvas 編集が textarea に反映
- [ ] 手動: textarea 編集 → "Unsaved edits" + Apply → canvas 更新
- [ ] 手動: 不正 JSON → 赤帯エラー表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)