### PR TITLE
build: add .gitattributes to force LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize all text files to LF line endings on commit and checkout.
+# biome (our formatter) writes LF; without this, Windows users with
+# core.autocrlf=true get CRLF in working tree → biome lint fails.
+* text=auto eol=lf
+
+# Keep binary files intact
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.wasm binary


### PR DESCRIPTION
## Summary
- Windows users with `core.autocrlf=true` were getting CRLF in their working tree, which failed biome format (writes LF) on every pre-commit run.
- The repo itself already stores LF — this just makes checkout consistent across platforms.
- Unblocks future PRs on Windows (pre-commit lint was failing on files that had no actual changes).

## Test plan
- [x] `bun run lint` — 30/30 tasks pass
- [ ] Verify on fresh Windows checkout that files land with LF
- [ ] Verify on Linux/macOS (should be unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)