### PR TITLE
refactor(renderer): extract camera (pan/zoom) into opt-in utility

### DIFF
--- a/apps/docs/app/[lang]/editor/EditorClient.tsx
+++ b/apps/docs/app/[lang]/editor/EditorClient.tsx
@@ -36,6 +36,7 @@ interface ShumokuRendererElement extends HTMLElement {
   graph: { links: Link[] } | undefined
   theme: Theme | undefined
   mode: 'view' | 'edit'
+  readonly svgElement: SVGSVGElement | null
   onshumokuselect: ((id: string | null, type: string | null) => void) | undefined
   onshumokuchange: ((links: Link[]) => void) | undefined
   onshumokulabeledit:
@@ -180,6 +181,17 @@ export default function EditorClient() {
           el.mode = mode
           el.layout = resolved
           setStatus('Ready')
+
+          // Attach a Miro-style pan/zoom camera to the rendered svg
+          // once it's mounted inside the web component's shadow root.
+          const { attachCamera } = await import('@shumoku/renderer')
+          // Defer one frame — WC mounts the svg synchronously on first
+          // `layout` assignment, but querySelector through shadowRoot
+          // needs the svg to be in the DOM.
+          requestAnimationFrame(() => {
+            const svg = el.svgElement
+            if (svg) attachCamera(svg)
+          })
         }
       } catch (e) {
         setStatus(`Error: ${e instanceof Error ? e.message : String(e)}`)

--- a/apps/docs/app/[lang]/editor/EditorClient.tsx
+++ b/apps/docs/app/[lang]/editor/EditorClient.tsx
@@ -182,15 +182,15 @@ export default function EditorClient() {
           el.layout = resolved
           setStatus('Ready')
 
-          // Attach a Miro-style pan/zoom camera to the rendered svg
-          // once it's mounted inside the web component's shadow root.
+          // Attach a mouse-wheel-zoom camera to the rendered svg once
+          // it's mounted inside the web component's shadow root.
           const { attachCamera } = await import('@shumoku/renderer')
           // Defer one frame — WC mounts the svg synchronously on first
           // `layout` assignment, but querySelector through shadowRoot
           // needs the svg to be in the DOM.
           requestAnimationFrame(() => {
             const svg = el.svgElement
-            if (svg) attachCamera(svg)
+            if (svg) attachCamera(svg, { wheelMode: 'zoom' })
           })
         }
       } catch (e) {

--- a/apps/docs/app/[lang]/editor/EditorClient.tsx
+++ b/apps/docs/app/[lang]/editor/EditorClient.tsx
@@ -190,7 +190,7 @@ export default function EditorClient() {
           // needs the svg to be in the DOM.
           requestAnimationFrame(() => {
             const svg = el.svgElement
-            if (svg) attachCamera(svg, { wheelMode: 'zoom' })
+            if (svg) attachCamera(svg)
           })
         }
       } catch (e) {

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -21,11 +21,12 @@
   let renderer: ShumokuRenderer | undefined = $state()
   let rendererSvg: SVGSVGElement | null = $state(null)
 
-  // Editor camera: Miro-style Alt/middle-click pan, trackpad pan +
-  // mouse wheel zoom. Attached as soon as the renderer mounts its svg.
+  // Editor camera: mouse-wheel zooms, Alt+left-click (or middle-click)
+  // pans, pinch always zooms. Trackpad users can still two-finger pan
+  // by holding Alt.
   $effect(() => {
     if (!rendererSvg) return
-    const camera = attachCamera(rendererSvg)
+    const camera = attachCamera(rendererSvg, { wheelMode: 'zoom' })
     return () => camera.detach()
   })
   let selected = $state<{ id: string; type: string } | null>(null)

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -21,12 +21,12 @@
   let renderer: ShumokuRenderer | undefined = $state()
   let rendererSvg: SVGSVGElement | null = $state(null)
 
-  // Editor camera: mouse-wheel zooms, Alt+left-click (or middle-click)
-  // pans, pinch always zooms. Trackpad users can still two-finger pan
-  // by holding Alt.
+  // Editor camera: auto-detects mouse (wheel → zoom) vs trackpad
+  // (two-finger → pan). Pinch always zooms. Alt+left or middle-click
+  // drags the viewport.
   $effect(() => {
     if (!rendererSvg) return
-    const camera = attachCamera(rendererSvg, { wheelMode: 'zoom' })
+    const camera = attachCamera(rendererSvg)
     return () => camera.detach()
   })
   let selected = $state<{ id: string; type: string } | null>(null)

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { type LinkEndpoint, type NodeSpec, newId } from '@shumoku/core'
+  import { attachCamera } from '@shumoku/renderer'
   // @ts-expect-error — SvelteKit resolves the svelte condition from package.json exports
   import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
   import { renderGraphToSvg } from '@shumoku/renderer-svg'
@@ -18,6 +19,15 @@
   // =========================================================================
 
   let renderer: ShumokuRenderer | undefined = $state()
+  let rendererSvg: SVGSVGElement | null = $state(null)
+
+  // Editor camera: Miro-style Alt/middle-click pan, trackpad pan +
+  // mouse wheel zoom. Attached as soon as the renderer mounts its svg.
+  $effect(() => {
+    if (!rendererSvg) return
+    const camera = attachCamera(rendererSvg)
+    return () => camera.detach()
+  })
   let selected = $state<{ id: string; type: string } | null>(null)
   let contextMenu = $state<{ id: string; type: string; x: number; y: number } | null>(null)
   let clipboard = $state<{
@@ -91,6 +101,7 @@
     {#if diagramState.nodes.size > 0 || diagramState.status !== 'Loading...'}
       <ShumokuRenderer
         bind:this={renderer}
+        bind:svgElement={rendererSvg}
         bind:nodes={diagramState.activeView.nodes}
         bind:ports={diagramState.activeView.ports}
         bind:edges={diagramState.activeView.edges}

--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -351,7 +351,6 @@
       theme={currentTheme}
       mode="view"
       sheetCacheStrategy="eager"
-      autoFit="initial"
       onselect={handleSelect}
     >
       {#snippet children({ svgElement, graph: activeGraph })}

--- a/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
+++ b/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
@@ -72,12 +72,13 @@
     interaction?: InteractionOptions
 
     /**
-     * Camera (pan/zoom) behaviour. Leave undefined to disable camera
-     * entirely (e.g. static preview). The shared SVG always renders a
-     * `<g class="viewport">`; passing options here attaches a d3-zoom
-     * camera from `@shumoku/renderer`.
+     * Camera (pan/zoom) behaviour. Defaults to `{ wheelMode: 'pan' }`
+     * — trackpad-friendly pan + pinch zoom — which suits dashboard
+     * widgets and the detail page. Pass a full `CameraOptions` to
+     * override, or `false` to disable camera entirely (e.g. static
+     * preview snapshots).
      */
-    camera?: CameraOptions | false
+    camera?: Partial<CameraOptions> | false
     /**
      * Reset the camera transform whenever the active sheet changes.
      * Default true. Set false to preserve user pan/zoom across sheet
@@ -272,7 +273,9 @@
       camera = null
       return
     }
-    const c = attachCamera(svgElement, cameraOptions)
+    // Trackpad-friendly default for dashboard-style usage; callers can
+    // override any field by passing a `Partial<CameraOptions>`.
+    const c = attachCamera(svgElement, { wheelMode: 'pan', ...cameraOptions })
     camera = c
     return () => {
       c.detach()
@@ -386,16 +389,16 @@
   }
 
   /* Interaction gating via pointer-events on specific element types.
-           Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
-           propagation on the canvas background. d3-zoom's filter already
-           handles wheel requiring ctrl/meta, but we also kill the background
-           grid's clickability when selection is off. */
+             Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
+             propagation on the canvas background. d3-zoom's filter already
+             handles wheel requiring ctrl/meta, but we also kill the background
+             grid's clickability when selection is off. */
   .topology-viewer.no-panzoom :global(.canvas-bg) {
     pointer-events: none;
   }
 
   /* LOD: toggleable ornament classes. Rules match @shumoku/renderer's
-           output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
+             output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
   .topology-viewer.hide-port-labels :global(.port-label),
   .topology-viewer.hide-port-labels :global(.port-label-bg) {
     display: none;

--- a/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
+++ b/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
@@ -16,7 +16,7 @@
     type ResolvedLayout,
     type Theme,
   } from '@shumoku/core'
-  import { ShumokuRenderer } from '@shumoku/renderer'
+  import { attachCamera, type Camera, type CameraOptions, ShumokuRenderer } from '@shumoku/renderer'
   import type { Snippet } from 'svelte'
 
   export interface ViewerContext {
@@ -72,17 +72,20 @@
     interaction?: InteractionOptions
 
     /**
-     * When to reset the user's zoom/pan transform:
-     * - 'initial' (default): once, when the graph/sheet first lays out
-     * - 'off': never (keep any previous transform, or whatever d3-zoom has set)
-     *
-     * The SVG's viewBox already covers the layout bounds, so 'initial'
-     * simply strips any viewport transform; preserveAspectRatio handles
-     * container resize naturally.
+     * Camera (pan/zoom) behaviour. Leave undefined to disable camera
+     * entirely (e.g. static preview). The shared SVG always renders a
+     * `<g class="viewport">`; passing options here attaches a d3-zoom
+     * camera from `@shumoku/renderer`.
      */
-    autoFit?: 'initial' | 'off'
+    camera?: CameraOptions | false
+    /**
+     * Reset the camera transform whenever the active sheet changes.
+     * Default true. Set false to preserve user pan/zoom across sheet
+     * switches.
+     */
+    resetCameraOnSheetChange?: boolean
 
-    // --- LOD (not yet wired into renderer internals — exposed for future use) ---
+    // --- LOD ---
     detail?: DetailOptions
 
     // --- Events (forwarded from ShumokuRenderer) ---
@@ -103,7 +106,8 @@
     theme,
     mode = 'view',
     interaction = {},
-    autoFit = 'initial',
+    camera: cameraOptions = {},
+    resetCameraOnSheetChange = true,
     detail = {},
     onselect,
     oncontextmenu,
@@ -177,10 +181,9 @@
   // --- React to graph / sheet changes ---
   //
   // Only tracked reads here are `graph`, `sheetId`, `layoutOverride`,
-  // `sheetCacheStrategy` (props) and `activeLayout` (for the override
-  // short-circuit). Everything else (the cache Maps, last-seen refs,
-  // hasFitted) is a plain `let`, so this effect runs exactly once per
-  // actual change.
+  // `sheetCacheStrategy` (props). Everything else (the cache Maps,
+  // last-seen refs) is a plain `let`, so this effect runs exactly
+  // once per actual change.
 
   $effect(() => {
     if (layoutOverride) {
@@ -199,12 +202,10 @@
       cachedGraphRef = graph
       layoutsBySheet = {}
       activeLayout = null
-      hasFitted = false
       if (sheetCacheStrategy === 'eager') void prewarmEagerSheets(graph)
     }
     if (sheetKey !== activeSheetKey) {
       activeSheetKey = sheetKey
-      hasFitted = false
     }
 
     void ensureSheetLayout(graph, sheetKey)
@@ -260,23 +261,32 @@
   })
   const showNodeShadow = $derived(detail.nodeShadow ?? true)
 
-  // --- Auto-fit on initial layout ---
-  //
-  // `hasFitted` is a plain `let` (not $state): writing it inside the
-  // effect below must not re-trigger the effect. The graph/sheet
-  // effect above resets it when the data changes.
+  // --- Camera (pan/zoom) — attach d3-zoom via @shumoku/renderer's
+  // attachCamera utility once the svg mounts. `camera={false}` opts out
+  // entirely (static preview). Re-attaches if the consumer swaps in a
+  // new `cameraOptions` reference.
 
-  let hasFitted = false
+  let camera = $state<Camera | null>(null)
   $effect(() => {
-    if (autoFit === 'off' || hasFitted) return
-    const svg = svgElement
-    if (!svg || !activeLayout) return
-    // ShumokuRenderer already chooses a viewBox covering the layout
-    // bounds; we just need to reset any user-applied zoom transform.
-    // d3-zoom transforms are on `.viewport` — clearing the attribute
-    // restores identity.
-    svg.querySelector<SVGGElement>('.viewport')?.removeAttribute('transform')
-    hasFitted = true
+    if (cameraOptions === false || !svgElement) {
+      camera = null
+      return
+    }
+    const c = attachCamera(svgElement, cameraOptions)
+    camera = c
+    return () => {
+      c.detach()
+      camera = null
+    }
+  })
+
+  // Reset camera transform when the active sheet (or graph) changes,
+  // so each sheet opens at 1:1 rather than inheriting the previous
+  // sheet's pan/zoom. Opt-out via `resetCameraOnSheetChange={false}`.
+  $effect(() => {
+    sheetId // track
+    graph // track
+    if (resetCameraOnSheetChange) camera?.reset()
   })
 
   function handleSelect(id: string | null, type: string | null) {
@@ -290,87 +300,29 @@
   }
 
   // =========================================================================
-  // Imperative viewport helpers
-  //
-  // @shumoku/renderer wraps d3-zoom internally; for programmatic control
-  // (zoom buttons, pan-to-node from a search palette, etc.) we expose a
-  // small helper API that manipulates the `.viewport` transform directly.
-  // This is compatible with d3-zoom's attribute-based state since both
-  // reflect changes through the same DOM.
+  // Imperative viewport API — delegates to the attached camera so
+  // d3-zoom's internal state stays consistent with what the consumer
+  // requests. Returns no-op silently if the camera is disabled.
   // =========================================================================
 
-  interface Transform {
-    x: number
-    y: number
-    k: number
-  }
-
-  function parseTransform(value: string | null): Transform {
-    if (!value) return { x: 0, y: 0, k: 1 }
-    const translateMatch = value.match(/translate\(([^,]+),\s*([^)]+)\)/)
-    const scaleMatch = value.match(/scale\(([^)]+)\)/)
-    return {
-      x: translateMatch ? Number(translateMatch[1]) : 0,
-      y: translateMatch ? Number(translateMatch[2]) : 0,
-      k: scaleMatch ? Number(scaleMatch[1]) : 1,
-    }
-  }
-
-  function setTransform(viewport: SVGGElement, t: Transform) {
-    viewport.setAttribute('transform', `translate(${t.x}, ${t.y}) scale(${t.k})`)
-  }
-
-  function getViewport(): SVGGElement | null {
-    return svgElement?.querySelector<SVGGElement>('.viewport') ?? null
-  }
-
   export function zoomBy(factor: number): void {
-    const viewport = getViewport()
-    if (!viewport || !svgElement) return
-    const t = parseTransform(viewport.getAttribute('transform'))
-    const rect = svgElement.getBoundingClientRect()
-    const cx = rect.width / 2
-    const cy = rect.height / 2
-    const newK = Math.max(0.1, Math.min(10, t.k * factor))
-    // Keep (cx, cy) fixed during scale (standard zoom-toward-center)
-    const newX = cx - ((cx - t.x) / t.k) * newK
-    const newY = cy - ((cy - t.y) / t.k) * newK
-    setTransform(viewport, { x: newX, y: newY, k: newK })
+    camera?.zoomBy(factor)
   }
 
   export function resetZoom(): void {
-    const viewport = getViewport()
-    viewport?.removeAttribute('transform')
+    camera?.reset()
   }
 
-  /** Pan + zoom so that the node with `nodeId` lands centered at ~5% area. */
+  /**
+   * Pan + zoom so the given node is focused (~5% of viewport area),
+   * plus a brief pulse-highlight animation on the node itself.
+   */
   export function panToNode(nodeId: string): void {
-    const svg = svgElement
-    if (!svg) return
-    const node = svg.querySelector<SVGGElement>(`g.node[data-id="${CSS.escape(nodeId)}"]`)
+    if (!svgElement) return
+    const found = camera?.panToNode(nodeId) ?? false
+    if (!found) return
+    const node = svgElement.querySelector<SVGGElement>(`g.node[data-id="${CSS.escape(nodeId)}"]`)
     if (!node) return
-    const viewport = getViewport()
-    if (!viewport) return
-
-    const rect = svg.getBoundingClientRect()
-    const nrect = node.getBoundingClientRect()
-    const t = parseTransform(viewport.getAttribute('transform'))
-
-    // Area-ratio based zoom (same idea as the old panzoom-based impl)
-    const areaRatio = Math.sqrt((rect.width * rect.height * 0.05) / (nrect.width * nrect.height))
-    const targetK = Math.max(2, Math.min(50, t.k * areaRatio))
-
-    // Translate so the node ends up at viewport center
-    const ncx = nrect.left + nrect.width / 2 - rect.left
-    const ncy = nrect.top + nrect.height / 2 - rect.top
-    const cx = rect.width / 2
-    const cy = rect.height / 2
-    const newX = cx - ((ncx - t.x) / t.k) * targetK
-    const newY = cy - ((ncy - t.y) / t.k) * targetK
-
-    setTransform(viewport, { x: newX, y: newY, k: targetK })
-
-    // Brief pulse highlight
     node.classList.add('node-highlighted')
     setTimeout(() => node.classList.remove('node-highlighted'), 3000)
   }
@@ -434,16 +386,16 @@
   }
 
   /* Interaction gating via pointer-events on specific element types.
-         Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
-         propagation on the canvas background. d3-zoom's filter already
-         handles wheel requiring ctrl/meta, but we also kill the background
-         grid's clickability when selection is off. */
+           Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
+           propagation on the canvas background. d3-zoom's filter already
+           handles wheel requiring ctrl/meta, but we also kill the background
+           grid's clickability when selection is off. */
   .topology-viewer.no-panzoom :global(.canvas-bg) {
     pointer-events: none;
   }
 
   /* LOD: toggleable ornament classes. Rules match @shumoku/renderer's
-         output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
+           output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
   .topology-viewer.hide-port-labels :global(.port-label),
   .topology-viewer.hide-port-labels :global(.port-label-bg) {
     display: none;

--- a/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
+++ b/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
@@ -72,13 +72,12 @@
     interaction?: InteractionOptions
 
     /**
-     * Camera (pan/zoom) behaviour. Defaults to `{ wheelMode: 'pan' }`
-     * — trackpad-friendly pan + pinch zoom — which suits dashboard
-     * widgets and the detail page. Pass a full `CameraOptions` to
-     * override, or `false` to disable camera entirely (e.g. static
-     * preview snapshots).
+     * Camera (pan/zoom) options, forwarded to `attachCamera`. Defaults
+     * to `{}` which uses `wheelMode: 'auto'` (detect mouse vs
+     * trackpad per-event). Pass `false` to disable camera entirely
+     * (e.g. static preview snapshots).
      */
-    camera?: Partial<CameraOptions> | false
+    camera?: CameraOptions | false
     /**
      * Reset the camera transform whenever the active sheet changes.
      * Default true. Set false to preserve user pan/zoom across sheet
@@ -273,9 +272,7 @@
       camera = null
       return
     }
-    // Trackpad-friendly default for dashboard-style usage; callers can
-    // override any field by passing a `Partial<CameraOptions>`.
-    const c = attachCamera(svgElement, { wheelMode: 'pan', ...cameraOptions })
+    const c = attachCamera(svgElement, cameraOptions)
     camera = c
     return () => {
       c.detach()
@@ -389,16 +386,16 @@
   }
 
   /* Interaction gating via pointer-events on specific element types.
-             Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
-             propagation on the canvas background. d3-zoom's filter already
-             handles wheel requiring ctrl/meta, but we also kill the background
-             grid's clickability when selection is off. */
+                   Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
+                   propagation on the canvas background. d3-zoom's filter already
+                   handles wheel requiring ctrl/meta, but we also kill the background
+                   grid's clickability when selection is off. */
   .topology-viewer.no-panzoom :global(.canvas-bg) {
     pointer-events: none;
   }
 
   /* LOD: toggleable ornament classes. Rules match @shumoku/renderer's
-             output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
+                   output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
   .topology-viewer.hide-port-labels :global(.port-label),
   .topology-viewer.hide-port-labels :global(.port-label-bg) {
     display: none;

--- a/apps/server/web/src/lib/widgets/TopologyWidget.svelte
+++ b/apps/server/web/src/lib/widgets/TopologyWidget.svelte
@@ -275,7 +275,6 @@
             keyboard: false,
             dragEdit: false,
           }}
-          autoFit="initial"
           detail={{
             portLabels: 'auto',
             linkLabels: 'auto',

--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,7 @@
         "d3-drag": "^3.0.0",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0",
+        "wheel-gestures": "^2.2.48",
       },
       "devDependencies": {
         "@sveltejs/package": "^2.3.2",
@@ -1796,6 +1797,8 @@
     "wait-on": ["wait-on@9.0.5", "", { "dependencies": { "axios": "^1.15.0", "joi": "^18.1.2", "lodash": "^4.18.1", "minimist": "^1.2.8", "rxjs": "^7.8.2" }, "bin": { "wait-on": "bin/wait-on" } }, "sha512-qgnbHDfDTRIp73ANEJNRW/7kn8CrDUcvZz18xotJQku/P4saTGkbIzvnMZebPmVvVNUiRq1qWAPyqCH+W4H8KA=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "wheel-gestures": ["wheel-gestures@2.2.48", "", {}, "sha512-f+Gy33Oa5Z14XY9679Zze+7VFhbsQfBFXodnU2x589l4kxGM9L5Y8zETTmcMR5pWOPQyRv4Z0lNax6xCO0NSlA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,6 +14,7 @@ focuses on the flows that span packages.
 - [Placement APIs — when to use which](#placement-apis--when-to-use-which)
 - [End-to-end use cases](#end-to-end-use-cases)
 - [Package boundaries](#package-boundaries)
+- [Camera (pan/zoom)](#camera-panzoom)
 - [Known gaps](#known-gaps)
 
 ---
@@ -524,6 +525,142 @@ The **canonical data shape** at every boundary is `NetworkGraph`
 (core's type). YAML and the project JSON (`NetedProject`, which wraps
 `NetworkGraph`) are boundary formats; everything inside the system
 speaks `NetworkGraph`.
+
+---
+
+## Camera (pan/zoom)
+
+Camera behaviour — how wheel events, trackpad gestures, pinch and
+pointer drags translate into viewport transforms — is deliberately
+**not** baked into `@shumoku/renderer`. Different apps want different
+policies (the editor wants mouse-wheel-zoom like a CAD tool; a static
+share preview wants no camera at all; SSR/CLI has no DOM to attach
+to), and a renderer that picks a default for everyone ends up either
+wrong-by-default or stuffed with opt-out props.
+
+```mermaid
+flowchart LR
+  subgraph RND[@shumoku/renderer]
+    SVG[SVG output<br/>stable DOM:<br/>g.viewport, g.node[data-id], path.link]
+    AC[attachCamera<br/>utility<br/>opt-in]
+  end
+
+  subgraph WG[wheel-gestures]
+    START[isStart marker]
+    MOM[isMomentum marker]
+  end
+
+  subgraph D3[d3-zoom]
+    ST[__zoom state]
+    TRF[transform on g.viewport]
+  end
+
+  subgraph APP[Host app]
+    EDT[editor]
+    WID[dashboard widget]
+    DET[detail page]
+    SHR[share page]
+  end
+
+  SVG -.- AC
+  AC --> WG
+  AC --> D3
+  D3 --> TRF
+  WG --> AC
+
+  EDT --> AC
+  WID --> AC
+  DET --> AC
+  SHR --> AC
+```
+
+### API shape
+
+```ts
+import { attachCamera } from '@shumoku/renderer'
+
+const camera = attachCamera(svgEl, {
+  scaleExtent: [0.2, 10],           // zoom bounds
+  panFilter: (e) => e.altKey,       // which pointer-down events pan
+  wheelZoomSensitivity: 1.0015,     // mouse tick feel
+  pinchZoomSensitivity: 1.01,       // trackpad pinch feel
+})
+camera.zoomBy(1.5)
+camera.panToNode('device-42')
+camera.reset()
+camera.detach()                     // cleanup on unmount
+```
+
+The renderer always emits a `<g class="viewport">` as its zoom target;
+`attachCamera` throws if that element isn't present. Apps that want
+**no** camera simply don't call `attachCamera`.
+
+### UX policy (Figma / Miro style)
+
+| Input | Result |
+|---|---|
+| Mouse wheel (plain) | zoom at cursor |
+| Mouse ctrl+wheel | zoom at cursor (explicit) |
+| Trackpad two-finger | pan (with natural momentum) |
+| Trackpad pinch | zoom at cursor (browser synthesises `ctrlKey=true`) |
+| Middle-click drag / Alt+left-drag | pan (via `panFilter`) |
+| Node drag (edit mode) | move node (handled per-element in `SvgNode`) |
+
+### Why we need three layers (d3-zoom + wheel-gestures + sticky detection)
+
+Each layer solves a problem the others can't:
+
+1. **d3-zoom** owns the transform state (`svg.__zoom`). It's a stable
+   base: attaching to the svg once and routing all transform changes
+   through `zoomBehavior` keeps state consistent regardless of whether
+   a change came from a wheel event, imperative `zoomBy`, or external
+   `panToNode` call. A previous version bypassed d3-zoom by writing
+   `transform=` directly on the viewport — d3-zoom's state went stale
+   and the next gesture jumped to wherever d3-zoom last remembered.
+
+2. **wheel-gestures** classifies each event as "user input", "momentum
+   tail", or "gesture start". We use two specific signals:
+   - `state.isStart` — the first event of a gesture. That's when we
+     decide "mouse or trackpad" and stick with the verdict. Per-event
+     classification doesn't work because Chrome's smooth-scrolling
+     makes mouse wheel ticks indistinguishable from trackpad scrolls
+     frame-by-frame (both can emit fractional deltaY with varying
+     magnitudes).
+   - `state.isMomentum` — OS-generated inertia events that continue
+     after the user's fingers have lifted. Critically, these often
+     drop `ctrlKey` partway through a pinch's decay. Skipping momentum
+     for zoom prevents phantom pans after a pinch; keeping it for
+     pan preserves the natural trackpad feel.
+
+3. **Sticky device detection** (inside `attachCamera`) runs at
+   `isStart` only, using `deltaMode`, presence of `deltaX`, and
+   magnitude of `deltaY` as signals. Once picked — `mouse` or
+   `trackpad` — the whole gesture uses that mode, so mid-flight
+   event ambiguity can't flip the verdict.
+
+### Coordinate-system discipline
+
+The renderer's SVG uses a `viewBox` sized to the layout bounds with
+`width="100%"` — so one viewBox user-space unit is NOT one CSS pixel.
+d3-zoom's transform is applied as an SVG `transform=` attribute on
+the viewport group, which is interpreted in user-space. The wheel
+event's `clientX/Y` is in screen pixels. Passing the cursor to
+d3-zoom directly drifts the zoom focus by the viewBox scale factor.
+
+`attachCamera` converts cursor to user-space via
+`svg.getScreenCTM().inverse()` and declares `zoom.extent` in user-space
+too, so d3-zoom's internal math and the applied transform agree.
+
+### Consumer summary
+
+- **editor** — `attachCamera(svg)` with defaults (Miro/Figma UX).
+- **docs/editor** — same, attached after the WebComponent's
+  `customElements.whenDefined('shumoku-renderer')` resolves.
+- **server/web TopologyViewer** — takes `camera?: CameraOptions | false`
+  as a prop; passes through to `attachCamera`. Widget, detail page
+  and share page all use this.
+- **CLI / PNG / SSR** — don't mount a Svelte component, so never see
+  `attachCamera`. d3-zoom isn't loaded at all in those paths.
 
 ---
 

--- a/libs/@shumoku/renderer/package.json
+++ b/libs/@shumoku/renderer/package.json
@@ -48,7 +48,8 @@
     "@shumoku/core": "workspace:*",
     "d3-drag": "^3.0.0",
     "d3-selection": "^3.0.0",
-    "d3-zoom": "^3.0.0"
+    "d3-zoom": "^3.0.0",
+    "wheel-gestures": "^2.2.48"
   },
   "devDependencies": {
     "@sveltejs/package": "^2.3.2",

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import type { Node, ResolvedEdge, ResolvedPort, Subgraph, Theme } from '@shumoku/core'
-  import { select } from 'd3-selection'
-  import { type D3ZoomEvent, zoom } from 'd3-zoom'
   import type { RenderColors } from '../../lib/render-colors'
   import SvgEdge from './SvgEdge.svelte'
   import SvgLinkPreview from './SvgLinkPreview.svelte'
@@ -58,63 +56,15 @@
     `${bounds.x - 50} ${bounds.y - 50} ${bounds.width + 100} ${bounds.height + 100}`,
   )
 
-  // Viewport group ref (d3-zoom applies transform to this)
-  let viewportEl: SVGGElement | undefined = $state()
-
-  // --- d3-zoom: pan/zoom on viewport <g> ---
-  // d3-zoom: pan/zoom always active
-  // Trackpad-friendly: two-finger scroll → pan, pinch (ctrl+wheel) → zoom
-  $effect(() => {
-    if (!svgEl || !viewportEl) return
-    const svg = svgEl
-
-    const svgSel = select(svg)
-    const zoomBehavior = zoom<SVGSVGElement, unknown>()
-      .scaleExtent([0.2, 10])
-      .filter((e) => {
-        // Wheel: only zoom on pinch (ctrlKey / metaKey)
-        if (e.type === 'wheel') return (e as WheelEvent).ctrlKey || (e as WheelEvent).metaKey
-        // Drag: middle button or Alt+left-click
-        if (e.type === 'mousedown' || e.type === 'pointerdown') {
-          return (e as MouseEvent).button === 1 || (e as MouseEvent).altKey
-        }
-        return false
-      })
-      .on('zoom', (e: D3ZoomEvent<SVGSVGElement, unknown>) => {
-        if (viewportEl) {
-          viewportEl.setAttribute('transform', e.transform.toString())
-        }
-      })
-
-    svgSel.call(zoomBehavior)
-
-    // Auto-detect input device (Miro-style):
-    // - deltaX !== 0 → trackpad two-finger scroll → pan
-    // - deltaX === 0 → mouse wheel → zoom at cursor
-    // - Ctrl/Cmd+wheel / pinch → zoom (d3-zoom filter above)
-    const handleWheel = (e: WheelEvent) => {
-      if (e.ctrlKey || e.metaKey) return // pinch-to-zoom handled by d3-zoom
-      e.preventDefault()
-      if (e.deltaX !== 0) {
-        zoomBehavior.translateBy(svgSel, -e.deltaX, -e.deltaY)
-      } else {
-        const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
-        const rect = svg.getBoundingClientRect()
-        zoomBehavior.scaleBy(svgSel, factor, [e.clientX - rect.left, e.clientY - rect.top])
-      }
-    }
-    svg.addEventListener('wheel', handleWheel, { passive: false })
-
-    // Prevent default context menu on SVG background only when nothing is targeted
-    svgSel.on('contextmenu.zoom', null)
-
-    return () => {
-      svgSel.on('.zoom', null)
-      svg.removeEventListener('wheel', handleWheel)
-    }
-  })
-
-  // d3-drag is now handled per-component via use: directive (no global re-binding)
+  // Camera (pan/zoom) is intentionally NOT attached here. Different host
+  // apps have different pan/zoom requirements, so the canvas only
+  // provides a stable `<g class="viewport">` target; apps call
+  // `attachCamera(svgEl, options)` from `@shumoku/renderer/camera` when
+  // they want interactive pan/zoom.
+  //
+  // Per-node d3-drag still lives inside each SvgNode/SvgSubgraph via
+  // the `use:elementDrag` directive — it only fires in edit mode and
+  // concerns element manipulation rather than viewport camera.
 </script>
 
 <svg
@@ -168,7 +118,7 @@
   </style>`}
 
   <!-- Viewport group: d3-zoom applies transform here -->
-  <g bind:this={viewportEl} class="viewport">
+  <g class="viewport">
     <!-- Background: grid in edit mode, transparent in view mode -->
     <rect
       class="canvas-bg"

--- a/libs/@shumoku/renderer/src/index.ts
+++ b/libs/@shumoku/renderer/src/index.ts
@@ -4,6 +4,14 @@
 
 // Renderer component (Svelte)
 export { default as ShumokuRenderer } from './components/ShumokuRenderer.svelte'
+// Camera (pan/zoom) — opt-in for host apps
+export {
+  attachCamera,
+  type Camera,
+  type CameraOptions,
+  type PanFilter,
+  type WheelMode,
+} from './lib/camera'
 // Utilities for consuming apps
 export { type RenderColors, themeToColors } from './lib/render-colors'
 // Serialization (save/load layout state)

--- a/libs/@shumoku/renderer/src/index.ts
+++ b/libs/@shumoku/renderer/src/index.ts
@@ -5,13 +5,7 @@
 // Renderer component (Svelte)
 export { default as ShumokuRenderer } from './components/ShumokuRenderer.svelte'
 // Camera (pan/zoom) — opt-in for host apps
-export {
-  attachCamera,
-  type Camera,
-  type CameraOptions,
-  type PanFilter,
-  type WheelMode,
-} from './lib/camera'
+export { attachCamera, type Camera, type CameraOptions, type PanFilter } from './lib/camera'
 // Utilities for consuming apps
 export { type RenderColors, themeToColors } from './lib/render-colors'
 // Serialization (save/load layout state)

--- a/libs/@shumoku/renderer/src/lib/camera.ts
+++ b/libs/@shumoku/renderer/src/lib/camera.ts
@@ -1,0 +1,205 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Camera (pan + zoom) attachment utility for Shumoku's rendered SVG.
+ *
+ * Intentionally NOT bundled into `<ShumokuRenderer>` itself — camera
+ * requirements differ per host app (Miro-style for the editor, plain
+ * left-drag for dashboards, read-only for share pages, etc.). Consumers
+ * call `attachCamera(svg, options)` on the rendered svg element when
+ * they want pan/zoom, and pass in a policy that fits their UX.
+ *
+ * Attaches d3-zoom to the svg; transforms the child `<g class="viewport">`
+ * produced by ShumokuRenderer.
+ */
+
+import { select } from 'd3-selection'
+import { type D3ZoomEvent, type ZoomBehavior, zoom, zoomIdentity, zoomTransform } from 'd3-zoom'
+
+export type PanFilter = (event: PointerEvent | MouseEvent) => boolean
+
+export type WheelMode =
+  /**
+   * Trackpad two-finger scroll pans (deltaX !== 0), pure vertical wheel
+   * zooms at cursor. Pinch (ctrl/meta + wheel) always zooms.
+   */
+  | 'pan-and-zoom'
+  /** Every wheel tick zooms at cursor. */
+  | 'zoom'
+  /** Every wheel tick pans. */
+  | 'pan'
+
+export interface CameraOptions {
+  /** Zoom scale bounds. Default: [0.2, 10]. */
+  scaleExtent?: [number, number]
+  /**
+   * Predicate: pointer-down events that should start a pan. Default:
+   * middle-button or Alt+left-click — leaves plain left-click free for
+   * selection handlers in the renderer.
+   */
+  panFilter?: PanFilter
+  /** Wheel behaviour when no modifier is held. Default: 'pan-and-zoom'. */
+  wheelMode?: WheelMode
+  /** Zoom step factor per wheel tick. Default 1.1. */
+  wheelZoomStep?: number
+}
+
+export interface Camera {
+  /** The current transform applied to the viewport. */
+  getTransform(): { x: number; y: number; k: number }
+  /** Scale by a factor, centred on the svg. */
+  zoomBy(factor: number): void
+  /** Set the absolute scale, optionally focused on a screen-space point. */
+  zoomTo(scale: number, point?: [number, number]): void
+  /** Set the absolute translation (viewport-space). */
+  panTo(x: number, y: number): void
+  /**
+   * Pan+zoom so a node with `data-id=nodeId` fills roughly `areaRatio` of
+   * the viewport (default 5%). Returns true if the node was found.
+   */
+  panToNode(nodeId: string, areaRatio?: number): boolean
+  /** Reset to identity transform. */
+  reset(): void
+  /** Detach all listeners. Safe to call multiple times. */
+  detach(): void
+}
+
+const DEFAULT_PAN_FILTER: PanFilter = (e) =>
+  ('button' in e && e.button === 1) || ('altKey' in e && e.altKey === true)
+
+/**
+ * Attach a pan+zoom camera to an svg with a `<g class="viewport">` child.
+ * Returns a handle with imperative controls + a `detach()` cleanup.
+ */
+export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): Camera {
+  const {
+    scaleExtent = [0.2, 10],
+    panFilter = DEFAULT_PAN_FILTER,
+    wheelMode = 'pan-and-zoom',
+    wheelZoomStep = 1.1,
+  } = options
+
+  const viewportEl = svg.querySelector<SVGGElement>('.viewport')
+  if (!viewportEl) {
+    throw new Error(
+      '[attachCamera] no `.viewport` <g> found in svg — ShumokuRenderer always produces one; was this called on the wrong element?',
+    )
+  }
+
+  const svgSel = select(svg)
+  const zoomBehavior: ZoomBehavior<SVGSVGElement, unknown> = zoom<SVGSVGElement, unknown>()
+    .scaleExtent(scaleExtent)
+    .filter((e) => {
+      if (e.type === 'wheel') {
+        return (e as WheelEvent).ctrlKey || (e as WheelEvent).metaKey
+      }
+      if (e.type === 'mousedown' || e.type === 'pointerdown') {
+        return panFilter(e as PointerEvent | MouseEvent)
+      }
+      return false
+    })
+    .on('zoom', (e: D3ZoomEvent<SVGSVGElement, unknown>) => {
+      viewportEl.setAttribute('transform', e.transform.toString())
+    })
+
+  svgSel.call(zoomBehavior)
+  // Prevent default context menu on the svg background (d3-zoom installs
+  // its own; we want that suppressed so right-click falls through to
+  // oncontextmenu handlers on specific elements).
+  svgSel.on('contextmenu.zoom', null)
+
+  const handleWheel = (e: WheelEvent) => {
+    if (e.ctrlKey || e.metaKey) return // pinch — d3-zoom handles via its filter
+    e.preventDefault()
+    switch (wheelMode) {
+      case 'zoom': {
+        const factor = e.deltaY < 0 ? wheelZoomStep : 1 / wheelZoomStep
+        const rect = svg.getBoundingClientRect()
+        zoomBehavior.scaleBy(svgSel, factor, [e.clientX - rect.left, e.clientY - rect.top])
+        break
+      }
+      case 'pan':
+        zoomBehavior.translateBy(svgSel, -e.deltaX, -e.deltaY)
+        break
+      case 'pan-and-zoom':
+        if (e.deltaX !== 0) {
+          zoomBehavior.translateBy(svgSel, -e.deltaX, -e.deltaY)
+        } else {
+          const factor = e.deltaY < 0 ? wheelZoomStep : 1 / wheelZoomStep
+          const rect = svg.getBoundingClientRect()
+          zoomBehavior.scaleBy(svgSel, factor, [e.clientX - rect.left, e.clientY - rect.top])
+        }
+        break
+    }
+  }
+  svg.addEventListener('wheel', handleWheel, { passive: false })
+
+  return {
+    getTransform() {
+      const t = zoomTransform(svg)
+      return { x: t.x, y: t.y, k: t.k }
+    },
+
+    zoomBy(factor: number) {
+      const rect = svg.getBoundingClientRect()
+      zoomBehavior.scaleBy(svgSel, factor, [rect.width / 2, rect.height / 2])
+    },
+
+    zoomTo(scale: number, point?: [number, number]) {
+      zoomBehavior.scaleTo(svgSel, scale, point)
+    },
+
+    panTo(x: number, y: number) {
+      const current = zoomTransform(svg)
+      zoomBehavior.transform(svgSel, zoomIdentity.translate(x, y).scale(current.k))
+    },
+
+    panToNode(nodeId: string, areaRatio = 0.05): boolean {
+      const cssEscapedId =
+        typeof CSS !== 'undefined' && 'escape' in CSS ? CSS.escape(nodeId) : nodeId
+      const node = svg.querySelector<SVGGElement>(`g.node[data-id="${cssEscapedId}"]`)
+      if (!node) return false
+
+      const svgRect = svg.getBoundingClientRect()
+      const nodeRect = node.getBoundingClientRect()
+      const current = zoomTransform(svg)
+
+      // Target scale so node ≈ sqrt(areaRatio) * viewport-dim on the larger axis.
+      const targetK = Math.max(
+        scaleExtent[0],
+        Math.min(
+          scaleExtent[1],
+          current.k *
+            Math.sqrt(
+              (svgRect.width * svgRect.height * areaRatio) / (nodeRect.width * nodeRect.height),
+            ),
+        ),
+      )
+
+      // Node centre in the screen-space of the svg, then in content-space.
+      const screenCx = nodeRect.left + nodeRect.width / 2 - svgRect.left
+      const screenCy = nodeRect.top + nodeRect.height / 2 - svgRect.top
+      const contentCx = (screenCx - current.x) / current.k
+      const contentCy = (screenCy - current.y) / current.k
+
+      // Translate so (contentCx, contentCy) lands at the svg centre under targetK.
+      const tx = svgRect.width / 2 - contentCx * targetK
+      const ty = svgRect.height / 2 - contentCy * targetK
+
+      zoomBehavior.transform(svgSel, zoomIdentity.translate(tx, ty).scale(targetK))
+      return true
+    },
+
+    reset() {
+      zoomBehavior.transform(svgSel, zoomIdentity)
+    },
+
+    detach() {
+      svgSel.on('.zoom', null)
+      svg.removeEventListener('wheel', handleWheel)
+      viewportEl.removeAttribute('transform')
+    },
+  }
+}

--- a/libs/@shumoku/renderer/src/lib/camera.ts
+++ b/libs/@shumoku/renderer/src/lib/camera.ts
@@ -22,13 +22,14 @@ export type PanFilter = (event: PointerEvent | MouseEvent) => boolean
 
 export type WheelMode =
   /**
-   * Trackpad two-finger scroll pans (deltaX !== 0), pure vertical wheel
-   * zooms at cursor. Pinch (ctrl/meta + wheel) always zooms.
+   * Every wheel event zooms at the cursor (mouse-wheel-friendly).
+   * Trackpad pinch still zooms independently via ctrl/meta detection.
    */
-  | 'pan-and-zoom'
-  /** Every wheel tick zooms at cursor. */
   | 'zoom'
-  /** Every wheel tick pans. */
+  /**
+   * Every wheel event pans (trackpad-friendly; two-finger scroll pans
+   * the canvas in both axes). Pinch (ctrl/meta + wheel) zooms.
+   */
   | 'pan'
 
 export interface CameraOptions {
@@ -40,10 +41,20 @@ export interface CameraOptions {
    * selection handlers in the renderer.
    */
   panFilter?: PanFilter
-  /** Wheel behaviour when no modifier is held. Default: 'pan-and-zoom'. */
-  wheelMode?: WheelMode
-  /** Zoom step factor per wheel tick. Default 1.1. */
-  wheelZoomStep?: number
+  /**
+   * What the mouse wheel does when no modifier is held. No default —
+   * caller must pick `'zoom'` (mouse-centric apps) or `'pan'`
+   * (trackpad-centric / infinite-canvas apps). Pinch (ctrl/meta +
+   * wheel) always zooms regardless of `wheelMode`.
+   */
+  wheelMode: WheelMode
+  /**
+   * Zoom sensitivity exponent. The per-event scale factor is
+   * `Math.pow(wheelZoomSensitivity, -deltaY)`. Higher = faster zoom.
+   * Default 1.0015 — tuned so one mouse-wheel tick (`deltaY ≈ 100`)
+   * ≈ 14% zoom, and trackpad pinches (`deltaY ≈ 3–5`) feel smooth.
+   */
+  wheelZoomSensitivity?: number
 }
 
 export interface Camera {
@@ -73,12 +84,12 @@ const DEFAULT_PAN_FILTER: PanFilter = (e) =>
  * Attach a pan+zoom camera to an svg with a `<g class="viewport">` child.
  * Returns a handle with imperative controls + a `detach()` cleanup.
  */
-export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): Camera {
+export function attachCamera(svg: SVGSVGElement, options: CameraOptions): Camera {
   const {
     scaleExtent = [0.2, 10],
     panFilter = DEFAULT_PAN_FILTER,
-    wheelMode = 'pan-and-zoom',
-    wheelZoomStep = 1.1,
+    wheelMode,
+    wheelZoomSensitivity = 1.0015,
   } = options
 
   const viewportEl = svg.querySelector<SVGGElement>('.viewport')
@@ -88,12 +99,55 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
     )
   }
 
+  // The renderer uses a viewBox sized to the layout bounds; the svg
+  // element itself is CSS-sized 100% of its container. That means the
+  // viewBox user-space unit is NOT one CSS pixel: content inside the
+  // svg (and our `.viewport` <g>) lives in user-space coordinates.
+  // d3-zoom stores its transform in whatever coordinate system we feed
+  // it, and applies that transform as an SVG `transform` attribute on
+  // the viewport <g> — which is interpreted in user-space. So we
+  // standardise everything in user-space: set the zoom's `extent` to
+  // the viewBox bounds, and convert wheel-event cursor positions from
+  // screen pixels to user-space before passing to d3-zoom.
+  //
+  // Without this, the "fixed point" d3-zoom is asked to preserve during
+  // a scale operation is in a different coordinate system than the
+  // transform actually applied, so the cursor drifts away from the
+  // zoom focus by a factor of viewBoxScale.
+
+  const cursorToUserCoords = (clientX: number, clientY: number): [number, number] | null => {
+    const ctm = svg.getScreenCTM()?.inverse()
+    if (!ctm) return null
+    const pt = svg.createSVGPoint()
+    pt.x = clientX
+    pt.y = clientY
+    const p = pt.matrixTransform(ctm)
+    return [p.x, p.y]
+  }
+
   const svgSel = select(svg)
   const zoomBehavior: ZoomBehavior<SVGSVGElement, unknown> = zoom<SVGSVGElement, unknown>()
     .scaleExtent(scaleExtent)
+    .extent((): [[number, number], [number, number]] => {
+      const vb = svg.viewBox.baseVal
+      // When no viewBox is set, fall back to clientSize (pixel-equivalent).
+      if (vb.width === 0 || vb.height === 0) {
+        return [
+          [0, 0],
+          [svg.clientWidth, svg.clientHeight],
+        ]
+      }
+      return [
+        [vb.x, vb.y],
+        [vb.x + vb.width, vb.y + vb.height],
+      ]
+    })
     .filter((e) => {
       if (e.type === 'wheel') {
-        return (e as WheelEvent).ctrlKey || (e as WheelEvent).metaKey
+        // d3-zoom's own wheel handling is disabled — we drive it via
+        // the custom wheel listener below to route cursor points
+        // through user-space coords.
+        return false
       }
       if (e.type === 'mousedown' || e.type === 'pointerdown') {
         return panFilter(e as PointerEvent | MouseEvent)
@@ -105,36 +159,38 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
     })
 
   svgSel.call(zoomBehavior)
-  // Prevent default context menu on the svg background (d3-zoom installs
-  // its own; we want that suppressed so right-click falls through to
-  // oncontextmenu handlers on specific elements).
+  // Suppress d3-zoom's default contextmenu handler so element-level
+  // oncontextmenu handlers can fire.
   svgSel.on('contextmenu.zoom', null)
 
   const handleWheel = (e: WheelEvent) => {
-    if (e.ctrlKey || e.metaKey) return // pinch — d3-zoom handles via its filter
     e.preventDefault()
-    switch (wheelMode) {
-      case 'zoom': {
-        const factor = e.deltaY < 0 ? wheelZoomStep : 1 / wheelZoomStep
-        const rect = svg.getBoundingClientRect()
-        zoomBehavior.scaleBy(svgSel, factor, [e.clientX - rect.left, e.clientY - rect.top])
-        break
-      }
-      case 'pan':
-        zoomBehavior.translateBy(svgSel, -e.deltaX, -e.deltaY)
-        break
-      case 'pan-and-zoom':
-        if (e.deltaX !== 0) {
-          zoomBehavior.translateBy(svgSel, -e.deltaX, -e.deltaY)
-        } else {
-          const factor = e.deltaY < 0 ? wheelZoomStep : 1 / wheelZoomStep
-          const rect = svg.getBoundingClientRect()
-          zoomBehavior.scaleBy(svgSel, factor, [e.clientX - rect.left, e.clientY - rect.top])
-        }
-        break
+    const point = cursorToUserCoords(e.clientX, e.clientY)
+    if (!point) return
+
+    // Pinch (ctrl/meta + wheel) always zooms, regardless of wheelMode.
+    // Browsers synthesise ctrlKey=true on trackpad pinch, so this
+    // handles both explicit ctrl+wheel and pinch gestures.
+    if (e.ctrlKey || e.metaKey || wheelMode === 'zoom') {
+      const factor = wheelZoomSensitivity ** -e.deltaY
+      zoomBehavior.scaleBy(svgSel, factor, point)
+      return
     }
+    // wheelMode === 'pan' — pan both axes as emitted. Two-finger
+    // trackpad scroll works naturally; mouse wheel pans vertically.
+    // Pan uses user-space units too (consistent with extent).
+    const current = zoomTransform(svg)
+    zoomBehavior.translateBy(svgSel, -e.deltaX / current.k, -e.deltaY / current.k)
   }
   svg.addEventListener('wheel', handleWheel, { passive: false })
+
+  const viewBoxCenter = (): [number, number] => {
+    const vb = svg.viewBox.baseVal
+    if (vb.width === 0 || vb.height === 0) {
+      return [svg.clientWidth / 2, svg.clientHeight / 2]
+    }
+    return [vb.x + vb.width / 2, vb.y + vb.height / 2]
+  }
 
   return {
     getTransform() {
@@ -143,12 +199,11 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
     },
 
     zoomBy(factor: number) {
-      const rect = svg.getBoundingClientRect()
-      zoomBehavior.scaleBy(svgSel, factor, [rect.width / 2, rect.height / 2])
+      zoomBehavior.scaleBy(svgSel, factor, viewBoxCenter())
     },
 
     zoomTo(scale: number, point?: [number, number]) {
-      zoomBehavior.scaleTo(svgSel, scale, point)
+      zoomBehavior.scaleTo(svgSel, scale, point ?? viewBoxCenter())
     },
 
     panTo(x: number, y: number) {
@@ -162,31 +217,26 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
       const node = svg.querySelector<SVGGElement>(`g.node[data-id="${cssEscapedId}"]`)
       if (!node) return false
 
-      const svgRect = svg.getBoundingClientRect()
-      const nodeRect = node.getBoundingClientRect()
-      const current = zoomTransform(svg)
+      // Work entirely in user-space: use getBBox() for node bounds in
+      // the viewport's local coords, then translate to put its centre
+      // at the viewBox centre under the target scale.
+      const bbox = node.getBBox()
+      const vb = svg.viewBox.baseVal
+      const vbCx = vb.x + vb.width / 2
+      const vbCy = vb.y + vb.height / 2
 
-      // Target scale so node ≈ sqrt(areaRatio) * viewport-dim on the larger axis.
       const targetK = Math.max(
         scaleExtent[0],
         Math.min(
           scaleExtent[1],
-          current.k *
-            Math.sqrt(
-              (svgRect.width * svgRect.height * areaRatio) / (nodeRect.width * nodeRect.height),
-            ),
+          Math.sqrt((vb.width * vb.height * areaRatio) / (bbox.width * bbox.height)),
         ),
       )
 
-      // Node centre in the screen-space of the svg, then in content-space.
-      const screenCx = nodeRect.left + nodeRect.width / 2 - svgRect.left
-      const screenCy = nodeRect.top + nodeRect.height / 2 - svgRect.top
-      const contentCx = (screenCx - current.x) / current.k
-      const contentCy = (screenCy - current.y) / current.k
-
-      // Translate so (contentCx, contentCy) lands at the svg centre under targetK.
-      const tx = svgRect.width / 2 - contentCx * targetK
-      const ty = svgRect.height / 2 - contentCy * targetK
+      const nodeCx = bbox.x + bbox.width / 2
+      const nodeCy = bbox.y + bbox.height / 2
+      const tx = vbCx - nodeCx * targetK
+      const ty = vbCy - nodeCy * targetK
 
       zoomBehavior.transform(svgSel, zoomIdentity.translate(tx, ty).scale(targetK))
       return true

--- a/libs/@shumoku/renderer/src/lib/camera.ts
+++ b/libs/@shumoku/renderer/src/lib/camera.ts
@@ -6,31 +6,38 @@
  * Camera (pan + zoom) attachment utility for Shumoku's rendered SVG.
  *
  * Intentionally NOT bundled into `<ShumokuRenderer>` itself — camera
- * requirements differ per host app (Miro-style for the editor, plain
- * left-drag for dashboards, read-only for share pages, etc.). Consumers
- * call `attachCamera(svg, options)` on the rendered svg element when
- * they want pan/zoom, and pass in a policy that fits their UX.
+ * requirements differ per host app, so apps call `attachCamera(svg)`
+ * when they want pan/zoom.
  *
- * Attaches d3-zoom to the svg; transforms the child `<g class="viewport">`
- * produced by ShumokuRenderer.
+ * Wheel handling delegates to the `wheel-gestures` library. It
+ * contributes two things the hand-rolled version couldn't nail:
+ *
+ * 1. A reliable `isStart` flag for the first event of a gesture. We
+ *    use it to pick mouse vs trackpad exactly once per gesture, so
+ *    subsequent ambiguous events (fractional deltaY from Chrome's
+ *    smooth-scroll, mid-gesture dropped ctrlKey, etc.) can't flip the
+ *    verdict.
+ * 2. `isMomentum` identifies post-gesture inertia events so we can
+ *    ignore them — the biggest source of "zoom flipped to pan
+ *    mid-gesture" in the original implementation was a pinch's
+ *    momentum tail arriving without ctrlKey.
+ *
+ * UX policy (Figma/Miro-style, common for canvas editors):
+ * - **Mouse wheel** (plain)        → zoom at cursor
+ * - **Mouse ctrl+wheel**           → zoom at cursor (explicit)
+ * - **Trackpad two-finger**        → pan
+ * - **Trackpad pinch**             → zoom at cursor
+ *     (browsers synthesise ctrlKey=true on trackpad pinch)
+ *
+ * Device detection runs at `isStart` only. Once picked, the gesture
+ * stays in that mode even if individual events look ambiguous.
  */
 
 import { select } from 'd3-selection'
 import { type D3ZoomEvent, type ZoomBehavior, zoom, zoomIdentity, zoomTransform } from 'd3-zoom'
+import { type WheelEventState, WheelGestures } from 'wheel-gestures'
 
 export type PanFilter = (event: PointerEvent | MouseEvent) => boolean
-
-export type WheelMode =
-  /**
-   * Every wheel event zooms at the cursor (mouse-wheel-friendly).
-   * Trackpad pinch still zooms independently via ctrl/meta detection.
-   */
-  | 'zoom'
-  /**
-   * Every wheel event pans (trackpad-friendly; two-finger scroll pans
-   * the canvas in both axes). Pinch (ctrl/meta + wheel) zooms.
-   */
-  | 'pan'
 
 export interface CameraOptions {
   /** Zoom scale bounds. Default: [0.2, 10]. */
@@ -42,33 +49,30 @@ export interface CameraOptions {
    */
   panFilter?: PanFilter
   /**
-   * What the mouse wheel does when no modifier is held. No default —
-   * caller must pick `'zoom'` (mouse-centric apps) or `'pan'`
-   * (trackpad-centric / infinite-canvas apps). Pinch (ctrl/meta +
-   * wheel) always zooms regardless of `wheelMode`.
-   */
-  wheelMode: WheelMode
-  /**
-   * Zoom sensitivity exponent. The per-event scale factor is
-   * `Math.pow(wheelZoomSensitivity, -deltaY)`. Higher = faster zoom.
-   * Default 1.0015 — tuned so one mouse-wheel tick (`deltaY ≈ 100`)
-   * ≈ 14% zoom, and trackpad pinches (`deltaY ≈ 3–5`) feel smooth.
+   * Zoom sensitivity for mouse wheel and mouse ctrl+wheel (one big
+   * discrete deltaY per tick). Default 1.0015 — a typical mouse tick
+   * (deltaY ≈ 100) → ~14% zoom.
    */
   wheelZoomSensitivity?: number
+  /**
+   * Zoom sensitivity for trackpad pinches (many small ctrlKey-wheel
+   * events per frame). Default 1.01 — deltaY ≈ 10 → ~10% per event.
+   */
+  pinchZoomSensitivity?: number
 }
 
 export interface Camera {
   /** The current transform applied to the viewport. */
   getTransform(): { x: number; y: number; k: number }
-  /** Scale by a factor, centred on the svg. */
+  /** Scale by a factor, centred on the viewBox. */
   zoomBy(factor: number): void
   /** Set the absolute scale, optionally focused on a screen-space point. */
   zoomTo(scale: number, point?: [number, number]): void
   /** Set the absolute translation (viewport-space). */
   panTo(x: number, y: number): void
   /**
-   * Pan+zoom so a node with `data-id=nodeId` fills roughly `areaRatio` of
-   * the viewport (default 5%). Returns true if the node was found.
+   * Pan+zoom so a node with `data-id=nodeId` fills roughly `areaRatio`
+   * of the viewport (default 5%). Returns true if the node was found.
    */
   panToNode(nodeId: string, areaRatio?: number): boolean
   /** Reset to identity transform. */
@@ -81,15 +85,40 @@ const DEFAULT_PAN_FILTER: PanFilter = (e) =>
   ('button' in e && e.button === 1) || ('altKey' in e && e.altKey === true)
 
 /**
+ * Magnitude above which a single wheel event is considered a mouse
+ * wheel tick (vs. a trackpad scroll frame). Chrome's smooth-scroll
+ * emits fractional deltaY even for mouse ticks, so we can't rely on
+ * `Number.isInteger(deltaY)` — magnitude is the practical signal.
+ */
+const MOUSE_TICK_THRESHOLD = 50
+
+/**
+ * Classify the very first event of a gesture. Only called at
+ * `state.isStart === true`, so the verdict doesn't flip within the
+ * gesture no matter what individual frames look like.
+ */
+function detectDevice(e: WheelEvent, axisDeltaX: number, axisDeltaY: number): 'mouse' | 'trackpad' {
+  // Firefox's LINE/PAGE deltaMode is only ever produced by mouse wheels.
+  if (e.deltaMode !== 0) return 'mouse'
+  // A trackpad is the only device that routinely emits horizontal
+  // scroll on the wheel event stream.
+  if (Math.abs(axisDeltaX) > 0) return 'trackpad'
+  // Otherwise the only reliable signal left is magnitude: a mouse
+  // wheel tick is large (≥ 50 after normalisation), a trackpad frame
+  // during an active gesture is small.
+  return Math.abs(axisDeltaY) >= MOUSE_TICK_THRESHOLD ? 'mouse' : 'trackpad'
+}
+
+/**
  * Attach a pan+zoom camera to an svg with a `<g class="viewport">` child.
  * Returns a handle with imperative controls + a `detach()` cleanup.
  */
-export function attachCamera(svg: SVGSVGElement, options: CameraOptions): Camera {
+export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): Camera {
   const {
     scaleExtent = [0.2, 10],
     panFilter = DEFAULT_PAN_FILTER,
-    wheelMode,
     wheelZoomSensitivity = 1.0015,
+    pinchZoomSensitivity = 1.01,
   } = options
 
   const viewportEl = svg.querySelector<SVGGElement>('.viewport')
@@ -101,19 +130,12 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions): Camera
 
   // The renderer uses a viewBox sized to the layout bounds; the svg
   // element itself is CSS-sized 100% of its container. That means the
-  // viewBox user-space unit is NOT one CSS pixel: content inside the
-  // svg (and our `.viewport` <g>) lives in user-space coordinates.
-  // d3-zoom stores its transform in whatever coordinate system we feed
-  // it, and applies that transform as an SVG `transform` attribute on
-  // the viewport <g> — which is interpreted in user-space. So we
-  // standardise everything in user-space: set the zoom's `extent` to
-  // the viewBox bounds, and convert wheel-event cursor positions from
-  // screen pixels to user-space before passing to d3-zoom.
-  //
-  // Without this, the "fixed point" d3-zoom is asked to preserve during
-  // a scale operation is in a different coordinate system than the
-  // transform actually applied, so the cursor drifts away from the
-  // zoom focus by a factor of viewBoxScale.
+  // viewBox user-space unit is NOT one CSS pixel. d3-zoom applies its
+  // transform as an SVG `transform` attribute on the viewport <g>,
+  // which is interpreted in user-space — so we feed d3-zoom user-space
+  // everywhere (extent = viewBox, wheel points converted via
+  // `svg.getScreenCTM().inverse()`). Otherwise the cursor drifts from
+  // the zoom focus by a factor of the viewBox scale.
 
   const cursorToUserCoords = (clientX: number, clientY: number): [number, number] | null => {
     const ctm = svg.getScreenCTM()?.inverse()
@@ -130,7 +152,6 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions): Camera
     .scaleExtent(scaleExtent)
     .extent((): [[number, number], [number, number]] => {
       const vb = svg.viewBox.baseVal
-      // When no viewBox is set, fall back to clientSize (pixel-equivalent).
       if (vb.width === 0 || vb.height === 0) {
         return [
           [0, 0],
@@ -143,12 +164,9 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions): Camera
       ]
     })
     .filter((e) => {
-      if (e.type === 'wheel') {
-        // d3-zoom's own wheel handling is disabled — we drive it via
-        // the custom wheel listener below to route cursor points
-        // through user-space coords.
-        return false
-      }
+      // wheel-gestures drives wheel handling; d3-zoom's own wheel
+      // path is disabled so the two don't both respond to one event.
+      if (e.type === 'wheel') return false
       if (e.type === 'mousedown' || e.type === 'pointerdown') {
         return panFilter(e as PointerEvent | MouseEvent)
       }
@@ -159,30 +177,53 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions): Camera
     })
 
   svgSel.call(zoomBehavior)
-  // Suppress d3-zoom's default contextmenu handler so element-level
-  // oncontextmenu handlers can fire.
   svgSel.on('contextmenu.zoom', null)
 
-  const handleWheel = (e: WheelEvent) => {
-    e.preventDefault()
-    const point = cursorToUserCoords(e.clientX, e.clientY)
+  // Sticky per-gesture device verdict — set at `isStart`, read on
+  // every subsequent event in the same gesture.
+  let gestureDevice: 'mouse' | 'trackpad' = 'mouse'
+
+  const wg = WheelGestures({ preventWheelAction: true })
+  const unobserve = wg.observe(svg)
+  const offWheel = wg.on('wheel', (state: WheelEventState) => {
+    const rawEvent = state.event as WheelEvent
+
+    // Detect device only on the first event of a gesture — `isStart`
+    // is reliable thanks to wheel-gestures' momentum tracking.
+    if (state.isStart) {
+      gestureDevice = detectDevice(rawEvent, rawEvent.deltaX, rawEvent.deltaY)
+    }
+
+    const point = cursorToUserCoords(rawEvent.clientX, rawEvent.clientY)
     if (!point) return
 
-    // Pinch (ctrl/meta + wheel) always zooms, regardless of wheelMode.
-    // Browsers synthesise ctrlKey=true on trackpad pinch, so this
-    // handles both explicit ctrl+wheel and pinch gestures.
-    if (e.ctrlKey || e.metaKey || wheelMode === 'zoom') {
-      const factor = wheelZoomSensitivity ** -e.deltaY
-      zoomBehavior.scaleBy(svgSel, factor, point)
+    // Zoom: ctrl/meta active + NOT momentum. Skipping momentum here
+    // prevents a post-pinch inertia tail from continuing to zoom
+    // after the user's fingers have lifted.
+    if ((rawEvent.ctrlKey || rawEvent.metaKey) && !state.isMomentum) {
+      const sensitivity = gestureDevice === 'mouse' ? wheelZoomSensitivity : pinchZoomSensitivity
+      zoomBehavior.scaleBy(svgSel, sensitivity ** -rawEvent.deltaY, point)
       return
     }
-    // wheelMode === 'pan' — pan both axes as emitted. Two-finger
-    // trackpad scroll works naturally; mouse wheel pans vertically.
-    // Pan uses user-space units too (consistent with extent).
+
+    // For mouse wheel (no ctrl): zoom. Mouse wheels don't emit
+    // OS-level momentum so `isMomentum` is effectively always false
+    // here; guarding on it anyway means if some system does emit
+    // momentum-like events, we don't double-fire a zoom step.
+    if (gestureDevice === 'mouse') {
+      if (state.isMomentum) return
+      zoomBehavior.scaleBy(svgSel, wheelZoomSensitivity ** -rawEvent.deltaY, point)
+      return
+    }
+
+    // Trackpad two-finger → pan. We deliberately do NOT skip momentum
+    // here: it's the inertia after a flick, and users expect a
+    // trackpad pan to decelerate naturally instead of snapping to a
+    // stop. Divide by k so on-screen pan distance matches the wheel
+    // delta regardless of current zoom level.
     const current = zoomTransform(svg)
-    zoomBehavior.translateBy(svgSel, -e.deltaX / current.k, -e.deltaY / current.k)
-  }
-  svg.addEventListener('wheel', handleWheel, { passive: false })
+    zoomBehavior.translateBy(svgSel, -rawEvent.deltaX / current.k, -rawEvent.deltaY / current.k)
+  })
 
   const viewBoxCenter = (): [number, number] => {
     const vb = svg.viewBox.baseVal
@@ -217,9 +258,9 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions): Camera
       const node = svg.querySelector<SVGGElement>(`g.node[data-id="${cssEscapedId}"]`)
       if (!node) return false
 
-      // Work entirely in user-space: use getBBox() for node bounds in
-      // the viewport's local coords, then translate to put its centre
-      // at the viewBox centre under the target scale.
+      // Work entirely in user-space: getBBox() returns bounds in the
+      // viewport's local coords, then translate to centre it in the
+      // viewBox at the target scale.
       const bbox = node.getBBox()
       const vb = svg.viewBox.baseVal
       const vbCx = vb.x + vb.width / 2
@@ -247,8 +288,9 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions): Camera
     },
 
     detach() {
+      offWheel()
+      unobserve()
       svgSel.on('.zoom', null)
-      svg.removeEventListener('wheel', handleWheel)
       viewportEl.removeAttribute('transform')
     },
   }


### PR DESCRIPTION
## Summary
- Removes hard-coded d3-zoom camera from `@shumoku/renderer` → each app was previously stuck with the editor's Miro-style (Alt+drag pan, ctrl+wheel zoom) even when dashboards / share pages wanted different UX.
- New export: `attachCamera(svg, options)` → `Camera` handle. Consumers attach whichever camera policy they want.
- Fixes the jitter TopologyViewer was causing by mutating \`.viewport\` transform via setAttribute while d3-zoom's \`svg.__zoom\` state stayed stale — both systems now route through d3-zoom.

## Why
Camera behaviour is app-specific, not renderer-specific:
- editor = Miro-style
- dashboard widget = could want plain-drag pan in the future
- share page = could disable zoom
- CLI/SSR = no camera at all

Baking d3-zoom into the renderer forces one policy on everyone.

## API
\`\`\`ts
import { attachCamera } from '@shumoku/renderer'

const camera = attachCamera(svgEl, {
  scaleExtent: [0.2, 10],       // default
  panFilter: (e) => e.altKey,    // default: middle-click or Alt+left
  wheelMode: 'pan-and-zoom',     // 'zoom' | 'pan' | 'pan-and-zoom'
  wheelZoomStep: 1.1,
})
camera.zoomBy(1.5)
camera.panToNode('device-42')
camera.reset()
camera.detach()
\`\`\`

## Migration impact
- \`apps/editor\` — attaches default (Miro-style) camera on mount
- \`apps/docs/editor\` — attaches camera after WC \`whenDefined\`
- \`apps/server/web\` (TopologyViewer) — now takes \`camera?: CameraOptions | false\` prop, delegates all imperative zoom to the camera handle (no more setAttribute vs d3-zoom conflicts). Adds \`resetCameraOnSheetChange\` (default true).

## Test plan
- [x] \`bun run typecheck\` — 30/30 green
- [x] \`bun run lint\` — clean
- [ ] editor pan/zoom still works (Alt+drag, trackpad zoom, pinch)
- [ ] dashboard widget wheel works
- [ ] detail page search→panToNode still centres on node
- [ ] sheet switch in detail page resets zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)