### PR TITLE
docs(editor): sheet, layout, and BOM model docs

### DIFF
--- a/apps/editor/docs/bom-model.md
+++ b/apps/editor/docs/bom-model.md
@@ -1,0 +1,250 @@
+## BOM モデル
+
+「カタログから取ってきた製品定義」「プロジェクトで実際に使う台数」「ダイヤグラム上のノード」を **三角形の関係** で扱う仕組み。Figma のコンポーネント / インスタンスのアナロジーで考えると分かりやすい。
+
+メンタルモデルは「**Palette**」「**BOM**」「**ノード**」の三つで成り立ちます。
+
+- **Palette（Spec Palette）** — このプロジェクトで使える製品の **定義** リスト。Cisco Catalyst 9300、Aruba 6300M、… のような **モデル単位**。Figma で言うところの "コンポーネント"。
+- **BOM** — Palette のエントリを「N 台使う」という **インスタンス** 行。Catalyst 9300 ×3、6300M ×1、…。**台数管理の master**（Bill of Materials）。
+- **ノード** — ダイヤグラム上の図形。`NetworkGraph.nodes` の各エントリ。位置・接続・ラベルを持つ。
+
+三者の関係は次のような **対応**：
+
+- Palette 1 つ ↔ BOM 複数（1 製品が何台あってもよい）
+- BOM 1 つ ↔ ノード **0 or 1**（未配置 BOM は `nodeId: undefined`、配置済みは ID 参照）
+- ノード ↔ Palette は BOM **経由のみ**（直接参照は持たない）
+
+この三角形の中で「ノードを作ってから Palette に紐付ける」「Palette から先に台数登録して後でダイヤグラムに置く」「ダイヤグラム上のノードと Palette を後から bind し直す」のどの導線でも整合するように、BOM が **間の anchor** として機能している。
+
+## 関係図
+
+```mermaid
+flowchart LR
+  subgraph CAT[Catalog 外部]
+    direction TB
+    C1[catalog entry<br/>Cisco Catalyst 9300]
+  end
+
+  subgraph PRJ[プロジェクト state]
+    direction TB
+    PE["palette entry<br/>id, source, spec, properties"]
+    B1["BOM item #1<br/>paletteId → PE<br/>nodeId → N1"]
+    B2["BOM item #2<br/>paletteId → PE<br/>nodeId → N2"]
+    B3["BOM item #3<br/>paletteId → PE<br/>nodeId: undefined"]
+  end
+
+  subgraph DIA[diagram]
+    direction TB
+    N1[node N1<br/>spec snapshot<br/>ports]
+    N2[node N2<br/>spec snapshot<br/>ports]
+  end
+
+  C1 -. 取り込み .-> PE
+  PE -- 1:N --> B1
+  PE -- 1:N --> B2
+  PE -- 1:N --> B3
+  B1 -- 1:1 --> N1
+  B2 -- 1:1 --> N2
+  B3 -. 未配置 .- DIA
+```
+
+- `B3` のような **未配置 BOM** は「数量だけ計上したいが配置はまだ」のために存在する。`placeNodeForBom(bomId)` でダイヤグラム右端に node を作って bind する。
+- `N1` / `N2` の `spec` は Palette からの **コピー（snapshot）**。Palette を編集すると bind 済みノードに **propagation** で反映される（後述）。
+
+## UI 導線
+
+入口は 3 ページに分かれているが、最終的に三角形のどれかが繋がる。
+
+```mermaid
+flowchart LR
+  subgraph S[Specs ページ]
+    SP[Palette CRUD<br/>カタログ取り込み<br/>カスタム追加]
+  end
+  subgraph BO[BOM ページ]
+    BL["BOM 行 list<br/>qty 増減 = 行追加/削除"]
+    BP["未配置 BOM の<br/>"配置" ボタン"]
+  end
+  subgraph DG[Diagram]
+    DN[ノード詳細パネル]
+    DC["canvas 上で<br/>node delete"]
+  end
+
+  SP --> BL
+  BP -- placeNodeForBom --> DG
+  DN -- bindNodeToPalette --> S
+  DC -- removeNodeBomItems --> BL
+```
+
+- **Specs ページ** — Palette のみ管理。catalog から取り込んで Palette に追加、または custom で手書き。
+- **BOM ページ** — 各 Palette エントリに対して BOM 行を増減（= 台数）。未配置の行に「配置」ボタンで diagram にノードを生成。
+- **Diagram** — 既存のノードに対して詳細パネルで Palette を当てる（`bindNodeToPalette`）。ノード削除時は `removeNodeBomItems` で対応 BOM 行も削除（`removeBomItem` 経由ではなく diagram → BOM 方向の連動）。
+
+## データモデル
+
+```mermaid
+classDiagram
+  class SpecPaletteEntry {
+    id: string
+    source: 'catalog'|'modified'|'custom'
+    catalogId?: string
+    spec: NodeSpec
+    properties?: HardwareProperties|...
+    notes?: string
+  }
+  class BomItem {
+    id: string
+    paletteId?: string
+    nodeId?: string
+    notes?: string
+  }
+  class Node {
+    id: string
+    label?
+    spec?: NodeSpec
+    ports?: NodePort[]
+    position?
+    parent?
+  }
+  class NetedProject {
+    version: 1
+    name: string
+    palette: SpecPaletteEntry[]
+    bom: BomItem[]
+    diagram: NetworkGraph
+  }
+
+  SpecPaletteEntry "1" o-- "*" BomItem : referenced by paletteId
+  BomItem "1" o-- "0..1" Node : referenced by nodeId
+  NetedProject *-- "*" SpecPaletteEntry
+  NetedProject *-- "*" BomItem
+  NetedProject *-- "1" NetworkGraph : diagram
+```
+
+- **`paletteId` / `nodeId` は両方 optional**。これが「未確定状態を一級市民として扱う」設計の核。
+  - `paletteId == null && nodeId != null` — ダイヤグラムだけある（未 bind ノード）
+  - `paletteId != null && nodeId == null` — 数量だけある未配置 BOM
+  - 両方 set — 通常の bind 済み状態
+- **Node は Palette を直接参照しない**。`spec` は値の snapshot。これで diagram-only の YAML 入力も成立し、Palette が無くてもノードは描ける。
+
+### NetedProject ファイル
+
+`.neted.json` がプロジェクトの保存単位で、3 つを束ねる：
+
+```json
+{
+  "version": 1,
+  "name": "campus-net",
+  "palette": [...],
+  "bom": [...],
+  "diagram": { "nodes": [...], "links": [...], "subgraphs": [...] }
+}
+```
+
+- 「Import Project」は 3 つ全部を上書き。
+- 「Import Diagram」は `diagram` のみ上書き、palette / bom は据え置き（カタログ管理を壊さないため）。
+
+## 伝播ルール
+
+Palette → Node、Node → BOM、BOM → Node の各方向で起きることを揃えておく。
+
+| 操作 | 伝播 | 理由 |
+| --- | --- | --- |
+| `addToPalette(entry)` | なし | Palette 追加だけ。bind は別アクション |
+| `updatePaletteEntry(id, { spec })` | bind 済み全 Node の `spec` を上書き、ports も再生成 | Figma 的 — コンポーネント編集 = 全インスタンス更新 |
+| `updatePaletteEntry(id, { properties / catalogId })` | bind 済み全 Node の ports を再生成 | catalog からの port 派生が変わるため |
+| `removeFromPalette(id)` | bind 済み Node の `spec` から **製品詳細だけ剥がし**、role（kind/type）は残す。BOM 行は削除 | Palette が消えても "switch（hardware/network）" のような **役割** は失わない |
+| `addBomItem(item)` | なし | 台数増加だけ |
+| `removeBomItem(id)` | `nodeId` があればダイヤグラムから node + 関連 port + link を削除 | BOM が真の master。BOM 行を消す = 物理機材を撤去するのと同じ意味 |
+| `bindNodeToBom(bomId, nodeId)` | Node.spec を Palette から再 snapshot、ports を再生成 | bind 確立時に一度同期させる |
+| `unbindNodes([nodeId])` | Node.spec の製品詳細を剥ぐ（role は残す）、ports クリア | Palette 切り離しは "role だけ残った状態" に戻す |
+| `bindNodeToPalette(nodeId, paletteId)` | 既存 BOM 行があれば `paletteId` 差し替え、なければ未配置 BOM を流用、それも無ければ新規 BOM 作成 | 「すでに bind されてる → 再 bind」「未配置在庫があれば消費」「無ければ新規」の 3 パターン |
+| `placeNodeForBom(bomId)` | 新 Node 作成（`computeNodeSize` + `resolvePosition` で右端に配置）、Palette spec / ports を当てる、BomItem.nodeId を埋める | 未配置 BOM 行 → ダイヤグラム配置の片方向 |
+| ダイヤグラムで node 削除 | `removeNodeBomItems([nodeId])` で対応 BOM 行を **削除** | 機材の撤去と整合 |
+
+「**unbind と remove の違い**」が要点：
+
+- **unbindNodes** — Node は残る、BOM 行も残る（`nodeId` を null に）、両者の関係だけ切れる。Palette だけ間違えてた、もう一度別の Palette を当てたい、というケース。
+- **removeBomItem** — BOM 行を削除し、bind 済みなら **Node も削除する**。台数管理上「無くなった」を意味するので、ダイヤグラム上にも残してはいけない。
+- **removeNodeBomItems** — Node が削除されたとき、対応 BOM 行を削除する逆向き。BOM 行を残してしまうと「このノードは無いのに BOM では計上されている」というドリフトが発生する。
+
+### 「製品詳細」と「役割」の分離
+
+`stripProductFromSpec(spec)` は次のように **role だけ残す**：
+
+```ts
+hardware: { kind, type }                    // vendor / model / series 等を捨てる
+compute:  { kind, type }                    // platform 等を捨てる
+service:  { kind, service }                 // resource / vendor 等を捨てる
+```
+
+これがあるおかげで：
+
+- Palette 削除しても「これは switch だ」「これは server だ」という **拓扑的に意味のある情報**は失われない。レイアウトもそのまま動く。
+- 接続バリデーション（`validateLinkCompatibility`）は port.cage を見るので、ports が落ちている間は静かに pass する。
+
+## PoE 予算
+
+PoE 予算解析は **Catalog の properties.power** だけを参照し、ノード instance（`Node.ports[].poe`）には capability flag のみ持たせる。
+
+```mermaid
+flowchart LR
+  N[Node] --> NP[Node.ports[].poe<br/>boolean のみ]
+  N -. paletteId 経由 .-> PA[palette entry]
+  PA --> CA[catalog entry]
+  CA --> PR[PowerProperties<br/>poe_in / poe_out]
+  PR --> A[poe-analysis.ts<br/>computePortPower<br/>budget 集計]
+```
+
+- ノードに duplicate して持たない理由は「Palette を差し替えるたびに class / 電力値も更新したい」「per-instance に持つと catalog 更新で取り残される」の 2 点。
+- `poe-analysis.ts` の `computePortPower` は **PSE と PD の min(class)** で実効クラスを決め、`reserved_w` を予算に積み上げる。`draw_w` は max-class の参考値で予算には使わない。
+- BOM 経由で Palette → catalog を辿るので、未 bind ノードや未割当 BOM があれば PoE 解析からは黙って除外される。
+
+## 設計のステータス
+
+主要な双方向同期は landed。残るのは UX レベルの隙間と、未配置 BOM の発見性。
+
+| 項目 | 状態 | issue / PR |
+| --- | --- | --- |
+| Palette / BOM / Node の三角形 | ✅ | #b9164c6（BomItem 導入）|
+| Palette spec → Node spec 伝播 | ✅ | `updatePaletteEntry` |
+| Palette ports → Node ports 伝播 | ✅ | `setNodePortsFromPalette` |
+| Node 削除 ↔ BOM 行削除の双方向 | ✅ | #435583f |
+| Palette 削除時に role だけ残す | ✅ | `stripProductFromSpec` |
+| 未配置 BOM の「配置」ボタン | ✅ | `placeNodeForBom` |
+| `bindNodeToPalette` の 3 パターン分岐 | ✅ | 既存再 bind / 未配置流用 / 新規 |
+| .neted.json で 3 つを束ねて save/load | ✅ | #d1a80f0 |
+| Diagram-only Import（palette / bom 据え置き）| ✅ | `importDiagram` |
+| BOM 行の qty カラム（行を 1 個にして N 持つ） | ❌ | 現状は 1 行 = 1 台。台数 3 のものは 3 行に展開される |
+| Palette 編集の undo / redo | ❌ | 履歴系全般が未実装 |
+| `properties` per-instance override | ❌ | BomItem.notes だけはある。spec / properties レベルの override は未対応 |
+| 未配置 BOM の visual 表示（diagram 側に "未配置" pill） | ❌ | 現状は BOM ページ内のみ |
+
+「BOM 行 = 1 台」の決定は、後で qty 列を入れたくなったら `BomItem.quantity?: number` を足して `placeNodeForBom` で複数 nodeId を生やす、という拡張の余地はある。現状は「物理機材 1 台 1 行」の方が直感的なので据え置き。
+
+## 実装履歴（PR ベース）
+
+- **#9a279f1** — Spec Palette / BOM / Connections の 3 ページを並列追加（初期形）。
+- **#b9164c6** — `BomItem` モデル導入。それまで Palette → Node 直結だったところに「device instance」中間層を挟む。
+- **#13d9239** — Spec 詳細ページ、サンプル palette 充実。
+- **#9568643** — `/project/[id]/` ベースのルーティングへ移行。3 ページが project スコープに入る。
+- **#d1a80f0** — `.neted.json` 形式を確定。`NetedProject = { palette, bom, diagram }`。
+- **#435583f** — Diagram ↔ BOM の双方向同期。`removeNodeBomItems` / `removeBomItem` の対称化、`bindNodeToBom` 経由の spec propagation。
+- **#3a1240f** — diagram state を 1 オブジェクトに統合（`diagram.nodes` / `diagram.subgraphs` / `diagram.ports` / `diagram.links` / `diagram.bounds`）。
+- **#45975f7** — save 形式を `NetworkGraph` 直書きに整理し、palette / bom と並列なフィールドにする（DiagramJson の中間ラッパを廃止）。
+- **#17d6ab5** — ID 生成を `newId()` factory に集約。Palette / BOM / Node / Port の id 生成入口を一本化。
+- **#148** — Import を 2 形式に分割：「Import Project」（`.neted.json`、palette/bom/diagram 全部上書き）と「Import Diagram」（`NetworkGraph` のみ上書き、palette/bom 据え置き）。
+
+## コード上の場所
+
+- `apps/editor/src/lib/types.ts` — `SpecPaletteEntry` / `BomItem` / `NetedProject` / `NETED_FILE_EXTENSION`、`paletteEntryLabel` / `specIdentifier` ヘルパ。
+- `apps/editor/src/lib/context.svelte.ts` — runtime state の本体。
+  - Palette: `palette` / `addToPalette` / `removeFromPalette` / `updatePaletteEntry`
+  - BOM: `bomItems` / `addBomItem` / `removeBomItem` / `updateBomItem` / `bindNodeToBom` / `getBomItemsForPalette` / `getPaletteIdForNode` / `getNodesForPalette` / `unbindNodes` / `removeNodeBomItems` / `bindNodeToPalette` / `placeNodeForBom`
+  - 伝播ヘルパ: `setNodeSpecs` / `setNodePortsFromPalette` / `nodePortsFromPaletteEntry` / `stripProductFromSpec`
+  - reconcile: `sanitizePaletteAndBom`（import 時の orphan 排除）
+  - I/O: `exportProject` / `importProject` / `importDiagram` / `applyYaml` / `loadProject`
+- `apps/editor/src/lib/poe-analysis.ts` — `computePortPower` / `PoEBudget`、catalog 経由で PoE 予算解析。
+- `apps/editor/src/routes/project/[id]/(content)/specs/+page.svelte` — Palette ページ。
+- `apps/editor/src/routes/project/[id]/(content)/specs/[specId]/+page.svelte` — Spec 詳細。
+- `apps/editor/src/routes/project/[id]/(content)/bom/+page.svelte` — BOM ページ。
+- `apps/editor/src/routes/+page.svelte` — Project 一覧、`.neted.json` Import / Diagram Import の 2 タブ。

--- a/apps/editor/docs/layout-model.md
+++ b/apps/editor/docs/layout-model.md
@@ -1,0 +1,230 @@
+## レイアウトモデル
+
+ノードを画面上に置く仕組み。"画面のどこに何を置くか" を決める入口は **二つだけ** に整理されていて、その下に Sugiyama スタイルのパイプラインと libavoid のエッジルータが入っている。
+
+メンタルモデルは「**幾何的配置**」「**構造的配置**」「**境界跨ぎ**」の三つで成り立ちます。
+
+- **幾何的配置** — `placeNode`。1 つの未配置ノードを「ユーザがクリックした座標」に置く。link 構造は **無視** する（ぶつからない一番近い点に snap するだけ）。drop / paste / BOM → diagram といった "周りを動かしたくない" 操作のための primitive。
+- **構造的配置** — `layoutNetwork`。NetworkGraph 全体に Sugiyama パイプライン（cycle 除去 → layer → 順序 → 座標）を流して、リンクのフローに沿って全ノードを並び替える。YAML import 後の初期レイアウト、Auto-arrange、選択範囲整列に使う。
+- **境界跨ぎ** — subgraph をネスト容器として扱った compound 拡張。子コンテナを再帰的にレイアウトしてから親レベルでまとめる。コンテナを跨ぐリンクは共通祖先のレベルに **昇格** されるので、container 同士の配置にも link 情報が効く。
+
+二つの入口を意図的に分けているのは「O(障害物数) の幾何問題」と「O(V + E) の構造問題」を一つの関数に押し込めると、ユーザ操作のたびに full re-layout が走ってしまうため。`placeNode` は cheap、`layoutNetwork` は expensive、と覚えておけば呼び分けで迷わない。
+
+## 関係図
+
+二つの API がそれぞれどこで何を見るかを 1 枚にすると、次のようになる。
+
+```mermaid
+flowchart TB
+  subgraph G[幾何的配置 placeNode]
+    direction LR
+    PI[node + initial xy]
+    PO[obstacles<br/>= 周囲の node + subgraph 境界]
+    PR[resolvePosition<br/>nearest non-overlapping]
+    PI --> PR
+    PO --> PR
+  end
+
+  subgraph S[構造的配置 layoutNetwork]
+    direction LR
+    SI[NetworkGraph 全体]
+    SP[Sugiyama pipeline<br/>4 phases]
+    SC[layoutCompound<br/>subgraph 再帰]
+    SF[fixed snap<br/>+ rebalanceSubgraphs]
+    SI --> SC --> SP --> SF
+  end
+
+  PR -. 共有 .-> CN[computeNodeSize]
+  SF -. 共有 .-> CN
+  SF -. 共有 .-> PP[placePorts<br/>direction-aware<br/>HA pair perpendicular]
+```
+
+`placeNode` は障害物を見るだけで link を見ない。`layoutNetwork` は link を見て layer を決め、その後ポート配置と subgraph bounds を再計算する。両者ともノードのサイズは `computeNodeSize`（label + icon + port count）で揃えている。
+
+## Sugiyama パイプライン
+
+`layoutNetwork` の核心は `sugiyama/` 配下の四段パイプライン。各段は独立した純関数になっていて、`compose.ts` の `layoutFlat` がこれを順番に流すだけ。
+
+```mermaid
+flowchart LR
+  N["nodes + edges<br/>(任意の有向グラフ)"] --> C[1. cycles.ts<br/>removeCycles]
+  C --> L[2. layers.ts<br/>assignLayers]
+  L --> O[3. ordering.ts<br/>reduceCrossings<br/>barycenter iterations]
+  O --> X[4. coords.ts<br/>assignCoordinates<br/>forward + backward 平均]
+  X --> P[Map of<br/>NodeId → Position]
+```
+
+- **Phase 1 — cycles**: フィードバックエッジを反転して DAG を作る。元の向きは `reversedEdges` で別途返す（renderer が必要なら使う）。
+- **Phase 2 — layers**: 縦軸（TB なら y）方向の層を整数で割り当てる。長辺は仮想ノードを挟まずに飛ばしている。
+- **Phase 3 — ordering**: 層内順序を barycenter iteration で交差最小化。`iterations` で反復回数を制御。
+- **Phase 4 — coords**: 層 + 順序 → 絶対座標。**barycenter-aligned** モードでは、各非ソースノードの希望 x を「親層での親ノードたちの平均 x」とし、forward pack（左寄せ）と backward pack（右寄せ）を **両方走らせて平均** する（Brandes-Köpf を 4 → 2 alignment に縮約）。これで「親 1 つに対して兄弟 2 つ」のときに兄弟が中央に揃う。
+
+二パスを平均しても重ならない理由は単純で、各入力が個別に non-overlap を満たしている → 隣接ノード `a, b` の x ギャップ制約は両入力で線形に成立 → 平均しても保たれる。
+
+### コンパウンド（subgraph 再帰）
+
+`compound.ts` の `layoutCompound` は subgraph をネスト容器として扱う。**bottom-up** に処理する。
+
+```mermaid
+flowchart TB
+  subgraph CO[layoutCompound]
+    direction TB
+    D[subgraph を depth で sort<br/>leaf-most から処理]
+    D --> LF["各 subgraph で<br/>layoutFlat(直接の子)<br/>→ 子の bounds 確定"]
+    LF --> SU[親レベルでは<br/>子 subgraph を<br/>"compound node" として扱う<br/>size = 子の bounds + padding + label]
+    SU --> P[親レベルで layoutFlat<br/>→ 親の中での position 確定]
+    P --> SH[各 subgraph 内の中身を<br/>shift して整合]
+  end
+```
+
+- 葉の subgraph から始め、`layoutFlat` で内部を解いて bounds を測る。
+- 親はその bounds を「単一ノードのサイズ」として扱い、リーフノードと並べて `layoutFlat` を流す。
+- 親レイアウトが終わったら、子 subgraph の中身を delta で shift して全体を整合させる。
+- **コンテナを跨ぐエッジ**は、`network-layout.ts` の `buildCompoundEdges` で **共通祖先レベルへ昇格** される。`sg1 内の deep node → sg2 内の deep node` は親レベルでは `sg1 → sg2` として layer に効く。これがないとコンテナ同士は link 情報を持たずバラバラに配置される。
+- HA 冗長 link（`link.redundancy`）は layer assignment から **除外** する。フロー方向を持たないので layer に効かせると pair の縦方向が崩れる。代わりに `placePorts` が perpendicular 方向のサイドを割り当てる。
+
+## オプション設計
+
+`NetworkLayoutOptions` は **直交する 2 つの constraint** を持つ。両方とも空が legacy 動作（全部レイアウト任せ）。
+
+| オプション | 種類 | 何をするか |
+| --- | --- | --- |
+| `fixed: Set<string>` | **hard pin** | Sugiyama を普通に流したあと、このセットに入っている各ノードを **入力の `position` にスナップ** で戻す。ポートも同じ delta で動かす。subgraph bounds は `rebalanceSubgraphs` で再計算 |
+| `hints: Map<string, {x}>` | **soft hint** | `assignCoordinates` 内で「親の barycenter」の代わりにこの x を希望値として使う。隣との詰め込みは普通に走るので、近所が混んでいれば最終 x はずれる。y は層が決めるので無視 |
+| `direction` | フロー方向 | TB / BT / LR / RL。座標は TB で計算してから rotate |
+| `gap` / `topLevelGap` | 間隔 | 層内ギャップ / 層間ギャップ |
+| `subgraphPadding` / `subgraphLabelHeight` | 入れ子余白 | container の内側余白とラベル高 |
+| `nodeWidth` / `minPortSpacing` | ノードサイズ下限 | port 数が多いノードはこの最小ピッチで横に伸びる |
+
+`fixed` と `hints` は **両立** する。「これは絶対動かさない」（fixed）と「これくらいの x に置きたい」（hints）はレイヤが違う。
+
+### 使い分け早見表
+
+| シーン | 使う API | オプション |
+| --- | --- | --- |
+| YAML import 直後 | `layoutNetwork` | （なし） |
+| 「Auto-arrange」ボタン | `layoutNetwork` | （なし） |
+| 「選択範囲だけ整列」 | `layoutNetwork` | `fixed = 選択外のノード全部` |
+| 「特定の x に寄せたい」 | `layoutNetwork` | `hints = Map(node → {x})` |
+| ユーザが drop した位置に新ノード | `placeNode` | （障害物 collision のみ） |
+| BOM → diagram の 1 個変換 | `placeNode` | （障害物 collision のみ） |
+| paste at cursor | `placeNode` | （障害物 collision のみ） |
+
+## ポート配置
+
+ノードの位置が決まったあと、ポートをノードの **どの辺に何個並べるか** を決めるのが `port-placement.ts`。
+
+```mermaid
+flowchart LR
+  L[links] --> H[detectHAPairs<br/>redundancy フィールド]
+  L --> N[normal links]
+  L --> HL[HA links]
+  N --> NS["normalSides(direction)<br/>TB: src=bottom, dst=top"]
+  HL --> HS["haSides(direction)<br/>TB: src=right, dst=left"]
+  NS --> A[assignPortSides]
+  HS --> A
+  A --> G[group by node:side]
+  G --> CP["computePortPosition<br/>(index+1)/(total+1)"]
+```
+
+- normal リンクは direction に沿った辺（TB なら上下）。
+- **HA 冗長**ペアは perpendicular（TB なら左右）。pair 検出は `detectHAPairs` が `[from, to].sort().join(':')` を Set に入れて行う。
+- 同じ side に乗ったポート同士は `(i+1)/(total+1)` の等比で並ぶ。3 ポートなら 1/4, 2/4, 3/4 の位置。
+
+## データモデル
+
+`layoutNetwork` の入出力。入力は normal な `NetworkGraph`、出力はランタイム表示用の `NetworkLayoutResult` で、これを `computeNetworkLayout` が `routeEdges`（libavoid）に通して最終的な `ResolvedLayout` を作る。
+
+```mermaid
+classDiagram
+  class NetworkGraph {
+    name: string
+    nodes: Node[]
+    links: Link[]
+    subgraphs?: Subgraph[]
+    settings?: NetworkSettings
+  }
+  class NetworkLayoutOptions {
+    direction?: Direction
+    gap?: number
+    topLevelGap?: number
+    fixed?: Set string
+    hints?: Map id -&gt; xhint
+  }
+  class NetworkLayoutResult {
+    nodes: Map id -&gt; Node
+    ports: Map id -&gt; ResolvedPort
+    subgraphs: Map id -&gt; Subgraph
+    bounds: Bounds
+  }
+  class ResolvedLayout {
+    nodes
+    ports
+    edges: Map id -&gt; ResolvedEdge
+    subgraphs
+    bounds
+    metadata
+  }
+
+  NetworkGraph --> NetworkLayoutResult : layoutNetwork
+  NetworkLayoutOptions ..> NetworkLayoutResult : tunes
+  NetworkLayoutResult --> ResolvedLayout : routeEdges adds edges
+```
+
+`computeNetworkLayout` がこの 2 段（layout → routing）をまとめる薄いラッパで、サーバ / CLI / renderer-html / renderer-svg 共通の入口になっている。エディタは `computeNetworkLayout` を直接呼んで `ResolvedLayout` をそのまま消費する（HTML renderer 用の legacy `LayoutEngine.layoutAsync` は createNetworkLayoutEngine 経由で残してある）。
+
+## 設計のステータス
+
+主要な抽象は landed。`placeNode` / `layoutNetwork` の二系統に整理されており、Sugiyama パイプラインは段階別の純関数になっている。
+
+| 項目 | 状態 | issue / PR |
+| --- | --- | --- |
+| placeNode（幾何）と layoutNetwork（構造）の API 分離 | ✅ | #141 で commentary を追加 |
+| Sugiyama 4 phases（cycles → layers → ordering → coords） | ✅ | #135-#138 |
+| 共通 `SugiyamaOptions` への型統合 | ✅ | #140 |
+| `layoutCompound` で subgraph 再帰 | ✅ | #137 |
+| `fixed` オプション | ✅ | #134 |
+| `hints` オプション | ✅ | #141 |
+| barycenter-aligned 座標（forward + backward 平均） | ✅ | #138 |
+| 共有幾何型を `models/types.ts` に集約 | ✅ | #139 |
+| HA pair → perpendicular ポート配置 | ✅ | port-placement.ts |
+| 共通祖先への cross-container edge 昇格 | ✅ | network-layout.ts |
+| エッジ経路の libavoid ルーティング | ✅ | libavoid-router.ts |
+| layer assignment が長辺で仮想ノードを使わない | ⚠️ | 仮想ノード入れれば交差最適化の精度が上がるが現状で実用十分 |
+| `coords.ts` の `hints` がローカル座標系前提 | ⚠️ | doc に明記。グローバル座標で深い node を hint したい場合は `fixed` を使う |
+| spline 風エッジ | ❌ | 設定としては受けるが現状は polyline に縮退 |
+
+## 実装履歴（PR ベース）
+
+このパイプラインは段階的に landed したので、各層がいつ入ったかを追えるようにしておく：
+
+- **#133 — Auto-arrange ボタン**: エディタ側の入口。当初は ELK ベースの一発レイアウトで、後段で Sugiyama に置き換えられた。
+- **#134 — `fixed` オプション**: 「選択外を pin」を可能にする。最初は `Map<id, Position>` の hard 制約として実装、Sugiyama 移行時に `Set<id>`（入力 position をそのまま使う）に簡略化。
+- **#135 — Sugiyama foundation**: cycle removal + layer assignment（phase 1, 2）を分離関数として導入。既存 ELK 経路と並走。
+- **#136 — Sugiyama phases 3-4**: crossing reduction + coordinate assignment（barycenter iterations + 単純 left-pack）。
+- **#137 — Compound + composition**: `layoutFlat` で 4 phase を合成し、`layoutCompound` で subgraph 再帰を導入。
+- **#138 — barycenter-aligned coords**: 単純 left-pack だと siblings が center に揃わない問題を Brandes-Köpf 風の forward + backward 平均で解決。
+- **#139 — 幾何型の統合**: `Position` / `Bounds` / `Size` / `Direction` を `models/types.ts` に集約し、各 layout モジュールから重複定義を削除。
+- **#140 — Option tower の崩壊**: `LayoutFlatOptions` / `CompoundOptions` / `AssignCoordinatesOptions` の重複を `SugiyamaOptions` 一つに統合。
+- **#141 — `hints` + 二 API split を文書化**: `assignCoordinates` に soft hint を追加、`placeNode` と `layoutNetwork` の役割分担を JSDoc で明示。
+
+`#143`（hierarchical sheet drill-down）以降は layout 自体は触らず、`buildChildSheetGraph` が **layout-free** に子シートの NetworkGraph を作って `computeNetworkLayout` に再投入する形になっている。シート側で独自レイアウトを持たないことで、Sugiyama の改良がそのままシートにも効く。
+
+## コード上の場所
+
+- `libs/@shumoku/core/src/layout/network-layout.ts` — `layoutNetwork`（公開 main entry）、`computeNodeSize`、`buildCompoundEdges`（共通祖先昇格）、`applyFixedOverride`、`countPortsPerNode`。
+- `libs/@shumoku/core/src/layout/sugiyama/` — 4 phase の純関数と合成。
+  - `cycles.ts` — `removeCycles`
+  - `layers.ts` — `assignLayers`
+  - `ordering.ts` — `reduceCrossings`
+  - `coords.ts` — `assignCoordinates`（barycenter-aligned + hints 受け）
+  - `compose.ts` — `layoutFlat`、`SugiyamaOptions`
+  - `compound.ts` — `layoutCompound`（subgraph 再帰）
+- `libs/@shumoku/core/src/layout/port-placement.ts` — `placePorts`、`detectHAPairs`、`computePortPosition`。
+- `libs/@shumoku/core/src/layout/interaction.ts` — `placeNode`（公開、幾何プリミティブ）、`moveNode`、`resolveNodePosition`、`rebalanceSubgraphs`、`collectObstacles`。
+- `libs/@shumoku/core/src/layout/libavoid-router.ts` — `routeEdges`（WASM）、`ensureLibavoidLoaded`。
+- `libs/@shumoku/core/src/layout/unified-engine.ts` — `computeNetworkLayout`（layout + routing 一括）、`createNetworkLayoutEngine`（legacy interface）。
+- `libs/@shumoku/core/src/layout/resolved-types.ts` — `ResolvedLayout` / `ResolvedEdge` / `ResolvedPort`。
+- `libs/@shumoku/core/src/models/types.ts` — `Position` / `Bounds` / `Size` / `Direction` の幾何共有型。
+- `apps/editor/src/lib/context.svelte.ts` — `autoArrange`（`layoutNetwork` 直接呼び出し）、`placeNodeForBom`（`resolvePosition` 経由で BOM → diagram 変換時のノード配置）、`switchSheet`（child sheet で `computeNetworkLayout`）。
+- `docs/ARCHITECTURE.md` — レイアウトエンジンの bird's-eye view。

--- a/apps/editor/docs/sheet-model.md
+++ b/apps/editor/docs/sheet-model.md
@@ -1,0 +1,203 @@
+# シートモデル
+
+階層的なネットワーク図を「ページの束」として扱う仕組み。KiCad のシート機能と同じ発想で、トップレベルの subgraph をクリックするとそのサブグラフ内部だけを丸ごと「子シート」として開き、外部とのリンクは境界に **export connector** として現れる。
+
+メンタルモデルは「Root シート」「子シート」「境界接続点」の三つで成り立ちます。
+
+- **Root シート** — ダイヤグラム全体を 1 枚に描いた表示。subgraph はその場で容器として描かれ、内部の node もそのまま見える。これまでのエディタはこれしか無かった。
+- **子シート** — トップレベル subgraph 1 つを取り出して、そのサブグラフの直接の子をルートに昇格して描く。subgraph 自身の枠は描かれず、内部 subgraph はネスト容器として残る。
+- **境界接続点** — 子シート内側のノードと外側のノードを繋ぐリンクは、内側からは「外への管」として扱う。これを stadium 形（`shape: 'stadium'`）の **export connector** ノードに置き換え、相手シート名をラベルにする。
+
+切替は `SheetBar`（画面下中央）で行う。状態は `diagramState.currentSheetId` に乗り、`null` が Root、それ以外は subgraph id。シート遷移は同期的に state を反映し、レイアウトの計算は非同期で完了次第 `sheetView` に流し込まれる。
+
+## 関係図
+
+Root と子シートの間で起きていることを 1 枚にすると、**フィルタ + プロモート + 連結器置換** の 3 つに分解できる。
+
+```mermaid
+flowchart TB
+  subgraph R[Root シート]
+    direction LR
+    SG1["subgraph<br/>perimeter"]
+    SG2["subgraph<br/>campus"]
+    N1[router]
+    SG1 --- LK1[link]
+    LK1 --- N1
+    N1 --- LK2[link]
+    LK2 --- SG2
+  end
+
+  R -->|drill-in to perimeter| C[子シート perimeter]
+
+  subgraph C[子シート perimeter]
+    direction LR
+    SGI["nested<br/>subgraph<br/>edge"]
+    NI[isp1]
+    EXP{{"export connector<br/>'campus'"}}
+    SGI --- LKI[link]
+    LKI --- NI
+    NI --- LKE[link via export]
+    LKE --- EXP
+  end
+```
+
+- 子シート構築時、**トップレベル subgraph の直接子（node + nested subgraph）だけをフィルタ**する。
+- ノード id とサブグラフ id は **prefix を剥がす**（例: `perimeter/edge` → `edge`、`perimeter/security` → `security`）。表示上ローカルな名前空間に正規化される。
+- リンクは両端が子シート内に閉じているものだけを残す。**境界を跨ぐリンク**は、外側の終端を相手 subgraph に置き換えた **export connector ノード** に差し替える（`__export_perimeter_to_campus_…` のような id）。dashed line で描画される。
+
+## UI 導線
+
+`SheetBar` は Root + トップレベル subgraph 各 1 つでタブ化される。クリックでそのシートに drill-in、もう一度 Root を押すと戻る。
+
+```mermaid
+flowchart LR
+  S0[Root タブクリック] --> SR[Root シート表示]
+  S1[子シート タブクリック] --> CK{cache hit?}
+  CK -- yes --> CA[applyResolvedLayout]
+  CK -- no --> CB[buildChildSheetGraph<br/>computeNetworkLayout<br/>cache 保存]
+  CB --> CA
+  CA --> RD[renderer 切替]
+  SR --> RD
+  RD --> ED[ユーザ閲覧<br/>編集は View モード強制]
+```
+
+- 子シート中は `editorState.mode` を強制的に `'view'` 扱いにする。`renderer` は `bind:` で `sheetView` のマップに書き戻すため、編集を許すと root canonical state に届かないままシート切替で消える。Layer 2（`#145`）で書き戻しを実装するまでは読み取り専用。
+- ネスト drill-in（子シート内の subgraph をさらにクリックして開く）は未実装。トップレベル subgraph のみが `availableSheets` に挙がる。`#144` 参照。
+- export connector ノードはクリックしても何も起きない。本来は相手シートに飛ばしたい（`#144` のスコープに含まれる）。
+
+## データモデル
+
+ランタイム状態は **Root とシートで二重持ち**にし、renderer は `activeView` getter 経由で active な側にバインドする。Root の編集は `diagram` を直接書き換え、シートの再構築は `sheetView` を別個に書き換える。
+
+```mermaid
+classDiagram
+  class diagramState {
+    currentSheetId: string ?
+    activeView: get
+    switchSheet(id) async
+    invalidateSheetCache()
+  }
+  class diagram {
+    nodes: SvelteMap
+    subgraphs: SvelteMap
+    ports: SvelteMap
+    edges: SvelteMap
+    bounds
+    links
+  }
+  class sheetView {
+    nodes: SvelteMap
+    subgraphs: SvelteMap
+    ports: SvelteMap
+    edges: SvelteMap
+    bounds
+    links
+  }
+  class sheetCache {
+    Map id -> ResolvedLayout
+    sheetCacheGeneration
+  }
+  class sheetLinkCache {
+    Map id -> Link[]
+  }
+
+  diagramState ..> diagram : exposes when sheet=null
+  diagramState ..> sheetView : exposes when sheet!=null
+  diagramState *-- sheetCache : reuses
+  diagramState *-- sheetLinkCache : reuses
+```
+
+`activeView` getter:
+
+```ts
+get activeView() {
+  if (currentSheetId === null) return diagram
+  return sheetView
+}
+```
+
+`+page.svelte` は単に `bind:nodes={diagramState.activeView.nodes}` のように書く。バインド先が `diagram` か `sheetView` かは getter が切替えるため、renderer 側の実装は変更不要。
+
+### `sheetCache` の世代管理
+
+子シートのレイアウトは Root のグラフ構造に依存する。**構造的な変更**（node / subgraph の追加削除、parent の付け替え、link の追加削除更新）が起きたら全シートのキャッシュは無効。**位置だけの変更**（drag、auto-arrange、ラベル編集）はシート構造に影響しないため無効化しない。
+
+| 操作                              | invalidate するか                  |
+| --------------------------------- | ---------------------------------- |
+| `applyGraph`（load 全置換）       | ✅ する                              |
+| `addLink` / `updateLink` / `removeLink` | ✅ する                        |
+| `updateNode({ parent: ... })`     | ✅ する（parent 変更時のみ）        |
+| `updateSubgraph({ parent: ... })` | ✅ する（parent 変更時のみ）        |
+| `moveNodeToGroup`                 | ✅ する                              |
+| `removeBomItem`（Node も削除）    | ✅ する                              |
+| renderer の `onnodeadd` / `onnodedelete` | ✅ する（`+page.svelte` で明示） |
+| ノード drag / autoArrange         | ❌ しない（位置のみ）                |
+| label / spec / link bandwidth 等の visual 変更 | ❌ しない                |
+
+`sheetCacheGeneration` カウンタは、**非同期で動いている `switchSheet` の途中で root が書き換わった**ケースを検出する。`switchSheet` が `computeNetworkLayout` を await している間に invalidate が走ると generation が増え、戻り値はもう信用できない → そのまま捨てる：
+
+```ts
+const generation = sheetCacheGeneration
+const childGraph = buildChildSheetGraph(rootGraph, id)
+const { resolved } = await computeNetworkLayout(childGraph)
+if (currentSheetId !== id || generation !== sheetCacheGeneration) return
+sheetCache.set(id, resolved)
+applyResolvedLayout(sheetView, resolved, childGraph.links)
+```
+
+stale guard は二段：`currentSheetId !== id`（ユーザが別タブを押した）と `generation !== sheetCacheGeneration`（root が変わった）。
+
+### `buildChildSheetGraph`
+
+`@shumoku/core/hierarchical.ts` から export される **layout-free** な関数。Root の `NetworkGraph` と subgraph id を受け取り、子シートの `NetworkGraph` を返す。レイアウトはやらない。ID prefix の剥離、export connector ノード生成、cross-boundary link の dashed link への置換、すべてここで完結する。
+
+エディタが `computeNetworkLayout` を直接呼ぶことで、`createNetworkLayoutEngine()` 経由の legacy interface（`LayoutEngine.layoutAsync`）を回避し、Sugiyama pipeline と一貫させている。
+
+## ロード経路
+
+`switchSheet` の流れ：
+
+```mermaid
+flowchart TD
+  S[switchSheet&#40;id&#41;] --> V{id is null?}
+  V -->|yes| C0[sheetView クリア<br/>currentSheetId = null]
+  V -->|no| K[currentSheetId = id]
+  K --> H{cache hit?}
+  H -->|yes| AP[applyResolvedLayout<br/>cached]
+  H -->|no| BG[buildChildSheetGraph]
+  BG --> CL[computeNetworkLayout]
+  CL --> SG{generation OK<br/>currentSheetId still id?}
+  SG -->|no| DR[結果を捨てる]
+  SG -->|yes| ST[sheetCache.set<br/>applyResolvedLayout]
+```
+
+`applyResolvedLayout` ヘルパは `sheetView` の SvelteMap identity を保ったまま中身を入れ替える（`replaceMap`）。renderer の `bind:` 接続が切れない。
+
+## 設計のステータス
+
+主要な機能は landed、UX 上の隙間と編集機能が残課題。
+
+| 項目                                        | 状態 | issue           |
+| ------------------------------------------- | ---- | --------------- |
+| Root + トップレベル subgraph の drill-in   | ✅    | #143 で実装済   |
+| Cache + structural-only invalidation        | ✅    | #143 で実装済   |
+| Boundary export connector の表示            | ✅    | core から流用   |
+| 子シート中の **書き戻し編集**               | ❌    | `#145`（要 #98）|
+| **ネスト drill-in**（子の中の subgraph）   | ❌    | `#144`           |
+| Cache 構造の polish（2 Map → 1 Map 等）     | ❌    | `#146`           |
+| Breadcrumb / parent 表示                    | ❌    | `#144` のスコープ |
+| 子シートで add node 時の自動 parent 設定    | ❌    | Layer 2 領域     |
+
+`#145` は renderer の operations separation（`#98`）に依存。それまでは sub-sheet 中は強制 View モード。
+
+## 実装履歴（PR ベース）
+
+- **#143** — Layer 0（state plumbing + SheetBar 機能化）と Layer 1（KiCad 的 drill-down）を 2 commit で landed。`buildHierarchicalSheets` 経由の重い経路で動かしてからすぐに `buildChildSheetGraph` + `computeNetworkLayout` 直接 + cache に置換。
+
+## コード上の場所
+
+- `libs/@shumoku/core/src/hierarchical.ts` — `buildChildSheetGraph`（公開）、`buildChildSheet` / `buildHierarchicalSheets`（HTML renderer 向け、layout 込み）、`generateExportConnectors`（境界 connector 生成）。
+- `apps/editor/src/lib/context.svelte.ts` — `currentSheetId` / `sheetView` / `sheetCache` / `sheetLinkCache` / `sheetCacheGeneration`、`switchSheet` / `availableSheets` / `activeView` / `invalidateSheetCache`、`applyResolvedLayout` ヘルパ。
+- `apps/editor/src/lib/components/SheetBar.svelte` — Root + 子シートのタブ UI。
+- `apps/editor/src/routes/project/[id]/diagram/+page.svelte` — `bind:nodes={diagramState.activeView.nodes}`、子シート時の View モード強制、renderer イベントから `invalidateSheetCache` 呼び出し。
+- `docs/ARCHITECTURE.md` — リポジトリ全体俯瞰の中の "Known gaps" 節。


### PR DESCRIPTION
## Summary

`apps/editor/docs/` に 3 本追加。`connection-model.md` と同じ構成（mental model → 関係図 → UI 導線 → データモデル → 設計のステータス → 作業ログ → コード上の場所）。

- **sheet-model.md** — Root + 子シート + 境界 export connector。`sheetCache` の世代管理、`switchSheet` の stale guard、cache invalidation truth table、PR #143 経由の実装履歴。
- **layout-model.md** — `placeNode`（幾何）と `layoutNetwork`（構造）の 2 API 分離、Sugiyama 4-phase + compound 再帰、`fixed`/`hints` オプション、PR #133–#143 の作業ログ。
- **bom-model.md** — Palette / BOM / Node の三角形、伝播ルール、unbind と remove の違い、PoE 予算が catalog だけを参照する根拠。

ドキュメント追加のみ。コードには触っていない。

## Test plan

- [ ] `apps/editor/docs/*.md` の Mermaid が GitHub 上で描画される
- [ ] 内部リンク・リファレンス（PR 番号、issue 番号、ファイルパス）が正しい
- [ ] 既存 `connection-model.md` と文体・構成が揃っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)