### PR TITLE
fix(editor): restore catalog suggestions on port-label edit popover

### DIFF
--- a/apps/editor/src/lib/components/LabelEditPopover.svelte
+++ b/apps/editor/src/lib/components/LabelEditPopover.svelte
@@ -24,8 +24,11 @@
 
   // Pull catalog port-name suggestions for the node owning this port.
   // Reactive so the list updates if the node's spec changes mid-edit.
-  const nodeId = $derived(portId.includes(':') ? portId.slice(0, portId.indexOf(':')) : portId)
-  const suggestions = $derived(diagramState.getPortLabelSuggestions(nodeId))
+  // Look up nodeId via the resolved-ports map — port ids became opaque
+  // ("port-<random>") in #124 so the previous "split on ':'" trick no
+  // longer works.
+  const nodeId = $derived(diagramState.ports.get(portId)?.nodeId ?? '')
+  const suggestions = $derived(nodeId ? diagramState.getPortLabelSuggestions(nodeId) : [])
 
   // Filter against typed text. When the field still holds the original
   // label (initial state), we show the full list so the user can browse.


### PR DESCRIPTION
## Summary

PR #159 がマージされた後、ダイアグラム上でポートラベルをクリックして編集するときの **suggestion list が出てこない** 不具合を修正。挙動としては「単純な input になっている」ように見えていた。

### 原因

ID 管理リファクタ（#124）で `NodePort.id` が `nodeId:portName` 形式 → 不透明な `port-<random>` 形式に変わった。`LabelEditPopover` は古い形式を前提に `portId.split(':')` で nodeId を取り出しており、新形式では parse 結果が portId 自身になり、結果として `getPortLabelSuggestions(portId)` が `[]` を返してリストが空になっていた。

### 修正

`diagramState.ports.get(portId)?.nodeId` で resolved port から正しい `nodeId` を引く。`ResolvedPort.nodeId` は #124 以降ずっと存在しているので、これが正しい source of truth。port が一時的に解決できない場合は空サジェストにフォールバックして UI を壊さない。

## Test plan

- [ ] dev server で diagram ページを開く
- [ ] 既存ノード（catalog 由来の hardware spec を持つもの。例: `core-sw` 等）の port label をクリック
- [ ] LabelEditPopover が出て、catalog の port name 候補リストが表示される
- [ ] 矢印キーで候補を選択 → Enter で確定
- [ ] catalog 情報が無いノード（custom / generic）では候補無し（plain input 同等）になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)