### PR TITLE
feat(editor): hierarchy dropdown replaces SheetBar tabs

### DIFF
--- a/apps/editor/src/lib/components/SheetBar.svelte
+++ b/apps/editor/src/lib/components/SheetBar.svelte
@@ -1,29 +1,48 @@
 <script lang="ts">
+  import { DropdownMenu } from 'bits-ui'
+  import { CaretDown, Stack } from 'phosphor-svelte'
   import { diagramState } from '$lib/context.svelte'
 
-  // Show the root sheet plus one tab per top-level subgraph. Sheet
-  // state is tracked in diagramState; Layer 0 only updates the state
-  // on click — visual filtering of the diagram is a follow-up once
-  // the renderer supports pure-view mode.
+  // Hierarchy drill-down: Root + each top-level subgraph. Conceptually
+  // this is "go deeper into this part of the diagram", not "switch to a
+  // different scene" — so we present it as a single trigger with a
+  // toggle-down menu rather than a row of parallel tabs.
   const sheets = $derived(diagramState.availableSheets)
   const activeId = $derived(diagramState.currentSheetId)
+  const activeLabel = $derived(sheets.find((s) => s.id === activeId)?.label ?? 'Root')
 </script>
 
-<div
-  class="flex items-center gap-1 px-2 py-1.5 bg-white/90 dark:bg-neutral-800/90 backdrop-blur-sm border border-neutral-200 dark:border-neutral-700 rounded-xl shadow-lg"
->
-  {#each sheets as sheet (sheet.id ?? '__root__')}
-    {@const isActive = sheet.id === activeId}
-    <button
-      type="button"
-      class="px-3 py-1 text-xs font-medium rounded-md transition-colors max-w-[160px] truncate
-        {isActive
-        ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
-        : 'text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700'}"
-      title={sheet.label}
-      onclick={() => diagramState.switchSheet(sheet.id)}
-    >
-      {sheet.label}
-    </button>
-  {/each}
-</div>
+<DropdownMenu.Root>
+  <DropdownMenu.Trigger>
+    {#snippet child({ props })}
+      <button
+        type="button"
+        class="flex items-center gap-1.5 rounded-xl border border-neutral-200 bg-white/90 px-3 py-1.5 text-xs font-medium text-neutral-700 shadow-lg backdrop-blur-sm hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-800/90 dark:text-neutral-200 dark:hover:bg-neutral-700/60"
+        title="Hierarchy"
+        {...props}
+      >
+        <Stack class="h-3.5 w-3.5 text-neutral-500" />
+        <span class="max-w-[180px] truncate">{activeLabel}</span>
+        <CaretDown class="h-3 w-3 text-neutral-400" />
+      </button>
+    {/snippet}
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content
+    align="center"
+    sideOffset={6}
+    class="z-50 min-w-[200px] rounded-lg border border-neutral-200 bg-white p-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-800"
+  >
+    {#each sheets as sheet (sheet.id ?? '__root__')}
+      {@const isActive = sheet.id === activeId}
+      {@const indent = sheet.id === null ? 0 : 1}
+      <DropdownMenu.Item
+        class="cursor-pointer rounded-md px-2 py-1.5 text-xs hover:bg-neutral-100 data-[highlighted]:bg-neutral-100 dark:hover:bg-neutral-700 dark:data-[highlighted]:bg-neutral-700/60 {isActive
+          ? 'font-semibold text-blue-700 dark:text-blue-300'
+          : 'text-neutral-700 dark:text-neutral-200'}"
+        onclick={() => diagramState.switchSheet(sheet.id)}
+      >
+        <span style="padding-left: {indent * 14}px" class="block truncate"> {sheet.label} </span>
+      </DropdownMenu.Item>
+    {/each}
+  </DropdownMenu.Content>
+</DropdownMenu.Root>


### PR DESCRIPTION
## Summary

The current SheetBar — a row of tabs at the bottom for Root + each top-level subgraph — visually reads like \"scene switching\" (multiple parallel diagrams) but is actually hierarchy drill-down. Replace it with a single trigger that opens a toggle-down menu, which fits the meaning better and frees the bottom-center space.

\"Scenes\" (genuinely independent diagrams) is a future feature and will get its own UI; the dropdown trigger leaves room for it without conflation.

## What changes

- \`SheetBar.svelte\`: row of tabs → single bits-ui DropdownMenu trigger labeled with the active sheet, opening a list of all available sheets (Root + top-level subgraphs).
- Active item is highlighted; root is unindented, subgraphs sit one indent in. Same data source (\`diagramState.availableSheets\`).
- \`switchSheet\` API and \`diagramState\` are untouched.

## Test plan

- [ ] Open the sample project; trigger reads \"Root\".
- [ ] Click trigger → menu shows Root + each top-level subgraph.
- [ ] Pick a subgraph → trigger label updates and the diagram drills in.
- [ ] Re-open menu and pick Root → returns to root.
- [ ] Trigger does not collide with the bottom toolbar / overlap any existing controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)