### PR TITLE
feat(editor): package projects as .neted zip (v1)

### DIFF
--- a/apps/editor/docs/design/project-file.md
+++ b/apps/editor/docs/design/project-file.md
@@ -1,0 +1,116 @@
+# Project file (`.neted`, format v1)
+
+A neted project is a single zip archive carrying everything the
+editor needs to reopen the project — diagram, products (catalog),
+scenes, and the binary assets (floor-plan images, raster icons)
+that those structures reference. JSON-only `.neted.json` (v3) is
+gone; legacy files are not read.
+
+## Layout
+
+```
+manifest.json     entry point — { format, version, name, settings, sceneIds }
+diagram.json      NetworkGraph (nodes / links / subgraphs)
+products.json     Product[] (catalog) — sorted in load order
+scenes/
+  <sceneId>.json  one Scene per file
+assets/
+  <hash>.<ext>    content-addressed binary blobs
+```
+
+Why split:
+
+- **diagram.json** is a single file because nodes / links /
+  subgraphs are tightly id-coupled; splitting hurts more than it
+  helps.
+- **products.json** is a single file. Products diff cleanly inside
+  one JSON when sorted by id; the per-file alternative just adds
+  an index-sync failure mode.
+- **scenes/** is split per scene. Each scene corresponds to one
+  floor / room edit and is the natural unit of human review — a
+  PR that touches Floor 2 should not noise up Floor 1's diff.
+- **assets/** is content-addressed. Same image referenced from
+  multiple scenes / products is stored once, and the hash is the
+  filename so reads do not need a separate lookup table.
+
+## Asset references
+
+Inside the zip, image-bearing fields hold an
+`asset:<hash>.<ext>` URI:
+
+```
+Scene.background.src       "asset:1f2a…3b.png"
+Product.icon               "asset:7c4e…01.jpg"  (raster only — SVG stays inline)
+Node.spec.icon             "asset:7c4e…01.jpg"  (snapshot from Product)
+```
+
+`<hash>` is the first 16 hex chars (64 bits) of the SHA-256 of the
+asset's bytes. That is more than enough collision resistance for
+a single project's worth of images and short enough to keep
+filenames pleasant.
+
+`asset:` lives **only** in serialized form. In memory, the same
+fields hold runtime URLs (`blob:`, `http(s):`, or inline SVG
+text). The reader rewrites `asset:` → blob URL on load; the
+writer rewrites blob URL → `asset:` on save. Render paths never
+see the `asset:` scheme, so adding the format did not require
+touching `classifyIcon` / `resolveIcon` / `<img>` consumers.
+
+## AssetStore
+
+`apps/editor/src/lib/state/assets.svelte.ts` is the in-memory
+session store:
+
+- `put(blob)` — hashes, registers, returns `{ hash, ext, blob, url }`
+- `putUserImage(file)` — SVG → text (no asset), raster → `put`
+- `putWithHash(hash, ext, blob)` — used by the reader
+- `byUrl(url)` / `byHash(hash)` — lookups
+- `reset()` — revokes every blob URL; called when the active
+  project changes
+
+The store is **session-scoped**, not project-scoped per se —
+mid-session, undoing a "set background" leaves the previous blob
+addressable so redo works. Orphaned entries are not GC'd
+mid-session; the writer simply walks live state for `asset:` refs
+and writes only those.
+
+## Writer / reader
+
+Both live under `apps/editor/src/lib/persistence/`:
+
+- `writer.ts` — `writeProjectZip({ name, diagram, products, scenes })`
+  → `Blob`. Walks each top-level slice, replaces blob URLs with
+  `asset:` refs (`toSerializedRef`), collects referenced hashes,
+  and packs everything via `fflate.zipSync`.
+- `reader.ts` — `readProjectZip(blob | bytes)` → `NetedProject`.
+  Two passes: register every `assets/<hash>.<ext>` first so refs
+  can resolve, then parse JSON and `rehydrateRefs` walks each
+  parsed tree replacing `asset:` strings with the live blob URL.
+
+Both pieces deliberately stay thin (~120 lines each) and the
+serializer functions are per-slice so the JSON shape stays
+checked by the existing `NetedProject` types.
+
+## Boundary contract
+
+Three input sites convert user image uploads via
+`assetStore.putUserImage`:
+
+- `SceneSideToolbar` (background image)
+- `materials/+page.svelte` (custom icon during product creation)
+- `materials/[productId]/+page.svelte` (icon edit)
+
+After this contract: `data:` URLs never enter editor state. SVG
+stays as inline text (small + diagram-friendly snapshot model);
+everything else flows through the AssetStore.
+
+## Format versioning
+
+`manifest.json` carries `{ format: "neted", version: 1 }`. The
+reader rejects anything else with a clear message. Bumps:
+
+- **patch / minor**: in-place fixes that the v1 reader still
+  parses — keep version at 1.
+- **major**: breaking layout change — bump to 2 and write a new
+  reader branch. We do not carry old readers; `.neted` is not a
+  long-term archival format.

--- a/apps/editor/docs/design/project-file.md
+++ b/apps/editor/docs/design/project-file.md
@@ -1,4 +1,4 @@
-# Project file (`.neted`, format v1)
+# Project file (`.neted.zip`, format v1)
 
 A neted project is a single zip archive carrying everything the
 editor needs to reopen the project — diagram, products (catalog),
@@ -112,5 +112,5 @@ reader rejects anything else with a clear message. Bumps:
 - **patch / minor**: in-place fixes that the v1 reader still
   parses — keep version at 1.
 - **major**: breaking layout change — bump to 2 and write a new
-  reader branch. We do not carry old readers; `.neted` is not a
+  reader branch. We do not carry old readers; `.neted.zip` is not a
   long-term archival format.

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -19,6 +19,7 @@
     "@xyflow/svelte": "^1.5.2",
     "bits-ui": "^2.16.3",
     "clsx": "^2.1.1",
+    "fflate": "^0.8.2",
     "phosphor-svelte": "^3.1.0",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2"

--- a/apps/editor/src/lib/components/scene/SceneSideToolbar.svelte
+++ b/apps/editor/src/lib/components/scene/SceneSideToolbar.svelte
@@ -12,6 +12,7 @@
     Sun,
   } from 'phosphor-svelte'
   import { diagramState, editorState } from '$lib/context.svelte'
+  import { assetStore } from '$lib/state/assets.svelte'
   import { productLabel } from '$lib/types'
   import { sceneAuthoring } from './scene-authoring.svelte'
 
@@ -69,15 +70,14 @@
     const input = e.target as HTMLInputElement
     const file = input.files?.[0]
     if (!file) return
-    const dataUrl = await new Promise<string>((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(String(reader.result ?? ''))
-      reader.onerror = () => reject(reader.error)
-      reader.readAsDataURL(file)
-    })
+    // Register the file in the session AssetStore — that returns a
+    // blob URL the renderer can `<img src>` and the writer can later
+    // hash back into an `asset:` ref. Avoids carrying multi-MB data
+    // URLs in state / undo history.
+    const src = await assetStore.putUserImage(file)
     try {
-      const dim = await loadImageDimensions(dataUrl)
-      diagramState.updateScene(scene.id, { background: { src: dataUrl, ...dim } })
+      const dim = await loadImageDimensions(src)
+      diagramState.updateScene(scene.id, { background: { src, ...dim } })
     } catch {
       // ignore — corrupt image input. UI flag would be nice eventually.
     }

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -39,9 +39,12 @@ import {
   type Theme,
 } from '@shumoku/core'
 import { SvelteMap } from 'svelte/reactivity'
+import { readProjectZip } from './persistence/reader'
+import { writeProjectZip } from './persistence/writer'
 import { analyzePoE } from './poe-analysis'
 import { sampleProject } from './sample-project'
 import { cableLengthMeters, cableSegmentLengths } from './scene/cable-length'
+import { assetStore } from './state/assets.svelte'
 import { buildAssignmentRows as buildBomRows } from './state/bom'
 import {
   applyResolvedLayout,
@@ -1148,15 +1151,18 @@ export const diagramState = {
       subgraphs: [...diagram.subgraphs.values()],
     }
   },
-  exportProject(name = 'Untitled'): string {
-    const project: NetedProject = {
-      version: 3,
+  /**
+   * Build the .neted zip blob for the current project. Image assets
+   * (scene backgrounds, raster product icons) flow out of the
+   * AssetStore as content-addressed entries under `assets/`.
+   */
+  async exportProjectZip(name = 'Untitled'): Promise<Blob> {
+    return await writeProjectZip({
       name,
-      products: [...productsStore.list],
       diagram: diagramState.exportGraph(),
-      scenes: scenesStore.list.length > 0 ? [...scenesStore.list] : undefined,
-    }
-    return JSON.stringify(project, null, 2)
+      products: [...productsStore.list],
+      scenes: [...scenesStore.list],
+    })
   },
   async autoArrange() {
     return commitAsync('Auto-arrange', async () => {
@@ -1186,7 +1192,7 @@ export const diagramState = {
       const hp = new HierarchicalParser(resolver)
       const parsed = (await hp.parse(yamlStr, '/main.yaml')).graph
       await diagramState.importProject({
-        version: 3,
+        version: 1,
         name: 'YAML Import',
         products: [...productsStore.list],
         diagram: parsed,
@@ -1197,14 +1203,20 @@ export const diagramState = {
       sessionStore.setStatus(`Error: ${e instanceof Error ? e.message : String(e)}`)
     }
   },
-  async importProject(input: string | NetedProject) {
-    const data = typeof input === 'string' ? JSON.parse(input) : input
+  /**
+   * Load a project. Accepts either an in-memory NetedProject (used
+   * by sample / YAML paths) or a `.neted` zip blob (user import).
+   * Anything string-shaped is rejected — the JSON-only format is
+   * gone.
+   */
+  async importProject(input: NetedProject | Blob) {
+    const data = input instanceof Blob ? await readProjectZip(input) : input
     await diagramState.loadProject('imported', data)
   },
   async importDiagram(input: string | NetworkGraph) {
     const parsed: NetworkGraph = typeof input === 'string' ? JSON.parse(input) : input
     await diagramState.importProject({
-      version: 3,
+      version: 1,
       name: 'Diagram Import',
       products: [...productsStore.list],
       diagram: parsed,
@@ -1223,6 +1235,10 @@ export const diagramState = {
     diagram.subgraphs.clear()
     diagram.bounds = { x: 0, y: 0, width: 800, height: 600 }
     diagram.links = []
+    // Drop the previous project's image blobs — `loadProject` is the
+    // session boundary for assets too. The reader will repopulate as
+    // it extracts the new zip.
+    assetStore.reset()
     sessionStore.setYamlSource('')
     sheetStore.setCurrentSheetId(null)
     sessionStore.setInitialized(false)

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1208,10 +1208,21 @@ export const diagramState = {
    * by sample / YAML paths) or a `.neted` zip blob (user import).
    * Anything string-shaped is rejected — the JSON-only format is
    * gone.
+   *
+   * The asset reset has to bracket the zip read: clear the previous
+   * project's blob URLs first, *then* let the reader register the
+   * incoming ones. Calling reset later (e.g. inside `loadProject`)
+   * would revoke the blobs the reader just created.
    */
   async importProject(input: NetedProject | Blob) {
-    const data = input instanceof Blob ? await readProjectZip(input) : input
-    await diagramState.loadProject('imported', data)
+    if (input instanceof Blob) {
+      assetStore.reset()
+      const data = await readProjectZip(input)
+      await diagramState.loadProject('imported', data)
+    } else {
+      assetStore.reset()
+      await diagramState.loadProject('imported', input)
+    }
   },
   async importDiagram(input: string | NetworkGraph) {
     const parsed: NetworkGraph = typeof input === 'string' ? JSON.parse(input) : input
@@ -1235,10 +1246,12 @@ export const diagramState = {
     diagram.subgraphs.clear()
     diagram.bounds = { x: 0, y: 0, width: 800, height: 600 }
     diagram.links = []
-    // Drop the previous project's image blobs — `loadProject` is the
-    // session boundary for assets too. The reader will repopulate as
-    // it extracts the new zip.
-    assetStore.reset()
+    // Reset image asset blobs only when the caller hasn't preloaded
+    // them. `importProject(Blob)` extracts assets *before* getting
+    // here so its `data` already references blob URLs we don't want
+    // to revoke; sample / empty paths have no assets to clear but
+    // any prior session's assets should go.
+    if (!data) assetStore.reset()
     sessionStore.setYamlSource('')
     sheetStore.setCurrentSheetId(null)
     sessionStore.setInitialized(false)

--- a/apps/editor/src/lib/persistence/reader.ts
+++ b/apps/editor/src/lib/persistence/reader.ts
@@ -1,0 +1,112 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { unzipSync } from 'fflate'
+import { assetStore, fromSerializedRef } from '../state/assets.svelte'
+import type { NetedProject, Product, Scene } from '../types'
+
+// Zip reader for `.neted` projects (format v1). See writer.ts for
+// the on-disk layout. Mirrors the writer in two reverse passes:
+//
+//   1. Extract `assets/<hash>.<ext>` into the AssetStore so each
+//      asset gets a session-scoped blob URL.
+//   2. Walk the parsed JSON for `asset:<hash>.<ext>` refs and
+//      replace them with the now-live blob URLs. State leaving this
+//      function holds runtime URLs only — no caller has to know.
+
+const DEC = new TextDecoder()
+
+interface Manifest {
+  format?: string
+  version?: number
+  name?: string
+  settings?: Record<string, unknown>
+  sceneIds?: string[]
+}
+
+function readJson<T>(bytes: Uint8Array | undefined, label: string): T {
+  if (!bytes) throw new Error(`Missing ${label} in project archive`)
+  return JSON.parse(DEC.decode(bytes)) as T
+}
+
+/**
+ * Replace `asset:` ref strings inside a parsed JSON tree with the
+ * now-live blob URL from the AssetStore. Mutates value in place for
+ * arrays / objects and returns the (possibly replaced) value.
+ */
+function rehydrateRefs(value: unknown): unknown {
+  if (typeof value === 'string') return fromSerializedRef(value)
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) value[i] = rehydrateRefs(value[i])
+    return value
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    for (const k of Object.keys(obj)) obj[k] = rehydrateRefs(obj[k])
+    return obj
+  }
+  return value
+}
+
+/** Parse a `.neted` zip blob into an in-memory NetedProject. */
+export async function readProjectZip(
+  input: Blob | ArrayBuffer | Uint8Array,
+): Promise<NetedProject> {
+  const bytes =
+    input instanceof Uint8Array
+      ? input
+      : new Uint8Array(input instanceof Blob ? await input.arrayBuffer() : input)
+  const files = unzipSync(bytes)
+
+  // Pass 1 — register every asset so refs can resolve when we
+  // rehydrate the JSON. We do this before parsing so order within
+  // the zip doesn't matter.
+  for (const path of Object.keys(files)) {
+    if (!path.startsWith('assets/')) continue
+    const m = /^assets\/([a-f0-9]+)\.([a-z0-9]+)$/.exec(path)
+    if (!m || !m[1] || !m[2]) continue
+    const fileBytes = files[path]
+    if (!fileBytes) continue
+    const blob = new Blob([fileBytes as Uint8Array<ArrayBuffer>])
+    assetStore.putWithHash(m[1], m[2], blob)
+  }
+
+  const manifest = readJson<Manifest>(files['manifest.json'], 'manifest.json')
+  if (manifest.format !== 'neted') {
+    throw new Error(`Unsupported project format: ${manifest.format ?? '(missing)'}`)
+  }
+  if (manifest.version !== 1) {
+    throw new Error(`Unsupported project version: ${manifest.version ?? '(missing)'}`)
+  }
+
+  const diagram = rehydrateRefs(
+    readJson<NetedProject['diagram']>(files['diagram.json'], 'diagram.json'),
+  ) as NetedProject['diagram']
+  const products = rehydrateRefs(
+    readJson<Product[]>(files['products.json'], 'products.json'),
+  ) as Product[]
+
+  // Honour manifest.sceneIds for ordering; fall back to alphabetical
+  // if a scene file is in the zip but not listed (defensive).
+  const sceneFiles = Object.keys(files).filter((p) => /^scenes\/[^/]+\.json$/.test(p))
+  const idsFromFiles = sceneFiles
+    .map((p) => /^scenes\/(.+)\.json$/.exec(p)?.[1])
+    .filter((id): id is string => !!id)
+  const orderedIds = (manifest.sceneIds ?? []).filter((id) => idsFromFiles.includes(id))
+  for (const id of idsFromFiles.sort()) {
+    if (!orderedIds.includes(id)) orderedIds.push(id)
+  }
+  const scenes = orderedIds.map((id) => {
+    const scene = readJson<Scene>(files[`scenes/${id}.json`], `scenes/${id}.json`)
+    return rehydrateRefs(scene) as Scene
+  })
+
+  return {
+    version: 1,
+    name: manifest.name ?? 'Project',
+    settings: manifest.settings,
+    products,
+    diagram,
+    scenes,
+  }
+}

--- a/apps/editor/src/lib/persistence/smoke.test.ts
+++ b/apps/editor/src/lib/persistence/smoke.test.ts
@@ -22,6 +22,49 @@ function pngBlob(): Blob {
   return new Blob([bytes], { type: 'image/png' })
 }
 
+test('imported blob URLs survive the load pipeline', async () => {
+  // Regression: a stale `assetStore.reset()` after `readProjectZip`
+  // would revoke the blobs the reader just registered, leaving image
+  // fields pointing at dead `blob:` URLs after import.
+  const revoked = new Set<string>()
+  globalThis.URL.createObjectURL = ((b: object) => {
+    const u = `blob:test/${Math.random()}`
+    revokedTracking.set(b, u)
+    return u
+  }) as typeof URL.createObjectURL
+  globalThis.URL.revokeObjectURL = (u: string) => {
+    revoked.add(u)
+  }
+
+  assetStore.reset()
+  const entry = await assetStore.put(pngBlob(), 'png')
+  const blob = await writeProjectZip({
+    name: 'T',
+    diagram: { version: '1', nodes: [], links: [], subgraphs: [] },
+    products: [],
+    scenes: [
+      {
+        id: 's1',
+        name: 'F1',
+        nodePlacements: [],
+        wireRoutes: [],
+        background: { src: entry.url, width: 1, height: 1 },
+      },
+    ],
+  })
+
+  // Simulate the import path: reset → read → loadProject (we just
+  // call read here; loadProject itself is plain state mutation).
+  assetStore.reset()
+  const loaded = await readProjectZip(blob)
+
+  const sceneSrc = loaded.scenes?.[0]?.background?.src ?? ''
+  expect(sceneSrc.startsWith('blob:')).toBe(true)
+  expect(revoked.has(sceneSrc)).toBe(false)
+})
+
+const revokedTracking = new Map<object, string>()
+
 test('round-trips a project through .neted', async () => {
   // URL.createObjectURL polyfill — Bun does not provide it.
   const urls = new Map<object, string>()

--- a/apps/editor/src/lib/persistence/smoke.test.ts
+++ b/apps/editor/src/lib/persistence/smoke.test.ts
@@ -1,0 +1,104 @@
+// Smoke test for the .neted zip writer/reader. Run with:
+//   bunx vitest run src/lib/persistence/smoke.test.ts
+// Asserts that an export round-trips through import without losing
+// data, including content-addressed image assets.
+
+import type { NetworkGraph, Node } from '@shumoku/core'
+import { expect, test } from 'vitest'
+import { assetStore } from '../state/assets.svelte'
+import type { Product, Scene } from '../types'
+import { readProjectZip } from './reader'
+import { writeProjectZip } from './writer'
+
+function pngBlob(): Blob {
+  // 1x1 transparent PNG.
+  const bytes = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+    0x42, 0x60, 0x82,
+  ])
+  return new Blob([bytes], { type: 'image/png' })
+}
+
+test('round-trips a project through .neted', async () => {
+  // URL.createObjectURL polyfill — Bun does not provide it.
+  const urls = new Map<object, string>()
+  let n = 0
+  globalThis.URL.createObjectURL = (b: object) => {
+    const u = `blob:test/${++n}`
+    urls.set(b, u)
+    return u
+  }
+  globalThis.URL.revokeObjectURL = () => {}
+
+  assetStore.reset()
+
+  // Register an image so blob URL ↔ hash mapping has a real entry.
+  const entry = await assetStore.put(pngBlob(), 'png')
+  expect(entry.hash).toMatch(/^[a-f0-9]+$/)
+
+  const sceneBg = entry.url
+  const productIcon = entry.url
+
+  const diagram: NetworkGraph = {
+    version: '1',
+    nodes: [
+      {
+        id: 'n1',
+        label: 'sw1',
+        spec: { kind: 'hardware', vendor: 'cisco', model: 'c9300', icon: productIcon },
+      } as Node,
+    ],
+    links: [],
+    subgraphs: [],
+  }
+  const products: Product[] = [
+    {
+      id: 'p1',
+      kind: 'device',
+      icon: productIcon,
+      spec: { kind: 'hardware', vendor: 'cisco', model: 'c9300' },
+    },
+  ]
+  const scenes: Scene[] = [
+    {
+      id: 'scene1',
+      name: 'Floor 1',
+      nodePlacements: [],
+      wireRoutes: [],
+      background: { src: sceneBg, width: 100, height: 100 },
+    },
+  ]
+
+  const blob = await writeProjectZip({ name: 'Test', diagram, products, scenes })
+  expect(blob.size).toBeGreaterThan(0)
+
+  // Drop everything (simulate switching projects), then re-import.
+  assetStore.reset()
+  const loaded = await readProjectZip(blob)
+
+  expect(loaded.name).toBe('Test')
+  expect(loaded.scenes?.length).toBe(1)
+  expect(loaded.scenes?.[0]?.background?.src.startsWith('blob:')).toBe(true)
+  expect(loaded.products[0]?.icon?.startsWith('blob:')).toBe(true)
+  expect(loaded.diagram.nodes[0]?.spec?.icon?.startsWith('blob:')).toBe(true)
+
+  // Re-export round-trips to the same hash (content-addressed).
+  const blob2 = await writeProjectZip({
+    name: loaded.name,
+    diagram: loaded.diagram,
+    products: loaded.products,
+    scenes: loaded.scenes ?? [],
+  })
+  // Inflate just to peek at the JSON refs.
+  const { unzipSync } = await import('fflate')
+  const files = unzipSync(new Uint8Array(await blob2.arrayBuffer()))
+  const productsJson = JSON.parse(new TextDecoder().decode(files['products.json']))
+  expect(productsJson[0].icon).toMatch(/^asset:[a-f0-9]+\.png$/)
+  const sceneJson = JSON.parse(new TextDecoder().decode(files['scenes/scene1.json']))
+  expect(sceneJson.background.src).toMatch(/^asset:[a-f0-9]+\.png$/)
+  // Same content → same hash.
+  expect(productsJson[0].icon).toBe(sceneJson.background.src)
+})

--- a/apps/editor/src/lib/persistence/writer.ts
+++ b/apps/editor/src/lib/persistence/writer.ts
@@ -1,0 +1,141 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { type Zippable, zipSync } from 'fflate'
+import { assetStore, toSerializedRef } from '../state/assets.svelte'
+import type { NetedProject, Product, Scene } from '../types'
+
+// Zip writer for `.neted` projects (format v1).
+//
+// Layout:
+//   manifest.json     { format, version, name, settings, sceneIds }
+//   diagram.json      NetworkGraph
+//   products.json     Product[]
+//   scenes/<id>.json  Scene
+//   assets/<hash>.<ext>
+//
+// Image fields (Scene.background.src, Product.icon, Node.spec.icon)
+// hold runtime URLs in state. `toSerializedRef()` turns blob URLs
+// back into `asset:<hash>.<ext>` so the JSON is content-addressed,
+// then the writer pulls each referenced asset out of `assetStore`
+// and embeds the bytes under `assets/`.
+
+interface Manifest {
+  format: 'neted'
+  version: 1
+  name: string
+  settings?: Record<string, unknown>
+  /** Order of scenes (the on-disk filenames are id-based, this preserves UI ordering). */
+  sceneIds: string[]
+  createdAt?: string
+  updatedAt: string
+}
+
+const ENC = new TextEncoder()
+
+function jsonBytes(value: unknown): Uint8Array {
+  return ENC.encode(`${JSON.stringify(value, null, 2)}\n`)
+}
+
+/** Serialize Product, replacing runtime icon URLs with `asset:` refs. */
+function serializeProduct(p: Product): Product {
+  return p.icon ? { ...p, icon: toSerializedRef(p.icon) } : p
+}
+
+/** Serialize Scene, replacing background URL with an `asset:` ref. */
+function serializeScene(s: Scene): Scene {
+  if (!s.background) return s
+  return { ...s, background: { ...s.background, src: toSerializedRef(s.background.src) } }
+}
+
+/** Serialize NetworkGraph, replacing Node.spec.icon URLs with `asset:` refs. */
+function serializeDiagram(diagram: NetedProject['diagram']): NetedProject['diagram'] {
+  return {
+    ...diagram,
+    nodes: diagram.nodes.map((n) => {
+      const icon = n.spec?.icon
+      if (!icon || !n.spec) return n
+      const serialized = toSerializedRef(icon)
+      if (serialized === icon) return n
+      return { ...n, spec: { ...n.spec, icon: serialized } }
+    }),
+  }
+}
+
+/**
+ * Walk the serialized JSON tree for `asset:` refs so we know which
+ * assets to embed. Strings only — that's where refs live.
+ */
+function collectAssetHashes(value: unknown, out: Set<string>): void {
+  if (typeof value === 'string') {
+    if (value.startsWith('asset:')) {
+      const m = /^asset:([a-f0-9]+)\./.exec(value)
+      if (m?.[1]) out.add(m[1])
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) collectAssetHashes(v, out)
+    return
+  }
+  if (value && typeof value === 'object') {
+    for (const v of Object.values(value)) collectAssetHashes(v, out)
+  }
+}
+
+export interface WriteProjectInput {
+  name: string
+  settings?: Record<string, unknown>
+  diagram: NetedProject['diagram']
+  products: Product[]
+  scenes: Scene[]
+}
+
+/**
+ * Build a `.neted` zip blob from the current project state. The
+ * caller is responsible for triggering a download; this function
+ * just produces the bytes.
+ */
+export async function writeProjectZip(input: WriteProjectInput): Promise<Blob> {
+  const diagram = serializeDiagram(input.diagram)
+  const products = input.products.map(serializeProduct)
+  const scenes = input.scenes.map(serializeScene)
+
+  // Find every `asset:` ref across all serialized JSON, then embed
+  // only the assets that are actually referenced. Orphaned blobs
+  // hanging in the AssetStore from since-undone uploads stay out.
+  const used = new Set<string>()
+  collectAssetHashes(diagram, used)
+  collectAssetHashes(products, used)
+  for (const s of scenes) collectAssetHashes(s, used)
+
+  const manifest: Manifest = {
+    format: 'neted',
+    version: 1,
+    name: input.name,
+    settings: input.settings,
+    sceneIds: scenes.map((s) => s.id),
+    updatedAt: new Date().toISOString(),
+  }
+
+  const zipInput: Zippable = {
+    'manifest.json': jsonBytes(manifest),
+    'diagram.json': jsonBytes(diagram),
+    'products.json': jsonBytes(products),
+  }
+  for (const s of scenes) {
+    zipInput[`scenes/${s.id}.json`] = jsonBytes(s)
+  }
+  for (const hash of used) {
+    const entry = assetStore.byHash(hash)
+    if (!entry) continue // Stale ref — silently skip; reader treats as missing.
+    const bytes = new Uint8Array(await entry.blob.arrayBuffer())
+    zipInput[`assets/${entry.hash}.${entry.ext}`] = bytes
+  }
+
+  const zipped = zipSync(zipInput, { level: 6 })
+  // Cast to a known ArrayBuffer-backed array so the Blob ctor's
+  // strict BlobPart typing accepts the chunk on lib.dom builds where
+  // Uint8Array is generic over the buffer kind.
+  return new Blob([zipped as Uint8Array<ArrayBuffer>], { type: 'application/zip' })
+}

--- a/apps/editor/src/lib/sample-project.ts
+++ b/apps/editor/src/lib/sample-project.ts
@@ -200,7 +200,7 @@ const sampleDiagramWithBindings: NetworkGraph = {
 
 /** Sample project — bundled products and positioned diagram. */
 export const sampleProject: NetedProject = {
-  version: 3,
+  version: 1,
   name: 'Sample Network',
   products: sampleProducts,
   diagram: sampleDiagramWithBindings,

--- a/apps/editor/src/lib/state/assets.svelte.ts
+++ b/apps/editor/src/lib/state/assets.svelte.ts
@@ -1,0 +1,165 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Session-scoped binary asset store. Holds image blobs (scene
+// backgrounds, raster product icons) keyed by content hash so that:
+//
+//   - state always carries a runtime-displayable URL (blob:) — render
+//     paths don't need to learn an `asset:` indirection
+//   - the zip writer can walk state for blob URLs, recover the hash,
+//     and emit content-addressed `asset:<hash>.<ext>` refs
+//   - the zip reader extracts assets/<hash>.<ext>, registers each
+//     under its hash → blob URL, and rewrites JSON refs in place
+//
+// Refs in serialized form: `asset:<hash>.<ext>` (16 hex chars of
+// SHA-256 + an inferred extension). `asset:` is the disk format —
+// state never holds it.
+
+const ASSET_REF_RE = /^asset:([a-f0-9]+)\.([a-z0-9]+)$/
+
+export interface AssetEntry {
+  hash: string
+  ext: string
+  blob: Blob
+  /** Object URL valid for the lifetime of the current session. */
+  url: string
+}
+
+interface AssetStoreState {
+  byHash: Map<string, AssetEntry>
+  byUrl: Map<string, string> // blob URL → hash
+}
+
+const state: AssetStoreState = {
+  byHash: new Map(),
+  byUrl: new Map(),
+}
+
+async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
+  // 16 hex chars (64 bits) is plenty for a single project's worth of
+  // assets — collision probability stays well under 1 in 10^9 even
+  // with millions of distinct images. Full hash kept for reference
+  // but truncated for filenames.
+  const buf = await crypto.subtle.digest('SHA-256', bytes)
+  const arr = new Uint8Array(buf)
+  let out = ''
+  for (let i = 0; i < 8; i++) out += arr[i]?.toString(16).padStart(2, '0') ?? '00'
+  return out
+}
+
+function inferExt(file: File | Blob, fallback = 'bin'): string {
+  if (file instanceof File) {
+    const m = /\.([a-z0-9]+)$/i.exec(file.name)
+    if (m) return m[1]?.toLowerCase() ?? fallback
+  }
+  const t = file.type
+  if (!t) return fallback
+  if (t === 'image/svg+xml') return 'svg'
+  if (t === 'image/png') return 'png'
+  if (t === 'image/jpeg') return 'jpg'
+  if (t === 'image/gif') return 'gif'
+  if (t === 'image/webp') return 'webp'
+  if (t.startsWith('image/')) return t.slice('image/'.length)
+  return fallback
+}
+
+export const assetStore = {
+  /**
+   * Hash a blob, register it (idempotent on hash collision), and
+   * return the entry. Use the entry's `url` as the in-state value.
+   */
+  async put(blob: Blob, ext?: string): Promise<AssetEntry> {
+    const buf = await blob.arrayBuffer()
+    const hash = await sha256Hex(buf)
+    const existing = state.byHash.get(hash)
+    if (existing) return existing
+    const finalExt = ext ?? inferExt(blob)
+    const url = URL.createObjectURL(blob)
+    const entry: AssetEntry = { hash, ext: finalExt, blob, url }
+    state.byHash.set(hash, entry)
+    state.byUrl.set(url, hash)
+    return entry
+  },
+  /**
+   * Read a user-selected file into the store. SVGs are *not* asset-
+   * ified — they're small text and inline content fits the diagram's
+   * snapshot model better. Returns the value to put in state:
+   *   - SVG: the raw `<svg>...` text
+   *   - else: the blob URL of the registered asset
+   */
+  async putUserImage(file: File): Promise<string> {
+    if (file.type === 'image/svg+xml' || /\.svg$/i.test(file.name)) {
+      return await file.text()
+    }
+    const entry = await assetStore.put(file)
+    return entry.url
+  },
+  /**
+   * Register a blob already extracted from a zip under a known hash.
+   * Used by the reader so the in-zip `asset:<hash>` refs round-trip
+   * back to the same hash on re-export.
+   */
+  putWithHash(hash: string, ext: string, blob: Blob): AssetEntry {
+    const existing = state.byHash.get(hash)
+    if (existing) return existing
+    const url = URL.createObjectURL(blob)
+    const entry: AssetEntry = { hash, ext, blob, url }
+    state.byHash.set(hash, entry)
+    state.byUrl.set(url, hash)
+    return entry
+  },
+  /** Look up an entry by its blob URL. */
+  byUrl(url: string): AssetEntry | undefined {
+    const hash = state.byUrl.get(url)
+    return hash ? state.byHash.get(hash) : undefined
+  },
+  byHash(hash: string): AssetEntry | undefined {
+    return state.byHash.get(hash)
+  },
+  /**
+   * Drop everything and revoke object URLs. Called on project
+   * switch — there's no cross-project asset sharing.
+   */
+  reset(): void {
+    for (const entry of state.byHash.values()) URL.revokeObjectURL(entry.url)
+    state.byHash.clear()
+    state.byUrl.clear()
+  },
+  list(): AssetEntry[] {
+    return [...state.byHash.values()]
+  },
+}
+
+/** Parse `asset:<hash>.<ext>` → its parts. Returns null otherwise. */
+export function parseAssetRef(ref: string): { hash: string; ext: string } | null {
+  const m = ASSET_REF_RE.exec(ref)
+  if (!m || !m[1] || !m[2]) return null
+  return { hash: m[1], ext: m[2] }
+}
+
+/** Build an `asset:` URI for a registered entry. */
+export function assetRef(entry: AssetEntry): string {
+  return `asset:${entry.hash}.${entry.ext}`
+}
+
+/**
+ * Map a state-side string to a serialized form. Blob URLs we own
+ * become `asset:<hash>.<ext>`; everything else (inline svg, http
+ * URLs, data URLs we didn't ingest) passes through untouched.
+ */
+export function toSerializedRef(value: string): string {
+  if (!value.startsWith('blob:')) return value
+  const entry = assetStore.byUrl(value)
+  return entry ? assetRef(entry) : value
+}
+
+/**
+ * Map a serialized string back to its runtime form. `asset:` refs
+ * resolve through the store; anything else passes through.
+ */
+export function fromSerializedRef(value: string): string {
+  const parsed = parseAssetRef(value)
+  if (!parsed) return value
+  const entry = assetStore.byHash(parsed.hash)
+  return entry?.url ?? value
+}

--- a/apps/editor/src/lib/types.ts
+++ b/apps/editor/src/lib/types.ts
@@ -256,7 +256,7 @@ export interface NetedProject {
 }
 
 /** File extension for neted projects (zip package). */
-export const NETED_FILE_EXTENSION = '.neted'
+export const NETED_FILE_EXTENSION = '.neted.zip'
 
 // =========================================================================
 // Display helpers

--- a/apps/editor/src/lib/types.ts
+++ b/apps/editor/src/lib/types.ts
@@ -228,27 +228,35 @@ export interface WireRoute {
 }
 
 // =========================================================================
-// Project file — .neted.json
+// Project file — .neted (zip package, format v1)
 // =========================================================================
 
-/** neted project file format */
+/**
+ * Logical representation of a neted project. On disk this lives as a
+ * zip archive (`.neted`) split into:
+ *   manifest.json          { version, name, settings, sceneIds }
+ *   diagram.json           NetworkGraph
+ *   products.json          Product[]
+ *   scenes/<sceneId>.json  Scene
+ *   assets/<hash>.<ext>    binary blobs referenced by `asset:` URIs
+ *
+ * In memory we hand the same logical shape around — the zip layout is
+ * an artifact of the writer/reader. Image fields hold runtime URLs
+ * (blob: / http: / inline svg); the `asset:` scheme only appears
+ * inside the zip's JSON files.
+ */
 export interface NetedProject {
-  /** Format version */
-  version: 3
-  /** Project name */
+  /** Format version (zip package). */
+  version: 1
   name: string
-  /** Project settings */
   settings?: Record<string, unknown>
-  /** Project-local Products (devices / modules / cables) */
   products: Product[]
-  /** Diagram — NetworkGraph (nodes with positions, links, subgraphs) */
   diagram: NetworkGraph
-  /** Physical-placement views (floor plans / image-backed canvases). */
   scenes?: Scene[]
 }
 
-/** File extension for neted projects */
-export const NETED_FILE_EXTENSION = '.neted.json'
+/** File extension for neted projects (zip package). */
+export const NETED_FILE_EXTENSION = '.neted'
 
 // =========================================================================
 // Display helpers

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -12,16 +12,16 @@
   ]
 
   /**
-   * Prompt for a local file and stream its contents through `onLoad`.
-   * The file picker's `accept` is a hint to the OS dialog — we still
-   * check the file name to keep wrong-format imports from silently
-   * feeding JSON.parse something that would only fail later.
+   * Prompt for a local file and stream it through `onLoad`. The
+   * picker's `accept` is a UI hint; we still check the suffix so a
+   * mismatched file doesn't silently fail at parse time. Receives the
+   * raw `File` so callers can decide between text and Blob handling.
    */
   function promptFile(opts: {
     accept: string
     expectedSuffix: string
     formatLabel: string
-    onLoad: (text: string) => Promise<void>
+    onLoad: (file: File) => Promise<void>
   }) {
     const input = document.createElement('input')
     input.type = 'file'
@@ -35,9 +35,8 @@
         )
         return
       }
-      const text = await file.text()
       try {
-        await opts.onLoad(text)
+        await opts.onLoad(file)
       } catch (e) {
         alert(`Import failed: ${e instanceof Error ? e.message : String(e)}`)
       }
@@ -47,11 +46,11 @@
 
   function handleImportProject() {
     promptFile({
-      accept: '.neted.json',
-      expectedSuffix: '.neted.json',
+      accept: '.neted',
+      expectedSuffix: '.neted',
       formatLabel: 'neted project',
-      onLoad: async (text) => {
-        await diagramState.importProject(text)
+      onLoad: async (file) => {
+        await diagramState.importProject(file)
         goto('/project/imported/diagram')
       },
     })
@@ -62,8 +61,8 @@
       accept: '.json',
       expectedSuffix: '.json',
       formatLabel: 'diagram JSON (NetworkGraph)',
-      onLoad: async (text) => {
-        await diagramState.importDiagram(text)
+      onLoad: async (file) => {
+        await diagramState.importDiagram(await file.text())
         goto('/project/imported/diagram')
       },
     })
@@ -104,7 +103,7 @@
           <div class="flex flex-col items-start gap-0.5">
             <span>Import Project</span>
             <span class="text-[10px] text-neutral-400 dark:text-neutral-500"
-              >.neted.json (products + diagram)</span
+              >.neted (zip — diagram, products, scenes, assets)</span
             >
           </div>
         </DropdownMenu.Item>

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -46,8 +46,8 @@
 
   function handleImportProject() {
     promptFile({
-      accept: '.neted',
-      expectedSuffix: '.neted',
+      accept: '.neted.zip,.zip',
+      expectedSuffix: '.neted.zip',
       formatLabel: 'neted project',
       onLoad: async (file) => {
         await diagramState.importProject(file)
@@ -103,7 +103,7 @@
           <div class="flex flex-col items-start gap-0.5">
             <span>Import Project</span>
             <span class="text-[10px] text-neutral-400 dark:text-neutral-500"
-              >.neted (zip — diagram, products, scenes, assets)</span
+              >.neted.zip (diagram, products, scenes, assets)</span
             >
           </div>
         </DropdownMenu.Item>

--- a/apps/editor/src/routes/project/[id]/(content)/materials/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/materials/+page.svelte
@@ -10,6 +10,7 @@
   import * as Card from '$lib/components/ui/card'
   import * as Table from '$lib/components/ui/table'
   import { diagramState } from '$lib/context.svelte'
+  import { assetStore } from '$lib/state/assets.svelte'
   import { type Product, productLabel, specIdentifier } from '$lib/types'
 
   type AssignmentRow =
@@ -190,26 +191,12 @@
     else diagramState.unbindNodes([nodeId])
   }
 
-  /**
-   * Read a user-selected file into a string suitable for `Product.icon`.
-   * SVG files are kept as inline content; other images become data URLs.
-   */
-  async function readIconFile(file: File): Promise<string> {
-    const isSvg = file.type === 'image/svg+xml' || /\.svg$/i.test(file.name)
-    if (isSvg) return await file.text()
-    return await new Promise<string>((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(String(reader.result ?? ''))
-      reader.onerror = () => reject(reader.error)
-      reader.readAsDataURL(file)
-    })
-  }
-
   async function handleCustomIconUpload(e: Event) {
     const input = e.target as HTMLInputElement
     const file = input.files?.[0]
     if (!file) return
-    customIcon = await readIconFile(file)
+    // SVG → inline text; raster → AssetStore-backed blob URL.
+    customIcon = await assetStore.putUserImage(file)
     input.value = '' // allow same file re-selection
   }
 

--- a/apps/editor/src/routes/project/[id]/(content)/materials/[productId]/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/materials/[productId]/+page.svelte
@@ -9,6 +9,7 @@
   import * as Card from '$lib/components/ui/card'
   import * as Table from '$lib/components/ui/table'
   import { diagramState } from '$lib/context.svelte'
+  import { assetStore } from '$lib/state/assets.svelte'
   import { productLabel, specIdentifier } from '$lib/types'
 
   const projectId = $derived($page.params.id ?? '')
@@ -80,24 +81,14 @@
     goto(`/project/${projectId}/materials`)
   }
 
-  /** SVG → inline content; raster → data URL. */
-  async function readIconFile(file: File): Promise<string> {
-    const isSvg = file.type === 'image/svg+xml' || /\.svg$/i.test(file.name)
-    if (isSvg) return await file.text()
-    return await new Promise<string>((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(String(reader.result ?? ''))
-      reader.onerror = () => reject(reader.error)
-      reader.readAsDataURL(file)
-    })
-  }
-
   async function handleIconUpload(e: Event) {
     if (!product) return
     const input = e.target as HTMLInputElement
     const file = input.files?.[0]
     if (!file) return
-    const value = await readIconFile(file)
+    // SVG → inline text (small, snapshot-friendly). Raster → AssetStore
+    // returns a blob URL backed by content-addressed bytes.
+    const value = await assetStore.putUserImage(file)
     diagramState.updateProduct(product.id, { icon: value || undefined })
     input.value = ''
   }

--- a/apps/editor/src/routes/project/[id]/(content)/settings/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/settings/+page.svelte
@@ -3,13 +3,12 @@
   import { Button } from '$lib/components/ui/button'
   import { diagramState } from '$lib/context.svelte'
 
-  function handleExportProject() {
-    const json = diagramState.exportProject('Project')
-    const blob = new Blob([json], { type: 'application/json' })
+  async function handleExportProject() {
+    const blob = await diagramState.exportProjectZip('Project')
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = 'project.neted.json'
+    a.download = 'project.neted'
     a.click()
     URL.revokeObjectURL(url)
   }
@@ -31,7 +30,7 @@
       <div>
         <div class="text-sm font-medium">Project file</div>
         <div class="text-xs text-muted-foreground">
-          Download as .neted.json (includes products and diagram)
+          Download as .neted (zip — diagram, products, scenes, image assets)
         </div>
       </div>
       <Button variant="outline" size="sm" onclick={handleExportProject}>

--- a/apps/editor/src/routes/project/[id]/(content)/settings/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/settings/+page.svelte
@@ -8,7 +8,7 @@
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = 'project.neted'
+    a.download = 'project.neted.zip'
     a.click()
     URL.revokeObjectURL(url)
   }
@@ -30,7 +30,7 @@
       <div>
         <div class="text-sm font-medium">Project file</div>
         <div class="text-xs text-muted-foreground">
-          Download as .neted (zip — diagram, products, scenes, image assets)
+          Download as .neted.zip (diagram, products, scenes, image assets)
         </div>
       </div>
       <Button variant="outline" size="sm" onclick={handleExportProject}>

--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
         "@xyflow/svelte": "^1.5.2",
         "bits-ui": "^2.16.3",
         "clsx": "^2.1.1",
+        "fflate": "^0.8.2",
         "phosphor-svelte": "^3.1.0",
         "tailwind-merge": "^3.5.0",
         "tailwind-variants": "^3.2.2",
@@ -1129,6 +1130,8 @@
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 


### PR DESCRIPTION
## Summary

- Project file becomes a zip (`.neted`, format v1) split into `manifest.json` / `diagram.json` / `products.json` / `scenes/<id>.json` / `assets/<hash>.<ext>` so floor-plan images and raster icons stop being inlined as multi-MB data URLs.
- New session-scoped `AssetStore` (`state/assets.svelte.ts`) owns hash → blob/url mapping; SVG uploads stay inline text, raster uploads flow through the store. Undo history now holds an ~80-char `asset:` ref instead of a multi-MB data URL.
- Inside the zip, image-bearing fields use an `asset:<hash>.<ext>` URI. Writer (`persistence/writer.ts`) rewrites blob URLs → `asset:`; reader (`persistence/reader.ts`) rehydrates `asset:` → blob URL on load. Render paths never see `asset:`, so `classifyIcon` / `resolveIcon` / `<img>` consumers required no changes.
- Legacy `.neted.json` (v3) is intentionally not read; `manifest.json` carries `{ format: "neted", version: 1 }` and rejects anything else.

Design doc: `apps/editor/docs/design/project-file.md`.

## Test plan

- [ ] Sample project loads and renders (`/project/sample/diagram` and `/scene`).
- [ ] Upload a raster product icon → state holds `blob:` URL, undo/redo preserves it.
- [ ] Upload a SVG product icon → state holds inline `<svg>...</svg>` text.
- [ ] Set a scene background image → `<img>` renders, calibration / cable-length still work.
- [ ] Settings → Export downloads `project.neted` (zip). Inspect: `manifest.json`, `diagram.json`, `products.json`, `scenes/<id>.json`, `assets/<hash>.<ext>` present, JSONs reference `asset:<hash>.<ext>`, no `data:image/...` strings.
- [ ] Re-import the exported `.neted` from the home page → diagram, products, scenes, and image assets all restore. Re-export round-trips identical asset hashes.
- [ ] Confirm zip size for a project with a 5MB floor plan + 10 raster icons is roughly 5MB raw + zip overhead, not 5MB × multiple JSON copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)