### PR TITLE
fix(editor): scene route at root creates a root scene

### DIFF
--- a/apps/editor/src/routes/project/[id]/scene/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/scene/+page.svelte
@@ -28,7 +28,11 @@
       diagramState.switchSheet(focusId)
     }
     const want = focus || undefined
-    if (diagramState.currentScene?.scopeSubgraphId !== want) {
+    const have = diagramState.currentScene
+    // The "no scene yet" case has to be handled explicitly: at root
+    // both `have?.scopeSubgraphId` and `want` are `undefined`, so a
+    // bare `!==` would short-circuit and never create the root scene.
+    if (!have || have.scopeSubgraphId !== want) {
       diagramState.setCurrentSceneForScope(want)
     }
   })


### PR DESCRIPTION
## Summary

Opening `/project/[id]/scene` with no `focus` param left the page stuck on the empty "Ready" placeholder. The URL→state `$effect` compared `diagramState.currentScene?.scopeSubgraphId !== want`, but at root both sides are `undefined` — the strict `!==` short-circuited so `setCurrentSceneForScope(undefined)` was never called and no scene was materialized.

Handle the "no scene yet" case explicitly so the first navigation to `/scene` at root creates a root-scoped scene.

## Test plan

- [ ] Sample project → Scene segment of ViewBar (no `?focus=`) → canvas renders an empty root scene instead of the "Ready" placeholder.
- [ ] Hierarchy → drill into a subgraph → Scene → still works (regression).
- [ ] Reload `/project/[id]/scene` → root scene rehydrates without freezing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)