### PR TITLE
fix(editor): diagram drag pushes undo + syncs to IDB

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1141,7 +1141,14 @@ export const diagramState = {
       snap.products.length !== after.products.length ||
       snap.scenes.length !== after.scenes.length ||
       JSON.stringify(snap) !== JSON.stringify(after)
-    if (changed) undoManager.push(label, snap)
+    if (changed) {
+      undoManager.push(label, snap)
+      // Same hook as `commit()` — close the transaction by telling
+      // the cache layer to sync. Without this, drag (which uses
+      // beginTx/endTx instead of per-frame commit()) would land in
+      // memory but never reach IndexedDB.
+      cache.touch()
+    }
   },
   get inTx(): boolean {
     return txActive

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -129,6 +129,8 @@
         bind:links={diagramState.activeView.links}
         theme={editorState.theme}
         mode={diagramState.currentSheetId === null ? editorState.mode : 'view'}
+        ondragstart={() => diagramState.beginTx('Move node')}
+        ondragend={() => diagramState.endTx()}
         onselect={(id: string | null, type: string | null) => { selected = id ? { id, type: type ?? 'node' } : null }}
         onchange={() => {}}
         onlabeledit={(portId: string, label: string, screenX: number, screenY: number) => { labelEdit = { portId, label, x: screenX, y: screenY } }}

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -71,6 +71,14 @@
     onnodeadd?: (id: string) => void
     onnodedelete?: (ids: string[]) => void
     /**
+     * Fires once when the user starts dragging a node or subgraph.
+     * Hosts open an undo / cache transaction here and close it in
+     * `ondragend` so the in-flight 60Hz drag mutations collapse
+     * into one undo step + one IDB write.
+     */
+    ondragstart?: (id: string) => void
+    ondragend?: (id: string) => void
+    /**
      * Fired when the user drags between two ports to request a new link.
      * The parent owns link identity — it must create the link (with an ID of
      * its choosing) and either push it via `bind:links` or call `appendLink()`.
@@ -96,6 +104,8 @@
     oncontextmenu: onctx,
     onnodeadd,
     onnodedelete,
+    ondragstart,
+    ondragend,
     oncreatelink,
     subgraphOverlay,
     linkOverlay,
@@ -574,7 +584,9 @@
     {portOverlay}
     linkPreview={linkDrag}
     bind:svgEl={svgElement}
+    {ondragstart}
     ondragmove={handleDragMove}
+    {ondragend}
     onselect={handleSelect}
     onaddport={handleAddPort}
     onlinkstart={handleLinkStart}

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -25,8 +25,10 @@
     portOverlay,
     linkPreview = null,
     svgEl = $bindable<SVGSVGElement | null>(null),
-    // Callbacks (unified: ondragmove/onselect work for all element types)
+    // Callbacks (unified: drag/select work for all element types)
+    ondragstart,
     ondragmove,
+    ondragend,
     onselect,
     onaddport,
     onlinkstart,
@@ -47,7 +49,9 @@
     linkedPorts?: Set<string>
     linkPreview?: { fromX: number; fromY: number; toX: number; toY: number } | null
     svgEl?: SVGSVGElement | null
+    ondragstart?: (id: string) => void
     ondragmove?: (id: string, x: number, y: number) => void
+    ondragend?: (id: string) => void
     onselect?: (id: string) => void
     onaddport?: (nodeId: string, side: 'top' | 'bottom' | 'left' | 'right') => void
     onlinkstart?: (portId: string, x: number, y: number) => void
@@ -143,7 +147,9 @@
         selected={selection.has(subgraph.id)}
         {interactive}
         overlay={subgraphOverlay}
+        {ondragstart}
         {ondragmove}
+        {ondragend}
         {onselect}
         oncontextmenu={(id, e) => onctx?.(id, 'subgraph', e)}
       />
@@ -168,7 +174,9 @@
         selected={selection.has(node.id)}
         {interactive}
         overlay={nodeOverlay}
+        {ondragstart}
         {ondragmove}
+        {ondragend}
         {onselect}
         {onaddport}
         oncontextmenu={(id, e) => onctx?.(id, 'node', e)}

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -19,7 +19,9 @@
     selected = false,
     interactive = false,
     overlay,
+    ondragstart,
     ondragmove,
+    ondragend,
     onaddport,
     onselect,
     oncontextmenu: onctx,
@@ -30,7 +32,11 @@
     selected?: boolean
     interactive?: boolean
     overlay?: NodeOverlaySnippet
+    /** Fires once when a drag begins — host opens an undo/sync transaction here. */
+    ondragstart?: (id: string) => void
     ondragmove?: (id: string, x: number, y: number) => void
+    /** Fires once on release — host closes the transaction (undo push + DB sync). */
+    ondragend?: (id: string) => void
     onaddport?: (nodeId: string, side: 'top' | 'bottom' | 'left' | 'right') => void
     onselect?: (id: string) => void
     oncontextmenu?: (id: string, e: MouseEvent) => void
@@ -139,7 +145,9 @@
       const t = e.target as Element
       return !t.closest('.port') && !t.closest('.edge-zone') && e.button === 0 && interactive
     },
+    onStart: () => ondragstart?.(node.id),
     onDrag: (dx, dy) => ondragmove?.(node.id, (node.position?.x ?? 0) + dx, (node.position?.y ?? 0) + dy),
+    onEnd: () => ondragend?.(node.id),
   })}
   onclick={(e) => { e.stopPropagation(); onselect?.(node.id) }}
   onpointerenter={() => { if (interactive) hovered = true }}

--- a/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
@@ -11,7 +11,9 @@
     selected = false,
     interactive = false,
     overlay,
+    ondragstart,
     ondragmove,
+    ondragend,
     onselect,
     oncontextmenu: onctx,
   }: {
@@ -21,7 +23,9 @@
     selected?: boolean
     interactive?: boolean
     overlay?: SubgraphOverlaySnippet
+    ondragstart?: (sgId: string) => void
     ondragmove?: (sgId: string, x: number, y: number) => void
+    ondragend?: (sgId: string) => void
     onselect?: (sgId: string) => void
     oncontextmenu?: (id: string, e: MouseEvent) => void
   } = $props()
@@ -84,7 +88,9 @@
     oncontextmenu={(e) => { e.preventDefault(); e.stopPropagation(); onselect?.(subgraph.id); onctx?.(subgraph.id, e) }}
     use:elementDrag={() => ({
       filter: (e) => e.button === 0 && interactive,
+      onStart: () => ondragstart?.(subgraph.id),
       onDrag: (dx, dy) => ondragmove?.(subgraph.id, (subgraph.bounds?.x ?? 0) + dx, (subgraph.bounds?.y ?? 0) + dy),
+      onEnd: () => ondragend?.(subgraph.id),
     })}
   />
   {@render overlay?.(subgraph, overlayContext)}

--- a/libs/@shumoku/renderer/src/lib/use-drag.ts
+++ b/libs/@shumoku/renderer/src/lib/use-drag.ts
@@ -12,20 +12,26 @@ interface DragOptions {
   interactive?: boolean
   // biome-ignore lint/suspicious/noExplicitAny: d3-drag filter signature uses any for event
   filter?: (e: any) => boolean
+  /** Fires once when the user starts dragging — use to open an undo/sync transaction. */
+  onStart?: () => void
   onDrag: (dx: number, dy: number) => void
+  /** Fires once on release — use to close the transaction and persist the result. */
+  onEnd?: () => void
 }
 
 /** Generic drag action for any SVG element (nodes, subgraphs, etc.) */
 export function elementDrag(element: SVGElement, opts: () => DragOptions) {
   function apply() {
-    const { interactive = true, filter, onDrag } = opts()
+    const { interactive = true, filter, onStart, onDrag, onEnd } = opts()
     const behavior = drag<SVGElement, unknown>()
     behavior.filter((e) => {
       if (!interactive) return false
       if (filter) return filter(e)
       return e.button === 0
     })
+    behavior.on('start', () => onStart?.())
     behavior.on('drag', (e) => onDrag(e.dx, e.dy))
+    behavior.on('end', () => onEnd?.())
     select<SVGElement, unknown>(element).call(behavior)
   }
 


### PR DESCRIPTION
## Summary

Dragging a node or subgraph in diagram view mutated `diagram.nodes` directly through the renderer's drag callback — no `commit()` ran, so the move was neither pushed onto the undo stack nor synced to IndexedDB. Reload reverted the position. Scene drag was already correct (Svelte Flow's `onnodedragstop` → `placeNodesInScene` → `commit()`).

Fix: wire d3-drag's start/end events all the way out so the host can bracket the drag in a transaction.

- `use-drag.ts` gains `onStart` / `onEnd`.
- `SvgNode` / `SvgSubgraph` re-emit `ondragstart` / `ondragend`.
- `SvgCanvas` / `ShumokuRenderer` forward them.
- Diagram page wires `ondragstart={beginTx('Move node')}` and `ondragend={endTx()}` — per-frame mutations land inside one transaction → one undo entry + one IDB write per drag.
- `endTx` now fires `cache.touch()` so post-drag state reaches the mirror (only `commit()` did this before; tx bypassed it).

## Test plan

- [ ] Diagram view → drag a node → release → Cmd+Z reverts the position.
- [ ] Diagram view → drag → reload → position is preserved (was: reverted).
- [ ] Drag does not produce a flood of IDB writes (one transaction at drag end).
- [ ] Subgraph drag also undoes / persists.
- [ ] Scene view drag still works (regression: scene path is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)