### PR TITLE
fix(editor): suppress browser zoom on Cmd/Ctrl+wheel over canvas pages

### DIFF
--- a/apps/editor/src/lib/utils/prevent-browser-zoom.ts
+++ b/apps/editor/src/lib/utils/prevent-browser-zoom.ts
@@ -1,0 +1,32 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { onMount } from 'svelte'
+
+/**
+ * Block the browser's built-in zoom on Cmd/Ctrl + wheel and pinch
+ * (which the OS synthesizes as `wheel` with `ctrlKey: true`).
+ * Without this, hovering over a floating button while zooming
+ * triggers the page-level zoom shortcut on macOS instead of the
+ * canvas zoom — Miro / Figma / Excalidraw all suppress it the
+ * same way.
+ *
+ * The listener is registered with `{ passive: false }` because the
+ * default `passive: true` on wheel events forbids preventDefault.
+ * `preventDefault` only stops the *browser default*, so Svelte
+ * Flow / d3-zoom / wheel-gestures listeners still see the event
+ * and run their pan/zoom logic.
+ *
+ * Use only on canvas pages (diagram / scene). Pages with normal
+ * scrollable content (settings, materials, BOM) should keep
+ * browser zoom working for accessibility.
+ */
+export function preventBrowserZoom(): void {
+  onMount(() => {
+    const handler = (e: WheelEvent) => {
+      if (e.ctrlKey || e.metaKey) e.preventDefault()
+    }
+    window.addEventListener('wheel', handler, { passive: false })
+    return () => window.removeEventListener('wheel', handler)
+  })
+}

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -14,6 +14,9 @@
   import StatusBadge from '$lib/components/StatusBadge.svelte'
   import ViewBar from '$lib/components/view-bar/ViewBar.svelte'
   import { diagramState, editorState } from '$lib/context.svelte'
+  import { preventBrowserZoom } from '$lib/utils/prevent-browser-zoom'
+
+  preventBrowserZoom()
 
   // =========================================================================
   // Local UI state (page-specific, not shared)

--- a/apps/editor/src/routes/project/[id]/scene/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/scene/+page.svelte
@@ -10,6 +10,9 @@
   import SceneSideToolbar from '$lib/components/scene/SceneSideToolbar.svelte'
   import ViewBar from '$lib/components/view-bar/ViewBar.svelte'
   import { diagramState } from '$lib/context.svelte'
+  import { preventBrowserZoom } from '$lib/utils/prevent-browser-zoom'
+
+  preventBrowserZoom()
 
   // Scene route — floor-plan view of a subgraph. URL convention:
   //   /project/[id]/scene                → root scene


### PR DESCRIPTION
On macOS, Cmd+scroll is the browser's accessibility zoom shortcut — hovering over a floating button (HeaderBar / ViewBar / ExportMenu) while zooming on the canvas zooms the whole page instead of the canvas. Same on Windows / Linux with Ctrl+scroll and on trackpad pinch (which the OS synthesizes as `wheel` with `ctrlKey: true`).

Miro / Figma / Excalidraw all suppress this the same way: a window-level `wheel` listener with `passive: false` calling `preventDefault()` when `ctrlKey || metaKey`. Doesn't stop event propagation, so the canvas's own pan/zoom handlers (Svelte Flow / wheel-gestures) still fire.

Applied only to `/diagram` and `/scene` pages — settings, materials, BOM keep browser zoom for accessibility.

(This commit was meant to ship in #178 but landed on the branch after that PR was merged. Standalone PR.)

## Test plan

- [ ] macOS: Cmd+scroll over a floating button (HeaderBar / ExportMenu / ViewBar) while on `/diagram` → no page zoom.
- [ ] macOS: Trackpad pinch over a floating button → canvas zooms, page does not.
- [ ] Windows: Ctrl+scroll behavior matches.
- [ ] `/project/[id]/settings` (and other content pages): Cmd/Ctrl+scroll still triggers normal browser zoom (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)