### PR TITLE
feat(editor): action registry + canvas right-click menu (PR-1)

### DIFF
--- a/apps/editor/src/lib/actions/builtin.ts
+++ b/apps/editor/src/lib/actions/builtin.ts
@@ -1,0 +1,118 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { ArrowsClockwise, ArrowUUpLeft, ArrowUUpRight, Trash } from 'phosphor-svelte'
+import { diagramState } from '../context.svelte'
+import { defineAction } from './registry'
+import type { Action, ActionContext } from './types'
+
+// Built-in v1 action set. Lives next to the registry rather than
+// inline in components so each surface (context menu / shortcut /
+// toolbar / palette) gets the same wiring for free.
+//
+// Calling this at app boot once registers everything. The module
+// itself is pure / side-effect-free; the entry route invokes
+// `registerBuiltinActions()` so SSR doesn't run side effects on
+// import.
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+const Mod = isMac ? '⌘' : 'Ctrl'
+
+const hasSelection = (ctx: ActionContext) => ctx.selection.ids.length > 0
+const inDiagram = (ctx: ActionContext) => ctx.mode === 'diagram'
+
+function deleteSelection(ctx: ActionContext): void {
+  // Snapshot so removals don't mutate the iteration.
+  const items = ctx.selection.ids.map((id, i) => ({ id, type: ctx.selection.types[i] }))
+  for (const it of items) {
+    if (it.type === 'edge' || it.type === 'link') diagramState.removeLink(it.id)
+    else diagramState.removeNode(it.id)
+  }
+}
+
+const builtinActions: Action[] = [
+  // ----- Edit ------------------------------------------------------------
+  {
+    id: 'edit.undo',
+    label: 'Undo',
+    shortcut: `${Mod}+Z`,
+    icon: ArrowUUpLeft,
+    group: 'edit',
+    enabled: () => diagramState.canUndo,
+    run: () => {
+      diagramState.undo()
+    },
+  },
+  {
+    id: 'edit.redo',
+    label: 'Redo',
+    shortcut: `${Mod}+Shift+Z`,
+    icon: ArrowUUpRight,
+    group: 'edit',
+    enabled: () => diagramState.canRedo,
+    run: () => {
+      diagramState.redo()
+    },
+  },
+  {
+    id: 'edit.delete',
+    label: 'Delete',
+    shortcut: 'Del',
+    icon: Trash,
+    group: 'edit',
+    enabled: hasSelection,
+    run: deleteSelection,
+  },
+
+  // ----- View ------------------------------------------------------------
+  {
+    id: 'view.fitAll',
+    label: 'Fit to view',
+    shortcut: `${Mod}+0`,
+    group: 'view',
+    enabled: (ctx) => !!ctx.camera,
+    run: (ctx) => ctx.camera?.fitAll(),
+  },
+  {
+    id: 'view.zoomIn',
+    label: 'Zoom in',
+    shortcut: `${Mod}+=`,
+    group: 'view',
+    enabled: (ctx) => !!ctx.camera,
+    run: (ctx) => ctx.camera?.zoomIn(),
+  },
+  {
+    id: 'view.zoomOut',
+    label: 'Zoom out',
+    shortcut: `${Mod}+-`,
+    group: 'view',
+    enabled: (ctx) => !!ctx.camera,
+    run: (ctx) => ctx.camera?.zoomOut(),
+  },
+  {
+    id: 'view.resetZoom',
+    label: 'Reset zoom',
+    group: 'view',
+    enabled: (ctx) => !!ctx.camera,
+    run: (ctx) => ctx.camera?.reset(),
+  },
+
+  // ----- Arrange (diagram only) ------------------------------------------
+  {
+    id: 'arrange.autoLayout',
+    label: 'Auto-arrange',
+    icon: ArrowsClockwise,
+    group: 'arrange',
+    when: inDiagram,
+    run: () => diagramState.autoArrange(),
+  },
+]
+
+let registered = false
+
+/** Register the built-in action set once. Idempotent. */
+export function registerBuiltinActions(): void {
+  if (registered) return
+  registered = true
+  for (const a of builtinActions) defineAction(a)
+}

--- a/apps/editor/src/lib/actions/registry.test.ts
+++ b/apps/editor/src/lib/actions/registry.test.ts
@@ -1,0 +1,74 @@
+// Action registry behavior. Doesn't exercise the built-in
+// actions (those touch editor state) — just the dispatcher.
+
+import { afterEach, expect, test } from 'vitest'
+import {
+  _resetRegistry,
+  defineAction,
+  runAction,
+  visibleActions,
+  visibleActionsByGroup,
+} from './registry'
+import type { ActionContext } from './types'
+
+const baseCtx: ActionContext = {
+  mode: 'diagram',
+  selection: { ids: [], types: [] },
+}
+
+afterEach(() => {
+  _resetRegistry()
+})
+
+test('visibleActions filters by `when`', () => {
+  defineAction({ id: 'a', label: 'A', run: () => {} })
+  defineAction({ id: 'b', label: 'B', when: (c) => c.mode === 'scene', run: () => {} })
+  defineAction({ id: 'c', label: 'C', when: () => false, run: () => {} })
+
+  const visible = visibleActions(baseCtx).map((a) => a.id)
+  expect(visible).toEqual(['a'])
+})
+
+test('visibleActionsByGroup buckets by group', () => {
+  defineAction({ id: 'e1', label: 'edit-1', group: 'edit', run: () => {} })
+  defineAction({ id: 'v1', label: 'view-1', group: 'view', run: () => {} })
+  defineAction({ id: 'e2', label: 'edit-2', group: 'edit', run: () => {} })
+  defineAction({ id: 'm1', label: 'misc-1', run: () => {} })
+
+  const groups = visibleActionsByGroup(baseCtx)
+  // Insertion order is preserved across groups.
+  expect(groups.map(([g]) => g)).toEqual(['edit', 'view', 'misc'])
+  expect(groups[0]?.[1].map((a) => a.id)).toEqual(['e1', 'e2'])
+})
+
+test('runAction skips when `enabled` is false', async () => {
+  let ran = false
+  defineAction({
+    id: 'gated',
+    label: 'Gated',
+    enabled: () => false,
+    run: () => {
+      ran = true
+    },
+  })
+  const result = await runAction('gated', baseCtx)
+  expect(result).toBe(false)
+  expect(ran).toBe(false)
+})
+
+test('runAction returns false for unknown id', async () => {
+  expect(await runAction('does.not.exist', baseCtx)).toBe(false)
+})
+
+test('runAction invokes run when allowed', async () => {
+  let ran = false
+  defineAction({
+    id: 'fire',
+    label: 'Fire',
+    run: () => {
+      ran = true
+    },
+  })
+  expect(await runAction('fire', baseCtx)).toBe(true)
+  expect(ran).toBe(true)
+})

--- a/apps/editor/src/lib/actions/registry.ts
+++ b/apps/editor/src/lib/actions/registry.ts
@@ -1,0 +1,64 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { Action, ActionContext, ActionGroup } from './types'
+
+// Single-process registry. Actions register themselves at module
+// load (see `builtin.ts`) and consumers query by id or by context.
+
+const actions = new Map<string, Action>()
+
+export function defineAction(action: Action): void {
+  if (actions.has(action.id)) {
+    console.warn(`[actions] re-defining action ${action.id}`)
+  }
+  actions.set(action.id, action)
+}
+
+export function getAction(id: string): Action | undefined {
+  return actions.get(id)
+}
+
+/**
+ * Actions visible for `ctx`, with `when` filter applied. Caller
+ * decides what to do with `enabled === false` (typically render
+ * disabled). Stable insertion order is preserved.
+ */
+export function visibleActions(ctx: ActionContext): Action[] {
+  const out: Action[] = []
+  for (const a of actions.values()) {
+    if (a.when && !a.when(ctx)) continue
+    out.push(a)
+  }
+  return out
+}
+
+/** Same as `visibleActions` but bucketed by group, group keys preserved in registration order. */
+export function visibleActionsByGroup(ctx: ActionContext): Array<[ActionGroup, Action[]]> {
+  const buckets = new Map<ActionGroup, Action[]>()
+  for (const a of visibleActions(ctx)) {
+    const g = a.group ?? 'misc'
+    let bucket = buckets.get(g)
+    if (!bucket) {
+      bucket = []
+      buckets.set(g, bucket)
+    }
+    bucket.push(a)
+  }
+  return [...buckets.entries()]
+}
+
+/** Run an action by id. Returns whether it ran (id matched and `enabled` allowed). */
+export async function runAction(id: string, ctx: ActionContext): Promise<boolean> {
+  const a = actions.get(id)
+  if (!a) return false
+  if (a.when && !a.when(ctx)) return false
+  if (a.enabled && !a.enabled(ctx)) return false
+  await a.run(ctx)
+  return true
+}
+
+/** Test-only / module-reset helper. */
+export function _resetRegistry(): void {
+  actions.clear()
+}

--- a/apps/editor/src/lib/actions/types.ts
+++ b/apps/editor/src/lib/actions/types.ts
@@ -1,0 +1,82 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Action / command pattern. UI surfaces (right-click context menu,
+// keyboard shortcuts, toolbar buttons, future Cmd+K palette) all
+// consume the same registry instead of each duplicating the
+// "what does Delete do here?" wiring.
+//
+// An Action is metadata + a `run` function. Surfaces ask the
+// registry for actions matching a given context, render whatever
+// fits their affordance (icon button vs menu item vs keystroke
+// match), and call `run(ctx)` when the user picks one.
+
+import type { Component } from 'svelte'
+
+/** Where the user invoked the action. Drives `when` / `enabled`. */
+export interface ActionContext {
+  /** Which canvas is active. */
+  mode: 'diagram' | 'scene'
+  /**
+   * Snapshot of the current selection (ids + element types). Empty
+   * arrays when nothing is selected.
+   */
+  selection: {
+    ids: string[]
+    types: ('node' | 'subgraph' | 'edge' | 'link' | 'port')[]
+  }
+  /**
+   * Canvas-space coordinates where the action was invoked, when
+   * applicable (right-click position for "paste here", etc.).
+   * `undefined` for keyboard / toolbar invocations.
+   */
+  canvasPos?: { x: number; y: number }
+  /**
+   * Camera handle exposed by whichever canvas is active. Diagram
+   * supplies `attachCamera`'s API; scene supplies a Svelte Flow
+   * adapter. Optional — actions that need it should use `enabled`
+   * to gate themselves.
+   */
+  camera?: CameraHandle
+}
+
+/** Subset of the diagram camera (and Svelte Flow's useSvelteFlow) shared by both canvases. */
+export interface CameraHandle {
+  fitAll(): void
+  zoomIn(): void
+  zoomOut(): void
+  reset(): void
+}
+
+/** Visual grouping in a context menu / palette. */
+export type ActionGroup = 'edit' | 'view' | 'arrange' | 'misc'
+
+export interface Action {
+  /** Stable id, dot-namespaced (`edit.undo`, `view.fitAll`). */
+  id: string
+  /** Human label for menu / palette entries. */
+  label: string
+  /**
+   * Keyboard shortcut, simplified syntax: `Mod+Z` (Mod = Cmd on
+   * macOS, Ctrl elsewhere). Display only for v1 — actual key
+   * dispatch lands in PR-2.
+   */
+  shortcut?: string
+  /** Icon component (Phosphor Svelte) — optional. */
+  icon?: Component
+  /** Group for menu sectioning. Defaults to `misc`. */
+  group?: ActionGroup
+  /**
+   * Hide the action when this returns false. Use for mode-specific
+   * (`mode === 'diagram'`) or selection-specific actions.
+   */
+  when?: (ctx: ActionContext) => boolean
+  /**
+   * Render the action but disabled when this returns false. Use
+   * for "available but not actionable right now" cases (e.g.
+   * Delete with empty selection).
+   */
+  enabled?: (ctx: ActionContext) => boolean
+  /** Side-effecting work — calls into editor state or camera. */
+  run: (ctx: ActionContext) => void | Promise<void>
+}

--- a/apps/editor/src/lib/components/CanvasContextMenu.svelte
+++ b/apps/editor/src/lib/components/CanvasContextMenu.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import { runAction, visibleActionsByGroup } from '$lib/actions/registry'
+  import type { Action, ActionContext } from '$lib/actions/types'
+
+  // Right-click menu on canvas surfaces. Renders whatever actions
+  // the registry exposes for the given context, grouped by their
+  // `group` field. Surfaces choose what `ctx` to pass (selection,
+  // canvas position, mode, camera handle).
+
+  let {
+    open = $bindable(false),
+    x = 0,
+    y = 0,
+    ctx,
+  }: {
+    open: boolean
+    x: number
+    y: number
+    ctx: ActionContext
+  } = $props()
+
+  const groups = $derived(open ? visibleActionsByGroup(ctx) : [])
+
+  function isEnabled(a: Action): boolean {
+    return a.enabled ? a.enabled(ctx) : true
+  }
+
+  async function pick(a: Action) {
+    if (!isEnabled(a)) return
+    open = false
+    await runAction(a.id, ctx)
+  }
+
+  function onkeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      open = false
+    }
+  }
+
+  // Close on any click outside the menu surface (the menu's own
+  // pointer events stop propagation below).
+  function onWindowPointerDown() {
+    if (open) open = false
+  }
+
+  $effect(() => {
+    if (!open) return
+    window.addEventListener('pointerdown', onWindowPointerDown, { capture: true })
+    window.addEventListener('keydown', onkeydown)
+    return () => {
+      window.removeEventListener('pointerdown', onWindowPointerDown, { capture: true })
+      window.removeEventListener('keydown', onkeydown)
+    }
+  })
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="fixed z-50 min-w-[200px] rounded-lg border border-neutral-200 bg-white py-1 text-sm shadow-lg dark:border-neutral-700 dark:bg-neutral-800"
+    style="left: {x}px; top: {y}px"
+    role="menu"
+    tabindex="-1"
+    onpointerdown={(e) => e.stopPropagation()}
+  >
+    {#each groups as [ group, items ], i (group)}
+      {#if i > 0}
+        <div class="my-1 h-px bg-neutral-200 dark:bg-neutral-700"></div>
+      {/if}
+      {#each items as a (a.id)}
+        {@const enabled = isEnabled(a)}
+        <button
+          type="button"
+          class="flex w-full items-center justify-between gap-4 px-3 py-1.5 text-left transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent dark:disabled:hover:bg-transparent"
+          disabled={!enabled}
+          onclick={() => pick(a)}
+        >
+          <span class="flex items-center gap-2">
+            {#if a.icon}
+              <a.icon class="h-4 w-4 text-neutral-500" />
+            {/if}
+            {a.label}
+          </span>
+          {#if a.shortcut}
+            <span class="text-[10px] font-mono text-muted-foreground">{a.shortcut}</span>
+          {/if}
+        </button>
+      {/each}
+    {/each}
+  </div>
+{/if}

--- a/apps/editor/src/routes/+layout.svelte
+++ b/apps/editor/src/routes/+layout.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
   import { Tooltip } from 'bits-ui'
+  import { registerBuiltinActions } from '$lib/actions/builtin'
   import { initDarkMode } from '$lib/context.svelte'
   import '../app.css'
 
   let { children } = $props()
 
+  // Register the action set once on app boot. Inside `$effect` so
+  // it runs in the browser only — the registry has no SSR side
+  // effects.
   $effect(() => {
+    registerBuiltinActions()
     return initDarkMode()
   })
 </script>

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -4,6 +4,8 @@
   import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
   import { renderGraphToSvg } from '@shumoku/renderer-svg'
   import { page } from '$app/stores'
+  import type { ActionContext, CameraHandle } from '$lib/actions/types'
+  import CanvasContextMenu from '$lib/components/CanvasContextMenu.svelte'
   import CodePanel from '$lib/components/CodePanel.svelte'
   import DetailPanel from '$lib/components/DetailPanel.svelte'
   import ExportMenu from '$lib/components/ExportMenu.svelte'
@@ -22,13 +24,29 @@
   let renderer: ShumokuRenderer | undefined = $state()
   let rendererSvg: SVGSVGElement | null = $state(null)
 
+  // Camera handle for the action registry — diagram's d3-zoom doesn't
+  // expose `fitAll`/`zoomIn`/`zoomOut` directly, so wrap its primitives.
+  let cameraHandle = $state<CameraHandle | null>(null)
+
   // Editor camera: auto-detects mouse (wheel → zoom) vs trackpad
   // (two-finger → pan). Pinch always zooms. Alt+left or middle-click
   // drags the viewport.
   $effect(() => {
     if (!rendererSvg) return
-    const camera = attachCamera(rendererSvg)
-    return () => camera.detach()
+    const c = attachCamera(rendererSvg)
+    cameraHandle = {
+      // `reset()` returns to the SVG viewBox (= layout bounds), which
+      // is exactly "fit everything" since the renderer sizes the
+      // viewBox to the computed graph extent.
+      fitAll: () => c.reset(),
+      zoomIn: () => c.zoomBy(1.25),
+      zoomOut: () => c.zoomBy(0.8),
+      reset: () => c.reset(),
+    }
+    return () => {
+      c.detach()
+      cameraHandle = null
+    }
   })
 
   // Sync URL → state. `?focus=<id>` drives Hierarchy drilldown so a
@@ -47,6 +65,25 @@
   })
   let selected = $state<{ id: string; type: string } | null>(null)
   let contextMenu = $state<{ id: string; type: string; x: number; y: number } | null>(null)
+  // Canvas-level (empty-area) right-click menu — driven by the
+  // action registry. NodeContextMenu still handles node/subgraph/
+  // edge clicks via `oncontextmenu` from the renderer (which
+  // stopPropagation's so this wrapper handler doesn't also fire).
+  let canvasMenuOpen = $state(false)
+  let canvasMenuX = $state(0)
+  let canvasMenuY = $state(0)
+
+  const actionCtx = $derived<ActionContext>({
+    mode: 'diagram',
+    selection: selected
+      ? {
+          ids: [selected.id],
+          types: [selected.type as ActionContext['selection']['types'][number]],
+        }
+      : { ids: [], types: [] },
+    canvasPos: canvasMenuOpen ? { x: canvasMenuX, y: canvasMenuY } : undefined,
+    camera: cameraHandle ?? undefined,
+  })
   let clipboard = $state<{
     label: string
     shape?: NodeShape
@@ -115,6 +152,15 @@
     class="absolute inset-0"
     ondblclick={() => {
       if (selected) openDetail(selected.id, selected.type)
+    }}
+    oncontextmenu={(e) => {
+      // Per-element handlers stopPropagation, so this only fires on
+      // the empty canvas. Open the action-registry-driven menu in
+      // place of the browser default.
+      e.preventDefault()
+      canvasMenuX = e.clientX
+      canvasMenuY = e.clientY
+      canvasMenuOpen = true
     }}
   >
     {#if diagramState.nodes.size > 0 || diagramState.status !== 'Loading...'}
@@ -259,4 +305,6 @@
     elementId={detailTarget?.id ?? null}
     onclose={() => { detailTarget = null }}
   />
+
+  <CanvasContextMenu bind:open={canvasMenuOpen} x={canvasMenuX} y={canvasMenuY} ctx={actionCtx} />
 </div>

--- a/apps/editor/src/routes/project/[id]/scene/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/scene/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { renderGraphToSvg } from '@shumoku/renderer-svg'
   import { page } from '$app/stores'
+  import type { ActionContext } from '$lib/actions/types'
+  import CanvasContextMenu from '$lib/components/CanvasContextMenu.svelte'
   import CodePanel from '$lib/components/CodePanel.svelte'
   import DetailPanel from '$lib/components/DetailPanel.svelte'
   import ExportMenu from '$lib/components/ExportMenu.svelte'
@@ -59,9 +61,33 @@
   }
 
   let codePanelOpen = $state(false)
+
+  // Canvas-level right-click menu (registry-driven). v1: no camera
+  // handle from scene yet — view actions render disabled. Wiring
+  // a CameraHandle through SceneCanvas → useSvelteFlow is a
+  // follow-up.
+  let canvasMenuOpen = $state(false)
+  let canvasMenuX = $state(0)
+  let canvasMenuY = $state(0)
+  const actionCtx = $derived<ActionContext>({
+    mode: 'scene',
+    selection: { ids: [], types: [] },
+    canvasPos: canvasMenuOpen ? { x: canvasMenuX, y: canvasMenuY } : undefined,
+  })
 </script>
 
-<div class="relative h-screen w-screen overflow-hidden bg-neutral-50 dark:bg-neutral-950">
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="relative h-screen w-screen overflow-hidden bg-neutral-50 dark:bg-neutral-950"
+  oncontextmenu={(e) => {
+    // Per-element handlers in Svelte Flow stopPropagation so this
+    // only fires for empty-canvas right-clicks.
+    e.preventDefault()
+    canvasMenuX = e.clientX
+    canvasMenuY = e.clientY
+    canvasMenuOpen = true
+  }}
+>
   <div class="absolute inset-0">
     {#if diagramState.currentScene}
       <SceneCanvas scene={diagramState.currentScene} />
@@ -102,4 +128,6 @@
       detailTarget = null
     }}
   />
+
+  <CanvasContextMenu bind:open={canvasMenuOpen} x={canvasMenuX} y={canvasMenuY} ctx={actionCtx} />
 </div>


### PR DESCRIPTION
First slice of the action / command pattern. UI surfaces (right-click context menu, future keyboard shortcuts, future toolbar buttons, future Cmd+K palette) all consume one registry instead of each duplicating "what does Delete do here?" / "is Undo enabled?" wiring.

This PR ships the core + the canvas right-click menu only. PR-2 migrates existing UI (HeaderBar Undo/Redo, NodeContextMenu, scene toolbar) to use the registry, and PR-3 adds keyboard / Cmd+K.

## Modules

- `lib/actions/types.ts` — `Action`, `ActionContext`, `CameraHandle` types.
- `lib/actions/registry.ts` — `defineAction`, `visibleActions`, `visibleActionsByGroup`, `runAction`. ~50 lines.
- `lib/actions/builtin.ts` — v1 actions: `edit.undo` / `edit.redo` / `edit.delete`, `view.fitAll` / `view.zoomIn` / `view.zoomOut` / `view.resetZoom`, `arrange.autoLayout` (diagram-only).
- `components/CanvasContextMenu.svelte` — Bits-style menu, grouped by `group` field, disabled state via `enabled` predicate.

## Wiring

- `routes/+layout.svelte` calls `registerBuiltinActions()` once on boot (inside `$effect` so SSR doesn't fire side effects).
- Diagram and scene pages open the menu on the canvas wrapper's `oncontextmenu`. Per-element handlers (SvgNode / SvgSubgraph etc.) already `stopPropagation`, so this only fires on empty canvas — no double menu.
- Diagram supplies a `CameraHandle` wrapping `attachCamera` primitives (`fitAll = reset`, `zoomIn/Out = zoomBy(1.25)/(0.8)`).
- Scene's view actions render disabled until a Svelte Flow camera adapter lands (follow-up — needs `useSvelteFlow` exposed up from `SceneCanvas`).

## Existing UI is unchanged

HeaderBar / NodeContextMenu / SideToolbar still work as before. The registry runs alongside; PR-2 will migrate them.

## Tests

5 unit tests for the dispatcher: filter by `when`, group bucketing, `enabled`-gated `runAction`, unknown id, happy path. All green (15 tests total in the editor).

## Test plan

- [ ] Diagram empty-canvas right-click → menu opens with Undo / Redo / Delete (disabled) / Fit / Zoom in / Zoom out / Reset / Auto-arrange.
- [ ] Scene empty-canvas right-click → menu opens with Undo / Redo / Delete / view actions disabled (no camera handle yet).
- [ ] Right-click on a node → existing NodeContextMenu, not the new one.
- [ ] Click a menu item → action runs (Fit zooms to bounds, Undo reverts, etc.).
- [ ] Click outside the menu → menu closes.
- [ ] Esc → menu closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)