### PR TITLE
feat(editor): keyboard shortcuts + HeaderBar/SideToolbar via registry (PR-2)

### DIFF
--- a/apps/editor/src/lib/actions/builtin.ts
+++ b/apps/editor/src/lib/actions/builtin.ts
@@ -57,7 +57,10 @@ const builtinActions: Action[] = [
   {
     id: 'edit.delete',
     label: 'Delete',
-    shortcut: 'Del',
+    // No shortcut field on purpose: both diagram (custom SVG) and
+    // scene (Svelte Flow) already handle Backspace/Delete natively
+    // on the canvas. Binding it here would double-fire. The menu
+    // entry stays so right-click → Delete works without keyboard.
     icon: Trash,
     group: 'edit',
     enabled: hasSelection,

--- a/apps/editor/src/lib/actions/context-provider.svelte.ts
+++ b/apps/editor/src/lib/actions/context-provider.svelte.ts
@@ -1,0 +1,33 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { ActionContext } from './types'
+
+// Single slot for "the currently active action context". Pages /
+// canvases publish their `ActionContext` here while mounted; the
+// global keyboard handler and any toolbar buttons read it.
+//
+// Reactive ($state) so consumers re-derive `enabled` flags as the
+// underlying state (selection, camera) changes.
+
+const provider = $state<{ ctx: ActionContext | null }>({ ctx: null })
+
+/** Replace the active context. Pages call this in $effect. */
+export function provideActionContext(ctx: ActionContext): void {
+  provider.ctx = ctx
+}
+
+/** Drop the active context — page is unmounting. */
+export function clearActionContext(): void {
+  provider.ctx = null
+}
+
+/**
+ * Read the currently active context, or a minimal stub if no
+ * canvas is mounted (e.g. on settings / materials / BOM pages).
+ * Toolbar buttons that don't need selection / camera (Undo /
+ * Redo) work fine with the stub.
+ */
+export function getActionContext(): ActionContext {
+  return provider.ctx ?? { mode: 'diagram', selection: { ids: [], types: [] } }
+}

--- a/apps/editor/src/lib/actions/keyboard.ts
+++ b/apps/editor/src/lib/actions/keyboard.ts
@@ -1,0 +1,89 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { getActionContext } from './context-provider.svelte'
+import { runAction, visibleActions } from './registry'
+import type { Action } from './types'
+
+// Window-level keyboard dispatcher. Reads the active context from
+// the provider, walks visible actions, and runs the first one
+// whose `shortcut` matches the event. Pages don't wire shortcuts
+// individually — defining a shortcut on an Action is enough.
+//
+// Skip-when-typing is built in: events from inputs / textareas /
+// contenteditable elements pass through to the page so users can
+// type Mod+Z to undo their text input rather than the diagram.
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+
+interface ParsedShortcut {
+  needsMod: boolean
+  needsShift: boolean
+  needsAlt: boolean
+  /** Lower-cased final key (e.g. 'z', '0', '=', '-', 'delete'). */
+  key: string
+}
+
+function parseShortcut(s: string): ParsedShortcut | null {
+  const parts = s.split('+').map((p) => p.trim())
+  const last = parts[parts.length - 1]?.toLowerCase()
+  if (!last) return null
+  return {
+    needsMod: parts.some((p) => p === 'Mod' || p === '⌘' || p === 'Ctrl' || p === 'Cmd'),
+    needsShift: parts.includes('Shift'),
+    needsAlt: parts.includes('Alt') || parts.includes('Option'),
+    key: last,
+  }
+}
+
+function eventMatches(parsed: ParsedShortcut, e: KeyboardEvent): boolean {
+  // ⌘ on macOS = metaKey; on Windows / Linux = ctrlKey. Either is
+  // accepted as "Mod" so people pasting Win shortcuts on Mac (or
+  // vice versa) still hit something sensible.
+  const modPressed = isMac ? e.metaKey : e.ctrlKey
+  if (parsed.needsMod !== modPressed) return false
+  if (parsed.needsShift !== e.shiftKey) return false
+  if (parsed.needsAlt !== e.altKey) return false
+
+  const k = e.key.toLowerCase()
+  // Tolerate '+' / '_' which require Shift on US layouts.
+  if (parsed.key === '=') return k === '=' || k === '+'
+  if (parsed.key === '-') return k === '-' || k === '_'
+  if (parsed.key === 'del' || parsed.key === 'delete') {
+    return k === 'delete' || k === 'backspace'
+  }
+  return k === parsed.key
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  return /^(input|textarea|select)$/i.test(target.tagName)
+}
+
+/** Install the global handler; returns a cleanup. */
+export function installKeyboardShortcuts(): () => void {
+  if (typeof window === 'undefined') return () => {}
+
+  function handler(e: KeyboardEvent) {
+    if (isTypingTarget(e.target)) return
+    const ctx = getActionContext()
+    let match: { action: Action; parsed: ParsedShortcut } | null = null
+    for (const a of visibleActions(ctx)) {
+      if (!a.shortcut) continue
+      const parsed = parseShortcut(a.shortcut)
+      if (!parsed) continue
+      if (eventMatches(parsed, e)) {
+        match = { action: a, parsed }
+        break
+      }
+    }
+    if (!match) return
+    if (match.action.enabled && !match.action.enabled(ctx)) return
+    e.preventDefault()
+    void runAction(match.action.id, ctx)
+  }
+
+  window.addEventListener('keydown', handler)
+  return () => window.removeEventListener('keydown', handler)
+}

--- a/apps/editor/src/lib/components/HeaderBar.svelte
+++ b/apps/editor/src/lib/components/HeaderBar.svelte
@@ -1,47 +1,31 @@
 <script lang="ts">
   import { Tooltip } from 'bits-ui'
   import { ArrowClockwise, ArrowCounterClockwise } from 'phosphor-svelte'
-  import { onDestroy, onMount } from 'svelte'
+  import { getActionContext } from '$lib/actions/context-provider.svelte'
+  import { getAction, runAction } from '$lib/actions/registry'
   import { diagramState } from '$lib/context.svelte'
 
-  const canUndo = $derived(diagramState.canUndo)
-  const canRedo = $derived(diagramState.canRedo)
+  // Toolbar surface for `edit.undo` / `edit.redo`. Reads everything
+  // (label, shortcut display, enabled state) from the action
+  // registry — no local copy of "is undo enabled" or the keyboard
+  // handler. The global keyboard handler installed in
+  // routes/+layout.svelte handles Mod+Z / Mod+Shift+Z.
+
+  const undo = $derived(getAction('edit.undo'))
+  const redo = $derived(getAction('edit.redo'))
+
+  // Reactively derive enabled state. Both actions' enabled
+  // predicates read `diagramState.canUndo` / `canRedo` (themselves
+  // $derived-backed), so this re-fires on every undo / redo.
+  const ctx = $derived(getActionContext())
+  const undoEnabled = $derived(undo?.enabled?.(ctx) ?? true)
+  const redoEnabled = $derived(redo?.enabled?.(ctx) ?? true)
+
+  // The undo/redo *labels* on the buttons come from the action;
+  // the tooltip adds the human label of the next undoable step
+  // ("Undo: Move node") which is editor-state, not action-state.
   const undoLabel = $derived(diagramState.undoLabel)
   const redoLabel = $derived(diagramState.redoLabel)
-
-  function isMac(): boolean {
-    if (typeof navigator === 'undefined') return false
-    return /mac/i.test(navigator.platform) || /mac/i.test(navigator.userAgent)
-  }
-  const modKey = $derived(isMac() ? '⌘' : 'Ctrl')
-
-  function onKeydown(e: KeyboardEvent) {
-    const target = e.target as HTMLElement | null
-    // Don't hijack typing in inputs / textareas / contenteditable
-    if (target && (/input|textarea|select/i.test(target.tagName) || target.isContentEditable)) {
-      return
-    }
-    const mod = e.metaKey || e.ctrlKey
-    if (!mod) return
-    if (e.key === 'z' && !e.shiftKey) {
-      e.preventDefault()
-      diagramState.undo()
-    } else if ((e.key === 'z' && e.shiftKey) || e.key === 'y') {
-      e.preventDefault()
-      diagramState.redo()
-    }
-  }
-
-  // onDestroy runs on the SSR side too, so guard the window access.
-  // onMount-only-on-client is fine but symmetry beats subtle bugs.
-  onMount(() => {
-    if (typeof window === 'undefined') return
-    window.addEventListener('keydown', onKeydown)
-  })
-  onDestroy(() => {
-    if (typeof window === 'undefined') return
-    window.removeEventListener('keydown', onKeydown)
-  })
 </script>
 
 <div
@@ -51,10 +35,10 @@
     <Tooltip.Trigger>
       <button
         type="button"
-        aria-label="Undo"
+        aria-label={undo?.label ?? 'Undo'}
         class="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-600 transition-colors hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent dark:text-neutral-300 dark:hover:bg-neutral-700"
-        disabled={!canUndo}
-        onclick={() => diagramState.undo()}
+        disabled={!undoEnabled}
+        onclick={() => runAction('edit.undo', ctx)}
       >
         <ArrowCounterClockwise class="h-4 w-4" />
       </button>
@@ -63,8 +47,10 @@
       side="bottom"
       class="rounded bg-neutral-800 px-2 py-1 text-xs text-white shadow-lg"
     >
-      {undoLabel ? `Undo: ${undoLabel}` : 'Undo'}
-      ({modKey}+Z)
+      {undoLabel ? `Undo: ${undoLabel}` : (undo?.label ?? 'Undo')}
+      {#if undo?.shortcut}
+        ({undo.shortcut})
+      {/if}
     </Tooltip.Content>
   </Tooltip.Root>
 
@@ -72,10 +58,10 @@
     <Tooltip.Trigger>
       <button
         type="button"
-        aria-label="Redo"
+        aria-label={redo?.label ?? 'Redo'}
         class="flex h-8 w-8 items-center justify-center rounded-lg text-neutral-600 transition-colors hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent dark:text-neutral-300 dark:hover:bg-neutral-700"
-        disabled={!canRedo}
-        onclick={() => diagramState.redo()}
+        disabled={!redoEnabled}
+        onclick={() => runAction('edit.redo', ctx)}
       >
         <ArrowClockwise class="h-4 w-4" />
       </button>
@@ -84,8 +70,10 @@
       side="bottom"
       class="rounded bg-neutral-800 px-2 py-1 text-xs text-white shadow-lg"
     >
-      {redoLabel ? `Redo: ${redoLabel}` : 'Redo'}
-      ({modKey}+Shift+Z)
+      {redoLabel ? `Redo: ${redoLabel}` : (redo?.label ?? 'Redo')}
+      {#if redo?.shortcut}
+        ({redo.shortcut})
+      {/if}
     </Tooltip.Content>
   </Tooltip.Root>
 </div>

--- a/apps/editor/src/lib/components/SideToolbar.svelte
+++ b/apps/editor/src/lib/components/SideToolbar.svelte
@@ -11,6 +11,8 @@
     SquaresFour,
     Sun,
   } from 'phosphor-svelte'
+  import { getActionContext } from '$lib/actions/context-provider.svelte'
+  import { runAction } from '$lib/actions/registry'
 
   let {
     mode = 'view',
@@ -18,7 +20,6 @@
     onmodechange,
     onaddnode,
     onaddsubgraph,
-    onautoarrange,
     onthemetoggle,
   }: {
     mode: 'edit' | 'view'
@@ -26,7 +27,6 @@
     onmodechange?: (mode: 'edit' | 'view') => void
     onaddnode?: (spec?: NodeSpec) => void
     onaddsubgraph?: () => void
-    onautoarrange?: () => void
     onthemetoggle?: () => void
   } = $props()
 
@@ -127,7 +127,7 @@
         <button
           type="button"
           class="flex items-center justify-center w-9 h-9 rounded-lg text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
-          onclick={() => onautoarrange?.()}
+          onclick={() => runAction('arrange.autoLayout', getActionContext())}
         >
           <ArrowsOutCardinal class="w-4.5 h-4.5" />
         </button>

--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -524,6 +524,7 @@
                          to drag from. Otherwise the fully-transparent handles leave the
                          "how do I draw a wire" UX a guess. */
   :global(.svelte-flow__node:hover .svelte-flow__handle) {
+    /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 1 !important;
     background: #3b82f6;
     border: 1px solid white;
@@ -535,11 +536,13 @@
                edge endpoint positions from each handle's bounding rect — only
                opacity is dropped. */
   .scene-canvas-readonly :global(.svelte-flow__node:hover .svelte-flow__handle) {
+    /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 0 !important;
   }
   /* Placement-pending: crosshair cursor on the pane so users see
                "click somewhere to drop the item". */
   .scene-canvas-placing :global(.svelte-flow__pane) {
+    /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     cursor: crosshair !important;
   }
 </style>

--- a/apps/editor/src/lib/persistence/reader.ts
+++ b/apps/editor/src/lib/persistence/reader.ts
@@ -64,7 +64,7 @@ export async function readProjectZip(
   for (const path of Object.keys(files)) {
     if (!path.startsWith('assets/')) continue
     const m = /^assets\/([a-f0-9]+)\.([a-z0-9]+)$/.exec(path)
-    if (!m || !m[1] || !m[2]) continue
+    if (!m?.[1] || !m[2]) continue
     const fileBytes = files[path]
     if (!fileBytes) continue
     const blob = new Blob([fileBytes as Uint8Array<ArrayBuffer>])

--- a/apps/editor/src/lib/state/assets.svelte.ts
+++ b/apps/editor/src/lib/state/assets.svelte.ts
@@ -133,7 +133,7 @@ export const assetStore = {
 /** Parse `asset:<hash>.<ext>` → its parts. Returns null otherwise. */
 export function parseAssetRef(ref: string): { hash: string; ext: string } | null {
   const m = ASSET_REF_RE.exec(ref)
-  if (!m || !m[1] || !m[2]) return null
+  if (!m?.[1] || !m[2]) return null
   return { hash: m[1], ext: m[2] }
 }
 

--- a/apps/editor/src/routes/+layout.svelte
+++ b/apps/editor/src/routes/+layout.svelte
@@ -1,17 +1,24 @@
 <script lang="ts">
   import { Tooltip } from 'bits-ui'
   import { registerBuiltinActions } from '$lib/actions/builtin'
+  import { installKeyboardShortcuts } from '$lib/actions/keyboard'
   import { initDarkMode } from '$lib/context.svelte'
   import '../app.css'
 
   let { children } = $props()
 
-  // Register the action set once on app boot. Inside `$effect` so
-  // it runs in the browser only — the registry has no SSR side
+  // Register the action set + install the global keyboard handler
+  // once on app boot. Inside `$effect` so it runs in the browser
+  // only — the registry / window listeners have no SSR side
   // effects.
   $effect(() => {
     registerBuiltinActions()
-    return initDarkMode()
+    const detachKeys = installKeyboardShortcuts()
+    const detachDarkMode = initDarkMode()
+    return () => {
+      detachKeys()
+      detachDarkMode?.()
+    }
   })
 </script>
 

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -4,6 +4,7 @@
   import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
   import { renderGraphToSvg } from '@shumoku/renderer-svg'
   import { page } from '$app/stores'
+  import { clearActionContext, provideActionContext } from '$lib/actions/context-provider.svelte'
   import type { ActionContext, CameraHandle } from '$lib/actions/types'
   import CanvasContextMenu from '$lib/components/CanvasContextMenu.svelte'
   import CodePanel from '$lib/components/CodePanel.svelte'
@@ -86,6 +87,14 @@
       : { ids: [], types: [] },
     canvasPos: canvasMenuOpen ? { x: canvasMenuX, y: canvasMenuY } : undefined,
     camera: cameraHandle ?? undefined,
+  })
+
+  // Publish to the global slot so the keyboard handler + any
+  // toolbar buttons see this page's context. Re-runs on every
+  // ctx change because of the $derived read.
+  $effect(() => {
+    provideActionContext(actionCtx)
+    return clearActionContext
   })
   let clipboard = $state<{
     label: string
@@ -220,7 +229,6 @@
       onmodechange={(m) => { editorState.mode = m }}
       onaddnode={(spec) => renderer?.addNewNode({ id: newId('node'), ...(spec ? { spec } : {}) })}
       onaddsubgraph={() => renderer?.addNewSubgraph({ id: newId('sg') })}
-      onautoarrange={() => diagramState.autoArrange()}
       onthemetoggle={() => editorState.toggleTheme()}
     />
   </div>

--- a/apps/editor/src/routes/project/[id]/scene/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/scene/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { renderGraphToSvg } from '@shumoku/renderer-svg'
   import { page } from '$app/stores'
+  import { clearActionContext, provideActionContext } from '$lib/actions/context-provider.svelte'
   import type { ActionContext } from '$lib/actions/types'
   import CanvasContextMenu from '$lib/components/CanvasContextMenu.svelte'
   import CodePanel from '$lib/components/CodePanel.svelte'
@@ -76,6 +77,10 @@
     mode: 'scene',
     selection: { ids: [], types: [] },
     canvasPos: canvasMenuOpen ? { x: canvasMenuX, y: canvasMenuY } : undefined,
+  })
+  $effect(() => {
+    provideActionContext(actionCtx)
+    return clearActionContext
   })
 </script>
 


### PR DESCRIPTION
Builds on #180. UI surfaces (HeaderBar undo/redo, SideToolbar Auto-arrange) now consume the action registry instead of duplicating wiring; a single keyboard dispatcher reads the active page's ActionContext and runs whichever action's shortcut matches.

## Changes

- `lib/actions/context-provider.svelte.ts` — \$state-backed slot. Pages publish ActionContext on mount, clear on unmount. Toolbar buttons read it via \`getActionContext()\`.
- `lib/actions/keyboard.ts` — \`installKeyboardShortcuts()\` walks visible actions, parses \`shortcut\`, matches \`keydown\`. Skip-when-typing built in. Mod is platform-aware (⌘/Ctrl). Tolerates \`=\`/\`+\` and \`-\`/\`_\`.
- `routes/+layout.svelte` calls the installer once on boot.
- `HeaderBar.svelte` rewritten — no local undo/redo keyboard listener, no hardcoded labels/shortcuts. Reads everything from \`getAction('edit.undo'|'edit.redo')\`.
- `SideToolbar.svelte`'s Auto-arrange button → \`runAction('arrange.autoLayout', ctx)\`. \`onautoarrange\` prop removed; diagram page drops the unused callback.
- \`edit.delete\` keeps its menu entry but no longer carries a \`Del\` shortcut — both renderers handle native Backspace/Delete already.

NodeContextMenu / scene NodeToolbar / per-element actions stay untouched; they'll move once element-targeted actions land alongside the Cmd+K palette in PR-3.

Drive-by: pre-existing biome lint nits (noImportantStyles in SceneCanvas, useOptionalChain in reader.ts / assets.svelte.ts) that were blocking the pre-commit hook on this branch.

## Test plan

- [ ] Mod+Z / Mod+Shift+Z trigger undo / redo on diagram and scene.
- [ ] Mod+0 fits the diagram view; Mod+= / Mod+- zoom in/out.
- [ ] Typing \`Z\` in a text input doesn't undo (input field skip).
- [ ] HeaderBar Undo/Redo buttons still work, are disabled appropriately, show correct shortcut hint.
- [ ] SideToolbar Auto-arrange still works.
- [ ] Renderer's native Backspace/Delete still deletes a selected node (no double-fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)