### PR TITLE
feat(editor): Cmd+K command palette (PR-3)

### DIFF
--- a/apps/editor/src/lib/actions/builtin.ts
+++ b/apps/editor/src/lib/actions/builtin.ts
@@ -1,8 +1,15 @@
 // Copyright (C) 2026-present Akitoshi Saeki
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ArrowsClockwise, ArrowUUpLeft, ArrowUUpRight, Trash } from 'phosphor-svelte'
+import {
+  ArrowsClockwise,
+  ArrowUUpLeft,
+  ArrowUUpRight,
+  MagnifyingGlass,
+  Trash,
+} from 'phosphor-svelte'
 import { diagramState } from '../context.svelte'
+import { openPalette } from './palette.svelte'
 import { defineAction } from './registry'
 import type { Action, ActionContext } from './types'
 
@@ -108,6 +115,16 @@ const builtinActions: Action[] = [
     group: 'arrange',
     when: inDiagram,
     run: () => diagramState.autoArrange(),
+  },
+
+  // ----- UI ---------------------------------------------------------------
+  {
+    id: 'ui.commandPalette',
+    label: 'Command palette',
+    shortcut: `${Mod}+K`,
+    icon: MagnifyingGlass,
+    group: 'misc',
+    run: () => openPalette(),
   },
 ]
 

--- a/apps/editor/src/lib/actions/palette.svelte.ts
+++ b/apps/editor/src/lib/actions/palette.svelte.ts
@@ -1,0 +1,21 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Tiny `$state` slot for the command palette's open/close. Lives
+// here (not inside `CommandPalette.svelte`) so the `ui.commandPalette`
+// action can flip it without importing the component, avoiding a
+// boot cycle (action registry → palette component → registry).
+
+const palette = $state({ open: false })
+
+export function openPalette(): void {
+  palette.open = true
+}
+
+export function closePalette(): void {
+  palette.open = false
+}
+
+export function isPaletteOpen(): boolean {
+  return palette.open
+}

--- a/apps/editor/src/lib/components/CommandPalette.svelte
+++ b/apps/editor/src/lib/components/CommandPalette.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import { Dialog } from 'bits-ui'
+  import { tick } from 'svelte'
+  import { getActionContext } from '$lib/actions/context-provider.svelte'
+  import { closePalette, isPaletteOpen } from '$lib/actions/palette.svelte'
+  import { runAction, visibleActions } from '$lib/actions/registry'
+  import type { Action } from '$lib/actions/types'
+
+  // Cmd+K-style command palette. Renders into +layout.svelte so it
+  // works on every page; consumes the action registry directly.
+  // Filtering is plain case-insensitive substring on label —
+  // fuzzy / scoring is a follow-up if it ever feels insufficient.
+
+  const open = $derived(isPaletteOpen())
+
+  let query = $state('')
+  let highlight = $state(0)
+  let inputEl = $state<HTMLInputElement | null>(null)
+
+  // Re-derive on every open or query / context change so the list
+  // reflects which actions are currently available + enabled.
+  const filtered = $derived.by<Action[]>(() => {
+    if (!open) return []
+    const ctx = getActionContext()
+    const q = query.trim().toLowerCase()
+    const all = visibleActions(ctx)
+    const matched = q ? all.filter((a) => a.label.toLowerCase().includes(q)) : all
+    return matched.slice(0, 50)
+  })
+
+  // Reset state + focus the input each time the palette opens. The
+  // `tick()` lets the dialog mount before we reach for inputEl.
+  $effect(() => {
+    if (!open) return
+    query = ''
+    highlight = 0
+    void (async () => {
+      await tick()
+      inputEl?.focus()
+    })()
+  })
+
+  $effect(() => {
+    // Keep highlight in range when filtered shrinks.
+    if (highlight >= filtered.length) highlight = Math.max(0, filtered.length - 1)
+  })
+
+  function pick(index: number) {
+    const a = filtered[index]
+    if (!a) return
+    if (a.enabled && !a.enabled(getActionContext())) return
+    closePalette()
+    void runAction(a.id, getActionContext())
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      highlight = Math.min(highlight + 1, filtered.length - 1)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      highlight = Math.max(highlight - 1, 0)
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      pick(highlight)
+    }
+    // Escape is handled by Dialog itself.
+  }
+</script>
+
+<Dialog.Root {open} onOpenChange={(v) => (v ? null : closePalette())}>
+  <Dialog.Portal>
+    <Dialog.Overlay class="fixed inset-0 z-40 bg-black/30 backdrop-blur-[2px] dark:bg-black/50" />
+    <Dialog.Content
+      class="fixed left-1/2 top-[20%] z-50 w-[min(560px,90vw)] -translate-x-1/2 overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-2xl focus:outline-none dark:border-neutral-700 dark:bg-neutral-900"
+    >
+      <Dialog.Title class="sr-only">Command palette</Dialog.Title>
+      <Dialog.Description class="sr-only">
+        Type to filter actions; arrow keys to navigate; Enter to run.
+      </Dialog.Description>
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        onkeydown={onKeydown}
+        placeholder="Search commands…"
+        class="w-full border-b border-neutral-200 bg-transparent px-4 py-3 text-sm outline-none placeholder:text-neutral-400 dark:border-neutral-700"
+        autocomplete="off"
+        spellcheck="false"
+      >
+      <div class="max-h-[60vh] overflow-y-auto py-1">
+        {#if filtered.length === 0}
+          <div class="px-4 py-6 text-center text-xs text-neutral-500">No matching commands.</div>
+        {:else}
+          {#each filtered as a, i (a.id)}
+            {@const enabled = a.enabled ? a.enabled(getActionContext()) : true}
+            <!-- svelte-ignore a11y_mouse_events_have_key_events -->
+            <button
+              type="button"
+              class="flex w-full items-center justify-between gap-4 px-4 py-2 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              class:bg-neutral-100={i === highlight}
+              class:dark:bg-neutral-800={i === highlight}
+              disabled={!enabled}
+              onmouseenter={() => (highlight = i)}
+              onclick={() => pick(i)}
+            >
+              <span class="flex items-center gap-2.5 truncate">
+                {#if a.icon}
+                  <a.icon class="h-4 w-4 shrink-0 text-neutral-500" />
+                {/if}
+                <span class="truncate">{a.label}</span>
+                {#if a.group}
+                  <span class="text-[10px] uppercase tracking-wider text-neutral-400"
+                    >{a.group}</span
+                  >
+                {/if}
+              </span>
+              {#if a.shortcut}
+                <span class="font-mono text-[10px] text-neutral-400">{a.shortcut}</span>
+              {/if}
+            </button>
+          {/each}
+        {/if}
+      </div>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>

--- a/apps/editor/src/routes/+layout.svelte
+++ b/apps/editor/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import { Tooltip } from 'bits-ui'
   import { registerBuiltinActions } from '$lib/actions/builtin'
   import { installKeyboardShortcuts } from '$lib/actions/keyboard'
+  import CommandPalette from '$lib/components/CommandPalette.svelte'
   import { initDarkMode } from '$lib/context.svelte'
   import '../app.css'
 
@@ -27,4 +28,7 @@
   <meta name="description" content="Interactive network topology diagram editor">
 </svelte:head>
 
-<Tooltip.Provider delayDuration={200}> {@render children()} </Tooltip.Provider>
+<Tooltip.Provider delayDuration={200}>
+  {@render children()}
+  <CommandPalette />
+</Tooltip.Provider>


### PR DESCRIPTION
Builds on #181. Adds the third UI surface that consumes the action registry: a Cmd+K palette listing every visible action and running it on Enter.

The palette is itself an action (\`ui.commandPalette\`, shortcut \`Mod+K\`), so the global keyboard handler from PR-2 opens it without any separate plumbing.

## Changes

- \`lib/actions/palette.svelte.ts\` — tiny \`\$state\` slot for the open flag, kept outside the component so the action can flip it without importing the component (avoids a registry → component → registry cycle on boot).
- \`lib/actions/builtin.ts\` — \`ui.commandPalette\` action with a magnifying-glass icon and \`Mod+K\` shortcut.
- \`components/CommandPalette.svelte\` — bits-ui Dialog with input + filtered list. Substring filter (lowercased), top 50 matches, ArrowUp/Down + Enter to navigate, hover or click to pick. Auto-focuses input on open. Disabled actions render dimmed and aren't dispatchable.
- \`routes/+layout.svelte\` mounts \`<CommandPalette />\` once so every page gets it.

## Test plan

- [ ] Cmd+K (Ctrl+K on Windows) opens the palette on any page.
- [ ] Typing filters the list (substring on label).
- [ ] Arrow keys move highlight; Enter runs; Esc / outside click closes.
- [ ] Disabled actions (e.g. Undo with empty history) render dimmed and don't dispatch.
- [ ] Auto-arrange shows in the palette only on diagram view (\`when\` filter still applies).
- [ ] Closing the palette returns focus to the canvas (Dialog default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)