### PR TITLE
fix(editor): drag-to-bend on EPS-split wire targets the right side

### DIFF
--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -252,6 +252,21 @@
       const segments: Array<Array<{ x: number; y: number }>> = idSegments.map((seg) =>
         seg.filter((id) => id !== from && id !== to).map((id) => centerOf(id)),
       )
+      // Per-segment via offset for drag-to-bend. The offset is the
+      // global via index of each visible segment's left endpoint:
+      //   - source-rooted segment → 0
+      //   - any other segment (room-side after EPS) → (via index of
+      //     its first id) + 1
+      // SceneEdge uses these to map a click on a specific visible
+      // polyline back to the right insertion index in `link.via`.
+      const via = link.via ?? []
+      const viaIndexOf = new Map<string, number>(via.map((id, i) => [id, i] as const))
+      const segmentViaOffsets: number[] = idSegments.map((seg) => {
+        const head = seg[0]
+        if (head === from) return 0
+        const j = head !== undefined ? viaIndexOf.get(head) : undefined
+        return j === undefined ? 0 : j + 1
+      })
       // Handle side picked toward the FIRST visible waypoint after the
       // source (and the LAST visible waypoint before the target). For
       // a wire that goes source → EPS → … via, we want to leave the
@@ -296,6 +311,7 @@
         data: {
           sceneId: scene.id,
           segments,
+          segmentViaOffsets,
           lengthMeters: eff?.meters ?? null,
           segmentMeters,
           wireScale: effectiveWireScale(link),

--- a/apps/editor/src/lib/components/scene/SceneEdge.svelte
+++ b/apps/editor/src/lib/components/scene/SceneEdge.svelte
@@ -21,6 +21,12 @@
      *  segments include source/target implicitly. Bends ride along in
      *  these segments since they're now via Nodes too. */
     segments?: Array<Waypoint[]>
+    /** Per-visible-segment via offset for drag-to-bend. Maps the
+     *  local nearest-segment index inside one visible polyline back
+     *  to the global insertion index in `link.via`. Source-rooted
+     *  segments are 0; room-side segments after an EPS skip past
+     *  the rack-side via entries. Computed in SceneCanvas. */
+    segmentViaOffsets?: number[]
     /** Effective real-world cable length, computed by the parent
      *  via the cableLengthMeters helper. */
     lengthMeters: number | null
@@ -83,9 +89,17 @@
       .map((seg) => polylinePath(seg, WIRE_CORNER_RADIUS))
       .join(' ')
   })
-  // First-segment points feed bendOnDrag's segment-search so a
-  // line-body pointerdown maps to the right insertion index.
-  const points = $derived<Waypoint[]>(visualSegments[0] ?? [])
+  // Visible polylines + per-segment via offsets feed bendOnDrag's
+  // search. Without offsets a click on the room-side polyline
+  // would resolve to the rack-side via slice (different
+  // geometric polylines but indices conflated). See
+  // wire-edit.ts:bendOnDrag for the offset → via index mapping.
+  const bendSegments = $derived(
+    visualSegments.map((points, i) => ({
+      points,
+      viaOffset: data?.segmentViaOffsets?.[i] ?? 0,
+    })),
+  )
 
   // Per-visible-segment label anchors: each segment shows its own
   // length pill so an EPS-split wire reads as two separate cables.
@@ -145,7 +159,7 @@
       sceneId,
       linkId: id,
       startClient: { x: e.clientX, y: e.clientY },
-      pointsForSegmentSearch: points,
+      segments: bendSegments,
       toFlow,
     })
   }

--- a/apps/editor/src/lib/components/scene/wire-edit.ts
+++ b/apps/editor/src/lib/components/scene/wire-edit.ts
@@ -143,24 +143,21 @@ export function bendOnDrag(args: {
         dragNodeId = near.id
       } else {
         // Pick the closest visible polyline first, then the
-        // closest line within it. Adding `viaOffset` for that
-        // polyline maps the local index back to a global via
-        // insertion index.
-        let bestSegIdx = 0
+        // closest line within it. Capture viaOffset alongside the
+        // local index in the same loop so we don't re-look the
+        // winner up after.
         let bestLocal = 0
+        let bestOffset = 0
         let bestDist = Infinity
-        for (let i = 0; i < segments.length; i++) {
-          const seg = segments[i]
-          if (!seg) continue
+        for (const seg of segments) {
           const { index, distSq } = nearestSegment(seg.points, flowStart)
           if (distSq < bestDist) {
             bestDist = distSq
-            bestSegIdx = i
             bestLocal = index
+            bestOffset = seg.viaOffset
           }
         }
-        const seg = segments[bestSegIdx]
-        const segIdx = (seg?.viaOffset ?? 0) + bestLocal
+        const segIdx = bestOffset + bestLocal
         // insertBendInLink wraps the create + via splice in its own
         // commit, so we don't double-wrap with our drag tx.
         dragNodeId = diagramState.insertBendInLink(sceneId, linkId, flowStart, segIdx)

--- a/apps/editor/src/lib/components/scene/wire-edit.ts
+++ b/apps/editor/src/lib/components/scene/wire-edit.ts
@@ -47,10 +47,12 @@ export function polylinePath(points: Waypoint[], radius = 12): string {
 }
 
 /**
- * Index of the polyline segment closest to `p`. Used by drag-to-bend
- * to decide where in via the new bend should land.
+ * Index of the polyline segment closest to `p` and the squared
+ * perpendicular distance to it. The squared distance lets callers
+ * pick between multiple polylines (e.g. EPS-split visible
+ * segments) without needing a sqrt.
  */
-function nearestSegmentIndex(points: Waypoint[], p: Waypoint): number {
+function nearestSegment(points: Waypoint[], p: Waypoint): { index: number; distSq: number } {
   let best = 0
   let bestDist = Infinity
   for (let i = 0; i < points.length - 1; i++) {
@@ -70,7 +72,7 @@ function nearestSegmentIndex(points: Waypoint[], p: Waypoint): number {
       best = i
     }
   }
-  return best
+  return { index: best, distSq: bestDist }
 }
 
 /**
@@ -80,29 +82,30 @@ function nearestSegmentIndex(points: Waypoint[], p: Waypoint): number {
  * already-placed bend (within `snapTol` flow units) instead of
  * spawning a duplicate.
  *
- * `pointsForSegmentSearch` is the rendered polyline (source +
- * existing via positions + target). The segment index found here
- * maps directly to the via insertion index since the polyline
- * mirrors via's order.
+ * `segments` is the array of visible polylines (one per side of an
+ * EPS, plus the trivial single-segment case). Each polyline carries
+ * its own `viaOffset` so a click resolves to the right insertion
+ * index in the link's via list:
+ *   global segIdx = viaOffset + nearestSegment(local).index
+ * Without this offset an EPS-split wire would always insert into
+ * the rack-side via slice regardless of which visible side the
+ * user clicked.
  */
+export interface BendDragSegment {
+  points: Waypoint[]
+  viaOffset: number
+}
+
 export function bendOnDrag(args: {
   sceneId: string
   linkId: string
   startClient: { x: number; y: number }
-  pointsForSegmentSearch: Waypoint[]
+  segments: BendDragSegment[]
   toFlow: (clientX: number, clientY: number) => Waypoint
   threshold?: number
   snapTol?: number
 }) {
-  const {
-    sceneId,
-    linkId,
-    startClient,
-    pointsForSegmentSearch,
-    toFlow,
-    threshold = 4,
-    snapTol = 18,
-  } = args
+  const { sceneId, linkId, startClient, segments, toFlow, threshold = 4, snapTol = 18 } = args
   let dragNodeId: string | null = null
   let txOpen = false
 
@@ -139,10 +142,25 @@ export function bendOnDrag(args: {
         txOpen = true
         dragNodeId = near.id
       } else {
-        // Insert a fresh bend into via at the segment the user clicked.
-        // pointsForSegmentSearch starts with source, so segIdx maps
-        // directly to via index (segIdx=0 → before via[0], etc.).
-        const segIdx = nearestSegmentIndex(pointsForSegmentSearch, flowStart)
+        // Pick the closest visible polyline first, then the
+        // closest line within it. Adding `viaOffset` for that
+        // polyline maps the local index back to a global via
+        // insertion index.
+        let bestSegIdx = 0
+        let bestLocal = 0
+        let bestDist = Infinity
+        for (let i = 0; i < segments.length; i++) {
+          const seg = segments[i]
+          if (!seg) continue
+          const { index, distSq } = nearestSegment(seg.points, flowStart)
+          if (distSq < bestDist) {
+            bestDist = distSq
+            bestSegIdx = i
+            bestLocal = index
+          }
+        }
+        const seg = segments[bestSegIdx]
+        const segIdx = (seg?.viaOffset ?? 0) + bestLocal
         // insertBendInLink wraps the create + via splice in its own
         // commit, so we don't double-wrap with our drag tx.
         dragNodeId = diagramState.insertBendInLink(sceneId, linkId, flowStart, segIdx)


### PR DESCRIPTION
A single wire that transits an EPS renders as two disjoint visible polylines (rack-side and room-side). \`SceneEdge\` was feeding only \`visualSegments[0]\` to \`bendOnDrag\`, so a click on the room-side resolved the nearest segment within the **rack-side** geometry — and the returned local index went straight into \`link.via\` as a global insertion, dropping the bend on the wrong side of the chase.

Symptom: dragging the wall-outlet→switch run made the rack-side wire react.

## Fix

- \`SceneCanvas.svelte\` computes \`segmentViaOffsets[]\` alongside \`segments[]\`. Source-rooted segment = 0; room-side segments after an EPS = \`(viaIndex of head id) + 1\`.
- \`SceneEdge.svelte\` passes \`{ points, viaOffset }[]\` to \`bendOnDrag\` instead of one \`pointsForSegmentSearch\` polyline.
- \`bendOnDrag\` (\`wire-edit.ts\`) picks the closest visible polyline first (squared perpendicular distance), then uses \`viaOffset + localIdx\` as the global via insertion index.
- \`nearestSegmentIndex\` becomes \`nearestSegment\` returning \`{ index, distSq }\` so the polyline-picker can compare distances across segments without sqrt.

## Test plan

- [ ] Wire panel → EPS → outlet → switch. Drag the room-side cable (outlet → switch) to bend it. Rack-side stays put; bend appears between outlet and switch.
- [ ] Drag the rack-side cable (panel → EPS). Room-side stays put; bend appears in the rack-side via slice.
- [ ] Existing single-segment wires (no EPS) still bend correctly (the \`viaOffset = 0\` path).
- [ ] Snap-to-existing bend still works near an already-placed bend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)