### PR TITLE
fix(editor): scene wire — per-segment hit path + selection visual

### DIFF
--- a/apps/editor/src/lib/components/scene/SceneEdge.svelte
+++ b/apps/editor/src/lib/components/scene/SceneEdge.svelte
@@ -147,19 +147,35 @@
     return anchor ? { anchor, meters: total } : null
   })
 
-  // Drag-to-bend on the line body: insert a bend Node into the
-  // link's via at the click, then drag its placement. snap-to-
-  // existing inside bendOnDrag grabs a nearby existing bend
-  // instead of duplicating.
-  function onLinePointerDown(e: PointerEvent) {
+  // Which visible polyline was last clicked. The selection
+  // highlight only colors this segment so the user can tell
+  // which side of an EPS-split wire they're acting on. Defaults
+  // to 0 (single-segment wires keep the existing visual).
+  let activeSegment = $state(0)
+
+  // Reset to 0 if visualSegments shrinks below activeSegment so we
+  // don't index out of range (e.g. EPS removed → single segment).
+  $effect(() => {
+    if (activeSegment >= visualSegments.length) activeSegment = 0
+  })
+
+  // Drag-to-bend on the line body. Each visible polyline has its
+  // own hit path so we know — at pixel level — which side of an
+  // EPS-split wire the user clicked. Forward that index to
+  // bendOnDrag instead of letting it geometrically re-infer
+  // (which could pick the wrong polyline when the two sides are
+  // perpendicular-close at the click point).
+  function onLinePointerDown(e: PointerEvent, segIdx: number) {
     if (!interactive) return
     if (e.button !== 0) return
+    activeSegment = segIdx
     e.stopImmediatePropagation()
     bendOnDrag({
       sceneId,
       linkId: id,
       startClient: { x: e.clientX, y: e.clientY },
       segments: bendSegments,
+      segmentIndex: segIdx,
       toFlow,
     })
   }
@@ -181,25 +197,52 @@
     pointer-events="none"
   />
 {/if}
+<!-- Slate base stroke for the whole wire — drawn first so the
+     active-segment overlay (when selected) sits on top. -->
 <BaseEdge
   path={pathD}
   {markerEnd}
   interactionWidth={0}
-  style="stroke: {selected ? '#3b82f6' : '#475569'}; stroke-width: {(selected ? 3.5 : 3) *
+  style="stroke: #475569; stroke-width: {3 *
     (data?.wireScale ?? 1)}; stroke-linecap: round; stroke-linejoin: round; {style ?? ''}"
 />
 
-<!-- Wire-body hit path. nopan/nodrag opt out of d3-zoom so the line
-     drag isn't hijacked into a pane pan. -->
-<path
-  d={pathD}
-  class="nopan nodrag"
-  fill="none"
-  stroke="transparent"
-  stroke-width="16"
-  style="cursor: grab; pointer-events: stroke;"
-  onpointerdown={onLinePointerDown}
-/>
+<!-- Per-segment selection highlight: only the polyline the user
+     clicked turns blue. EPS-split wires read as two distinct
+     cables instead of "the whole logical link lights up". -->
+{#if selected}
+  {#each visualSegments as seg, i (i)}
+    {#if i === activeSegment && seg.length >= 2}
+      <path
+        d={polylinePath(seg, WIRE_CORNER_RADIUS)}
+        fill="none"
+        stroke="#3b82f6"
+        stroke-width={3.5 * (data?.wireScale ?? 1)}
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        pointer-events="none"
+      />
+    {/if}
+  {/each}
+{/if}
+
+<!-- Per-segment hit path. Each visible polyline gets its own
+     pointerdown handler so we can track which side of the wire
+     the user is interacting with. nopan/nodrag opts out of
+     d3-zoom so a line drag isn't hijacked into a pane pan. -->
+{#each visualSegments as seg, i (i)}
+  {#if seg.length >= 2}
+    <path
+      d={polylinePath(seg, WIRE_CORNER_RADIUS)}
+      class="nopan nodrag"
+      fill="none"
+      stroke="transparent"
+      stroke-width="16"
+      style="cursor: grab; pointer-events: stroke;"
+      onpointerdown={(e) => onLinePointerDown(e, i)}
+    />
+  {/if}
+{/each}
 
 <!-- Cable length pill — only when the scene is calibrated. Fully
      opaque white with a soft outer ring so it stands clear of any

--- a/apps/editor/src/lib/components/scene/wire-edit.ts
+++ b/apps/editor/src/lib/components/scene/wire-edit.ts
@@ -82,14 +82,16 @@ function nearestSegment(points: Waypoint[], p: Waypoint): { index: number; distS
  * already-placed bend (within `snapTol` flow units) instead of
  * spawning a duplicate.
  *
- * `segments` is the array of visible polylines (one per side of an
- * EPS, plus the trivial single-segment case). Each polyline carries
- * its own `viaOffset` so a click resolves to the right insertion
- * index in the link's via list:
+ * `segmentIndex` identifies which visible polyline the user
+ * clicked. SceneEdge knows this from pixel-level hit testing
+ * (each polyline has its own hit path), so bendOnDrag doesn't try
+ * to re-infer it geometrically — that previously misfired on
+ * EPS-split wires when one polyline was perpendicular-closer to
+ * the click than the one actually under the cursor. The matching
+ * `BendDragSegment` carries its own `viaOffset`, so:
  *   global segIdx = viaOffset + nearestSegment(local).index
- * Without this offset an EPS-split wire would always insert into
- * the rack-side via slice regardless of which visible side the
- * user clicked.
+ * inside the polyline picks where in the link's via the new bend
+ * lands.
  */
 export interface BendDragSegment {
   points: Waypoint[]
@@ -101,11 +103,21 @@ export function bendOnDrag(args: {
   linkId: string
   startClient: { x: number; y: number }
   segments: BendDragSegment[]
+  segmentIndex: number
   toFlow: (clientX: number, clientY: number) => Waypoint
   threshold?: number
   snapTol?: number
 }) {
-  const { sceneId, linkId, startClient, segments, toFlow, threshold = 4, snapTol = 18 } = args
+  const {
+    sceneId,
+    linkId,
+    startClient,
+    segments,
+    segmentIndex,
+    toFlow,
+    threshold = 4,
+    snapTol = 18,
+  } = args
   let dragNodeId: string | null = null
   let txOpen = false
 
@@ -142,22 +154,16 @@ export function bendOnDrag(args: {
         txOpen = true
         dragNodeId = near.id
       } else {
-        // Pick the closest visible polyline first, then the
-        // closest line within it. Capture viaOffset alongside the
-        // local index in the same loop so we don't re-look the
-        // winner up after.
-        let bestLocal = 0
-        let bestOffset = 0
-        let bestDist = Infinity
-        for (const seg of segments) {
-          const { index, distSq } = nearestSegment(seg.points, flowStart)
-          if (distSq < bestDist) {
-            bestDist = distSq
-            bestLocal = index
-            bestOffset = seg.viaOffset
-          }
-        }
-        const segIdx = bestOffset + bestLocal
+        // Use the segment SceneEdge told us was clicked (pixel-
+        // level hit test) — only resolve the *line within that
+        // polyline* geometrically. This avoids the
+        // EPS-split footgun where two polylines were both fed to
+        // a global nearestSegment loop and a perpendicular-closer
+        // line on the other polyline could win.
+        const seg = segments[segmentIndex] ?? segments[0]
+        if (!seg) return
+        const { index: localIdx } = nearestSegment(seg.points, flowStart)
+        const segIdx = seg.viaOffset + localIdx
         // insertBendInLink wraps the create + via splice in its own
         // commit, so we don't double-wrap with our drag tx.
         dragNodeId = diagramState.insertBendInLink(sceneId, linkId, flowStart, segIdx)


### PR DESCRIPTION
Addresses two related issues with EPS-split wires that were both visible in the screenshot the user shared.

## What was wrong

1. **Drag-to-bend went to the wrong polyline.** \`bendOnDrag\` resolved which polyline was clicked geometrically — squared perpendicular distance from \`flowStart\` to each visible polyline. When the two polylines passed near each other in the layout (or one was perpendicular-closer at the click point), the picker chose the wrong polyline. The new bend was inserted into the other side's via slice and visually \"flew\" to a position on the wrong cable.

2. **Selection highlighted both polylines.** They share one BaseEdge with a single combined path string, so \`selected = true\` painted the whole \`d=\"M...M...\"\` blue. No way to tell which side the user was acting on.

## Fix

- **Per-segment hit paths**: render one transparent hit \`<path>\` per visible polyline in SceneEdge, each with \`onpointerdown={(e) => onLinePointerDown(e, i)}\`. Pixel-level click resolution — no geometric inference about *which* polyline was clicked.
- **bendOnDrag takes \`segmentIndex\`**: SceneEdge passes the clicked segment index directly. \`nearestSegment\` is now only used to pick *which line within that polyline* (the piece between two via points). It can no longer cross-pick between polylines.
- **\`activeSegment\` state in SceneEdge**: tracks the last-clicked polyline index. When the wire is selected, paint a blue overlay only on that segment; the underlying BaseEdge stays slate. EPS-split wires read as two distinct cables with independent visual feedback.

## Test plan

- [ ] Wire panel → EPS → outlet → switch. Click on the room-side cable → only that polyline turns blue.
- [ ] Click on the rack-side cable → only that polyline turns blue (and the room-side returns to slate).
- [ ] Drag-to-bend on the room-side → bend appears between outlet and switch, the rack-side stays put.
- [ ] Drag-to-bend on the rack-side → bend appears in the rack-side via slice, room-side stays put.
- [ ] Single-segment wire (no EPS) — selection still highlights normally; drag-to-bend works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)