### PR TITLE
refactor(editor): one Svelte Flow edge per visible cable segment

### DIFF
--- a/apps/editor/src/lib/components/scene/SceneBackgroundNode.svelte
+++ b/apps/editor/src/lib/components/scene/SceneBackgroundNode.svelte
@@ -21,10 +21,10 @@
 
 <style>
   /* The Svelte Flow node wrapper around this bg would otherwise
-           swallow clicks (and route them as node clicks, not pane clicks),
-           breaking calibration / click-to-place which both rely on
-           onPaneClick. Disabling pointer-events on the wrapper lets clicks
-           fall through to the pane underneath. */
+             swallow clicks (and route them as node clicks, not pane clicks),
+             breaking calibration / click-to-place which both rely on
+             onPaneClick. Disabling pointer-events on the wrapper lets clicks
+             fall through to the pane underneath. */
   :global(.svelte-flow__node.svelte-flow__node-background) {
     pointer-events: none;
   }

--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -226,101 +226,80 @@
     return out
   })
 
+  // One Svelte Flow edge per *visible cable segment* (i.e. per
+  // physical cable run). A logical Link with via passing through
+  // an EPS becomes 2 edges — rack-side and room-side — so that
+  // each cable selects, hovers, and gets dragged on its own. The
+  // underlying Link is unchanged: deleting any one edge removes
+  // the whole logical wire (the data model is still all-or-
+  // nothing per Link); deleting a TP node strips it from `via` so
+  // the segments rejoin or disappear naturally.
   const sfEdges = $derived.by<Edge[]>(() => {
     const out: Edge[] = []
     for (const link of visibleLinks) {
       if (!link.id) continue
-      // Both endpoints are now real SceneNodes (in-scope or cross-
-      // boundary), no synthetic anchor IDs to substitute.
-      const from = link.from.node
-      const to = link.to.node
-      const crossBoundary = !inScopeIds.has(from) || !inScopeIds.has(to)
-      const fromPos = centerOf(from)
-      const toPos = centerOf(to)
-      // Wire path: split into visible cable segments at every EPS in
-      // via. Cable physically enters the chase at the EPS and exits
-      // at an outlet on the other side; the wall-internal portion is
-      // hidden, so we render two disjoint polylines (source → EPS,
-      // outlet → target) instead of one continuous line. The
-      // visibleCableSegments helper keeps this consistent with the
-      // length math.
+      const linkFrom = link.from.node
+      const linkTo = link.to.node
+      const crossBoundary = !inScopeIds.has(linkFrom) || !inScopeIds.has(linkTo)
       const idSegments = visibleCableSegments(link, diagramState.nodes)
-      // Inner via points target the icon's CENTER so the smoothstep
-      // curves enter the TP at the visual edge, not its top-left
-      // corner. Source/target endpoints stay handle-driven via
-      // sourceX/Y / targetX/Y from Svelte Flow.
-      const segments: Array<Array<{ x: number; y: number }>> = idSegments.map((seg) =>
-        seg.filter((id) => id !== from && id !== to).map((id) => centerOf(id)),
-      )
-      // Per-segment via offset for drag-to-bend. The offset is the
-      // global via index of each visible segment's left endpoint:
-      //   - source-rooted segment → 0
-      //   - any other segment (room-side after EPS) → (via index of
-      //     its first id) + 1
-      // SceneEdge uses these to map a click on a specific visible
-      // polyline back to the right insertion index in `link.via`.
+      // Per-segment via offset — global via index of the segment's
+      // left endpoint. Source-rooted segment = 0; room-side (after
+      // EPS) = (viaIndex of head) + 1. Drag-to-bend uses this to
+      // map a local insertion within this segment to the right
+      // position in `link.via`.
       const via = link.via ?? []
       const viaIndexOf = new Map<string, number>(via.map((id, i) => [id, i] as const))
-      const segmentViaOffsets: number[] = idSegments.map((seg) => {
-        const head = seg[0]
-        if (head === from) return 0
-        const j = head !== undefined ? viaIndexOf.get(head) : undefined
-        return j === undefined ? 0 : j + 1
-      })
-      // Handle side picked toward the FIRST visible waypoint after the
-      // source (and the LAST visible waypoint before the target). For
-      // a wire that goes source → EPS → … via, we want to leave the
-      // source pointing toward the EPS, not toward the eventual far
-      // device (which our line never actually heads to in segment A).
-      const firstAfterSource = segments[0]?.[0] ?? toPos
-      const lastBeforeTarget =
-        segments[segments.length - 1]?.[(segments[segments.length - 1]?.length ?? 0) - 1] ?? fromPos
-      const sourceHandle = pickSideForDirection(
-        firstAfterSource.x - fromPos.x,
-        firstAfterSource.y - fromPos.y,
-      )
-      const targetHandle = pickSideForDirection(
-        lastBeforeTarget.x - toPos.x,
-        lastBeforeTarget.y - toPos.y,
-      )
-      // Cable length: compute per-segment meters once; total is the
-      // sum. cableLengthMeters() also calls cableSegmentLengths()
-      // internally, so calling both would walk the via list and the
-      // scene placements twice per link per derive. With many wires
-      // and live drag, that's the kind of repeated work we want to
-      // skip — derive once, sum here.
+      // Cable length per segment (already computed by
+      // cableSegmentLengths in the same order as visibleCableSegments).
       const segParts = cableSegmentLengths(link, [scene], diagramState.nodes)
-      const segmentMeters: Array<number | null> = idSegments.map(
-        (_, i) => segParts[i]?.meters ?? null,
-      )
-      const totalSceneMeters = segParts.length ? segParts.reduce((s, p) => s + p.meters, 0) : null
-      const storedMeters = link.cable?.length_m
-      const eff: { meters: number; source: 'scene' | 'stored' } | null =
-        totalSceneMeters !== null
-          ? { meters: totalSceneMeters, source: 'scene' }
-          : storedMeters !== undefined && Number.isFinite(storedMeters)
-            ? { meters: storedMeters, source: 'stored' }
-            : null
-      out.push({
-        id: link.id,
-        source: from,
-        target: to,
-        sourceHandle,
-        targetHandle,
-        type: 'wire',
-        data: {
-          sceneId: scene.id,
-          segments,
-          segmentViaOffsets,
-          lengthMeters: eff?.meters ?? null,
-          segmentMeters,
-          wireScale: effectiveWireScale(link),
-        },
-        animated: false,
-        style: crossBoundary ? 'stroke-dasharray: 5 3;' : '',
-        // No arrow marker — cables are physical runs, not directional
-        // signals. Direction is implicit from the endpoints.
-      })
+      const wireScale = effectiveWireScale(link)
+      for (let i = 0; i < idSegments.length; i++) {
+        const segIds = idSegments[i] ?? []
+        const segFrom = segIds[0]
+        const segTo = segIds[segIds.length - 1]
+        if (!segFrom || !segTo || segFrom === segTo) continue
+        const segFromPos = centerOf(segFrom)
+        const segToPos = centerOf(segTo)
+        // Inner via points (between segFrom and segTo) target each
+        // icon's center.
+        const innerWaypoints: Array<{ x: number; y: number }> = segIds
+          .slice(1, -1)
+          .map((id) => centerOf(id))
+        // Handle side: out from segFrom toward the next visible
+        // point; into segTo from the previous one.
+        const firstInner = innerWaypoints[0] ?? segToPos
+        const lastInner = innerWaypoints[innerWaypoints.length - 1] ?? segFromPos
+        const sourceHandle = pickSideForDirection(
+          firstInner.x - segFromPos.x,
+          firstInner.y - segFromPos.y,
+        )
+        const targetHandle = pickSideForDirection(
+          lastInner.x - segToPos.x,
+          lastInner.y - segToPos.y,
+        )
+        const j = viaIndexOf.get(segFrom)
+        const viaOffset = segFrom === linkFrom ? 0 : j === undefined ? 0 : j + 1
+        const meters = segParts[i]?.meters ?? null
+        out.push({
+          id: `${link.id}::${i}`,
+          source: segFrom,
+          target: segTo,
+          sourceHandle,
+          targetHandle,
+          type: 'wire',
+          data: {
+            sceneId: scene.id,
+            linkId: link.id,
+            segmentIndex: i,
+            viaOffset,
+            innerWaypoints,
+            lengthMeters: meters,
+            wireScale,
+          },
+          animated: false,
+          style: crossBoundary ? 'stroke-dasharray: 5 3;' : '',
+        })
+      }
     }
     return out
   })
@@ -477,10 +456,21 @@
     onconnect={onConnect}
     onpaneclick={onPaneClick}
     ondelete={({ nodes, edges }: { nodes: SfNode[]; edges: Edge[] }) => {
-      // Native Backspace/Delete keyboard path. NodeToolbar's Delete
-      // button calls removeNode directly; this catches edges and
-      // multi-select.
-      for (const e of edges) if (e.id) diagramState.removeLink(e.id)
+      // Native Backspace/Delete keyboard path. Each Svelte Flow
+      // edge corresponds to a single visible cable segment, but
+      // its id is `${linkId}::${segmentIndex}` and the underlying
+      // data model is one Link — deleting any segment removes the
+      // whole logical wire. Dedupe via a Set so a multi-segment
+      // selection (rare via keyboard) doesn't re-call removeLink
+      // for the same Link.
+      const linkIds = new Set<string>()
+      for (const e of edges) {
+        const linkId =
+          (e.data as { linkId?: string } | undefined)?.linkId ??
+          (typeof e.id === 'string' ? e.id.split('::')[0] : undefined)
+        if (linkId) linkIds.add(linkId)
+      }
+      for (const id of linkIds) diagramState.removeLink(id)
       for (const n of nodes) diagramState.removeNode(n.id)
     }}
     proOptions={{ hideAttribution: true }}
@@ -529,7 +519,7 @@
 
 <style>
   /* Soften Svelte Flow's default dotted background when no floor
-                               plan is set, but otherwise let its theming through. */
+                                 plan is set, but otherwise let its theming through. */
   :global(.svelte-flow__background) {
     background: #f8fafc;
   }
@@ -537,8 +527,8 @@
     stroke-linecap: round;
   }
   /* Make connection handles visible on hover so users can see where
-                             to drag from. Otherwise the fully-transparent handles leave the
-                             "how do I draw a wire" UX a guess. */
+                               to drag from. Otherwise the fully-transparent handles leave the
+                               "how do I draw a wire" UX a guess. */
   :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 1 !important;
@@ -548,15 +538,15 @@
     height: 8px;
   }
   /* Read-only cue: don't reveal connection handles on hover in view
-                   mode. Keep size + DOM presence so Svelte Flow can still resolve
-                   edge endpoint positions from each handle's bounding rect — only
-                   opacity is dropped. */
+                     mode. Keep size + DOM presence so Svelte Flow can still resolve
+                     edge endpoint positions from each handle's bounding rect — only
+                     opacity is dropped. */
   .scene-canvas-readonly :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 0 !important;
   }
   /* Placement-pending: crosshair cursor on the pane so users see
-                   "click somewhere to drop the item". */
+                     "click somewhere to drop the item". */
   .scene-canvas-placing :global(.svelte-flow__pane) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     cursor: crosshair !important;

--- a/apps/editor/src/lib/components/scene/SceneEdge.svelte
+++ b/apps/editor/src/lib/components/scene/SceneEdge.svelte
@@ -5,41 +5,37 @@
   import { WIRE_CORNER_RADIUS } from '$lib/scene/node-geometry'
   import { bendOnDrag, polylinePath, type Waypoint } from './wire-edit'
 
-  // Custom Svelte Flow edge for floor-plan wiring. The path is a
-  // BaseEdge so it inherits standard styling / selection. Drag on
-  // the line body inserts a waypoint and starts dragging it (the
-  // bend lives in scene.wireRoutes; no handle UI on top of the
-  // wire). Length pills sit at each visible-segment midpoint.
+  // One Svelte Flow edge per visible cable segment. SceneCanvas
+  // emits N edges per logical Link (one per side of an EPS) so
+  // each physical cable run has its own selection / hover /
+  // context menu / drag-to-bend interaction. SceneEdge therefore
+  // renders a single polyline; the multi-polyline complexity is
+  // gone.
 
   type SceneEdgeData = {
     sceneId: string
-    /** Visible cable segments (one entry per disjoint subpath). When
-     *  the wire transits an EPS, the chase-internal portion is hidden
-     *  — that breaks one logical wire into multiple visible polylines.
-     *  Each entry is the via positions BETWEEN source/target (which the
-     *  edge gets from sourceX/Y / targetX/Y). The first and last
-     *  segments include source/target implicitly. Bends ride along in
-     *  these segments since they're now via Nodes too. */
-    segments?: Array<Waypoint[]>
-    /** Per-visible-segment via offset for drag-to-bend. Maps the
-     *  local nearest-segment index inside one visible polyline back
-     *  to the global insertion index in `link.via`. Source-rooted
-     *  segments are 0; room-side segments after an EPS skip past
-     *  the rack-side via entries. Computed in SceneCanvas. */
-    segmentViaOffsets?: number[]
-    /** Effective real-world cable length, computed by the parent
-     *  via the cableLengthMeters helper. */
+    /** Logical Link this segment belongs to. Used by drag-to-bend
+     *  to insert into the correct Link.via. */
+    linkId: string
+    /** Index of this segment in the Link's visibleCableSegments
+     *  output. Diagnostic only — interaction uses `viaOffset`. */
+    segmentIndex: number
+    /** Global via index where insertions for this segment land:
+     *  source-rooted segment = 0, post-EPS segment = (via index of
+     *  segment head) + 1. */
+    viaOffset: number
+    /** Inner via points between source and target (not including
+     *  the segment endpoints). Used to compose the polyline. */
+    innerWaypoints: Array<{ x: number; y: number }>
+    /** Per-segment cable length in meters when the scene has a
+     *  calibration; null otherwise. */
     lengthMeters: number | null
-    /** Per-visible-segment lengths in meters, parallel to `segments`.
-     *  One pill per segment for EPS-split wires. */
-    segmentMeters?: Array<number | null>
     /** Per-scene stroke width multiplier (Scene.display.wireScale). */
     wireScale?: number
   }
   type SceneEdgeT = Edge<SceneEdgeData, 'wire'>
 
   let {
-    id,
     data,
     sourceX,
     sourceY,
@@ -54,69 +50,34 @@
   const toFlow = (cx: number, cy: number) => sf.screenToFlowPosition({ x: cx, y: cy })
 
   const sceneId = $derived(data?.sceneId ?? '')
+  const linkId = $derived(data?.linkId ?? '')
+  const viaOffset = $derived(data?.viaOffset ?? 0)
   const interactive = $derived(editorState.interactive)
 
-  // Composed visible segments: each becomes one continuous polyline.
-  // Source attaches to the first segment, target to the last. Bends
-  // are inside via now, so they ride within `segments` — no separate
-  // userBends interleave needed.
-  const visualSegments = $derived.by<Waypoint[][]>(() => {
-    const segs = data?.segments ?? [[]]
-    const result: Waypoint[][] = []
-    const last = segs.length - 1
-    for (let i = 0; i < segs.length; i++) {
-      const inner = segs[i] ?? []
-      const pts: Waypoint[] = []
-      if (i === 0) pts.push({ x: sourceX, y: sourceY })
-      pts.push(...inner)
-      if (i === last) pts.push({ x: targetX, y: targetY })
-      if (pts.length >= 2) result.push(pts)
-    }
-    return result
-  })
+  // Composed polyline: source endpoint + inner via centers + target endpoint.
+  const points = $derived<Waypoint[]>([
+    { x: sourceX, y: sourceY },
+    ...(data?.innerWaypoints ?? []),
+    { x: targetX, y: targetY },
+  ])
 
-  // Render every segment as a rounded polyline. Multi-segment wires
-  // (EPS-split) get joined into one path string with separate
-  // subpaths so the wall-gap shows as a break.
-  const pathD = $derived.by(() => {
-    if (visualSegments.length === 0) return ''
-    // Plain polyline. Corner radius is shared with WIRE_CORNER_RADIUS
-    // so the bend dot (sized at 2× this in node-geometry) exactly
-    // covers the rounded-corner cutout — the bend visually sits ON
-    // the line even though the bezier control is at the corner peak.
-    return visualSegments
-      .filter((seg) => seg.length >= 2)
-      .map((seg) => polylinePath(seg, WIRE_CORNER_RADIUS))
-      .join(' ')
-  })
-  // Visible polylines + per-segment via offsets feed bendOnDrag's
-  // search. Without offsets a click on the room-side polyline
-  // would resolve to the rack-side via slice (different
-  // geometric polylines but indices conflated). See
-  // wire-edit.ts:bendOnDrag for the offset → via index mapping.
-  const bendSegments = $derived(
-    visualSegments.map((points, i) => ({
-      points,
-      viaOffset: data?.segmentViaOffsets?.[i] ?? 0,
-    })),
-  )
+  const pathD = $derived(polylinePath(points, WIRE_CORNER_RADIUS))
 
-  // Per-visible-segment label anchors: each segment shows its own
-  // length pill so an EPS-split wire reads as two separate cables.
-  function midpointOf(seg: Waypoint[]): Waypoint | null {
-    if (seg.length < 2) return null
+  // Length-pill anchor at the polyline midpoint.
+  const labelAnchor = $derived.by<Waypoint | null>(() => {
+    if (points.length < 2) return null
     let total = 0
-    for (let i = 0; i < seg.length - 1; i++) {
-      const a = seg[i]
-      const b = seg[i + 1]
+    for (let i = 0; i < points.length - 1; i++) {
+      const a = points[i]
+      const b = points[i + 1]
       if (!a || !b) continue
       total += Math.hypot(b.x - a.x, b.y - a.y)
     }
     const half = total / 2
     let walked = 0
-    for (let i = 0; i < seg.length - 1; i++) {
-      const a = seg[i]
-      const b = seg[i + 1]
+    for (let i = 0; i < points.length - 1; i++) {
+      const a = points[i]
+      const b = points[i + 1]
       if (!a || !b) continue
       const len = Math.hypot(b.x - a.x, b.y - a.y)
       if (walked + len >= half) {
@@ -125,51 +86,27 @@
       }
       walked += len
     }
-    return seg[seg.length - 1] ?? null
-  }
-  // For each visible segment, an anchor point and its meters reading.
-  // Segments with no scene-derived length get null and skip the pill.
-  const segmentLabels = $derived.by(() => {
-    const segMeters = data?.segmentMeters ?? []
-    return visualSegments.map((seg, i) => ({
-      anchor: midpointOf(seg),
-      meters: segMeters[i] ?? null,
-    }))
-  })
-  // Single-segment fallback: if SceneCanvas didn't supply per-segment
-  // meters but did supply a total, attach it to the only segment.
-  const fallbackSinglePill = $derived.by(() => {
-    if ((data?.segmentMeters?.length ?? 0) > 0) return null
-    if (visualSegments.length !== 1) return null
-    const total = data?.lengthMeters
-    if (total == null) return null
-    const anchor = midpointOf(visualSegments[0] ?? [])
-    return anchor ? { anchor, meters: total } : null
+    return points[points.length - 1] ?? null
   })
 
-  // Drag-to-bend on the line body: insert a bend Node into the
-  // link's via at the click, then drag its placement. snap-to-
-  // existing inside bendOnDrag grabs a nearby existing bend
-  // instead of duplicating.
   function onLinePointerDown(e: PointerEvent) {
     if (!interactive) return
     if (e.button !== 0) return
     e.stopImmediatePropagation()
     bendOnDrag({
       sceneId,
-      linkId: id,
+      linkId,
+      viaOffset,
       startClient: { x: e.clientX, y: e.clientY },
-      segments: bendSegments,
+      points,
       toFlow,
     })
   }
 </script>
 
-<!-- Subtle white halo behind the wire so a dark stroke stays
-     legible over busy / dark floor-plan backgrounds. Skipped while
-     selected — the bright blue selection color provides its own
-     contrast, and a halo behind it just reads as a white smear
-     under the waypoint / midpoint markers. -->
+<!-- White halo so a dark stroke stays legible over busy / dark
+     floor-plan backgrounds. Hidden while selected — the bright
+     blue selection color provides its own contrast. -->
 {#if !selected}
   <path
     d={pathD}
@@ -181,6 +118,7 @@
     pointer-events="none"
   />
 {/if}
+
 <BaseEdge
   path={pathD}
   {markerEnd}
@@ -189,8 +127,8 @@
     (data?.wireScale ?? 1)}; stroke-linecap: round; stroke-linejoin: round; {style ?? ''}"
 />
 
-<!-- Wire-body hit path. nopan/nodrag opt out of d3-zoom so the line
-     drag isn't hijacked into a pane pan. -->
+<!-- Wire-body hit path. nopan/nodrag opts out of d3-zoom so the
+     line drag isn't hijacked into a pane pan. -->
 <path
   d={pathD}
   class="nopan nodrag"
@@ -201,44 +139,15 @@
   onpointerdown={onLinePointerDown}
 />
 
-<!-- Cable length pill — only when the scene is calibrated. Fully
-     opaque white with a soft outer ring so it stands clear of any
-     image content beneath. -->
-<!-- One pill per visible segment so EPS-split wires show their
-     rack-side and room-side cables as separate numbers — matches
-     the breakdown in the Connections list. Hidden while selected
-     to keep the wire-edit space uncluttered. -->
-{#if !selected}
-  {#each segmentLabels as label, i (i)}
-    {#if label.anchor && label.meters !== null}
-      <EdgeLabel x={label.anchor.x} y={label.anchor.y}>
-        <span
-          class="block rounded-[3px] border border-black/15 bg-white px-1.5 text-[10px] leading-[14px] font-medium text-slate-800 shadow-[0_0_0_1.5px_rgba(255,255,255,0.9),0_1px_2px_rgba(0,0,0,0.2)]"
-          style="transform: translate(-50%, -50%); pointer-events: none;"
-        >
-          {formatMeters(label.meters)}m
-        </span>
-      </EdgeLabel>
-    {/if}
-  {/each}
-  {#if fallbackSinglePill}
-    <EdgeLabel x={fallbackSinglePill.anchor.x} y={fallbackSinglePill.anchor.y}>
-      <span
-        class="block rounded-[3px] border border-black/15 bg-white px-1.5 text-[10px] leading-[14px] font-medium text-slate-800 shadow-[0_0_0_1.5px_rgba(255,255,255,0.9),0_1px_2px_rgba(0,0,0,0.2)]"
-        style="transform: translate(-50%, -50%); pointer-events: none;"
-      >
-        {formatMeters(fallbackSinglePill.meters)}m
-      </span>
-    </EdgeLabel>
-  {/if}
+<!-- Cable length pill, hidden while selected to keep the
+     wire-edit space uncluttered. -->
+{#if !selected && labelAnchor && data?.lengthMeters !== null && data?.lengthMeters !== undefined}
+  <EdgeLabel x={labelAnchor.x} y={labelAnchor.y}>
+    <span
+      class="block rounded-[3px] border border-black/15 bg-white px-1.5 text-[10px] leading-[14px] font-medium text-slate-800 shadow-[0_0_0_1.5px_rgba(255,255,255,0.9),0_1px_2px_rgba(0,0,0,0.2)]"
+      style="transform: translate(-50%, -50%); pointer-events: none;"
+    >
+      {formatMeters(data.lengthMeters)}m
+    </span>
+  </EdgeLabel>
 {/if}
-
-<!-- No floating per-wire toolbar — Svelte Flow doesn't have an
-     EdgeToolbar primitive, and the custom one collided with
-     waypoint handles. Delete is via Backspace / Delete (native);
-     routing edits are accessed from the source node's NodeToolbar
-     or from the right-side DetailPanel. -->
-
-<!-- Waypoint / midpoint markers temporarily disabled — drag-to-bend
-     on the line body still creates waypoints in data, but no UI
-     handles render on top of the wire. -->

--- a/apps/editor/src/lib/components/scene/wire-edit.ts
+++ b/apps/editor/src/lib/components/scene/wire-edit.ts
@@ -46,13 +46,8 @@ export function polylinePath(points: Waypoint[], radius = 12): string {
   return d
 }
 
-/**
- * Index of the polyline segment closest to `p` and the squared
- * perpendicular distance to it. The squared distance lets callers
- * pick between multiple polylines (e.g. EPS-split visible
- * segments) without needing a sqrt.
- */
-function nearestSegment(points: Waypoint[], p: Waypoint): { index: number; distSq: number } {
+/** Index of the polyline segment closest to `p`. */
+function nearestSegmentIndex(points: Waypoint[], p: Waypoint): number {
   let best = 0
   let bestDist = Infinity
   for (let i = 0; i < points.length - 1; i++) {
@@ -72,40 +67,44 @@ function nearestSegment(points: Waypoint[], p: Waypoint): { index: number; distS
       best = i
     }
   }
-  return { index: best, distSq: bestDist }
+  return best
 }
 
 /**
- * Drag-to-bend: pointerdown on the line body. Creates a bend Node in
- * the link's `via` chain at the right insertion index, then drags
- * its scene placement until pointerup. Snap-to-existing grabs an
- * already-placed bend (within `snapTol` flow units) instead of
- * spawning a duplicate.
+ * Drag-to-bend: pointerdown on a wire's hit path. Creates a bend
+ * Node in the link's `via` chain at the right insertion index,
+ * then drags its scene placement until pointerup. Snap-to-existing
+ * grabs an already-placed bend within `snapTol` flow units instead
+ * of spawning a duplicate.
  *
- * `segments` is the array of visible polylines (one per side of an
- * EPS, plus the trivial single-segment case). Each polyline carries
- * its own `viaOffset` so a click resolves to the right insertion
- * index in the link's via list:
- *   global segIdx = viaOffset + nearestSegment(local).index
- * Without this offset an EPS-split wire would always insert into
- * the rack-side via slice regardless of which visible side the
- * user clicked.
+ * Each Svelte Flow edge in the scene corresponds to a single
+ * visible cable segment — `points` is that segment's polyline and
+ * `viaOffset` is the global via index of its left endpoint
+ * (source-rooted segment = 0; post-EPS segment = `viaIndex(head) + 1`).
+ * Local nearest-segment-index + offset = global insertion index.
  */
-export interface BendDragSegment {
-  points: Waypoint[]
-  viaOffset: number
-}
-
 export function bendOnDrag(args: {
   sceneId: string
   linkId: string
+  /** This segment's polyline, in flow coordinates. */
+  points: Waypoint[]
+  /** Global via offset for this segment. */
+  viaOffset: number
   startClient: { x: number; y: number }
-  segments: BendDragSegment[]
   toFlow: (clientX: number, clientY: number) => Waypoint
   threshold?: number
   snapTol?: number
 }) {
-  const { sceneId, linkId, startClient, segments, toFlow, threshold = 4, snapTol = 18 } = args
+  const {
+    sceneId,
+    linkId,
+    points,
+    viaOffset,
+    startClient,
+    toFlow,
+    threshold = 4,
+    snapTol = 18,
+  } = args
   let dragNodeId: string | null = null
   let txOpen = false
 
@@ -142,22 +141,8 @@ export function bendOnDrag(args: {
         txOpen = true
         dragNodeId = near.id
       } else {
-        // Pick the closest visible polyline first, then the
-        // closest line within it. Capture viaOffset alongside the
-        // local index in the same loop so we don't re-look the
-        // winner up after.
-        let bestLocal = 0
-        let bestOffset = 0
-        let bestDist = Infinity
-        for (const seg of segments) {
-          const { index, distSq } = nearestSegment(seg.points, flowStart)
-          if (distSq < bestDist) {
-            bestDist = distSq
-            bestLocal = index
-            bestOffset = seg.viaOffset
-          }
-        }
-        const segIdx = bestOffset + bestLocal
+        const localIdx = nearestSegmentIndex(points, flowStart)
+        const segIdx = viaOffset + localIdx
         // insertBendInLink wraps the create + via splice in its own
         // commit, so we don't double-wrap with our drag tx.
         dragNodeId = diagramState.insertBendInLink(sceneId, linkId, flowStart, segIdx)

--- a/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
+++ b/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
@@ -400,16 +400,16 @@
   }
 
   /* Interaction gating via pointer-events on specific element types.
-                     Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
-                     propagation on the canvas background. d3-zoom's filter already
-                     handles wheel requiring ctrl/meta, but we also kill the background
-                     grid's clickability when selection is off. */
+                       Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
+                       propagation on the canvas background. d3-zoom's filter already
+                       handles wheel requiring ctrl/meta, but we also kill the background
+                       grid's clickability when selection is off. */
   .topology-viewer.no-panzoom :global(.canvas-bg) {
     pointer-events: none;
   }
 
   /* LOD: toggleable ornament classes. Rules match @shumoku/renderer's
-                     output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
+                       output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
   .topology-viewer.hide-port-labels :global(.port-label),
   .topology-viewer.hide-port-labels :global(.port-label-bg) {
     display: none;

--- a/apps/server/web/src/routes/(app)/topologies/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/+page.svelte
@@ -15,18 +15,18 @@
   let formSubmitting = $state(false)
 
   const sampleYaml = `name: My Network
-  nodes:
-    - id: router1
-      label: Core Router
-      type: router
-    - id: switch1
-      label: Switch 1
-      type: switch
-  links:
-    - from: router1
-      to: switch1
-      bandwidth: 1G
-  `
+    nodes:
+      - id: router1
+        label: Core Router
+        type: router
+      - id: switch1
+        label: Switch 1
+        type: switch
+    links:
+      - from: router1
+        to: switch1
+        bandwidth: 1G
+    `
 
   onMount(() => {
     topologies.load()


### PR DESCRIPTION
The visual fix in #190 was a band-aid. The real issue was architectural: an EPS-split wire **rendered** as two polylines but **interacted** as one edge — Svelte Flow tracked one selection, hover, drag-to-bend handler for the whole logical Link.

Match the interaction model to the rendering: emit **one Svelte Flow edge per visible cable segment**. The underlying \`Link\` data model is unchanged (still one logical port-to-port connection), but each physical cable run gets its own selectable / hoverable / draggable edge in the scene canvas.

## Changes

- \`SceneCanvas.sfEdges\` loops \`visibleCableSegments(link)\` and emits one edge per segment. Edge id is \`\`\`\`\${linkId}::\${segmentIndex}\`\`\`\`; \`data\` carries \`linkId\`, \`segmentIndex\`, \`viaOffset\`, \`innerWaypoints\`, per-segment \`lengthMeters\`. Source / target are the segment's actual endpoints (e.g. for a panel→EPS→outlet→switch wire, the rack-side edge has \`source: panel, target: EPS\` and the room-side has \`source: outlet, target: switch\`).
- \`SceneEdge\` becomes a single-polyline component. Multi-segment data shape (\`segments[]\` / \`segmentMeters[]\` / \`segmentViaOffsets[]\`) is gone, as is the per-segment hit-path bookkeeping I added in #190.
- \`bendOnDrag\` drops the \`segments[]\` / \`segmentIndex\` parameters and just takes the polyline + viaOffset for one segment. \`nearestSegmentIndex\` only picks the line within the (single) polyline.
- \`ondelete\` (Backspace) maps each Svelte Flow edge id back to its \`linkId\` via \`data.linkId\`, dedupes via a Set, then \`removeLink(linkId)\`. Multi-segment selections still remove the whole logical wire — the data model is all-or-nothing per Link, matching existing semantics.
- Removing a TP node continues to strip it from \`Link.via\` (existing \`removeNode\` behavior). Deleting an EPS naturally rejoins the segments because \`visibleCableSegments\` no longer splits there.

## Why this is the right fix

- **Per-cable selection** falls out of Svelte Flow's edge model — no custom \`activeSegment\` state or overlay paint logic.
- **Drag-to-bend** can no longer pick the wrong polyline geometrically — there's only one polyline per edge.
- **Per-cable cable-length pill** likewise becomes one pill per edge naturally.
- **Future per-cable actions** (replace cable, change spec) have a clean place to land — the edge IS the cable.

## Test plan

- [ ] Wire panel → EPS → outlet → switch. Click the room-side cable → only it highlights. Click the rack-side → only it highlights.
- [ ] Drag-to-bend on the room-side → bend appears between outlet and switch; rack-side stays put.
- [ ] Delete one segment with Backspace → the whole logical Link is removed.
- [ ] Delete the EPS node → the two segments rejoin into one wire (single visible cable).
- [ ] Delete the outlet node → outlet is stripped from via, segments adjust.
- [ ] Single-segment wire (no EPS) — renders / selects / bends as before.
- [ ] Cable-length pill shows per visible segment when the scene is calibrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)