### PR TITLE
refactor(editor): drop vestigial Scene.wireRoutes field

### DIFF
--- a/apps/editor/src/lib/components/scene/SceneBackgroundNode.svelte
+++ b/apps/editor/src/lib/components/scene/SceneBackgroundNode.svelte
@@ -21,10 +21,10 @@
 
 <style>
   /* The Svelte Flow node wrapper around this bg would otherwise
-             swallow clicks (and route them as node clicks, not pane clicks),
-             breaking calibration / click-to-place which both rely on
-             onPaneClick. Disabling pointer-events on the wrapper lets clicks
-             fall through to the pane underneath. */
+               swallow clicks (and route them as node clicks, not pane clicks),
+               breaking calibration / click-to-place which both rely on
+               onPaneClick. Disabling pointer-events on the wrapper lets clicks
+               fall through to the pane underneath. */
   :global(.svelte-flow__node.svelte-flow__node-background) {
     pointer-events: none;
   }

--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -519,7 +519,7 @@
 
 <style>
   /* Soften Svelte Flow's default dotted background when no floor
-                                 plan is set, but otherwise let its theming through. */
+                                   plan is set, but otherwise let its theming through. */
   :global(.svelte-flow__background) {
     background: #f8fafc;
   }
@@ -527,8 +527,8 @@
     stroke-linecap: round;
   }
   /* Make connection handles visible on hover so users can see where
-                               to drag from. Otherwise the fully-transparent handles leave the
-                               "how do I draw a wire" UX a guess. */
+                                 to drag from. Otherwise the fully-transparent handles leave the
+                                 "how do I draw a wire" UX a guess. */
   :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 1 !important;
@@ -538,15 +538,15 @@
     height: 8px;
   }
   /* Read-only cue: don't reveal connection handles on hover in view
-                     mode. Keep size + DOM presence so Svelte Flow can still resolve
-                     edge endpoint positions from each handle's bounding rect — only
-                     opacity is dropped. */
+                       mode. Keep size + DOM presence so Svelte Flow can still resolve
+                       edge endpoint positions from each handle's bounding rect — only
+                       opacity is dropped. */
   .scene-canvas-readonly :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 0 !important;
   }
   /* Placement-pending: crosshair cursor on the pane so users see
-                     "click somewhere to drop the item". */
+                       "click somewhere to drop the item". */
   .scene-canvas-placing :global(.svelte-flow__pane) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     cursor: crosshair !important;

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -74,7 +74,6 @@ import type {
   NetedProject,
   Product,
   Scene,
-  WireRoute,
 } from './types'
 import { productLabel } from './types'
 import { type ProjectSnapshot, undoManager } from './undo.svelte'
@@ -856,7 +855,6 @@ export const diagramState = {
         id: newId('scene'),
         name,
         nodePlacements: [],
-        wireRoutes: [],
         scopeSubgraphId,
       }
       scenesStore.add(scene)
@@ -888,28 +886,10 @@ export const diagramState = {
     commit('Move items', () => scenesStore.placeNodes(sceneId, updates))
   },
   removePlacementFromScene(sceneId: string, nodeId: string) {
-    commit('Remove placement', () => {
-      scenesStore.removePlacement(sceneId, nodeId, (linkId) => {
-        const link = diagram.links.find((l) => l.id === linkId)
-        if (!link) return false
-        return link.from.node !== nodeId && link.to.node !== nodeId
-      })
-    })
-  },
-  setWireRoute(sceneId: string, route: WireRoute) {
-    commit('Route wire', () => scenesStore.setWireRoute(sceneId, route))
-  },
-  removeWireFromScene(sceneId: string, linkId: string) {
-    commit('Remove wire route', () => scenesStore.removeWireRoute(sceneId, linkId))
+    commit('Remove placement', () => scenesStore.removePlacement(sceneId, nodeId))
   },
   hideNodeInScene(sceneId: string, nodeId: string) {
-    commit('Hide node', () => {
-      scenesStore.hideNode(sceneId, nodeId, (linkId) => {
-        const link = diagram.links.find((l) => l.id === linkId)
-        if (!link) return false
-        return link.from.node !== nodeId && link.to.node !== nodeId
-      })
-    })
+    commit('Hide node', () => scenesStore.hideNode(sceneId, nodeId))
   },
   unhideNodeInScene(sceneId: string, nodeId: string) {
     commit('Unhide node', () => scenesStore.unhideNode(sceneId, nodeId))
@@ -1063,30 +1043,22 @@ export const diagramState = {
       rebuildPortsAndEdges()
     })
   },
-  addWireInScene(
-    sceneId: string,
-    fromNodeId: string,
-    toNodeId: string,
-    options?: { pathStyle?: WireRoute['pathStyle']; controlPoints?: WireRoute['controlPoints'] },
-  ): string | undefined {
+  addWireInScene(_sceneId: string, fromNodeId: string, toNodeId: string): string | undefined {
     return commit('Add wire', () => {
       const fromNode = diagram.nodes.get(fromNodeId)
       const toNode = diagram.nodes.get(toNodeId)
       if (!fromNode || !toNode) return undefined
       const linkId = newId('link')
-      // Init an empty cable record so the BOM / detail panel pick the
-      // wire up immediately. Type/grade/length stay unset; the user
-      // (or scene-derived length) fills them in afterward.
+      // Init an empty cable record so the BOM / detail panel pick
+      // the wire up immediately. Type / grade / length stay unset;
+      // the user (or scene-derived length) fills them in
+      // afterward. The wire's scene appearance is fully derived
+      // from `link.via` placements — no per-scene route record.
       diagramState.addLink({
         id: linkId,
         from: { node: fromNodeId, port: '' },
         to: { node: toNodeId, port: '' },
         cable: {},
-      })
-      diagramState.setWireRoute(sceneId, {
-        linkId,
-        pathStyle: options?.pathStyle ?? 'orthogonal',
-        controlPoints: options?.controlPoints,
       })
       return linkId
     })
@@ -1540,28 +1512,43 @@ async function applyProject(data: Partial<NetedProject>) {
   await rerouteEdges()
 
   const linkIdSet = new Set(diagram.links.map((l) => l.id).filter((id): id is string => !!id))
+  // Migration must run BEFORE sanitize so the legacy `wireRoutes`
+  // field (already stripped by sanitize) is still readable from
+  // the raw input. addTerminationInScene needs the scene present
+  // in scenesStore though, so we set sanitized first and then
+  // migrate from the raw payload.
   scenesStore.set(sanitizeScenes(data.scenes ?? [], diagram.nodes, linkIdSet))
   scenesStore.setCurrentId(null)
-
-  // Backwards compat: convert legacy wireRoutes.controlPoints into
-  // bend Nodes inserted in Link.via. Old projects stored bends as
-  // anonymous absolute coords; the new model treats every transit
-  // point (including user bends) as a Node so multi-drag, deletion,
-  // and selection all flow through Svelte Flow's native node
-  // machinery. Run once after sanitize so node ids are stable.
-  migrateWireRoutesToBendNodes()
+  migrateLegacyWireRoutes(data.scenes ?? [])
 }
 
-function migrateWireRoutesToBendNodes() {
-  for (const scene of scenesStore.list) {
-    const routesWithBends = scene.wireRoutes.filter((r) => (r.controlPoints?.length ?? 0) > 0)
-    if (routesWithBends.length === 0) continue
-    for (const route of routesWithBends) {
+/**
+ * One-shot migration of legacy `Scene.wireRoutes[].controlPoints`
+ * (anonymous absolute-coord bends) into bend Nodes spliced into
+ * `Link.via`. The new model treats every transit point — bends
+ * included — as a Node, so multi-drag / deletion / selection all
+ * flow through Svelte Flow's native node machinery. The
+ * `wireRoutes` field is gone from the Scene type; the migration
+ * reads it via a loose cast on the raw input.
+ */
+type LegacyScene = {
+  id: string
+  wireRoutes?: Array<{ linkId: string; controlPoints?: Array<{ x: number; y: number }> }>
+}
+
+function migrateLegacyWireRoutes(rawScenes: unknown[]) {
+  for (const raw of rawScenes) {
+    const legacy = raw as LegacyScene
+    const routes = legacy.wireRoutes
+    if (!routes?.length) continue
+    for (const route of routes) {
+      const points = route.controlPoints
+      if (!points?.length) continue
       const link = diagram.links.find((l) => l.id === route.linkId)
       if (!link) continue
       const newBendIds: string[] = []
-      for (const pt of route.controlPoints ?? []) {
-        const id = diagramState.addTerminationInScene(scene.id, pt, 'bend')
+      for (const pt of points) {
+        const id = diagramState.addTerminationInScene(legacy.id, pt, 'bend')
         newBendIds.push(id)
       }
       // Bends go before any existing TPs in via — preserves the
@@ -1569,12 +1556,6 @@ function migrateWireRoutesToBendNodes() {
       // first-class waypoints.
       diagramState.updateLink(route.linkId, { via: [...newBendIds, ...(link.via ?? [])] })
     }
-    // Clear migrated controlPoints; pathStyle stays for routing
-    // hints in the future, but controlPoints is no longer the
-    // source of truth.
-    scenesStore.update(scene.id, {
-      wireRoutes: scene.wireRoutes.map((r) => ({ ...r, controlPoints: [] })),
-    })
   }
 }
 

--- a/apps/editor/src/lib/persistence/smoke.test.ts
+++ b/apps/editor/src/lib/persistence/smoke.test.ts
@@ -47,7 +47,6 @@ test('imported blob URLs survive the load pipeline', async () => {
         id: 's1',
         name: 'F1',
         nodePlacements: [],
-        wireRoutes: [],
         background: { src: entry.url, width: 1, height: 1 },
       },
     ],
@@ -110,7 +109,6 @@ test('round-trips a project through .neted', async () => {
       id: 'scene1',
       name: 'Floor 1',
       nodePlacements: [],
-      wireRoutes: [],
       background: { src: sceneBg, width: 100, height: 100 },
     },
   ]

--- a/apps/editor/src/lib/persistence/sync.test.ts
+++ b/apps/editor/src/lib/persistence/sync.test.ts
@@ -23,7 +23,7 @@ const link = (id: string): Link => ({ id, from: { node: 'a' }, to: { node: 'b' }
 const sg = (id: string): Subgraph => ({ id, label: id }) as Subgraph
 const product = (id: string): Product =>
   ({ id, kind: 'device', spec: { kind: 'hardware' } }) as Product
-const scene = (id: string): Scene => ({ id, name: id, nodePlacements: [], wireRoutes: [] })
+const scene = (id: string): Scene => ({ id, name: id, nodePlacements: [] })
 
 test('empty diff is a no-op', () => {
   expect(diffSize(diffSnapshots(snap(), snap()))).toBe(0)

--- a/apps/editor/src/lib/scene/cable-length.ts
+++ b/apps/editor/src/lib/scene/cable-length.ts
@@ -35,34 +35,18 @@ function endpointPos(
   return nodes.get(nodeId)?.position ?? null
 }
 
-/**
- * Length in pixels of one segment (a, b) within a scene. Uses the
- * link's wireRoute controlPoints only when this segment is the entire
- * link (via-less) — controlPoints aren't keyed per-segment, so they
- * can't be split across via hops without ambiguity.
- */
+/** Pixel distance between two scene endpoints, or null if either
+ *  endpoint can't be resolved. */
 function segmentPx(
   scene: Scene,
-  link: Link,
   aId: string,
   bId: string,
   nodes: Map<string, Node>,
-  isOnlySegment: boolean,
 ): number | null {
   const a = endpointPos(scene, aId, nodes)
   const b = endpointPos(scene, bId, nodes)
   if (!a || !b) return null
-  if (!isOnlySegment) return Math.hypot(b.x - a.x, b.y - a.y)
-  const route = link.id ? scene.wireRoutes.find((w) => w.linkId === link.id) : undefined
-  const points = [a, ...(route?.controlPoints ?? []), b]
-  let len = 0
-  for (let i = 0; i < points.length - 1; i++) {
-    const p = points[i]
-    const q = points[i + 1]
-    if (!p || !q) continue
-    len += Math.hypot(q.x - p.x, q.y - p.y)
-  }
-  return len
+  return Math.hypot(b.x - a.x, b.y - a.y)
 }
 
 /**
@@ -123,7 +107,6 @@ export function cableSegmentLengths(
 ): Array<{ fromId: string; toId: string; meters: number }> {
   const segments = visibleCableSegments(link, nodes)
   if (segments.length === 0) return []
-  const isOnlySegment = segments.length === 1 && segments[0]?.length === 2
   const out: Array<{ fromId: string; toId: string; meters: number }> = []
   for (const seg of segments) {
     let segMeters = 0
@@ -135,7 +118,7 @@ export function cableSegmentLengths(
       for (const scene of scenes) {
         const ratio = scene.calibration?.pxPerMeter
         if (!ratio || ratio <= 0) continue
-        const px = segmentPx(scene, link, aId, bId, nodes, isOnlySegment)
+        const px = segmentPx(scene, aId, bId, nodes)
         if (px === null) continue
         segMeters += px / ratio
         any = true

--- a/apps/editor/src/lib/state/assets.test.ts
+++ b/apps/editor/src/lib/state/assets.test.ts
@@ -45,7 +45,6 @@ test('serializeEntity replaces blob URLs in nested fields with asset: refs', asy
       name: 'F1',
       background: { src: entry.url, width: 100, height: 100 },
       nodePlacements: [],
-      wireRoutes: [],
     }
     const serialized = serializeEntity(scene)
     expect(serialized.background?.src).toBe(`asset:${entry.hash}.png`)

--- a/apps/editor/src/lib/state/scenes.svelte.ts
+++ b/apps/editor/src/lib/state/scenes.svelte.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2026-present Akitoshi Saeki
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { Scene, WireRoute } from '../types'
+import type { Scene } from '../types'
 
 // Scenes store — pure list + currentSceneId. Mutations are leaf-
 // level (no commit, no cross-store side effects). Composite ops
@@ -75,50 +75,19 @@ export const scenesStore = {
       return { ...s, nodePlacements: next }
     })
   },
-  removePlacement(
-    sceneId: string,
-    nodeId: string,
-    /** Predicate to keep a wire route. Caller passes a check that
-     *  references diagram links since this store doesn't know them. */
-    keepWire: (linkId: string) => boolean,
-  ) {
+  removePlacement(sceneId: string, nodeId: string) {
     scenesState.list = scenesState.list.map((s) =>
       s.id === sceneId
-        ? {
-            ...s,
-            nodePlacements: s.nodePlacements.filter((p) => p.nodeId !== nodeId),
-            wireRoutes: s.wireRoutes.filter((w) => keepWire(w.linkId)),
-          }
+        ? { ...s, nodePlacements: s.nodePlacements.filter((p) => p.nodeId !== nodeId) }
         : s,
     )
   },
-  setWireRoute(sceneId: string, route: WireRoute) {
-    scenesState.list = scenesState.list.map((s) => {
-      if (s.id !== sceneId) return s
-      const idx = s.wireRoutes.findIndex((w) => w.linkId === route.linkId)
-      if (idx >= 0) {
-        const next = [...s.wireRoutes]
-        next[idx] = route
-        return { ...s, wireRoutes: next }
-      }
-      return { ...s, wireRoutes: [...s.wireRoutes, route] }
-    })
-  },
-  removeWireRoute(sceneId: string, linkId: string) {
-    scenesState.list = scenesState.list.map((s) =>
-      s.id === sceneId ? { ...s, wireRoutes: s.wireRoutes.filter((w) => w.linkId !== linkId) } : s,
-    )
-  },
-  hideNode(sceneId: string, nodeId: string, keepWire: (linkId: string) => boolean) {
+  hideNode(sceneId: string, nodeId: string) {
     scenesState.list = scenesState.list.map((s) => {
       if (s.id !== sceneId) return s
       const hidden = new Set(s.hiddenNodeIds ?? [])
       hidden.add(nodeId)
-      return {
-        ...s,
-        hiddenNodeIds: [...hidden],
-        wireRoutes: s.wireRoutes.filter((w) => keepWire(w.linkId)),
-      }
+      return { ...s, hiddenNodeIds: [...hidden] }
     })
   },
   unhideNode(sceneId: string, nodeId: string) {
@@ -146,19 +115,29 @@ export const scenesStore = {
 }
 
 /**
- * Drop placements / wires / hidden ids that point at orphan node or
- * link ids. Used on project import.
+ * Drop placements / hidden ids that point at orphan node or link
+ * ids. Also strips any legacy `wireRoutes` field from incoming
+ * data (the field was deprecated when bends moved to `Link.via`).
+ * Used on project import.
  */
 export function sanitizeScenes(
   rawScenes: Scene[],
   nodes: Map<string, unknown>,
   linkIdSet: Set<string>,
 ): Scene[] {
-  return rawScenes.map((scene) => ({
-    ...scene,
-    nodePlacements: scene.nodePlacements.filter((p) => nodes.has(p.nodeId)),
-    wireRoutes: scene.wireRoutes.filter((w) => linkIdSet.has(w.linkId)),
-    hiddenNodeIds: scene.hiddenNodeIds?.filter((id) => nodes.has(id)),
-    hiddenLinkIds: scene.hiddenLinkIds?.filter((id) => linkIdSet.has(id)),
-  }))
+  return rawScenes.map((scene) => {
+    // Strip the legacy field if it survived through import. The
+    // load-time migration converts `wireRoutes[].controlPoints` →
+    // bend Nodes before sanitize runs, so by this point the field
+    // (if present) carries no information.
+    const { wireRoutes: _wireRoutes, ...rest } = scene as Scene & {
+      wireRoutes?: unknown[]
+    }
+    return {
+      ...rest,
+      nodePlacements: scene.nodePlacements.filter((p) => nodes.has(p.nodeId)),
+      hiddenNodeIds: scene.hiddenNodeIds?.filter((id) => nodes.has(id)),
+      hiddenLinkIds: scene.hiddenLinkIds?.filter((id) => linkIdSet.has(id)),
+    }
+  })
 }

--- a/apps/editor/src/lib/types.ts
+++ b/apps/editor/src/lib/types.ts
@@ -149,12 +149,6 @@ export interface Scene {
    * scene at its `Node.position` unless an entry here overrides it.
    */
   nodePlacements: NodePlacement[]
-  /**
-   * Wire routing overrides. Sparse — every diagram link renders in
-   * this scene with a default orthogonal route unless an entry here
-   * overrides it.
-   */
-  wireRoutes: WireRoute[]
   /** Node ids explicitly hidden from this scene. */
   hiddenNodeIds?: string[]
   /** Link ids explicitly hidden from this scene. */
@@ -214,17 +208,6 @@ export interface NodePlacement {
   rotation?: number
   /** Uniform scale (default 1). */
   scale?: number
-}
-
-export type WirePathStyle = 'straight' | 'orthogonal' | 'free'
-
-export interface WireRoute {
-  /** Reference to NetworkGraph.links[].id */
-  linkId: string
-  /** Path style; default 'orthogonal'. */
-  pathStyle: WirePathStyle
-  /** Optional waypoints between endpoints; renderer connects them in order. */
-  controlPoints?: { x: number; y: number }[]
 }
 
 // =========================================================================


### PR DESCRIPTION
\`Scene.wireRoutes[]\` and the \`WireRoute\` / \`WirePathStyle\` types were vestigial after the bend-as-Node refactor. Removing them now while the field is still small — every saved scene currently carries dead data, and every new feature that touches scenes has to remember to plumb \`wireRoutes\` correctly.

## What was dead

- \`pathStyle\` was set in \`addWireInScene\` but read by no one.
- \`controlPoints\` was migrated to bend Nodes on every load and saved back as an empty array — pure overhead per scene.

Every \`.neted.zip\` and IDB-cached scene carried these dead fields.

## Changes

- \`Scene.wireRoutes\` field gone. \`WireRoute\` / \`WirePathStyle\` types deleted.
- \`migrateWireRoutesToBendNodes\` → \`migrateLegacyWireRoutes\`, reads the legacy shape from the raw input via a loose cast. Old projects that import a \`.neted.zip\` containing \`wireRoutes\` still convert to bend Nodes on first load. New saves never include the field.
- \`segmentPx\` (cable-length) no longer special-cases the via-less single-segment case to walk \`wireRoute.controlPoints\` (always empty by the time it ran). Plain Euclidean distance.
- \`removePlacement\` / \`hideNode\` lose their \`keepWire\` predicate parameter — the only thing they did with it was filter a \`wireRoutes\` array that's gone now.
- \`addWireInScene\` no longer takes \`pathStyle\` / \`controlPoints\` options.
- \`setWireRoute\` / \`removeWireFromScene\` composer methods + underlying \`scenesStore\` operations removed.
- \`sanitizeScenes\` strips the legacy field via spread on incoming data so re-imports of old \`.neted.zip\` payloads cleanly drop it.

## Test plan

- [ ] 18 unit tests still passing.
- [ ] Sample project loads and renders normally.
- [ ] An old \`.neted.zip\` with \`scene.wireRoutes[].controlPoints\` imports → bends appear in the scene as bend Nodes; re-export has no \`wireRoutes\` field.
- [ ] Cached projects in IDB load without errors (legacy \`wireRoutes\` field is silently dropped on sanitize / re-save).
- [ ] Drag-to-bend / EPS-split wire / cable length still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)