### PR TITLE
fix(editor): diagram view hides termination-role nodes

### DIFF
--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -201,6 +201,7 @@
         bind:links={diagramState.activeView.links}
         theme={editorState.theme}
         mode={diagramState.currentSheetId === null ? editorState.mode : 'view'}
+        hideNode={(n) => !!n.termination}
         ondragstart={() => diagramState.beginTx('Move node')}
         ondragend={() => diagramState.endTx()}
         onselect={(id: string | null, type: string | null) => { selected = id ? { id, type: type ?? 'node' } : null }}

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -79,6 +79,13 @@
     ondragstart?: (id: string) => void
     ondragend?: (id: string) => void
     /**
+     * Predicate to skip rendering specific nodes — useful when the
+     * host stores extra nodes the user shouldn't see in this view
+     * (e.g. the editor hides scene-physical termination nodes from
+     * the logical diagram view).
+     */
+    hideNode?: (node: Node) => boolean
+    /**
      * Fired when the user drags between two ports to request a new link.
      * The parent owns link identity — it must create the link (with an ID of
      * its choosing) and either push it via `bind:links` or call `appendLink()`.
@@ -106,6 +113,7 @@
     onnodedelete,
     ondragstart,
     ondragend,
+    hideNode,
     oncreatelink,
     subgraphOverlay,
     linkOverlay,
@@ -587,6 +595,7 @@
     {ondragstart}
     ondragmove={handleDragMove}
     {ondragend}
+    {hideNode}
     onselect={handleSelect}
     onaddport={handleAddPort}
     onlinkstart={handleLinkStart}

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -25,6 +25,12 @@
     portOverlay,
     linkPreview = null,
     svgEl = $bindable<SVGSVGElement | null>(null),
+    // Optional rendering filter — predicate that returns true for
+    // nodes the host wants hidden from this canvas (e.g. the editor's
+    // termination-role nodes that are scene-physical, not logical-
+    // diagram concepts). Hidden nodes still exist in `nodes`; they
+    // just aren't drawn here.
+    hideNode,
     // Callbacks (unified: drag/select work for all element types)
     ondragstart,
     ondragmove,
@@ -49,6 +55,7 @@
     linkedPorts?: Set<string>
     linkPreview?: { fromX: number; fromY: number; toX: number; toY: number } | null
     svgEl?: SVGSVGElement | null
+    hideNode?: (node: Node) => boolean
     ondragstart?: (id: string) => void
     ondragmove?: (id: string, x: number, y: number) => void
     ondragend?: (id: string) => void
@@ -168,19 +175,21 @@
 
     <!-- Nodes layer -->
     {#each nodes.values() as node (node.id)}
-      <SvgNode
-        {node}
-        {colors}
-        selected={selection.has(node.id)}
-        {interactive}
-        overlay={nodeOverlay}
-        {ondragstart}
-        {ondragmove}
-        {ondragend}
-        {onselect}
-        {onaddport}
-        oncontextmenu={(id, e) => onctx?.(id, 'node', e)}
-      />
+      {#if !hideNode?.(node)}
+        <SvgNode
+          {node}
+          {colors}
+          selected={selection.has(node.id)}
+          {interactive}
+          overlay={nodeOverlay}
+          {ondragstart}
+          {ondragmove}
+          {ondragend}
+          {onselect}
+          {onaddport}
+          oncontextmenu={(id, e) => onctx?.(id, 'node', e)}
+        />
+      {/if}
     {/each}
 
     <!-- Ports layer (above nodes so they're always clickable) -->


### PR DESCRIPTION
Bends, outlets, EPSes, and panels are scene-physical concepts. They live in the same \`diagram.nodes\` map as logical devices because (1) \`Link.via\` chains address them by id, and (2) Svelte Flow's node infrastructure (drag / select / multi-select / delete) applies to them for free in the scene canvas.

The diagram view is the **logical** port-to-port graph, though, so these termination-role nodes shouldn't appear there. Currently every bend the user creates in the scene shows up as a pin in the diagram.

## Fix

Add a generic \`hideNode?: (node: Node) => boolean\` prop to \`SvgCanvas\` + \`ShumokuRenderer\`. Diagram page passes \`(n) => !!n.termination\` so any node carrying a \`termination\` role is silently skipped during render. Existing renderer consumers (web component, docs site) default to showing every node.

Closes #20.

## Why a render-time filter (not data-side)

- The nodes need to exist in \`diagram.nodes\` for via lookups + scene rendering. We can't strip them from state.
- The renderer is shared across surfaces; making it editor-aware (e.g. hard-coding \"hide if termination\") would couple the library to one consumer's data model. A generic predicate prop keeps it agnostic.
- Filtering at the render iteration is cheap (already iterating).

## Test plan

- [ ] Add a bend in scene view → bend stays visible in scene, doesn't appear in diagram view.
- [ ] Same for outlet / EPS / panel TPs.
- [ ] Wires (Links) still render in diagram view because they connect logical port endpoints, not termination nodes.
- [ ] Web component / docs renderer untouched (no \`hideNode\` prop passed → default shows everything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)