### PR TITLE
fix(editor): persist scene assets across reload (asset-load order + tx cache.touch)

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1338,18 +1338,20 @@ export const diagramState = {
       if (!project && projectId === 'sample') project = sampleProject
       if (!project && projectId !== 'sample') {
         sessionStore.setStatus('Loading from cache...')
+        // Asset rows MUST be registered into the AssetStore before
+        // we read the snapshot — `loadSnapshot` rehydrates each
+        // entity's `asset:<hash>` refs back into blob URLs by
+        // looking the hash up, and an empty store means every ref
+        // gets left as a literal string. The visible symptom of
+        // getting the order wrong: scene backgrounds and product
+        // icons render as broken `<img>`.
+        const assets = await projectsDb.getAssets(projectId)
+        for (const a of assets) {
+          assetStore.putWithHash(a.hash, a.ext, a.blob)
+          persistedAssetHashes.add(a.hash)
+        }
         const cached = await projectsDb.loadSnapshot(projectId)
         if (cached) {
-          // Repopulate the AssetStore from per-project asset rows
-          // before applying state — image fields hold blob URLs that
-          // need their backing entries to exist before render. Also
-          // seed `persistedAssetHashes` so the next sync skips
-          // re-putting these.
-          const assets = await projectsDb.getAssets(projectId)
-          for (const a of assets) {
-            assetStore.putWithHash(a.hash, a.ext, a.blob)
-            persistedAssetHashes.add(a.hash)
-          }
           // Translate the persisted snapshot back into a NetedProject
           // so the existing applyProject pipeline (sanitize, port
           // placement, asset rehydration) handles it uniformly.

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -248,7 +248,24 @@ let txSnap: ProjectSnapshot | null = null
 let txLabel = ''
 
 function commit<T>(label: string, fn: () => T): T {
-  if (inCommit || txActive) return fn()
+  if (inCommit) return fn()
+  // While a transaction is open (e.g. the user is in edit mode, or
+  // a multi-tick drag is in progress) the bracket — not commit() —
+  // owns undo grouping: we skip undoManager.push so individual
+  // ticks don't pollute the undo stack. Cache sync is orthogonal,
+  // so per-commit state changes still mirror to IDB; otherwise
+  // anything done during edit mode (image upload, sidebar edits)
+  // would be lost on reload.
+  if (txActive) {
+    inCommit = true
+    try {
+      const result = fn()
+      cache.touch()
+      return result
+    } finally {
+      inCommit = false
+    }
+  }
   const before = getProjectSnapshot()
   inCommit = true
   try {
@@ -262,7 +279,17 @@ function commit<T>(label: string, fn: () => T): T {
 }
 
 async function commitAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
-  if (inCommit || txActive) return await fn()
+  if (inCommit) return await fn()
+  if (txActive) {
+    inCommit = true
+    try {
+      const result = await fn()
+      cache.touch()
+      return result
+    } finally {
+      inCommit = false
+    }
+  }
   const before = getProjectSnapshot()
   inCommit = true
   try {


### PR DESCRIPTION
## Summary
リロードで写真が消えるバグ。原因は2層あった。

### 1. `loadProject()` の rehydrate 順 (最初の commit)
`loadSnapshot` → 内部で entity ごとに `rehydrateEntity` を呼んで `asset:<hash>` ref を blob URL に解決。AssetStore はその直後の `getAssets` で初めて埋まるので、空のまま引かれて ref がリテラル文字列で残っていた。`getAssets` を先にしてから `loadSnapshot` を呼ぶよう順序を入れ替え。

### 2. 編集モード中は cache.touch がそもそも発火していなかった (本丸)
`editorState.mode = 'edit'` で `beginTx('Edit')` が走り、edit を抜けるまで `txActive=true`。一方 `commit()` は `if (inCommit || txActive) return fn()` で短絡していて、tx 中の状態変化は `cache.touch()` が呼ばれず IDB に書き込まれない。結果、edit モード中の画像アップロードもサイドバー編集も全部メモリのみ。リロードで丸ごと消える。

tx ブラケットは undo グルーピングのためのもので、IDB ミラーリングとは直交。`commit()` の tx 短絡を `inCommit` (純粋な再入) のみに絞り、tx 中も `cache.touch()` は走るように分離。multi-tick drag 由来のミラー連打は cache 側の pending+single-flight が自然に coalesce する。

## Test plan
- [x] chrome-devtools で実機再現 → 修正後 IDB に asset 行 + scene の `background.src = "asset:<hash>.png"` が残る
- [x] リロード後 `currentScene.background.src` が `blob:` URL に rehydrate される