### PR TITLE
fix(editor): unify Delete behavior, drop renderer-side dead code

### DIFF
--- a/apps/editor/src/lib/actions/builtin.ts
+++ b/apps/editor/src/lib/actions/builtin.ts
@@ -162,9 +162,13 @@ const builtinActions: Action[] = [
   {
     id: 'edit.delete',
     label: 'Delete',
-    // No `shortcut` (would double-fire with the renderer's native
-    // Backspace handler), but show the hint so users know which
-    // key removes a selection.
+    // Window-level handler — the renderer's local keydown listener
+    // is attached to <svg>, which isn't focusable by default, so
+    // Delete only fired when the user happened to have the SVG in
+    // focus. Owning the shortcut here makes it work everywhere a
+    // selection exists; the renderer no longer handles Delete to
+    // avoid double-fire.
+    shortcut: 'Del',
     shortcutHint: 'Del',
     icon: Trash,
     group: 'edit',

--- a/apps/editor/src/lib/actions/builtin.ts
+++ b/apps/editor/src/lib/actions/builtin.ts
@@ -40,6 +40,7 @@ function deleteSelection(ctx: ActionContext): void {
   const items = ctx.selection.ids.map((id, i) => ({ id, type: ctx.selection.types[i] }))
   for (const it of items) {
     if (it.type === 'edge' || it.type === 'link') diagramState.removeLink(it.id)
+    else if (it.type === 'subgraph') diagramState.removeSubgraph(it.id)
     else diagramState.removeNode(it.id)
   }
 }

--- a/apps/editor/src/lib/actions/builtin.ts
+++ b/apps/editor/src/lib/actions/builtin.ts
@@ -41,6 +41,7 @@ function deleteSelection(ctx: ActionContext): void {
   for (const it of items) {
     if (it.type === 'edge' || it.type === 'link') diagramState.removeLink(it.id)
     else if (it.type === 'subgraph') diagramState.removeSubgraph(it.id)
+    else if (it.type === 'port') diagramState.removePort(it.id)
     else diagramState.removeNode(it.id)
   }
 }

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1052,62 +1052,32 @@ export const diagramState = {
     })
   },
   /**
-   * Remove a subgraph and everything physically inside it: descendant
-   * nodes (recursive), nested subgraphs, links touching any deleted
-   * node, scene placements / hidden refs that pointed at them, and
-   * `Link.via` entries that named a deleted node. Scenes whose
-   * `scopeSubgraphId` was the deleted subgraph (or any descendant)
-   * fall back to root scope rather than getting orphaned.
+   * Remove a subgraph but leave its contents intact — children
+   * (nodes and nested subgraphs) re-parent to the deleted
+   * subgraph's parent, so the subgraph "unwraps" rather than
+   * cascading. Scenes that scoped to this subgraph fall back to
+   * its parent (or root if it was a top-level subgraph).
    *
-   * Mirrors `removeNode`'s data-consistency contract — kept on the
-   * editor side so undo, cache.touch, and scene/Link.via cleanup all
-   * happen in one commit. The renderer no longer needs its own delete
-   * implementation.
+   * Recursive descendant deletion is intentionally not the default:
+   * users almost always want to ungroup, not nuke. If they do want
+   * to remove the contents, they can multi-select and Delete.
    */
   removeSubgraph(id: string) {
     commit('Remove subgraph', () => {
-      const sgsToDelete = new Set<string>()
-      const nodesToDelete = new Set<string>()
-      const collect = (sgId: string) => {
-        sgsToDelete.add(sgId)
-        for (const [nid, n] of diagram.nodes) {
-          if (n.parent === sgId) nodesToDelete.add(nid)
-        }
-        for (const [cid, c] of diagram.subgraphs) {
-          if (c.parent === sgId) collect(cid)
-        }
+      const sg = diagram.subgraphs.get(id)
+      if (!sg) return
+      const newParent = sg.parent
+      for (const [nid, n] of diagram.nodes) {
+        if (n.parent === id) diagram.nodes.set(nid, { ...n, parent: newParent })
       }
-      collect(id)
-
-      for (const nid of nodesToDelete) diagram.nodes.delete(nid)
-      for (const sgId of sgsToDelete) diagram.subgraphs.delete(sgId)
-
-      diagram.links = diagram.links.flatMap((l) => {
-        if (nodesToDelete.has(l.from.node) || nodesToDelete.has(l.to.node)) return []
-        const via = l.via
-        if (!via) return [l]
-        const next = via.filter((v) => !nodesToDelete.has(v))
-        if (next.length === via.length) return [l]
-        return [{ ...l, via: next.length > 0 ? next : undefined }]
-      })
+      for (const [cid, c] of diagram.subgraphs) {
+        if (c.parent === id) diagram.subgraphs.set(cid, { ...c, parent: newParent })
+      }
+      diagram.subgraphs.delete(id)
 
       for (const scene of scenesStore.list) {
-        const placements = scene.nodePlacements.filter((p) => !nodesToDelete.has(p.nodeId))
-        const hidden = (scene.hiddenNodeIds ?? []).filter((nid) => !nodesToDelete.has(nid))
-        const scope =
-          scene.scopeSubgraphId && sgsToDelete.has(scene.scopeSubgraphId)
-            ? undefined
-            : scene.scopeSubgraphId
-        const changed =
-          placements.length !== scene.nodePlacements.length ||
-          hidden.length !== (scene.hiddenNodeIds?.length ?? 0) ||
-          scope !== scene.scopeSubgraphId
-        if (changed) {
-          scenesStore.update(scene.id, {
-            nodePlacements: placements,
-            hiddenNodeIds: hidden,
-            scopeSubgraphId: scope,
-          })
+        if (scene.scopeSubgraphId === id) {
+          scenesStore.update(scene.id, { scopeSubgraphId: newParent })
         }
       }
 

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1051,6 +1051,70 @@ export const diagramState = {
       rebuildPortsAndEdges()
     })
   },
+  /**
+   * Remove a subgraph and everything physically inside it: descendant
+   * nodes (recursive), nested subgraphs, links touching any deleted
+   * node, scene placements / hidden refs that pointed at them, and
+   * `Link.via` entries that named a deleted node. Scenes whose
+   * `scopeSubgraphId` was the deleted subgraph (or any descendant)
+   * fall back to root scope rather than getting orphaned.
+   *
+   * Mirrors `removeNode`'s data-consistency contract — kept on the
+   * editor side so undo, cache.touch, and scene/Link.via cleanup all
+   * happen in one commit. The renderer no longer needs its own delete
+   * implementation.
+   */
+  removeSubgraph(id: string) {
+    commit('Remove subgraph', () => {
+      const sgsToDelete = new Set<string>()
+      const nodesToDelete = new Set<string>()
+      const collect = (sgId: string) => {
+        sgsToDelete.add(sgId)
+        for (const [nid, n] of diagram.nodes) {
+          if (n.parent === sgId) nodesToDelete.add(nid)
+        }
+        for (const [cid, c] of diagram.subgraphs) {
+          if (c.parent === sgId) collect(cid)
+        }
+      }
+      collect(id)
+
+      for (const nid of nodesToDelete) diagram.nodes.delete(nid)
+      for (const sgId of sgsToDelete) diagram.subgraphs.delete(sgId)
+
+      diagram.links = diagram.links.flatMap((l) => {
+        if (nodesToDelete.has(l.from.node) || nodesToDelete.has(l.to.node)) return []
+        const via = l.via
+        if (!via) return [l]
+        const next = via.filter((v) => !nodesToDelete.has(v))
+        if (next.length === via.length) return [l]
+        return [{ ...l, via: next.length > 0 ? next : undefined }]
+      })
+
+      for (const scene of scenesStore.list) {
+        const placements = scene.nodePlacements.filter((p) => !nodesToDelete.has(p.nodeId))
+        const hidden = (scene.hiddenNodeIds ?? []).filter((nid) => !nodesToDelete.has(nid))
+        const scope =
+          scene.scopeSubgraphId && sgsToDelete.has(scene.scopeSubgraphId)
+            ? undefined
+            : scene.scopeSubgraphId
+        const changed =
+          placements.length !== scene.nodePlacements.length ||
+          hidden.length !== (scene.hiddenNodeIds?.length ?? 0) ||
+          scope !== scene.scopeSubgraphId
+        if (changed) {
+          scenesStore.update(scene.id, {
+            nodePlacements: placements,
+            hiddenNodeIds: hidden,
+            scopeSubgraphId: scope,
+          })
+        }
+      }
+
+      invalidateSheetCache()
+      rebuildPortsAndEdges()
+    })
+  },
   setEpsRoutingForLinks(epsId: string, linkIds: string[], included: boolean) {
     if (linkIds.length === 0) return
     commit('Update EPS routing', () => {

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -34,6 +34,7 @@ import {
   newId,
   placePorts,
   rebalanceSubgraphs,
+  removePort as removePortCore,
   resolvePosition,
   type Subgraph,
   type Theme,
@@ -1048,6 +1049,22 @@ export const diagramState = {
         }
       }
       invalidateSheetCache()
+      rebuildPortsAndEdges()
+    })
+  },
+  /**
+   * Remove a port: drops it from its parent Node's `ports` array,
+   * deletes any links that referenced it, and rebalances the
+   * remaining ports on the node. Wraps the core helper so undo +
+   * cache.touch + edge re-routing all happen in one commit.
+   */
+  removePort(id: string) {
+    commit('Remove port', () => {
+      const result = removePortCore(id, diagram.nodes, diagram.ports, diagram.links)
+      if (!result) return
+      diagram.nodes = result.nodes as typeof diagram.nodes
+      diagram.ports = result.ports as typeof diagram.ports
+      diagram.links = result.links
       rebuildPortsAndEdges()
     })
   },

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -222,10 +222,6 @@
           // before emitting this event — invalidate cached sheets now.
           diagramState.invalidateSheetCache()
         }}
-        onnodedelete={(ids: string[]) => {
-          diagramState.unbindNodes(ids)
-          diagramState.invalidateSheetCache()
-        }}
         oncreatelink={(from: LinkEndpoint, to: LinkEndpoint) => {
           diagramState.addLink({ id: newId('link'), from, to })
         }}

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -20,7 +20,6 @@
     moveNode,
     moveSubgraph,
     rebalanceSubgraphs,
-    removePort,
     resolvePosition,
     routeEdges,
     specDeviceType,
@@ -69,7 +68,6 @@
     onlabeledit?: (portId: string, label: string, screenX: number, screenY: number) => void
     oncontextmenu?: (id: string, type: string, screenX: number, screenY: number) => void
     onnodeadd?: (id: string) => void
-    onnodedelete?: (ids: string[]) => void
     /**
      * Fires once when the user starts dragging a node or subgraph.
      * Hosts open an undo / cache transaction here and close it in
@@ -110,7 +108,6 @@
     onlabeledit,
     oncontextmenu: onctx,
     onnodeadd,
-    onnodedelete,
     ondragstart,
     ondragend,
     hideNode,
@@ -220,11 +217,6 @@
       selection = new Set()
       linkDrag = null
     }
-    // Delete / Backspace are owned by the host's action registry
-    // (window-level handler) — see `edit.delete` in builtin actions.
-    // Handling them here too would double-fire and bypass the
-    // editor-side cleanup contract (undo, cache, scene/Link.via
-    // integrity).
   }
 
   // =========================================================================
@@ -333,72 +325,6 @@
     })
     finalizeAdd(id)
     return id
-  }
-
-  // =========================================================================
-  // Delete (unified, recursive for subgraphs)
-  // =========================================================================
-
-  export function deleteById(id: string) {
-    const deletedNodeIds: string[] = []
-
-    if (nodes.has(id)) {
-      deletedNodeIds.push(id)
-      nodes.delete(id)
-      for (const [portId, port] of ports) {
-        if (port.nodeId === id) ports.delete(portId)
-      }
-      links = links.filter((l) => {
-        const from = typeof l.from === 'string' ? l.from : l.from.node
-        const to = typeof l.to === 'string' ? l.to : l.to.node
-        return from !== id && to !== id
-      })
-    } else if (edges.has(id)) {
-      const edge = edges.get(id)
-      if (edge?.link?.id) links = links.filter((l) => l.id !== edge.link?.id)
-    } else if (ports.has(id)) {
-      const result = removePort(id, nodes, ports, links)
-      if (result) {
-        replaceMap(nodes, result.nodes)
-        replaceMap(ports, result.ports)
-        links = result.links
-      }
-    } else if (subgraphs.has(id)) {
-      // Collect all descendants first, then delete in one pass
-      const toDeleteNodes = new Set<string>()
-      const toDeleteSgs = new Set<string>()
-      function collect(sgId: string) {
-        toDeleteSgs.add(sgId)
-        for (const [nid, n] of nodes) {
-          if (n.parent === sgId) toDeleteNodes.add(nid)
-        }
-        for (const [cid, c] of subgraphs) {
-          if (c.parent === sgId) collect(cid)
-        }
-      }
-      collect(id)
-
-      for (const nid of toDeleteNodes) {
-        deletedNodeIds.push(nid)
-        nodes.delete(nid)
-        for (const [portId, port] of ports) {
-          if (port.nodeId === nid) ports.delete(portId)
-        }
-      }
-      for (const sgId of toDeleteSgs) subgraphs.delete(sgId)
-      links = links.filter((l) => {
-        const from = typeof l.from === 'string' ? l.from : l.from.node
-        const to = typeof l.to === 'string' ? l.to : l.to.node
-        return !toDeleteNodes.has(from) && !toDeleteNodes.has(to)
-      })
-    }
-
-    selection = new Set()
-    routeEdges(nodes, ports, links).then((e) => {
-      replaceMap(edges, e)
-    })
-    onchange?.(links)
-    if (deletedNodeIds.length > 0) onnodedelete?.(deletedNodeIds)
   }
 
   // =========================================================================

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -220,10 +220,11 @@
       selection = new Set()
       linkDrag = null
     }
-    if (!interactive) return
-    if (e.key === 'Delete' || e.key === 'Backspace') {
-      for (const id of selection) deleteById(id)
-    }
+    // Delete / Backspace are owned by the host's action registry
+    // (window-level handler) — see `edit.delete` in builtin actions.
+    // Handling them here too would double-fire and bypass the
+    // editor-side cleanup contract (undo, cache, scene/Link.via
+    // integrity).
   }
 
   // =========================================================================


### PR DESCRIPTION
## Summary

Delete 関連が action registry と renderer に二重化していて、結果どちらも片手落ち。整理して registry 一本化、renderer 側のデッドコード除去。**#198 の本格リファクタ（renderer = pure intent emitter）の前哨戦**。

### 1. Delete ボタン / 右クリック / Cmd+K が subgraph に効かない
\`deleteSelection\` が edge/link 以外を全部 \`removeNode\` に流していた → \`removeSubgraph\` を **unwrap セマンティクス**で追加（子は親 sg の parent に re-parent、scope してた scene もそこにフォールバック）。中身ごと消したい時は multi-select + Delete。

### 2. Delete キーが効かない
- renderer の keydown は \`<svg>\` に attach、SVG はデフォルト focusable じゃないからフォーカスが他に行くと届かない
- registry の \`edit.delete\` には \`shortcutHint\` だけで実 shortcut が貼られていない

window-level の registry handler に \`shortcut: 'Del'\` 寄せ（Mac の慣習で Backspace alias）。renderer 側の Delete 分岐を削除。

### 3. デッドコード掃除
registry が削除を全部担うようになると、renderer 側の以下が dead:
- \`deleteById\` export — keydown が呼ばなくなった、外部コンシューマもなし
- \`onnodedelete\` prop — \`deleteById\` だけが emit していた
- \`removePort\` import — \`deleteById\` だけが使っていた
- diagram page の \`onnodedelete → unbindNodes\` 配線 — そもそも renderer の delete 経路用の band-aid だった

editor 側に \`removePort\` を追加して、port 選択 Delete も他と同じ commit/undo/cache/rebuild の経路に揃えた。

## Out of scope

renderer は addPort / addNewNode / addNewSubgraph / drag 等で依然 bindable Map を直接 mutate している。完全に pure intent emitter にする本格リファクタは #198。

## Test plan

- [ ] node 選択 → Delete キーで消える（フォーカスがトップレベルどこにあっても）
- [ ] subgraph 選択 → Delete キーで sg だけ消えて中身は残る、ネスト sg は親の親に re-parent
- [ ] subgraph 選択 → 右クリック Delete / Cmd+K Delete でも同じ
- [ ] port 選択 → Delete でその port と関連 link が消える、他 port が再配置される
- [ ] edge / link 選択 → Delete で link が消える
- [ ] Cmd+Z で全部復元できる
- [ ] 削除後リロードしても復活しない
- [ ] 削除した sg を scope にしていた scene は scope が親 sg にフォールバックして残る