### PR TITLE
fix(editor): heal orphan port refs on load (legacy data recovery)

### DIFF
--- a/apps/editor/src/lib/state/diagram.svelte.ts
+++ b/apps/editor/src/lib/state/diagram.svelte.ts
@@ -202,5 +202,35 @@ export function sanitizeGraph(graph: NetworkGraph): {
     console.warn(`[import] dropped ${droppedLinks} link(s) with unknown endpoints`)
   }
 
+  // Heal orphan port references: a link's endpoint may point at a port id
+  // that no longer exists on the node (legacy data from when product
+  // updates regenerated port ids). Materialize a stub NodePort with the
+  // referenced id and an empty label so the link stays attached and the
+  // user can rename it from the popover. We mutate `nodes` in place
+  // because the maps haven't been replaced into the reactive store yet.
+  const portsByNode = new Map<string, Set<string>>()
+  for (const [id, node] of nodes) {
+    portsByNode.set(id, new Set((node.ports ?? []).map((p) => p.id)))
+  }
+  let healed = 0
+  for (const link of validLinks) {
+    for (const ep of [link.from, link.to]) {
+      if (!ep.port) continue
+      const existing = portsByNode.get(ep.node)
+      if (!existing || existing.has(ep.port)) continue
+      const node = nodes.get(ep.node)
+      if (!node) continue
+      const stub = { id: ep.port, label: '', connectors: [], source: 'custom' as const }
+      nodes.set(ep.node, { ...node, ports: [...(node.ports ?? []), stub] })
+      existing.add(ep.port)
+      healed++
+    }
+  }
+  if (healed > 0) {
+    console.warn(
+      `[import] materialized ${healed} stub port(s) for link endpoints referencing missing ids`,
+    )
+  }
+
   return { nodes, subgraphs, links: validLinks }
 }


### PR DESCRIPTION
## Why

Follow-up to #200. Projects saved before the immutable-port-id fix can carry link endpoints pointing at \`port-…\` ids that are no longer present on the referenced node — leftovers from when \`updateProduct\` was regenerating port ids on every property edit.

When such a project loads, \`getNodePortLabel\` doesn't find the port on the node and falls back to rendering the raw port id as the label. That's exactly the \`port-HQ7yO3T7D\`-style strings the user was still seeing in the diagram even after #200 landed — the new immutability rule prevents future damage but doesn't repair already-saved data.

User-supplied evidence: \`クラウドネイティブ会議NOC.neted.zip\` carried 5 orphan link endpoints across 4 nodes (noc-sw01, noc01-rt01 ×2, hall-sw02, foyer-sw02). One of them (\`port--HQ7yO3T7D\` on noc-sw01) is exactly the label visible in the bug-report video.

## What changes

\`apps/editor/src/lib/state/diagram.svelte.ts\` — \`sanitizeGraph\` adds a heal pass after dropping invalid links. For every endpoint that references a missing port id on its node, we materialize a stub \`NodePort\` with:
- \`id\` = the referenced port id (so the existing link continues to resolve to it)
- \`label\` = empty (the SVG renders no text, instead of a confusing \`port-…\` string — user can rename via the popover)
- \`source: 'custom'\` so subsequent product updates don't blow it away

A console warning records how many stubs were materialized so we have visibility on real-world data drift.

## Test plan
- [ ] \`bun run typecheck\` clean
- [ ] \`bun run lint\` clean
- [ ] Open the affected \`.neted\` project: previously-orphaned port labels disappear; the link is still drawn end-to-end. Console shows \`[import] materialized N stub port(s)…\`.
- [ ] Click the now-blank port: rename works, persists across reload.