### PR TITLE
feat(editor): snapshot catalog ports onto Product and add Resync action

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -90,7 +90,11 @@ export { initDarkMode }
 const catalog = new Catalog()
 catalog.registerAll(builtinEntries)
 
-const poeBudgets = $derived(analyzePoE([...diagram.nodes.values()], diagram.links, catalog))
+// Index Products by id for fast `node.productId → product.properties`
+// lookups inside `analyzePoE`. Re-derived on every productsStore change
+// so PoE budgets reflect resync events without manual cache invalidation.
+const productsById = $derived(new Map(productsStore.list.map((p) => [p.id, p])))
+const poeBudgets = $derived(analyzePoE([...diagram.nodes.values()], diagram.links, productsById))
 
 // =========================================================================
 // Cross-store derivations / helpers
@@ -206,15 +210,32 @@ function snapshotCatalogPortsForProduct(product: DeviceProduct): NodePort[] {
 }
 
 /**
- * Materialize port snapshots on a Product if missing. Called once at
- * import / load time so every Product carries its own port list.
+ * Materialize the catalog snapshot (ports + properties) on a Product
+ * when missing. Called once at import / load time so every Product
+ * carries its own copy of the catalog data — steady-state code paths
+ * never need to consult the live catalog after this.
  */
 function ensureProductPorts(product: Product): Product {
   if (product.kind !== 'device') return product
-  if (product.ports && product.ports.length > 0) return product
-  const ports = snapshotCatalogPortsForProduct(product)
-  if (ports.length === 0) return product
-  return { ...product, ports, catalogSyncedAt: product.catalogSyncedAt ?? new Date().toISOString() }
+  let next = product
+  // Snapshot ports if not already present.
+  if (!next.ports || next.ports.length === 0) {
+    const ports = snapshotCatalogPortsForProduct(next)
+    if (ports.length > 0) {
+      next = { ...next, ports, catalogSyncedAt: next.catalogSyncedAt ?? new Date().toISOString() }
+    }
+  }
+  // Snapshot properties from catalog if missing (legacy projects saved
+  // before properties was populated). This is what poe-analysis et al.
+  // read at steady state, so without it they'd silently fall back to
+  // empty data.
+  if (!next.properties && next.catalogId) {
+    const entry = catalog.lookup(next.catalogId)
+    if (entry) {
+      next = { ...next, properties: entry.properties as DeviceProduct['properties'] }
+    }
+  }
+  return next
 }
 
 function productPortTemplates(product: DeviceProduct | undefined): readonly NodePort[] {
@@ -648,13 +669,14 @@ export const diagramState = {
     return diagram.nodes.get(nodeId)?.ports ?? []
   },
   getPortLabelSuggestions(nodeId: string): string[] {
-    const spec = diagram.nodes.get(nodeId)?.spec
-    if (spec?.kind !== 'hardware' || !spec.vendor || !spec.model) return []
-    const entry = catalog.lookup(`${spec.vendor}/${spec.model}`)
-    if (!entry) return []
-    return expandCatalogPorts(entry)
-      .map((t) => t.label)
-      .filter(Boolean)
+    // Source from the bound Product's port snapshot — never the live
+    // catalog. Steady-state UI (the label-edit popover) keeps working
+    // even if the upstream catalog entry is renamed or removed.
+    const node = diagram.nodes.get(nodeId)
+    if (!node?.productId) return []
+    const product = productsStore.find(node.productId)
+    if (product?.kind !== 'device') return []
+    return (product.ports ?? []).map((p) => p.label).filter(Boolean)
   },
   getPortUsage(nodeId: string): Map<string, string[]> {
     const usage = new Map<string, string[]>()
@@ -884,10 +906,19 @@ export const diagramState = {
       const product = productsStore.find(id)
       if (!product || product.kind !== 'device') return 0
       const ports = snapshotCatalogPortsForProduct(product)
-      productsStore.update(id, {
+      const updates: Partial<DeviceProduct> = {
         ports,
         catalogSyncedAt: new Date().toISOString(),
-      } as Partial<Product>)
+      }
+      // Refresh properties from catalog too — poe-analysis and other
+      // steady-state consumers read from product.properties (PoE budget,
+      // power draw), so a port resync without a properties refresh would
+      // leave those views stale.
+      if (product.catalogId) {
+        const entry = catalog.lookup(product.catalogId)
+        if (entry) updates.properties = entry.properties as DeviceProduct['properties']
+      }
+      productsStore.update(id, updates as Partial<Product>)
       const refreshed = productsStore.find(id) as DeviceProduct | undefined
       let touched = 0
       for (const [nodeId, node] of diagram.nodes) {

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -65,6 +65,7 @@ import {
   sheetView,
 } from './state/diagram.svelte'
 import { editorStore, initDarkMode } from './state/editor.svelte'
+import { instantiatePortsFromProduct, mergeProductPortsIntoExisting } from './state/product-ports'
 import { productsStore, sanitizeProducts } from './state/products.svelte'
 import { sanitizeScenes, scenesStore } from './state/scenes.svelte'
 import { sessionStore } from './state/session.svelte'
@@ -166,146 +167,92 @@ function stripProductFromSpec(spec: NodeSpec | undefined): NodeSpec | undefined 
 //
 //   Catalog      = global, immutable, shipped via the npm package
 //   Product      = project-local snapshot of a catalog entry, with its own
-//                  `ports` list. Survives catalog drift; refreshed on
-//                  demand via "Resync from catalog" in Materials.
+//                  `ports` and `properties`. Survives catalog drift;
+//                  refreshed on demand via "Resync from catalog" in
+//                  Materials.
 //   Node.ports   = per-instance, owns each port's stable id and user-
 //                  edited label.
 //
 // Catalog is read here only at *snapshot time* (Product creation /
-// resync). Steady-state Node operations consult Product.ports — never
-// the live catalog directly — so projects keep rendering even if a
-// catalog entry is later renamed or removed.
+// load-shim / explicit resync). Steady-state Node operations consult
+// Product.ports — never the live catalog directly — so projects keep
+// rendering even if a catalog entry is later renamed or removed.
+//
+// Pure Product → Node helpers (`instantiatePortsFromProduct`,
+// `mergeProductPortsIntoExisting`) live in `./state/product-ports.ts`
+// and are unit-tested there.
 // =========================================================================
 
 /**
- * Read catalog port templates for a product. Used only when snapshotting
- * a Product from catalog (initial import or "Resync from catalog").
- * Steady-state code paths must read from `product.ports` instead.
+ * Build a fresh catalog-derived snapshot of a Product (`ports` +
+ * `properties` + `catalogSyncedAt`). The single place that reads the
+ * live catalog for snapshotting purposes — every other catalog read is
+ * either initialization or a UI helper that lists catalog entries
+ * directly.
+ *
+ * Returns a `Partial<DeviceProduct>` so callers can decide whether to
+ * overwrite existing fields (`resyncProductFromCatalog`) or only fill
+ * missing ones (`ensureProductSnapshot`).
  */
-function catalogPortTemplates(product: DeviceProduct | undefined) {
-  if (!product) return []
+function snapshotCatalogIntoProduct(product: DeviceProduct): Partial<DeviceProduct> {
+  // Try the upstream catalog first; if absent, fall back to an inline
+  // entry built from the Product's own `properties` so catalog-less
+  // products that declare ports inline still get a snapshot.
   const catalogEntry = product.catalogId ? catalog.lookup(product.catalogId) : undefined
-  return expandCatalogPorts(
-    catalogEntry ?? {
-      id: product.id,
-      label: productLabel(product),
-      spec: product.spec,
-      tags: [],
-      properties: product.properties ?? {},
-    },
-  )
+  const entry = catalogEntry ?? {
+    id: product.id,
+    label: productLabel(product),
+    spec: product.spec,
+    tags: [],
+    properties: product.properties ?? {},
+  }
+  const templates = expandCatalogPorts(entry)
+  const out: Partial<DeviceProduct> = {}
+  if (templates.length > 0) {
+    out.ports = templates.map((t) => ({
+      id: newId('port'),
+      ...t,
+      connectors: t.connectors ?? [],
+    }))
+    out.catalogSyncedAt = new Date().toISOString()
+  }
+  // Only refresh properties when the upstream catalog actually had an
+  // entry — the inline fallback's properties are just `product.properties`
+  // round-tripped, so writing them back would be a no-op churn.
+  if (catalogEntry) {
+    out.properties = catalogEntry.properties as DeviceProduct['properties']
+  }
+  return out
 }
 
 /**
- * Snapshot the catalog template into a fresh `NodePort[]` — each port
- * gets a stable `port-…` id that becomes the canonical handle for any
- * Node instantiated from this Product.
+ * Materialize the catalog snapshot on a Product when missing. Called
+ * once per product at import / load time so every Product carries its
+ * own copy of the catalog data. Existing fields are preserved — this
+ * never overwrites a user's customizations.
+ *
+ * For an explicit refresh that DOES overwrite, see
+ * `resyncProductFromCatalog`.
  */
-function snapshotCatalogPortsForProduct(product: DeviceProduct): NodePort[] {
-  return catalogPortTemplates(product).map((t) => ({
-    id: newId('port'),
-    ...t,
-    connectors: t.connectors ?? [],
-  }))
-}
-
-/**
- * Materialize the catalog snapshot (ports + properties) on a Product
- * when missing. Called once at import / load time so every Product
- * carries its own copy of the catalog data — steady-state code paths
- * never need to consult the live catalog after this.
- */
-function ensureProductPorts(product: Product): Product {
+function ensureProductSnapshot(product: Product): Product {
   if (product.kind !== 'device') return product
-  let next = product
-  // Snapshot ports if not already present.
-  if (!next.ports || next.ports.length === 0) {
-    const ports = snapshotCatalogPortsForProduct(next)
-    if (ports.length > 0) {
-      next = { ...next, ports, catalogSyncedAt: next.catalogSyncedAt ?? new Date().toISOString() }
+  const needsPorts = !product.ports || product.ports.length === 0
+  const needsProps = !product.properties && !!product.catalogId
+  if (!needsPorts && !needsProps) return product
+
+  const snap = snapshotCatalogIntoProduct(product)
+  let next: DeviceProduct = product
+  if (needsPorts && snap.ports?.length) {
+    next = {
+      ...next,
+      ports: snap.ports,
+      catalogSyncedAt: next.catalogSyncedAt ?? snap.catalogSyncedAt,
     }
   }
-  // Snapshot properties from catalog if missing (legacy projects saved
-  // before properties was populated). This is what poe-analysis et al.
-  // read at steady state, so without it they'd silently fall back to
-  // empty data.
-  if (!next.properties && next.catalogId) {
-    const entry = catalog.lookup(next.catalogId)
-    if (entry) {
-      next = { ...next, properties: entry.properties as DeviceProduct['properties'] }
-    }
+  if (needsProps && snap.properties) {
+    next = { ...next, properties: snap.properties }
   }
   return next
-}
-
-function productPortTemplates(product: DeviceProduct | undefined): readonly NodePort[] {
-  return product?.ports ?? []
-}
-
-/**
- * First-time port instantiation from a Product's snapshot. Each port
- * gets a fresh node-side id so multiple placements of the same Product
- * have distinct port handles. Used by `placeProductAsNode` and
- * `bindNodeToProduct` when the node has no existing ports.
- */
-function instantiatePortsFromProduct(product: DeviceProduct | undefined): NodePort[] | undefined {
-  const tpl = productPortTemplates(product)
-  if (tpl.length === 0) return undefined
-  return tpl.map((p) => ({ ...p, id: newId('port') }))
-}
-
-/**
- * Merge a Product's port snapshot into an existing port list, preserving
- * every existing port's `id` and user-edited `label`. Product-owned
- * physical attributes (`connectors`, `speed`, `poe`, `interfaceName`,
- * `faceplateLabel`) are refreshed from the snapshot.
- *
- * Match key: `interfaceName` first (most stable), else exact label
- * match against the snapshot's default label. Ports that don't match
- * any template (user-added customs or stale catalog ports) are
- * appended at the end so links keep resolving.
- */
-function mergeProductPortsIntoExisting(
-  existing: readonly NodePort[],
-  product: DeviceProduct | undefined,
-): NodePort[] {
-  const tpl = productPortTemplates(product)
-  if (tpl.length === 0) return [...existing]
-
-  const usedIds = new Set<string>()
-  const merged: NodePort[] = []
-
-  for (const t of tpl) {
-    const match = existing.find((e) => {
-      if (usedIds.has(e.id)) return false
-      if (t.interfaceName && e.interfaceName === t.interfaceName) return true
-      if (e.label && t.label && e.label === t.label) return true
-      return false
-    })
-    if (match) {
-      usedIds.add(match.id)
-      merged.push({
-        ...match,
-        // Product-owned physical attributes refresh; user label stays.
-        speed: t.speed ?? match.speed,
-        connectors: t.connectors ?? match.connectors,
-        poe: t.poe ?? match.poe,
-        interfaceName: t.interfaceName ?? match.interfaceName,
-        faceplateLabel: t.faceplateLabel ?? match.faceplateLabel,
-        role: t.role ?? match.role,
-        aliases: t.aliases ?? match.aliases,
-      })
-    } else {
-      merged.push({ ...t, id: newId('port') })
-    }
-  }
-  // Surface any existing ports the snapshot didn't claim (user-added
-  // custom ports, or template ports that disappeared) so links don't
-  // go orphan.
-  for (const e of existing) {
-    if (!usedIds.has(e.id)) merged.push(e)
-  }
-  return merged
 }
 
 /**
@@ -794,7 +741,7 @@ export const diagramState = {
     return productsStore.list
   },
   addProduct(entry: Product) {
-    commit('Add product', () => productsStore.add(ensureProductPorts(entry)))
+    commit('Add product', () => productsStore.add(ensureProductSnapshot(entry)))
   },
   removeProduct(id: string) {
     commit('Remove product', () => {
@@ -878,12 +825,8 @@ export const diagramState = {
             // Product, then merge the new template into each bound
             // node's existing ports. Existing ids and user-edited labels
             // survive; only physical attributes refresh.
-            const nextProduct = product as DeviceProduct
-            const ports = snapshotCatalogPortsForProduct(nextProduct)
-            productsStore.update(id, {
-              ports,
-              catalogSyncedAt: new Date().toISOString(),
-            } as Partial<Product>)
+            const snap = snapshotCatalogIntoProduct(product as DeviceProduct)
+            productsStore.update(id, snap as Partial<Product>)
             const refreshed = productsStore.find(id) as DeviceProduct | undefined
             for (const nodeId of boundNodeIds) setNodePortsFromProduct(nodeId, refreshed)
           }
@@ -905,20 +848,8 @@ export const diagramState = {
     return commit('Resync product from catalog', () => {
       const product = productsStore.find(id)
       if (!product || product.kind !== 'device') return 0
-      const ports = snapshotCatalogPortsForProduct(product)
-      const updates: Partial<DeviceProduct> = {
-        ports,
-        catalogSyncedAt: new Date().toISOString(),
-      }
-      // Refresh properties from catalog too — poe-analysis and other
-      // steady-state consumers read from product.properties (PoE budget,
-      // power draw), so a port resync without a properties refresh would
-      // leave those views stale.
-      if (product.catalogId) {
-        const entry = catalog.lookup(product.catalogId)
-        if (entry) updates.properties = entry.properties as DeviceProduct['properties']
-      }
-      productsStore.update(id, updates as Partial<Product>)
+      const snap = snapshotCatalogIntoProduct(product)
+      productsStore.update(id, snap as Partial<Product>)
       const refreshed = productsStore.find(id) as DeviceProduct | undefined
       let touched = 0
       for (const [nodeId, node] of diagram.nodes) {
@@ -1814,7 +1745,7 @@ async function applyProject(data: Partial<NetedProject>) {
       // Materialize port snapshot for legacy projects saved before
       // Product.ports existed. New `addProduct` flow already populates
       // this; the shim only fires once on load.
-      next = ensureProductPorts(next)
+      next = ensureProductSnapshot(next)
       return next
     }),
   )

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -824,11 +824,15 @@ export const diagramState = {
             // Vendor/model changed — re-snapshot the catalog into the
             // Product, then merge the new template into each bound
             // node's existing ports. Existing ids and user-edited labels
-            // survive; only physical attributes refresh.
+            // survive; only physical attributes refresh. One reroute at
+            // the end covers all bound nodes — cheaper than once per.
             const snap = snapshotCatalogIntoProduct(product as DeviceProduct)
             productsStore.update(id, snap as Partial<Product>)
             const refreshed = productsStore.find(id) as DeviceProduct | undefined
-            for (const nodeId of boundNodeIds) setNodePortsFromProduct(nodeId, refreshed)
+            for (const nodeId of boundNodeIds) {
+              setNodePortsFromProduct(nodeId, refreshed, { reroute: false })
+            }
+            if (boundNodeIds.length > 0) rebuildPortsAndEdges()
           }
         }
       }
@@ -852,11 +856,15 @@ export const diagramState = {
       productsStore.update(id, snap as Partial<Product>)
       const refreshed = productsStore.find(id) as DeviceProduct | undefined
       let touched = 0
+      // Mutate all bound nodes in one pass with rerouting suppressed —
+      // a single full reroute at the end is far cheaper than rerouting
+      // once per bound node (each call walks every node + every link).
       for (const [nodeId, node] of diagram.nodes) {
         if (node.productId !== id) continue
-        setNodePortsFromProduct(nodeId, refreshed)
+        setNodePortsFromProduct(nodeId, refreshed, { reroute: false })
         touched++
       }
+      if (touched > 0) rebuildPortsAndEdges()
       return touched
     })
   },

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -155,9 +155,28 @@ function stripProductFromSpec(spec: NodeSpec | undefined): NodeSpec | undefined 
   return undefined
 }
 
+// =========================================================================
+// Catalog → Product (snapshot) and Product → Node (instantiate / merge)
+//
+// Three layers, modeled after KiCad's library/cache/instance hierarchy:
+//
+//   Catalog      = global, immutable, shipped via the npm package
+//   Product      = project-local snapshot of a catalog entry, with its own
+//                  `ports` list. Survives catalog drift; refreshed on
+//                  demand via "Resync from catalog" in Materials.
+//   Node.ports   = per-instance, owns each port's stable id and user-
+//                  edited label.
+//
+// Catalog is read here only at *snapshot time* (Product creation /
+// resync). Steady-state Node operations consult Product.ports — never
+// the live catalog directly — so projects keep rendering even if a
+// catalog entry is later renamed or removed.
+// =========================================================================
+
 /**
- * Catalog port templates for a product. Returns the list of `CatalogPortTemplate`s
- * — without instantiated ids. Empty array when no ports are declared.
+ * Read catalog port templates for a product. Used only when snapshotting
+ * a Product from catalog (initial import or "Resync from catalog").
+ * Steady-state code paths must read from `product.ports` instead.
  */
 function catalogPortTemplates(product: DeviceProduct | undefined) {
   if (!product) return []
@@ -174,43 +193,68 @@ function catalogPortTemplates(product: DeviceProduct | undefined) {
 }
 
 /**
- * First-time port instantiation from a product. Each template gets a fresh
- * stable `port-...` id. Used by `placeProductAsNode` and `bindNodeToProduct`
- * when the node has no existing ports.
+ * Snapshot the catalog template into a fresh `NodePort[]` — each port
+ * gets a stable `port-…` id that becomes the canonical handle for any
+ * Node instantiated from this Product.
  */
-function instantiatePortsFromProduct(product: DeviceProduct | undefined): NodePort[] | undefined {
-  const templates = catalogPortTemplates(product)
-  if (templates.length === 0) return undefined
-  return templates.map((port) => ({
+function snapshotCatalogPortsForProduct(product: DeviceProduct): NodePort[] {
+  return catalogPortTemplates(product).map((t) => ({
     id: newId('port'),
-    ...port,
-    connectors: port.connectors ?? [],
+    ...t,
+    connectors: t.connectors ?? [],
   }))
 }
 
 /**
- * Merge a product's catalog port templates into an existing port list,
- * preserving every existing port's `id` and user-edited `label`. Catalog
+ * Materialize port snapshots on a Product if missing. Called once at
+ * import / load time so every Product carries its own port list.
+ */
+function ensureProductPorts(product: Product): Product {
+  if (product.kind !== 'device') return product
+  if (product.ports && product.ports.length > 0) return product
+  const ports = snapshotCatalogPortsForProduct(product)
+  if (ports.length === 0) return product
+  return { ...product, ports, catalogSyncedAt: product.catalogSyncedAt ?? new Date().toISOString() }
+}
+
+function productPortTemplates(product: DeviceProduct | undefined): readonly NodePort[] {
+  return product?.ports ?? []
+}
+
+/**
+ * First-time port instantiation from a Product's snapshot. Each port
+ * gets a fresh node-side id so multiple placements of the same Product
+ * have distinct port handles. Used by `placeProductAsNode` and
+ * `bindNodeToProduct` when the node has no existing ports.
+ */
+function instantiatePortsFromProduct(product: DeviceProduct | undefined): NodePort[] | undefined {
+  const tpl = productPortTemplates(product)
+  if (tpl.length === 0) return undefined
+  return tpl.map((p) => ({ ...p, id: newId('port') }))
+}
+
+/**
+ * Merge a Product's port snapshot into an existing port list, preserving
+ * every existing port's `id` and user-edited `label`. Product-owned
  * physical attributes (`connectors`, `speed`, `poe`, `interfaceName`,
- * `faceplateLabel`) are refreshed from the template; user-typed `label`
- * is left intact.
+ * `faceplateLabel`) are refreshed from the snapshot.
  *
- * Match key: `interfaceName` first (most stable), else the catalog
- * default `label` against the existing port's `label`. Ports that don't
- * match any template (user-added customs or stale catalog ports) are
+ * Match key: `interfaceName` first (most stable), else exact label
+ * match against the snapshot's default label. Ports that don't match
+ * any template (user-added customs or stale catalog ports) are
  * appended at the end so links keep resolving.
  */
-function mergeCatalogIntoExistingPorts(
+function mergeProductPortsIntoExisting(
   existing: readonly NodePort[],
   product: DeviceProduct | undefined,
 ): NodePort[] {
-  const templates = catalogPortTemplates(product)
-  if (templates.length === 0) return [...existing]
+  const tpl = productPortTemplates(product)
+  if (tpl.length === 0) return [...existing]
 
   const usedIds = new Set<string>()
   const merged: NodePort[] = []
 
-  for (const t of templates) {
+  for (const t of tpl) {
     const match = existing.find((e) => {
       if (usedIds.has(e.id)) return false
       if (t.interfaceName && e.interfaceName === t.interfaceName) return true
@@ -221,7 +265,7 @@ function mergeCatalogIntoExistingPorts(
       usedIds.add(match.id)
       merged.push({
         ...match,
-        // Catalog-owned physical attributes refresh; user label stays.
+        // Product-owned physical attributes refresh; user label stays.
         speed: t.speed ?? match.speed,
         connectors: t.connectors ?? match.connectors,
         poe: t.poe ?? match.poe,
@@ -231,12 +275,12 @@ function mergeCatalogIntoExistingPorts(
         aliases: t.aliases ?? match.aliases,
       })
     } else {
-      merged.push({ id: newId('port'), ...t, connectors: t.connectors ?? [] })
+      merged.push({ ...t, id: newId('port') })
     }
   }
-  // Surface any existing ports the templates didn't claim (user-added
-  // custom ports, or catalog ports that disappeared from the new
-  // template) so links don't go orphan.
+  // Surface any existing ports the snapshot didn't claim (user-added
+  // custom ports, or template ports that disappeared) so links don't
+  // go orphan.
   for (const e of existing) {
     if (!usedIds.has(e.id)) merged.push(e)
   }
@@ -244,7 +288,7 @@ function mergeCatalogIntoExistingPorts(
 }
 
 /**
- * Apply a product's port template to a node — instantiate fresh ids
+ * Apply a Product's port template to a node — instantiate fresh ids
  * when the node has none, otherwise merge into existing ports preserving
  * ids and user-edited labels.
  *
@@ -265,7 +309,7 @@ function setNodePortsFromProduct(
   if (!node) return
   if (options.preserveExisting && node.ports) return
   const ports = node.ports?.length
-    ? mergeCatalogIntoExistingPorts(node.ports, product)
+    ? mergeProductPortsIntoExisting(node.ports, product)
     : instantiatePortsFromProduct(product)
   diagram.nodes.set(nodeId, { ...node, ports })
   const migrated = migrateLinkEndpointPortsForNode(nodeId, ports)
@@ -728,7 +772,7 @@ export const diagramState = {
     return productsStore.list
   },
   addProduct(entry: Product) {
-    commit('Add product', () => productsStore.add(entry))
+    commit('Add product', () => productsStore.add(ensureProductPorts(entry)))
   },
   removeProduct(id: string) {
     commit('Remove product', () => {
@@ -808,13 +852,50 @@ export const diagramState = {
             setNodeSpecs(boundNodeIds, nextSpec)
           }
           if (catalogIdentityChanged) {
-            // Vendor/model changed — merge the new catalog template into
-            // each bound node's existing ports. Existing ids and user-
-            // edited labels survive; only physical attributes refresh.
-            for (const nodeId of boundNodeIds) setNodePortsFromProduct(nodeId, product)
+            // Vendor/model changed — re-snapshot the catalog into the
+            // Product, then merge the new template into each bound
+            // node's existing ports. Existing ids and user-edited labels
+            // survive; only physical attributes refresh.
+            const nextProduct = product as DeviceProduct
+            const ports = snapshotCatalogPortsForProduct(nextProduct)
+            productsStore.update(id, {
+              ports,
+              catalogSyncedAt: new Date().toISOString(),
+            } as Partial<Product>)
+            const refreshed = productsStore.find(id) as DeviceProduct | undefined
+            for (const nodeId of boundNodeIds) setNodePortsFromProduct(nodeId, refreshed)
           }
         }
       }
+    })
+  },
+  /**
+   * Re-snapshot the catalog template into the Product and cascade the
+   * new ports into every bound Node's `node.ports`. The merge logic
+   * preserves stable port ids and user-edited labels, so this is safe
+   * to invoke after a catalog YAML upgrade. No-op for catalog-less
+   * products.
+   *
+   * Returns the count of bound nodes that were touched, for the UI
+   * to surface ("Resynced N nodes").
+   */
+  resyncProductFromCatalog(id: string): number {
+    return commit('Resync product from catalog', () => {
+      const product = productsStore.find(id)
+      if (!product || product.kind !== 'device') return 0
+      const ports = snapshotCatalogPortsForProduct(product)
+      productsStore.update(id, {
+        ports,
+        catalogSyncedAt: new Date().toISOString(),
+      } as Partial<Product>)
+      const refreshed = productsStore.find(id) as DeviceProduct | undefined
+      let touched = 0
+      for (const [nodeId, node] of diagram.nodes) {
+        if (node.productId !== id) continue
+        setNodePortsFromProduct(nodeId, refreshed)
+        touched++
+      }
+      return touched
     })
   },
   /**
@@ -1693,9 +1774,17 @@ async function applyProject(data: Partial<NetedProject>) {
   )
   productsStore.set(
     cleanProducts.map((p) => {
-      if (p.icon || !p.catalogId) return p
-      const entry = catalog.lookup(p.catalogId)
-      return entry?.icon ? ({ ...p, icon: entry.icon } as Product) : p
+      let next = p
+      // Inherit icon from catalog if the saved product has none.
+      if (!next.icon && next.catalogId) {
+        const entry = catalog.lookup(next.catalogId)
+        if (entry?.icon) next = { ...next, icon: entry.icon } as Product
+      }
+      // Materialize port snapshot for legacy projects saved before
+      // Product.ports existed. New `addProduct` flow already populates
+      // this; the shim only fires once on load.
+      next = ensureProductPorts(next)
+      return next
     }),
   )
   diagram.links = cleanLinks

--- a/apps/editor/src/lib/poe-analysis.ts
+++ b/apps/editor/src/lib/poe-analysis.ts
@@ -24,13 +24,13 @@
  */
 
 import {
-  type Catalog,
   classReservationW,
   effectivePoeClass,
   type HardwareProperties,
   type PowerProperties,
 } from '@shumoku/catalog'
 import type { Link, Node } from '@shumoku/core'
+import type { Product } from './types'
 import { nodeDisplayLabel } from './utils/labels'
 
 export interface PoEPassthrough {
@@ -84,18 +84,17 @@ function round1(n: number): number {
   return Math.round(n * 10) / 10
 }
 
-function catalogId(node: Node): string | undefined {
-  const s = node.spec
-  if (!s || s.kind !== 'hardware' || !s.vendor || !s.model) return undefined
-  return `${s.vendor}/${s.model}`
-}
-
-function getPower(node: Node, catalog: Catalog): PowerProperties | undefined {
-  const id = catalogId(node)
-  if (!id) return undefined
-  const entry = catalog.lookup(id)
-  if (!entry || entry.spec.kind !== 'hardware') return undefined
-  return (entry.properties as HardwareProperties).power
+/**
+ * Read PoE-relevant power properties from the Product the node is
+ * bound to. Properties are snapshotted onto Product at import / load
+ * time (see `ensureProductPorts` in context.svelte.ts), so this stays
+ * decoupled from the live catalog.
+ */
+function getPower(node: Node, products: Map<string, Product>): PowerProperties | undefined {
+  if (!node.productId) return undefined
+  const product = products.get(node.productId)
+  if (product?.kind !== 'device' || product.spec.kind !== 'hardware') return undefined
+  return (product.properties as HardwareProperties | undefined)?.power
 }
 
 function displayPort(nodeMap: Map<string, Node>, nodeId: string, portId: string): string {
@@ -158,7 +157,11 @@ function computePortPower(
  * PSE — they generate their own separate budget entry. Downstream draws from a
  * passthrough device are surfaced as informational sub-rows.
  */
-export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEBudget[] {
+export function analyzePoE(
+  nodes: Node[],
+  links: Link[],
+  products: Map<string, Product>,
+): PoEBudget[] {
   const nodeMap = new Map<string, Node>()
   for (const node of nodes) nodeMap.set(node.id, node)
 
@@ -188,7 +191,7 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
   const budgets: PoEBudget[] = []
 
   for (const node of nodes) {
-    const pse = getPower(node, catalog)
+    const pse = getPower(node, products)
     if (!pse?.poe_out?.budget_w) continue
 
     const neighbors = adj.get(node.id) ?? []
@@ -201,7 +204,7 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
       const peer = nodeMap.get(peerId)
       if (!peer) continue
 
-      const peerPower = getPower(peer, catalog)
+      const peerPower = getPower(peer, products)
       if (!peerPower) continue
 
       const port = computePortPower(peerPower, pse)
@@ -214,7 +217,7 @@ export function analyzePoE(nodes: Node[], links: Link[], catalog: Catalog): PoEB
           if (ds.peerId === node.id) continue
           const dsNode = nodeMap.get(ds.peerId)
           if (!dsNode) continue
-          const dsPower = getPower(dsNode, catalog)
+          const dsPower = getPower(dsNode, products)
           if (!dsPower) continue
           const dsPort = computePortPower(dsPower, peerPower)
           if (!dsPort) continue

--- a/apps/editor/src/lib/state/product-ports.test.ts
+++ b/apps/editor/src/lib/state/product-ports.test.ts
@@ -1,0 +1,176 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { NodePort } from '@shumoku/core'
+import { describe, expect, test } from 'vitest'
+import type { DeviceProduct } from '../types'
+import { instantiatePortsFromProduct, mergeProductPortsIntoExisting } from './product-ports'
+
+function template(overrides: Partial<NodePort>): NodePort {
+  return {
+    id: `tpl-${overrides.label ?? 'p'}`,
+    label: '',
+    connectors: ['rj45'],
+    ...overrides,
+  } as NodePort
+}
+
+function deviceProduct(ports: NodePort[]): DeviceProduct {
+  return {
+    id: 'product-test',
+    kind: 'device',
+    spec: { kind: 'hardware', vendor: 'cisco', model: 'test' },
+    ports,
+  }
+}
+
+describe('instantiatePortsFromProduct', () => {
+  test('returns undefined when the product has no port snapshot', () => {
+    expect(instantiatePortsFromProduct(undefined)).toBeUndefined()
+    expect(instantiatePortsFromProduct(deviceProduct([]))).toBeUndefined()
+  })
+
+  test('every instantiated port gets a fresh node-side id', () => {
+    const product = deviceProduct([
+      template({ label: 'Gi1/0/1', faceplateLabel: '1' }),
+      template({ label: 'Gi1/0/2', faceplateLabel: '2' }),
+    ])
+    const a = instantiatePortsFromProduct(product)
+    const b = instantiatePortsFromProduct(product)
+    expect(a?.length).toBe(2)
+    expect(b?.length).toBe(2)
+    // Two placements get different port ids
+    const aIds = a?.map((p) => p.id)
+    const bIds = b?.map((p) => p.id)
+    expect(new Set([...(aIds ?? []), ...(bIds ?? [])]).size).toBe(4)
+    // Template attrs are preserved
+    expect(a?.[0]?.label).toBe('Gi1/0/1')
+    expect(a?.[0]?.faceplateLabel).toBe('1')
+    expect(a?.[0]?.id).toMatch(/^port-/)
+  })
+})
+
+describe('mergeProductPortsIntoExisting', () => {
+  test('returns existing untouched when product has no template', () => {
+    const existing: NodePort[] = [{ id: 'p1', label: 'GE0', connectors: ['rj45'] }]
+    expect(mergeProductPortsIntoExisting(existing, undefined)).toEqual(existing)
+    expect(mergeProductPortsIntoExisting(existing, deviceProduct([]))).toEqual(existing)
+  })
+
+  test('matches existing ports by interfaceName and refreshes catalog attrs', () => {
+    const existing: NodePort[] = [
+      // Stale: legacy 1G/SFP-only data baked at first placement
+      {
+        id: 'old-port-id',
+        label: 'GE2',
+        interfaceName: 'GigaEthernet2.0',
+        speed: '1g',
+        connectors: ['sfp'],
+      },
+    ]
+    // Catalog updated: GE2 is now 10G combo
+    const product = deviceProduct([
+      template({
+        label: 'GE2',
+        interfaceName: 'GigaEthernet2.0',
+        speed: '10g',
+        connectors: ['rj45', 'sfp+'],
+      }),
+    ])
+    const merged = mergeProductPortsIntoExisting(existing, product)
+    expect(merged).toHaveLength(1)
+    // Stable id preserved
+    expect(merged[0]?.id).toBe('old-port-id')
+    // Physical attrs refreshed
+    expect(merged[0]?.speed).toBe('10g')
+    expect(merged[0]?.connectors).toEqual(['rj45', 'sfp+'])
+    // Existing label preserved (catalog default would also be 'GE2'; this
+    // covers both unedited-and-still-default and the refresh-attrs case)
+    expect(merged[0]?.label).toBe('GE2')
+  })
+
+  test('preserves user-edited label even when catalog default differs', () => {
+    const existing: NodePort[] = [
+      {
+        id: 'p',
+        label: 'MyCustomLabel',
+        interfaceName: 'GigaEthernet0.0',
+        speed: '1g',
+        connectors: ['rj45'],
+      },
+    ]
+    const product = deviceProduct([
+      template({
+        label: 'GE0',
+        interfaceName: 'GigaEthernet0.0',
+        speed: '1g',
+        connectors: ['rj45', 'sfp'],
+      }),
+    ])
+    const merged = mergeProductPortsIntoExisting(existing, product)
+    expect(merged[0]?.label).toBe('MyCustomLabel')
+    expect(merged[0]?.connectors).toEqual(['rj45', 'sfp'])
+  })
+
+  test('falls back to exact label match when interfaceName is absent', () => {
+    const existing: NodePort[] = [{ id: 'p', label: '1', connectors: ['rj45'] }]
+    const product = deviceProduct([
+      template({ label: '1', faceplateLabel: '1', poe: true, connectors: ['rj45'] }),
+    ])
+    const merged = mergeProductPortsIntoExisting(existing, product)
+    expect(merged[0]?.id).toBe('p')
+    expect(merged[0]?.poe).toBe(true)
+  })
+
+  test('appends template ports that have no existing match (catalog grew)', () => {
+    const existing: NodePort[] = [
+      { id: 'p1', label: 'GE0', interfaceName: 'GigaEthernet0.0', connectors: ['rj45'] },
+    ]
+    const product = deviceProduct([
+      template({ label: 'GE0', interfaceName: 'GigaEthernet0.0', connectors: ['rj45'] }),
+      template({ label: 'GE1', interfaceName: 'GigaEthernet1.0', connectors: ['rj45'] }),
+    ])
+    const merged = mergeProductPortsIntoExisting(existing, product)
+    expect(merged).toHaveLength(2)
+    expect(merged[0]?.id).toBe('p1')
+    expect(merged[1]?.id).toMatch(/^port-/)
+    expect(merged[1]?.label).toBe('GE1')
+  })
+
+  test('keeps existing ports the template no longer mentions (custom + orphans)', () => {
+    const existing: NodePort[] = [
+      { id: 'p1', label: 'GE0', interfaceName: 'GigaEthernet0.0', connectors: ['rj45'] },
+      // Custom user-added port — must survive a resync
+      {
+        id: 'p2',
+        label: 'extra',
+        connectors: ['rj45'],
+        source: 'custom',
+      },
+      // Orphan: catalog used to have GE99 but no longer does
+      { id: 'p3', label: 'GE99', interfaceName: 'GigaEthernet99.0', connectors: ['rj45'] },
+    ]
+    const product = deviceProduct([
+      template({ label: 'GE0', interfaceName: 'GigaEthernet0.0', connectors: ['rj45'] }),
+    ])
+    const merged = mergeProductPortsIntoExisting(existing, product)
+    expect(merged).toHaveLength(3)
+    expect(merged.map((p) => p.id)).toEqual(['p1', 'p2', 'p3'])
+  })
+
+  test('does not reuse the same existing port for two templates', () => {
+    // Two templates that would both happen to match the same existing
+    // port by label — the matcher should pick exactly one.
+    const existing: NodePort[] = [{ id: 'p1', label: 'shared', connectors: ['rj45'] }]
+    const product = deviceProduct([
+      template({ label: 'shared', connectors: ['rj45'] }),
+      template({ label: 'shared', connectors: ['rj45'] }),
+    ])
+    const merged = mergeProductPortsIntoExisting(existing, product)
+    expect(merged).toHaveLength(2)
+    // First template claims the existing id; second gets a fresh one.
+    expect(merged[0]?.id).toBe('p1')
+    expect(merged[1]?.id).toMatch(/^port-/)
+    expect(merged[1]?.id).not.toBe('p1')
+  })
+})

--- a/apps/editor/src/lib/state/product-ports.ts
+++ b/apps/editor/src/lib/state/product-ports.ts
@@ -1,0 +1,85 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Pure helpers that translate a Product's port snapshot into Node ports.
+ *
+ * These live outside `context.svelte.ts` so they can be unit-tested in
+ * isolation. They never read the live catalog — that's the job of the
+ * snapshot helpers in `context.svelte.ts`. By the time these run, the
+ * Product already carries its own catalog-derived `ports` array.
+ */
+
+import { type NodePort, newId } from '@shumoku/core'
+import type { DeviceProduct } from '../types'
+
+function productPortTemplates(product: DeviceProduct | undefined): readonly NodePort[] {
+  return product?.ports ?? []
+}
+
+/**
+ * First-time port instantiation from a Product's snapshot. Each port
+ * gets a fresh node-side id so multiple placements of the same Product
+ * have distinct port handles.
+ */
+export function instantiatePortsFromProduct(
+  product: DeviceProduct | undefined,
+): NodePort[] | undefined {
+  const tpl = productPortTemplates(product)
+  if (tpl.length === 0) return undefined
+  return tpl.map((p) => ({ ...p, id: newId('port') }))
+}
+
+/**
+ * Merge a Product's port snapshot into an existing port list, preserving
+ * every existing port's `id` and user-edited `label`. Product-owned
+ * physical attributes (`connectors`, `speed`, `poe`, `interfaceName`,
+ * `faceplateLabel`) are refreshed from the snapshot.
+ *
+ * Match key: `interfaceName` first (most stable), else exact label
+ * match against the snapshot's default label. Ports that don't match
+ * any template (user-added customs or stale catalog ports) are
+ * appended at the end so links keep resolving.
+ */
+export function mergeProductPortsIntoExisting(
+  existing: readonly NodePort[],
+  product: DeviceProduct | undefined,
+): NodePort[] {
+  const tpl = productPortTemplates(product)
+  if (tpl.length === 0) return [...existing]
+
+  const usedIds = new Set<string>()
+  const merged: NodePort[] = []
+
+  for (const t of tpl) {
+    const match = existing.find((e) => {
+      if (usedIds.has(e.id)) return false
+      if (t.interfaceName && e.interfaceName === t.interfaceName) return true
+      if (e.label && t.label && e.label === t.label) return true
+      return false
+    })
+    if (match) {
+      usedIds.add(match.id)
+      merged.push({
+        ...match,
+        // Product-owned physical attributes refresh; user label stays.
+        speed: t.speed ?? match.speed,
+        connectors: t.connectors ?? match.connectors,
+        poe: t.poe ?? match.poe,
+        interfaceName: t.interfaceName ?? match.interfaceName,
+        faceplateLabel: t.faceplateLabel ?? match.faceplateLabel,
+        role: t.role ?? match.role,
+        aliases: t.aliases ?? match.aliases,
+      })
+    } else {
+      merged.push({ ...t, id: newId('port') })
+    }
+  }
+  // Surface any existing ports the snapshot didn't claim (user-added
+  // custom ports, or template ports that disappeared) so links don't
+  // go orphan.
+  for (const e of existing) {
+    if (!usedIds.has(e.id)) merged.push(e)
+  }
+  return merged
+}

--- a/apps/editor/src/lib/types.ts
+++ b/apps/editor/src/lib/types.ts
@@ -8,6 +8,7 @@ import type {
   CableMedium,
   EthernetStandard,
   NetworkGraph,
+  NodePort,
   NodeSpec,
   PortConnector,
 } from '@shumoku/core'
@@ -52,6 +53,25 @@ export interface DeviceProduct extends ProductBase {
   spec: NodeSpec
   /** Resolved properties from catalog or custom input */
   properties?: HardwareProperties | ComputeProperties | ServiceProperties
+  /**
+   * Port template snapshot — taken from the catalog entry at import time
+   * (or from the inline `properties` for catalog-less products). Holds the
+   * canonical port list that bound Nodes instantiate from. Decoupled from
+   * `@shumoku/catalog` so the project file remains openable even if the
+   * upstream catalog version drifts or the entry disappears.
+   *
+   * Refreshed via the "Resync from catalog" action in the Materials view,
+   * which also cascades the new template into every bound Node's
+   * `node.ports` (preserving user-edited labels and stable port ids).
+   */
+  ports?: NodePort[]
+  /**
+   * Free-form marker recording the catalog version this Product was last
+   * synced against. Empty = never synced (legacy file before this field
+   * was introduced; the loader populates from the current catalog as a
+   * one-time materialization).
+   */
+  catalogSyncedAt?: string
 }
 
 export interface ModuleSpec {

--- a/apps/editor/src/routes/project/[id]/(content)/materials/[productId]/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/materials/[productId]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { classifyIcon } from '@shumoku/core'
   import { Dialog } from 'bits-ui'
-  import { ArrowLeft, GitBranch, Trash, X } from 'phosphor-svelte'
+  import { ArrowClockwise, ArrowLeft, GitBranch, Trash, X } from 'phosphor-svelte'
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
   import { Badge } from '$lib/components/ui/badge'
@@ -97,6 +97,26 @@
     if (!product) return
     diagramState.updateProduct(product.id, { icon: undefined })
   }
+
+  // === Resync from catalog ===
+  let resyncStatus = $state<{ kind: 'idle' } | { kind: 'done'; touched: number; at: number }>({
+    kind: 'idle',
+  })
+  function resyncFromCatalog() {
+    if (!product || product.kind !== 'device' || !product.catalogId) return
+    const touched = diagramState.resyncProductFromCatalog(product.id)
+    resyncStatus = { kind: 'done', touched, at: Date.now() }
+  }
+  const formattedSyncTimestamp = $derived.by(() => {
+    if (product?.kind !== 'device') return null
+    const iso = product.catalogSyncedAt
+    if (!iso) return null
+    try {
+      return new Date(iso).toLocaleString()
+    } catch {
+      return iso
+    }
+  })
 
   const labelClass = 'text-[10px] font-medium text-muted-foreground uppercase tracking-wider'
 </script>
@@ -272,6 +292,49 @@
       </dl>
     </Card.Content>
   </Card.Root>
+
+  <!-- Catalog sync (device products with catalogId only) -->
+  {#if product.kind === 'device' && product.catalogId}
+    <Card.Root class="mb-6 py-0">
+      <Card.Content class="px-5 py-4">
+        <div class="mb-2 flex items-center justify-between">
+          <div class="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Catalog sync
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onclick={resyncFromCatalog}
+            title="Re-snapshot port template from catalog and merge into all bound nodes"
+          >
+            <ArrowClockwise class="mr-1 h-3.5 w-3.5" />
+            Resync from catalog
+          </Button>
+        </div>
+        <div class="text-xs text-muted-foreground">
+          {#if formattedSyncTimestamp}
+            Last synced <span class="font-mono text-foreground/80">{formattedSyncTimestamp}</span>
+          {:else}
+            Not yet synced.
+          {/if}
+          {#if product.ports?.length}
+            ·
+            <span class="font-mono">{product.ports.length}</span>
+            port{product.ports.length === 1 ? '' : 's'}
+            in snapshot
+          {/if}
+        </div>
+        {#if resyncStatus.kind === 'done'}
+          <div
+            class="mt-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-2 py-1.5 text-[11px] text-emerald-700 dark:text-emerald-400"
+          >
+            Resynced. Updated <span class="font-mono">{resyncStatus.touched}</span> bound node{resyncStatus.touched === 1 ? '' : 's'}.
+            Existing port ids and edited labels preserved.
+          </div>
+        {/if}
+      </Card.Content>
+    </Card.Root>
+  {/if}
 
   <!-- Icon edit -->
   <Card.Root class="mb-6 py-0">


### PR DESCRIPTION
## Why

When a catalog YAML changes, projects saved against the older spec used to silently ignore the update — \`Node.ports\` was instantiated from the live catalog at placement time and then frozen. Bug reports kept surfacing as \"GE2 shows 1G even though the catalog now says 10G combo\" — the node was carrying stale port data baked at import time, and there was no clean way to refresh.

The underlying issue: there was no clear separation between the catalog (upstream library), the project's snapshot of it, and the per-node instance. Catalog was looked up live whenever ports were instantiated, while \`Node.ports\` was the only place that held a copy. KiCad solves this with three explicit layers and an explicit \"Update Symbol from Library\" action; this PR moves shumoku to the same model.

## What changes

**Schema** (\`apps/editor/src/lib/types.ts\`):
- \`DeviceProduct\` gains \`ports?: NodePort[]\` (catalog port template snapshot) and \`catalogSyncedAt?: string\`.

**Data flow refactor** (\`apps/editor/src/lib/context.svelte.ts\`):
- \`catalogPortTemplates\` is now used only at snapshot time, not steady-state.
- \`snapshotCatalogPortsForProduct\` materializes catalog templates into \`port-…\`-id \`NodePort[]\` for storage on the Product.
- \`ensureProductPorts\` populates the snapshot once per product (called by \`addProduct\` for new imports and by the load path for legacy projects without \`ports\`).
- \`instantiatePortsFromProduct\` and \`mergeProductPortsIntoExisting\` read from \`product.ports\` instead of looking up the catalog directly.

**New action**:
- \`diagramState.resyncProductFromCatalog(id)\` re-snapshots the catalog into Product, updates \`catalogSyncedAt\`, and cascades the new template into every bound Node via the existing merge logic. Returns the number of bound nodes touched.

**UI**:
- Materials product detail page gains a \"Catalog sync\" card with a \"Resync from catalog\" button (visible for catalog-bound device products only). Shows last-synced timestamp, snapshot port count, and a success banner after each click.

## Verified end-to-end

In the editor against the sample project (\`product-cisco-3560cx-8pc\`, bound to one node \`sw-a1\`):
1. Edit a port label on the bound node to \`USER-EDITED\`.
2. Click \"Resync from catalog\" on the product detail page.
3. Result: 1 bound node updated, port id \`uplink\` preserved, label \`USER-EDITED\` preserved, \`catalogSyncedAt\` updated, success banner displayed.

## Migration

\`productsStore.set\` on load passes every product through \`ensureProductPorts\`. Projects saved before this PR get their port snapshots materialized once at load time, no user action required.

## Test plan
- [ ] \`bun run typecheck\` clean across all 30 packages
- [ ] \`bun run lint\` clean
- [ ] \`bun run test\` passes
- [ ] Open an existing \`.neted\` project, navigate to Materials, open a catalog-bound device product. Verify the Catalog sync card appears with port count and last-synced timestamp.
- [ ] Click Resync from catalog. Verify success banner shows the bound-nodes count and that user-edited port labels survive on bound nodes.
- [ ] For products without \`catalogId\` (custom or pre-catalog imports), the Catalog sync card is hidden.