### PR TITLE
fix(editor): pick the populated scene when scope has duplicates

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1046,9 +1046,20 @@ export const diagramState = {
     scenesStore.setCurrentId(id)
   },
   setCurrentSceneForScope(scopeSubgraphId: string | undefined) {
-    const existing = scenesStore.list.find((s) => s.scopeSubgraphId === scopeSubgraphId)
-    if (existing) {
-      scenesStore.setCurrentId(existing.id)
+    const matches = scenesStore.list.filter((s) => s.scopeSubgraphId === scopeSubgraphId)
+    if (matches.length > 0) {
+      // Pick the most "interesting" scene when more than one shares
+      // the same scope. Older builds occasionally created a stray
+      // empty Root scene during load races (see the !initialized
+      // guard below); plain `find` returned the dud first by
+      // insertion / id order and the actual imported scene with the
+      // floor plan got hidden. Prefer scenes with a background or
+      // populated placements so projects with leftover empties still
+      // open on the user's data.
+      const score = (s: Scene): number =>
+        (s.background ? 1000 : 0) + (s.nodePlacements?.length ?? 0)
+      const best = matches.reduce((a, b) => (score(b) > score(a) ? b : a))
+      scenesStore.setCurrentId(best.id)
       return
     }
     commit('Open scene', () => {


### PR DESCRIPTION
## Background

Today (#197 merged) — for an imported project with one floor-plan scene scoped to root, reload-and-navigate-to-/scene showed an empty canvas even though the floor plan was sitting in IDB intact.

## Root cause

Two scenes shared scope=undefined in the user's IDB:
1. \`scene-2IQuHPoDb9\` — empty (auto-created by an old build's load-race; the !initialized guard from PR #195 prevents this for *new* projects, but earlier dud scenes are still in IDB)
2. \`scene-oYXlII1ZYV\` — the imported one, with the bg + 103 placements

\`scenesStore.list.find(s => s.scopeSubgraphId === undefined)\` returns the dud first (id order), and that becomes the current scene. The user's actual data hides under the picker.

## Fix

When multiple scenes match the requested scope, score by has-bg + placement count and pick the max. Empties lose to populated scenes — even if they came first in the list.

## Test plan

- [ ] Import a .neted.zip with a floor-plan scene → reload → scene shows immediately
- [ ] Project with no scenes → default empty Root scene still gets created (no regression)
- [ ] Multi-scene project (one per subgraph) → drilldown still resolves to that subgraph's scene