### PR TITLE
fix(editor): full template overwrite on Product → Node port merge

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -841,9 +841,12 @@ export const diagramState = {
   /**
    * Re-snapshot the catalog template into the Product and cascade the
    * new ports into every bound Node's `node.ports`. The merge logic
-   * preserves stable port ids and user-edited labels, so this is safe
-   * to invoke after a catalog YAML upgrade. No-op for catalog-less
-   * products.
+   * preserves stable port ids (so existing links keep resolving) but
+   * refreshes every Product-owned field — including `label` — from
+   * the new template, since the `(label, iface, faceplate, speed,
+   * connectors)` tuple is owned by the catalog. User-added custom
+   * ports that don't match any template port survive at the end of
+   * the list. No-op for catalog-less products.
    *
    * Returns the count of bound nodes that were touched, for the UI
    * to surface ("Resynced N nodes").

--- a/apps/editor/src/lib/state/product-ports.test.ts
+++ b/apps/editor/src/lib/state/product-ports.test.ts
@@ -89,7 +89,13 @@ describe('mergeProductPortsIntoExisting', () => {
     expect(merged[0]?.label).toBe('GE2')
   })
 
-  test('preserves user-edited label even when catalog default differs', () => {
+  test('overwrites label from template — no special preservation', () => {
+    // Earlier the merge tried to preserve user-edited labels, but
+    // there's no way to distinguish "user typed this" from "old
+    // catalog default left behind", so stale labels rode forward and
+    // broke (label, iface) pairing. Resync now always overwrites
+    // label from the template; the planned Resync diff popup gives
+    // users visibility before applying.
     const existing: NodePort[] = [
       {
         id: 'p',
@@ -108,7 +114,8 @@ describe('mergeProductPortsIntoExisting', () => {
       }),
     ])
     const merged = mergeProductPortsIntoExisting(existing, product)
-    expect(merged[0]?.label).toBe('MyCustomLabel')
+    expect(merged[0]?.id).toBe('p')
+    expect(merged[0]?.label).toBe('GE0')
     expect(merged[0]?.connectors).toEqual(['rj45', 'sfp'])
   })
 
@@ -156,6 +163,68 @@ describe('mergeProductPortsIntoExisting', () => {
     const merged = mergeProductPortsIntoExisting(existing, product)
     expect(merged).toHaveLength(3)
     expect(merged.map((p) => p.id)).toEqual(['p1', 'p2', 'p3'])
+  })
+
+  test('bind-after-manual: labels matching catalog ports get full template overwrite', () => {
+    // Realistic flow: user creates an empty node, adds a few ports
+    // by hand naming them after what they expect ("GE0", "GE2",
+    // plus a custom one), then binds the node to a catalog Product.
+    // bindNodeToProduct routes through this merge.
+    const existing: NodePort[] = [
+      { id: 'manual-ge0', label: 'GE0', connectors: [] },
+      { id: 'manual-ge2', label: 'GE2', connectors: [] },
+      { id: 'manual-custom', label: 'uplink-to-isp', connectors: [] },
+    ]
+    const product = deviceProduct([
+      template({
+        label: 'GE0',
+        faceplateLabel: 'GE0',
+        interfaceName: 'GigaEthernet0.0',
+        speed: '1g',
+        connectors: ['rj45', 'sfp'],
+      }),
+      template({
+        label: 'GE1',
+        faceplateLabel: 'GE1',
+        interfaceName: 'GigaEthernet1.0',
+        speed: '1g',
+        connectors: ['rj45', 'sfp'],
+      }),
+      template({
+        label: 'GE2',
+        faceplateLabel: 'GE2',
+        interfaceName: 'GigaEthernet2.0',
+        speed: '10g',
+        connectors: ['rj45', 'sfp+'],
+      }),
+    ])
+    const merged = mergeProductPortsIntoExisting(existing, product)
+    // Three template ports + one orphan custom port
+    expect(merged).toHaveLength(4)
+
+    // GE0: matched by label, full overwrite, id preserved
+    const ge0 = merged.find((p) => p.label === 'GE0')
+    expect(ge0?.id).toBe('manual-ge0')
+    expect(ge0?.interfaceName).toBe('GigaEthernet0.0')
+    expect(ge0?.connectors).toEqual(['rj45', 'sfp'])
+    expect(ge0?.faceplateLabel).toBe('GE0')
+
+    // GE1: no manual counterpart, gets a fresh id
+    const ge1 = merged.find((p) => p.label === 'GE1')
+    expect(ge1?.id).toMatch(/^port-/)
+    expect(ge1?.interfaceName).toBe('GigaEthernet1.0')
+
+    // GE2: matched by label; physical attrs now reflect the 10G combo
+    const ge2 = merged.find((p) => p.label === 'GE2')
+    expect(ge2?.id).toBe('manual-ge2')
+    expect(ge2?.speed).toBe('10g')
+    expect(ge2?.connectors).toEqual(['rj45', 'sfp+'])
+    expect(ge2?.interfaceName).toBe('GigaEthernet2.0')
+
+    // Custom port survives untouched at the end
+    const orphan = merged[merged.length - 1]
+    expect(orphan?.id).toBe('manual-custom')
+    expect(orphan?.label).toBe('uplink-to-isp')
   })
 
   test('does not reuse the same existing port for two templates', () => {

--- a/apps/editor/src/lib/state/product-ports.ts
+++ b/apps/editor/src/lib/state/product-ports.ts
@@ -32,14 +32,21 @@ export function instantiatePortsFromProduct(
 
 /**
  * Merge a Product's port snapshot into an existing port list, preserving
- * every existing port's `id` and user-edited `label`. Product-owned
- * physical attributes (`connectors`, `speed`, `poe`, `interfaceName`,
- * `faceplateLabel`) are refreshed from the snapshot.
+ * every existing port's stable `id` but refreshing **all** template-owned
+ * fields — including `label` — from the snapshot.
+ *
+ * Why label is not preserved: `(label, faceplateLabel, interfaceName,
+ * speed, connectors)` form a single tuple owned by the Product. Keeping
+ * `label` from the existing port while updating the rest lets stale
+ * catalog leftovers ride forward as if they were user edits, breaking
+ * the pairing (e.g. label "GE2" surviving on a port whose iface is now
+ * `GigaEthernet1.0`). The Resync action surfaces a diff so users see
+ * what gets overwritten before applying.
  *
  * Match key: `interfaceName` first (most stable), else exact label
- * match against the snapshot's default label. Ports that don't match
- * any template (user-added customs or stale catalog ports) are
- * appended at the end so links keep resolving.
+ * match. Existing ports that don't match any template (user-added
+ * customs or stale catalog ports the snapshot dropped) are appended
+ * at the end so existing links keep resolving.
  */
 export function mergeProductPortsIntoExisting(
   existing: readonly NodePort[],
@@ -60,17 +67,10 @@ export function mergeProductPortsIntoExisting(
     })
     if (match) {
       usedIds.add(match.id)
-      merged.push({
-        ...match,
-        // Product-owned physical attributes refresh; user label stays.
-        speed: t.speed ?? match.speed,
-        connectors: t.connectors ?? match.connectors,
-        poe: t.poe ?? match.poe,
-        interfaceName: t.interfaceName ?? match.interfaceName,
-        faceplateLabel: t.faceplateLabel ?? match.faceplateLabel,
-        role: t.role ?? match.role,
-        aliases: t.aliases ?? match.aliases,
-      })
+      // Stable id is the only thing carried over. Every Product-owned
+      // field comes from the template so the (label, iface, faceplate,
+      // speed, connectors) tuple stays internally consistent.
+      merged.push({ ...t, id: match.id })
     } else {
       merged.push({ ...t, id: newId('port') })
     }


### PR DESCRIPTION
## Summary

The Product → Node port merge preserved every existing port's \`label\` while refreshing every other field from the catalog template. There's no way to distinguish a real user edit from a leftover default of an older catalog generation, so stale labels rode forward and broke the \`(label, iface, faceplate, speed, connectors)\` tuple the Product owns as a single unit.

**Concrete failure** observed in a real project: an IX3315 link kept selecting a port labeled \"GE2\" whose iface had since been migrated to \`GigaEthernet1.0\` with 1G/SFP. The SFP+ option was unselectable because that port was physically GE1 — the \"GE2\" label was leftover from an earlier catalog generation that ran through the merge before the upgrade. The actual GE2 port (now 10G combo at \`GigaEthernet2.0\`) had \"GE4.0/1\" written on it from the same kind of historical drift.

## Change

\`mergeProductPortsIntoExisting\` now keeps only the stable port \`id\` (so existing links continue resolving) and takes every other field from the template. User-added custom ports that don't match any template still survive as orphans at the end of the list.

The planned Resync diff popup (deferred from #203) will surface what gets overwritten so users can review before applying — that becomes the visibility mechanism for any genuine label edits the user wants to keep.

The same merge runs for both code paths, so this fixes both:
- \`resyncProductFromCatalog\` — explicit catalog refresh
- \`bindNodeToProduct\` — when a manual node is bound to a Product after the user added ports

## Test plan

- [x] \`bun x vitest run src/lib/state/product-ports.test.ts\` (10 tests pass)
- [x] Updated the prior \"preserves user-edited label\" test to assert override
- [x] Added \`bind-after-manual\` test simulating the realistic flow
- [x] Verified live in the editor against the affected IX3315 node — after one resync, every port's label / iface / speed / connectors line up consistently
- [ ] Visually walk an existing project: confirm placed nodes still render and links still resolve after a resync of any catalog product

🤖 Generated with [Claude Code](https://claude.com/claude-code)