### PR TITLE
docs(editor): update stale port-merge comments after #206

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -257,8 +257,12 @@ function ensureProductSnapshot(product: Product): Product {
 
 /**
  * Apply a Product's port template to a node — instantiate fresh ids
- * when the node has none, otherwise merge into existing ports preserving
- * ids and user-edited labels.
+ * when the node has none, otherwise merge into existing ports keeping
+ * the stable port `id` (so existing links continue resolving) and
+ * refreshing every Product-owned field from the template, including
+ * `label`. The `(label, iface, faceplate, speed, connectors)` tuple
+ * is owned as one unit by the catalog, so we can't preserve label
+ * piecewise without breaking that pairing.
  *
  * Callers:
  * - `placeProductAsNode` / initial bind → no existing ports → instantiate
@@ -823,9 +827,10 @@ export const diagramState = {
           if (catalogIdentityChanged) {
             // Vendor/model changed — re-snapshot the catalog into the
             // Product, then merge the new template into each bound
-            // node's existing ports. Existing ids and user-edited labels
-            // survive; only physical attributes refresh. One reroute at
-            // the end covers all bound nodes — cheaper than once per.
+            // node's existing ports. Stable port ids survive (so links
+            // keep resolving) but every Product-owned field — labels
+            // included — is taken from the new template. One reroute
+            // at the end covers all bound nodes — cheaper than once per.
             const snap = snapshotCatalogIntoProduct(product as DeviceProduct)
             productsStore.update(id, snap as Partial<Product>)
             const refreshed = productsStore.find(id) as DeviceProduct | undefined

--- a/apps/editor/src/lib/types.ts
+++ b/apps/editor/src/lib/types.ts
@@ -62,7 +62,10 @@ export interface DeviceProduct extends ProductBase {
    *
    * Refreshed via the "Resync from catalog" action in the Materials view,
    * which also cascades the new template into every bound Node's
-   * `node.ports` (preserving user-edited labels and stable port ids).
+   * `node.ports`. Stable port ids are preserved so existing links keep
+   * resolving; every Product-owned field (label included) is taken from
+   * the new template since the (label, iface, faceplate, speed,
+   * connectors) tuple is owned as one unit by the catalog.
    */
   ports?: NodePort[]
   /**


### PR DESCRIPTION
## Summary

Three docblocks still claimed the merge \"preserves user-edited labels\" which is no longer true after #206. Brought the wording in line:

- \`setNodePortsFromProduct\` — explains stable id is preserved while every Product-owned field (label included) refreshes from the template
- \`updateProduct\` \`catalogIdentityChanged\` branch — same correction for the in-place vendor/model swap path
- \`DeviceProduct.ports\` JSDoc — same correction for the public type doc

No behavior change.

## Follow-ups (deferred, out of scope here)

- **Resync diff popup** — now load-bearing for visibility since label preservation is gone. Without it users have no warning before overwrite. Worth a dedicated PR.
- **Custom port management UI** — \`removePort\` exists at the data layer but isn't surfaced in the node detail panel, so orphan custom ports (label \"\", connectors []) accumulate silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)