### PR TITLE
feat(editor): preview-and-confirm dialog for catalog resync

### DIFF
--- a/apps/editor/src/lib/components/ResyncDiffDialog.svelte
+++ b/apps/editor/src/lib/components/ResyncDiffDialog.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import { Dialog } from 'bits-ui'
+  import { ArrowClockwise, ArrowRight, X } from 'phosphor-svelte'
+  import { Button } from '$lib/components/ui/button'
+  import type { ResyncPreview } from '$lib/state/resync-diff'
+
+  let {
+    open = $bindable(false),
+    productLabel,
+    preview,
+    onConfirm,
+  }: {
+    open?: boolean
+    productLabel: string
+    preview: ResyncPreview | null
+    onConfirm: () => void
+  } = $props()
+
+  const totalChanges = $derived(
+    preview ? preview.added.length + preview.removed.length + preview.changed.length : 0,
+  )
+  const hasNoChanges = $derived(
+    preview !== null && totalChanges === 0 && !preview.propertiesChanged,
+  )
+
+  function apply() {
+    onConfirm()
+    open = false
+  }
+</script>
+
+<Dialog.Root bind:open>
+  <Dialog.Portal>
+    <Dialog.Overlay class="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm" />
+    <Dialog.Content
+      class="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-[min(640px,calc(100vw-2rem))] max-h-[min(80vh,40rem)] flex flex-col rounded-lg border bg-background shadow-2xl"
+    >
+      <div class="flex items-start justify-between px-5 py-4 border-b">
+        <div>
+          <Dialog.Title class="text-sm font-semibold">Resync from catalog</Dialog.Title>
+          <Dialog.Description class="mt-0.5 text-xs text-muted-foreground truncate"
+            >{productLabel}</Dialog.Description
+          >
+        </div>
+        <Dialog.Close class="p-1 rounded hover:bg-muted text-muted-foreground" aria-label="Close"
+          ><X class="w-4 h-4" /></Dialog.Close
+        >
+      </div>
+
+      <div class="flex-1 overflow-y-auto px-5 py-4 text-xs space-y-4">
+        {#if !preview}
+          <p class="text-muted-foreground">
+            Preview unavailable — no catalog template found for this product.
+          </p>
+        {:else if hasNoChanges}
+          <p class="text-muted-foreground">
+            Already in sync. The catalog template matches the current product snapshot.
+          </p>
+        {:else}
+          <div class="rounded-md border bg-muted/30 px-3 py-2 text-[11px]">
+            <span class="font-mono">{preview.affectedNodeCount}</span>
+            bound node{preview.affectedNodeCount === 1 ? '' : 's'}
+            will be updated. Stable port ids are preserved so existing links keep resolving.
+          </div>
+
+          {#if preview.propertiesChanged}
+            <div>
+              <div
+                class="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground"
+              >
+                Properties
+              </div>
+              <p class="text-muted-foreground">
+                PoE / switching / wireless / physical / management properties will be refreshed from
+                the catalog.
+              </p>
+            </div>
+          {/if}
+
+          {#if preview.added.length > 0}
+            <div>
+              <div
+                class="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-emerald-600 dark:text-emerald-400"
+              >
+                Added ({preview.added.length})
+              </div>
+              <ul class="space-y-0.5">
+                {#each preview.added as p (p.id)}
+                  <li class="flex items-center gap-2 px-2 py-1 rounded bg-emerald-500/5">
+                    <span class="font-mono font-semibold">{p.label || 'unnamed'}</span>
+                    {#if p.faceplateLabel && p.faceplateLabel !== p.label}
+                      <span class="text-[10px] text-muted-foreground"
+                        >panel {p.faceplateLabel}</span
+                      >
+                    {/if}
+                    <span class="text-muted-foreground">
+                      {[p.speed, p.connectors?.join('/'), p.poe ? 'PoE' : '']
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </span>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+
+          {#if preview.removed.length > 0}
+            <div>
+              <div
+                class="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-red-600 dark:text-red-400"
+              >
+                Removed ({preview.removed.length})
+              </div>
+              <p class="mb-1 text-[10px] text-muted-foreground">
+                These ports stay on each bound node so existing links don't go orphan, but they lose
+                their catalog source.
+              </p>
+              <ul class="space-y-0.5">
+                {#each preview.removed as p (p.id)}
+                  <li class="flex items-center gap-2 px-2 py-1 rounded bg-red-500/5">
+                    <span class="font-mono font-semibold line-through opacity-70"
+                      >{p.label || 'unnamed'}</span
+                    >
+                    {#if p.faceplateLabel && p.faceplateLabel !== p.label}
+                      <span class="text-[10px] text-muted-foreground"
+                        >panel {p.faceplateLabel}</span
+                      >
+                    {/if}
+                    <span class="text-muted-foreground">
+                      {[p.speed, p.connectors?.join('/'), p.poe ? 'PoE' : '']
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </span>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+
+          {#if preview.changed.length > 0}
+            <div>
+              <div
+                class="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-amber-600 dark:text-amber-400"
+              >
+                Changed ({preview.changed.length})
+              </div>
+              <ul class="space-y-1">
+                {#each preview.changed as ch (ch.before.id)}
+                  <li class="rounded bg-amber-500/5 px-2 py-1.5">
+                    <div class="flex items-center gap-1.5 font-mono font-semibold">
+                      {ch.identity}
+                    </div>
+                    <ul class="mt-0.5 space-y-0.5 pl-3">
+                      {#each ch.diffs as d}
+                        <li class="flex items-center gap-1.5 text-[10px]">
+                          <span class="text-muted-foreground w-16">{d.field}</span>
+                          <span class="font-mono line-through opacity-70">{d.before || '—'}</span>
+                          <ArrowRight class="w-3 h-3 text-muted-foreground" />
+                          <span class="font-mono">{d.after || '—'}</span>
+                        </li>
+                      {/each}
+                    </ul>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+        {/if}
+      </div>
+
+      <div class="flex items-center justify-end gap-2 border-t px-5 py-3">
+        <Dialog.Close>
+          {#snippet child({ props })}
+            <Button {...props} variant="ghost" size="sm">Cancel</Button>
+          {/snippet}
+        </Dialog.Close>
+        <Button variant="default" size="sm" onclick={apply} disabled={!preview || hasNoChanges}>
+          <ArrowClockwise class="mr-1 h-3.5 w-3.5" />
+          Apply resync
+        </Button>
+      </div>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -67,6 +67,7 @@ import {
 import { editorStore, initDarkMode } from './state/editor.svelte'
 import { instantiatePortsFromProduct, mergeProductPortsIntoExisting } from './state/product-ports'
 import { productsStore, sanitizeProducts } from './state/products.svelte'
+import { computeResyncPortDiff, type ResyncPreview } from './state/resync-diff'
 import { sanitizeScenes, scenesStore } from './state/scenes.svelte'
 import { sessionStore } from './state/session.svelte'
 import type {
@@ -851,6 +852,33 @@ export const diagramState = {
    * Returns the count of bound nodes that were touched, for the UI
    * to surface ("Resynced N nodes").
    */
+  /**
+   * Pure preview of `resyncProductFromCatalog`. Computes what would
+   * change if the user applied the resync — port additions, removals,
+   * field-level changes, whether properties differ, and how many
+   * bound nodes would be touched. Mutates nothing. Returns null when
+   * the product can't be resynced (not a device, or no template
+   * available).
+   */
+  previewResyncProductFromCatalog(id: string): ResyncPreview | null {
+    const product = productsStore.find(id)
+    if (!product || product.kind !== 'device') return null
+    const snap = snapshotCatalogIntoProduct(product)
+    const template = snap.ports
+    if (!template) return null
+
+    const { added, removed, changed } = computeResyncPortDiff(product.ports ?? [], template)
+    const propertiesChanged =
+      snap.properties !== undefined &&
+      JSON.stringify(snap.properties) !== JSON.stringify(product.properties)
+
+    let affectedNodeCount = 0
+    for (const [, node] of diagram.nodes) {
+      if (node.productId === id) affectedNodeCount++
+    }
+
+    return { added, removed, changed, propertiesChanged, affectedNodeCount }
+  },
   resyncProductFromCatalog(id: string): number {
     return commit('Resync product from catalog', () => {
       const product = productsStore.find(id)

--- a/apps/editor/src/lib/state/resync-diff.test.ts
+++ b/apps/editor/src/lib/state/resync-diff.test.ts
@@ -1,0 +1,123 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { NodePort } from '@shumoku/core'
+import { describe, expect, test } from 'vitest'
+import { computeResyncPortDiff } from './resync-diff'
+
+function port(overrides: Partial<NodePort>): NodePort {
+  return {
+    id: `id-${Math.random().toString(36).slice(2, 8)}`,
+    label: '',
+    connectors: [],
+    ...overrides,
+  } as NodePort
+}
+
+describe('computeResyncPortDiff', () => {
+  test('empty current + empty template → no diff', () => {
+    const r = computeResyncPortDiff([], [])
+    expect(r).toEqual({ added: [], removed: [], changed: [] })
+  })
+
+  test('template port with no match in current goes to added', () => {
+    const tpl = [port({ label: 'GE0', interfaceName: 'Gi0.0', speed: '1g' })]
+    const r = computeResyncPortDiff([], tpl)
+    expect(r.added).toHaveLength(1)
+    expect(r.added[0]?.label).toBe('GE0')
+    expect(r.removed).toHaveLength(0)
+    expect(r.changed).toHaveLength(0)
+  })
+
+  test('current port with no match in template goes to removed', () => {
+    const cur = [port({ label: 'old', interfaceName: 'GiX', speed: '1g' })]
+    const r = computeResyncPortDiff(cur, [])
+    expect(r.removed).toHaveLength(1)
+    expect(r.removed[0]?.label).toBe('old')
+  })
+
+  test('matched ports with identical fields produce no diff', () => {
+    const cur = [
+      port({
+        id: 'a',
+        label: 'GE0',
+        interfaceName: 'Gi0.0',
+        speed: '1g',
+        connectors: ['rj45'],
+      }),
+    ]
+    const tpl = [
+      port({
+        id: 'b',
+        label: 'GE0',
+        interfaceName: 'Gi0.0',
+        speed: '1g',
+        connectors: ['rj45'],
+      }),
+    ]
+    const r = computeResyncPortDiff(cur, tpl)
+    expect(r.changed).toHaveLength(0)
+    expect(r.added).toHaveLength(0)
+    expect(r.removed).toHaveLength(0)
+  })
+
+  test('matched ports with differing physical fields land in changed', () => {
+    const cur = [
+      port({
+        id: 'a',
+        label: 'GE2',
+        interfaceName: 'Gi2.0',
+        speed: '1g',
+        connectors: ['sfp'],
+      }),
+    ]
+    const tpl = [
+      port({
+        id: 'b',
+        label: 'GE2',
+        interfaceName: 'Gi2.0',
+        speed: '10g',
+        connectors: ['rj45', 'sfp+'],
+      }),
+    ]
+    const r = computeResyncPortDiff(cur, tpl)
+    expect(r.changed).toHaveLength(1)
+    const ch = r.changed[0]
+    expect(ch?.identity).toBe('Gi2.0')
+    const fields = ch?.diffs.map((d) => d.field).sort()
+    expect(fields).toEqual(['connectors', 'speed'])
+    const speedDiff = ch?.diffs.find((d) => d.field === 'speed')
+    expect(speedDiff?.before).toBe('1g')
+    expect(speedDiff?.after).toBe('10g')
+  })
+
+  test('matches by interfaceName even when labels differ', () => {
+    const cur = [port({ id: 'a', label: 'CustomLabel', interfaceName: 'Gi1.0', speed: '1g' })]
+    const tpl = [port({ id: 'b', label: 'GE1', interfaceName: 'Gi1.0', speed: '1g' })]
+    const r = computeResyncPortDiff(cur, tpl)
+    expect(r.added).toHaveLength(0)
+    expect(r.removed).toHaveLength(0)
+    expect(r.changed).toHaveLength(1)
+    expect(r.changed[0]?.diffs.find((d) => d.field === 'label')?.before).toBe('CustomLabel')
+    expect(r.changed[0]?.diffs.find((d) => d.field === 'label')?.after).toBe('GE1')
+  })
+
+  test('falls back to label match when interfaceName is absent on either side', () => {
+    const cur = [port({ id: 'a', label: 'shared', speed: '1g' })]
+    const tpl = [port({ id: 'b', label: 'shared', speed: '10g' })]
+    const r = computeResyncPortDiff(cur, tpl)
+    expect(r.changed).toHaveLength(1)
+    expect(r.added).toHaveLength(0)
+    expect(r.removed).toHaveLength(0)
+  })
+
+  test('does not match the same current port to two templates', () => {
+    const cur = [port({ id: 'a', label: 'shared' })]
+    const tpl = [port({ label: 'shared' }), port({ label: 'shared' })]
+    const r = computeResyncPortDiff(cur, tpl)
+    // First template claims the existing port (no field diff = no changed
+    // entry); second template gets no match and lands in added.
+    expect(r.added).toHaveLength(1)
+    expect(r.removed).toHaveLength(0)
+  })
+})

--- a/apps/editor/src/lib/state/resync-diff.ts
+++ b/apps/editor/src/lib/state/resync-diff.ts
@@ -1,0 +1,125 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Pure preview of what `resyncProductFromCatalog` would do, without
+ * mutating any state. Drives the Resync confirmation dialog so users
+ * can see which ports get added / removed / changed before the merge
+ * cascades into every bound node.
+ */
+
+import type { NodePort } from '@shumoku/core'
+
+export interface ResyncPortChange {
+  /** Stable identity for display — interface name when present, else label. */
+  identity: string
+  /** Original port (what's currently on the Product). */
+  before: NodePort
+  /** Template port (what the catalog snapshot now defines). */
+  after: NodePort
+  /** Field-level differences worth showing to the user. */
+  diffs: ResyncFieldDiff[]
+}
+
+export interface ResyncFieldDiff {
+  field: 'label' | 'faceplateLabel' | 'interfaceName' | 'speed' | 'connectors' | 'poe' | 'role'
+  before: string
+  after: string
+}
+
+export interface ResyncPreview {
+  /** Template ports not currently on the Product. */
+  added: NodePort[]
+  /** Current Product ports the new template no longer mentions. */
+  removed: NodePort[]
+  /** Current ports that match a template port but with at least one diff. */
+  changed: ResyncPortChange[]
+  /** True when properties (PoE, switching, etc.) differ from the snapshot. */
+  propertiesChanged: boolean
+  /** Number of bound nodes that will receive the new template. */
+  affectedNodeCount: number
+}
+
+function joinConnectors(c: readonly string[] | undefined): string {
+  if (!c || c.length === 0) return '—'
+  return c.join('/')
+}
+
+function fieldDiffs(before: NodePort, after: NodePort): ResyncFieldDiff[] {
+  const out: ResyncFieldDiff[] = []
+  if ((before.label ?? '') !== (after.label ?? '')) {
+    out.push({ field: 'label', before: before.label ?? '', after: after.label ?? '' })
+  }
+  if ((before.faceplateLabel ?? '') !== (after.faceplateLabel ?? '')) {
+    out.push({
+      field: 'faceplateLabel',
+      before: before.faceplateLabel ?? '',
+      after: after.faceplateLabel ?? '',
+    })
+  }
+  if ((before.interfaceName ?? '') !== (after.interfaceName ?? '')) {
+    out.push({
+      field: 'interfaceName',
+      before: before.interfaceName ?? '',
+      after: after.interfaceName ?? '',
+    })
+  }
+  if ((before.speed ?? '') !== (after.speed ?? '')) {
+    out.push({ field: 'speed', before: before.speed ?? '', after: after.speed ?? '' })
+  }
+  const cBefore = joinConnectors(before.connectors)
+  const cAfter = joinConnectors(after.connectors)
+  if (cBefore !== cAfter) {
+    out.push({ field: 'connectors', before: cBefore, after: cAfter })
+  }
+  if (!!before.poe !== !!after.poe) {
+    out.push({ field: 'poe', before: before.poe ? 'yes' : 'no', after: after.poe ? 'yes' : 'no' })
+  }
+  if ((before.role ?? '') !== (after.role ?? '')) {
+    out.push({ field: 'role', before: before.role ?? '', after: after.role ?? '' })
+  }
+  return out
+}
+
+function identityOf(p: NodePort): string {
+  return p.interfaceName || p.label || p.faceplateLabel || p.id
+}
+
+/**
+ * Compute the diff between a Product's current `ports` and a freshly
+ * snapshotted template. Pure — neither input is mutated.
+ *
+ * Match strategy mirrors `mergeProductPortsIntoExisting`: by
+ * interfaceName first, then by exact label match. Each existing port
+ * can claim at most one template port (no double-matching).
+ */
+export function computeResyncPortDiff(
+  current: readonly NodePort[],
+  template: readonly NodePort[],
+): { added: NodePort[]; removed: NodePort[]; changed: ResyncPortChange[] } {
+  const consumedExisting = new Set<string>()
+  const matched: ResyncPortChange[] = []
+  const added: NodePort[] = []
+
+  for (const t of template) {
+    const match = current.find((c) => {
+      if (consumedExisting.has(c.id)) return false
+      if (t.interfaceName && c.interfaceName === t.interfaceName) return true
+      if (c.label && t.label && c.label === t.label) return true
+      return false
+    })
+    if (match) {
+      consumedExisting.add(match.id)
+      const diffs = fieldDiffs(match, t)
+      if (diffs.length > 0) {
+        matched.push({ identity: identityOf(t), before: match, after: t, diffs })
+      }
+    } else {
+      added.push(t)
+    }
+  }
+
+  const removed = current.filter((c) => !consumedExisting.has(c.id))
+
+  return { added, removed, changed: matched }
+}

--- a/apps/editor/src/routes/project/[id]/(content)/materials/[productId]/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/materials/[productId]/+page.svelte
@@ -5,12 +5,14 @@
   import { ArrowClockwise, ArrowLeft, GitBranch, Trash, X } from 'phosphor-svelte'
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
+  import ResyncDiffDialog from '$lib/components/ResyncDiffDialog.svelte'
   import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
   import * as Card from '$lib/components/ui/card'
   import * as Table from '$lib/components/ui/table'
   import { diagramState } from '$lib/context.svelte'
   import { assetStore } from '$lib/state/assets.svelte'
+  import type { ResyncPreview } from '$lib/state/resync-diff'
   import { productLabel } from '$lib/types'
 
   const projectId = $derived($page.params.id ?? '')
@@ -103,7 +105,14 @@
   let resyncStatus = $state<{ kind: 'idle' } | { kind: 'done'; touched: number; at: number }>({
     kind: 'idle',
   })
-  function resyncFromCatalog() {
+  let resyncDialogOpen = $state(false)
+  let resyncPreview = $state<ResyncPreview | null>(null)
+  function openResyncDialog() {
+    if (!product || product.kind !== 'device' || !product.catalogId) return
+    resyncPreview = diagramState.previewResyncProductFromCatalog(product.id)
+    resyncDialogOpen = true
+  }
+  function applyResync() {
     if (!product || product.kind !== 'device' || !product.catalogId) return
     const touched = diagramState.resyncProductFromCatalog(product.id)
     resyncStatus = { kind: 'done', touched, at: Date.now() }
@@ -338,11 +347,11 @@
           <Button
             variant="outline"
             size="sm"
-            onclick={resyncFromCatalog}
-            title="Re-snapshot port template from catalog and merge into all bound nodes"
+            onclick={openResyncDialog}
+            title="Preview catalog changes, then optionally cascade them into all bound nodes"
           >
             <ArrowClockwise class="mr-1 h-3.5 w-3.5" />
-            Resync from catalog
+            Resync from catalog…
           </Button>
         </div>
         <div class="text-xs text-muted-foreground">
@@ -820,3 +829,12 @@
     </Dialog.Content>
   </Dialog.Portal>
 </Dialog.Root>
+
+{#if product}
+  <ResyncDiffDialog
+    bind:open={resyncDialogOpen}
+    productLabel={productLabel(product)}
+    preview={resyncPreview}
+    onConfirm={applyResync}
+  />
+{/if}


### PR DESCRIPTION
## Summary

After #206, resync overwrites every Product-owned port field — labels included. Users had no way to see what would be overwritten before clicking the button. This PR turns the Materials Resync action into a preview-then-confirm flow so the overwrite is no longer a surprise.

## What's added

- **\`state/resync-diff.ts\`** — pure \`computeResyncPortDiff\` that classifies the prospective template against the current Product ports as **added / removed / changed**, with field-level before/after tuples. Uses the same identity-matching keys as the live merge (interfaceName first, then exact label) so the preview reflects what the merge will actually do.
- **\`context.svelte.ts\`** — \`previewResyncProductFromCatalog\` wraps the pure diff with a property-changed flag and bound-node count. No mutation.
- **\`ResyncDiffDialog.svelte\`** — bits-ui dialog rendering each section color-coded (added green, removed red, changed amber) with Cancel / Apply Resync buttons. Apply is disabled when nothing differs (\"Already in sync\").
- **8 unit tests** covering empty inputs, identity matches by iface and label, label-divergent matches, and the no-double-claim rule.

The Materials button text changes from \"Resync from catalog\" to \"Resync from catalog…\" to signal confirmation is now required.

## Test plan

- [x] Open IX3315 product with up-to-date snapshot → dialog shows \"Already in sync\", Apply disabled
- [x] Tamper Product.ports to simulate stale data → dialog correctly classifies (verified live: GE3 added, fake \"OLD\" port removed, GE2 shown as changed with speed 1g→10g, connectors sfp→rj45/sfp+)
- [x] Apply confirms and runs the existing \`resyncProductFromCatalog\` cascade
- [x] Cancel closes the dialog without mutating
- [x] \`bun x vitest run resync-diff.test.ts\` — 8/8 passing
- [x] svelte-check 0 errors, biome clean

## Builds on

- #206 (full template overwrite — landed)
- #207 (stale doc comments — open)
- #208 (node detail Ports section + custom port removal — open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)