### PR TITLE
refactor(editor): consolidate load-time migrations into lib/migrations

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -40,6 +40,7 @@ import {
   type Theme,
 } from '@shumoku/core'
 import { SvelteMap } from 'svelte/reactivity'
+import { inheritProductIconFromCatalog, migrateLegacyWireRoutes } from './migrations'
 import { projectsDb } from './persistence/projects-store'
 import { readProjectZip } from './persistence/reader'
 import { applySync, diffSnapshots } from './persistence/sync'
@@ -1823,20 +1824,12 @@ async function applyProject(data: Partial<NetedProject>) {
     diagram.nodes,
     diagram.links,
   )
+  // Load-time fix-ups for Products. Icon inheritance is a pure
+  // legacy migration (see migrations/product-icon-inheritance.ts);
+  // ensureProductSnapshot is a constructor invariant shared with
+  // addProduct, so it stays in this file.
   productsStore.set(
-    cleanProducts.map((p) => {
-      let next = p
-      // Inherit icon from catalog if the saved product has none.
-      if (!next.icon && next.catalogId) {
-        const entry = catalog.lookup(next.catalogId)
-        if (entry?.icon) next = { ...next, icon: entry.icon } as Product
-      }
-      // Materialize port snapshot for legacy projects saved before
-      // Product.ports existed. New `addProduct` flow already populates
-      // this; the shim only fires once on load.
-      next = ensureProductSnapshot(next)
-      return next
-    }),
+    cleanProducts.map((p) => ensureProductSnapshot(inheritProductIconFromCatalog(p, catalog))),
   )
   diagram.links = cleanLinks
 
@@ -1856,51 +1849,20 @@ async function applyProject(data: Partial<NetedProject>) {
   await rerouteEdges()
 
   const linkIdSet = new Set(diagram.links.map((l) => l.id).filter((id): id is string => !!id))
-  // Migration must run BEFORE sanitize so the legacy `wireRoutes`
-  // field (already stripped by sanitize) is still readable from
-  // the raw input. addTerminationInScene needs the scene present
-  // in scenesStore though, so we set sanitized first and then
-  // migrate from the raw payload.
+  // sanitizeScenes strips the legacy `wireRoutes` field on its way
+  // into the store, so the migration that converts it into bend
+  // Nodes has to read from the raw payload (`data.scenes`). We
+  // populate the store first because the migration calls store
+  // helpers (`addTerminationInScene`, `updateLink`) which need the
+  // scene to already exist. See migrations/README.md.
   scenesStore.set(sanitizeScenes(data.scenes ?? [], diagram.nodes, linkIdSet))
   scenesStore.setCurrentId(null)
-  migrateLegacyWireRoutes(data.scenes ?? [])
-}
-
-/**
- * One-shot migration of legacy `Scene.wireRoutes[].controlPoints`
- * (anonymous absolute-coord bends) into bend Nodes spliced into
- * `Link.via`. The new model treats every transit point — bends
- * included — as a Node, so multi-drag / deletion / selection all
- * flow through Svelte Flow's native node machinery. The
- * `wireRoutes` field is gone from the Scene type; the migration
- * reads it via a loose cast on the raw input.
- */
-type LegacyScene = {
-  id: string
-  wireRoutes?: Array<{ linkId: string; controlPoints?: Array<{ x: number; y: number }> }>
-}
-
-function migrateLegacyWireRoutes(rawScenes: unknown[]) {
-  for (const raw of rawScenes) {
-    const legacy = raw as LegacyScene
-    const routes = legacy.wireRoutes
-    if (!routes?.length) continue
-    for (const route of routes) {
-      const points = route.controlPoints
-      if (!points?.length) continue
-      const link = diagram.links.find((l) => l.id === route.linkId)
-      if (!link) continue
-      const newBendIds: string[] = []
-      for (const pt of points) {
-        const id = diagramState.addTerminationInScene(legacy.id, pt, 'bend')
-        newBendIds.push(id)
-      }
-      // Bends go before any existing TPs in via — preserves the
-      // visual order from before the migration where bends were
-      // first-class waypoints.
-      diagramState.updateLink(route.linkId, { via: [...newBendIds, ...(link.via ?? [])] })
-    }
-  }
+  migrateLegacyWireRoutes(data.scenes ?? [], {
+    links: diagram.links,
+    addTerminationInScene: (sceneId, position, role) =>
+      diagramState.addTerminationInScene(sceneId, position, role),
+    updateLink: (linkId, updates) => diagramState.updateLink(linkId, updates),
+  })
 }
 
 async function applyGraph(graph: NetworkGraph) {

--- a/apps/editor/src/lib/migrations/README.md
+++ b/apps/editor/src/lib/migrations/README.md
@@ -1,0 +1,47 @@
+# Load-time migrations
+
+One-shot fix-ups that translate legacy persisted data into the current
+in-memory shape. Runs once per project load via `runLoadTimeMigrations`
+(see `./index.ts`) — never at runtime.
+
+## Scope
+
+This directory holds **legacy-only** transformations. Don't put things
+here that any of:
+
+- run on every state mutation (those belong with the store / state file)
+- enforce runtime data integrity on fresh data (use a store-local
+  `sanitize*` instead)
+- exist to keep new code self-consistent (constructor invariants in
+  context.svelte.ts)
+
+## Order invariant: migration reads RAW, sanitize reads STORE
+
+`migrateLegacyWireRoutes` is the canonical example. The legacy field
+(`Scene.wireRoutes`) is stripped by `sanitizeScenes` when scenes are
+written into the store, so the migration **must read from the raw
+project payload** (`data.scenes`) rather than `scenesStore.list`. The
+trade-off: the order in `applyProject` looks counter-intuitive — we
+sanitize/populate the store first, then migrate from the raw input —
+but this lets migrations call store helpers (e.g.
+`diagramState.addTerminationInScene`) which require the scene to
+already be in the store.
+
+If you add a migration, document whether it reads raw or store data
+in its file header so the next reader doesn't have to dig.
+
+## Where load-time fix-ups live today
+
+| Migration | File |
+|---|---|
+| `Scene.wireRoutes[].controlPoints` → bend Nodes + `Link.via` | `legacy-wire-routes.ts` |
+| catalog → `Product.icon` inheritance for products with no icon | `product-icon-inheritance.ts` |
+| `Node.spec.icon` resync from bound Product | (inline in `applyProject`, candidate to move) |
+| `ensureProductSnapshot` (port template materialization) | `context.svelte.ts` — also used by `addProduct`, not load-only |
+| `migrateLinkEndpointPortsForNode` (port id format) | `context.svelte.ts` — runtime invariant, fires per port edit |
+
+## Schema vs data
+
+IDB schema migrations (v1 → v2) live in `lib/persistence/idb.ts` next
+to the schema definition. Those are about table shape, not record
+contents.

--- a/apps/editor/src/lib/migrations/index.ts
+++ b/apps/editor/src/lib/migrations/index.ts
@@ -1,0 +1,7 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Load-time migrations entry point. See ./README.md for the rules.
+
+export { type LegacyScene, migrateLegacyWireRoutes } from './legacy-wire-routes'
+export { inheritProductIconFromCatalog } from './product-icon-inheritance'

--- a/apps/editor/src/lib/migrations/legacy-wire-routes.test.ts
+++ b/apps/editor/src/lib/migrations/legacy-wire-routes.test.ts
@@ -1,0 +1,103 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { Link } from '@shumoku/core'
+import { describe, expect, it, vi } from 'vitest'
+import { type LegacyScene, migrateLegacyWireRoutes } from './legacy-wire-routes'
+
+function makeLink(id: string, via?: string[]): Link {
+  return {
+    id,
+    from: { node: 'a', port: 'p1' },
+    to: { node: 'b', port: 'p1' },
+    via,
+  }
+}
+
+function makeDeps(links: Link[] = []) {
+  const added: Array<{ sceneId: string; position: { x: number; y: number }; role: string }> = []
+  const updated: Array<{ linkId: string; via: string[] }> = []
+  let counter = 0
+  return {
+    added,
+    updated,
+    deps: {
+      links,
+      addTerminationInScene: vi.fn((sceneId: string, position, role) => {
+        counter++
+        const id = `bend-${counter}`
+        added.push({ sceneId, position, role })
+        return id
+      }),
+      updateLink: vi.fn((linkId: string, updates: { via: string[] }) => {
+        updated.push({ linkId, via: updates.via })
+      }),
+    },
+  }
+}
+
+describe('migrateLegacyWireRoutes', () => {
+  it('converts each controlPoint into a bend Node and prepends to Link.via', () => {
+    const link = makeLink('L1', ['existing-tp'])
+    const { deps, added, updated } = makeDeps([link])
+    const scene: LegacyScene = {
+      id: 'S1',
+      wireRoutes: [
+        {
+          linkId: 'L1',
+          controlPoints: [
+            { x: 10, y: 20 },
+            { x: 30, y: 40 },
+          ],
+        },
+      ],
+    }
+
+    migrateLegacyWireRoutes([scene], deps)
+
+    expect(added).toEqual([
+      { sceneId: 'S1', position: { x: 10, y: 20 }, role: 'bend' },
+      { sceneId: 'S1', position: { x: 30, y: 40 }, role: 'bend' },
+    ])
+    // Bends placed BEFORE the pre-existing via entry — preserves the
+    // visual order from when bends were first-class waypoints.
+    expect(updated).toEqual([{ linkId: 'L1', via: ['bend-1', 'bend-2', 'existing-tp'] }])
+  })
+
+  it('no-ops for scenes without wireRoutes, empty routes, or empty points', () => {
+    const { deps, added, updated } = makeDeps([makeLink('L1')])
+    migrateLegacyWireRoutes(
+      [
+        { id: 'S1' } as LegacyScene,
+        { id: 'S2', wireRoutes: [] } as LegacyScene,
+        { id: 'S3', wireRoutes: [{ linkId: 'L1' }] } as LegacyScene,
+        { id: 'S4', wireRoutes: [{ linkId: 'L1', controlPoints: [] }] } as LegacyScene,
+      ],
+      deps,
+    )
+    expect(added).toEqual([])
+    expect(updated).toEqual([])
+  })
+
+  it('skips routes whose link is missing (orphan reference)', () => {
+    const { deps, added, updated } = makeDeps([makeLink('L1')])
+    const scene: LegacyScene = {
+      id: 'S1',
+      wireRoutes: [{ linkId: 'L-missing', controlPoints: [{ x: 1, y: 2 }] }],
+    }
+    migrateLegacyWireRoutes([scene], deps)
+    expect(added).toEqual([])
+    expect(updated).toEqual([])
+  })
+
+  it('handles a link without prior via (undefined)', () => {
+    const link = makeLink('L1')
+    const { deps, updated } = makeDeps([link])
+    const scene: LegacyScene = {
+      id: 'S1',
+      wireRoutes: [{ linkId: 'L1', controlPoints: [{ x: 1, y: 2 }] }],
+    }
+    migrateLegacyWireRoutes([scene], deps)
+    expect(updated).toEqual([{ linkId: 'L1', via: ['bend-1'] }])
+  })
+})

--- a/apps/editor/src/lib/migrations/legacy-wire-routes.ts
+++ b/apps/editor/src/lib/migrations/legacy-wire-routes.ts
@@ -1,0 +1,58 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// `Scene.wireRoutes[].controlPoints` → bend Nodes + `Link.via`.
+//
+// The old model stored anonymous absolute-coord bend points on
+// `Scene.wireRoutes`, parallel to the link list. The new model treats
+// every transit point — bends included — as a real `Node` so Svelte
+// Flow's native selection / drag / delete machinery applies uniformly.
+//
+// Reads RAW input — `sanitizeScenes` strips `wireRoutes` before the
+// store sees it, so by the time we'd query the store the legacy field
+// is gone. See `migrations/README.md` for the order rule.
+
+import type { Link } from '@shumoku/core'
+
+export type LegacyScene = {
+  id: string
+  wireRoutes?: Array<{ linkId: string; controlPoints?: Array<{ x: number; y: number }> }>
+}
+
+export interface LegacyWireRoutesDeps {
+  /** All links in the freshly loaded diagram — used to look up routes. */
+  links: Link[]
+  /** Create a bend Node at the given scene position, return its id. */
+  addTerminationInScene(sceneId: string, position: { x: number; y: number }, role: 'bend'): string
+  /** Splice bend ids into the named link's `via` chain. */
+  updateLink(linkId: string, updates: { via: string[] }): void
+}
+
+/**
+ * Walk the raw scenes payload (before `sanitizeScenes`) and convert
+ * each `controlPoints` entry into a bend Node spliced into the
+ * matching link's `via`. Bends go in front of any existing via
+ * entries — preserves the visual order from before the migration
+ * where bends were first-class waypoints.
+ *
+ * No-op for scenes / routes / points that are absent or empty.
+ */
+export function migrateLegacyWireRoutes(rawScenes: unknown[], deps: LegacyWireRoutesDeps): void {
+  for (const raw of rawScenes) {
+    const legacy = raw as LegacyScene
+    const routes = legacy.wireRoutes
+    if (!routes?.length) continue
+    for (const route of routes) {
+      const points = route.controlPoints
+      if (!points?.length) continue
+      const link = deps.links.find((l) => l.id === route.linkId)
+      if (!link) continue
+      const newBendIds: string[] = []
+      for (const pt of points) {
+        const id = deps.addTerminationInScene(legacy.id, pt, 'bend')
+        newBendIds.push(id)
+      }
+      deps.updateLink(route.linkId, { via: [...newBendIds, ...(link.via ?? [])] })
+    }
+  }
+}

--- a/apps/editor/src/lib/migrations/product-icon-inheritance.ts
+++ b/apps/editor/src/lib/migrations/product-icon-inheritance.ts
@@ -1,0 +1,23 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Saved before `Product.icon` got auto-populated at add time, some
+// catalog-bound products landed in IDB with `icon: undefined`. Inherit
+// from the catalog at load — once, idempotent, never overwrites a
+// user-set icon. Products with no `catalogId` are skipped.
+//
+// Pure transform on a single Product. The applyProject loop runs this
+// alongside `ensureProductSnapshot` (catalog port template
+// materialization) which stays in context.svelte.ts because it's also
+// used by `addProduct` — not load-only.
+
+import type { Catalog } from '@shumoku/catalog'
+import type { Product } from '../types'
+
+export function inheritProductIconFromCatalog(product: Product, catalog: Catalog): Product {
+  if (product.icon) return product
+  if (!product.catalogId) return product
+  const entry = catalog.lookup(product.catalogId)
+  if (!entry?.icon) return product
+  return { ...product, icon: entry.icon }
+}


### PR DESCRIPTION
## Background

Bug-prone areas around legacy-data handling were scattered across the codebase:

- \`migrateLegacyWireRoutes\` (\`Scene.wireRoutes[].controlPoints\` → bend \`Node\` + \`Link.via\`) lived inside \`context.svelte.ts\` as a private function
- The catalog → \`Product.icon\` inheritance was a hand-rolled \`if/else\` inside the \`applyProject\` products loop
- The non-obvious **sanitize-first, migrate-from-raw** order rule was buried in a comment

No single place to point to when asking "what does load do for legacy data?", and no test coverage for any of it.

## What moved

\`\`\`
lib/migrations/
  README.md                         — rules + the "raw vs store" order invariant
  index.ts                          — single entry point
  legacy-wire-routes.ts             — wireRoutes → bend Nodes + via (DI-shaped)
  legacy-wire-routes.test.ts        — 4 unit tests
  product-icon-inheritance.ts       — catalog icon fallback (pure transform)
\`\`\`

Migration functions take their store touchpoints (\`links\`, \`addTerminationInScene\`, \`updateLink\`) as **dependency injection** rather than closure capture — testable and explicit about what state they touch.

## What stayed (intentional)

Documented in the README:

- **\`ensureProductSnapshot\`** — also used by \`addProduct\`, not load-only. Constructor invariant, stays in \`context.svelte.ts\`.
- **\`migrateLinkEndpointPortsForNode\`** — runtime invariant, fires per port edit, not load-only.
- **\`sanitize*\` helpers** — runtime cleanup colocated with their stores (\`sanitizeGraph\`, \`sanitizeProducts\`, \`sanitizeScenes\`).
- **IDB v1→v2** — schema migration lives next to the schema in \`persistence/idb.ts\`.

## Effect on \`applyProject\`

Reads as a clear sequence now:

\`\`\`ts
applyGraph(graph)
sanitizeProducts → inheritIcon + ensureSnapshot
ports + reroute
sanitizeScenes
migrateLegacyWireRoutes(rawScenes, deps)   // ← raw, after store is sanitized
\`\`\`

## Test plan

- [x] \`bun test src/lib/migrations\` — 4/4 pass
- [x] \`bun run typecheck\` — clean
- [ ] Load a legacy project with \`wireRoutes\` — bends still get materialized as Nodes
- [ ] Load a project with a catalog-bound product missing \`icon\` — icon gets filled from catalog