### PR TITLE
feat(editor): show transit peers under EPS / Outlet / Panel labels

### DIFF
--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -150,6 +150,35 @@
     return { x: tl.x + w / 2, y: tl.y + h / 2 }
   }
 
+  // Compact "device(port)" formatter for the transit-peer sub-label.
+  // Resolves port id to the user-visible port label (falls back to
+  // the id when the port isn't found, which would only happen for
+  // partially-migrated data).
+  function endpointSummary(nodeId: string, portId: string | undefined): string {
+    const node = diagramState.nodes.get(nodeId)
+    const baseLabel = Array.isArray(node?.label) ? node?.label[0] : (node?.label ?? nodeId)
+    if (!portId) return baseLabel ?? nodeId
+    const port = node?.ports?.find((p) => p.id === portId)
+    const portLabel = port?.label || port?.faceplateLabel || port?.interfaceName || portId
+    return `${baseLabel}(${portLabel})`
+  }
+
+  // Wires passing through this transit node — one entry per link
+  // whose `via` chain includes the node. Each entry is the two
+  // device endpoints as `device(port)` strings so the scene can
+  // surface them under the termination's label.
+  function peersForTransit(nodeId: string): Array<{ a: string; b: string }> {
+    const out: Array<{ a: string; b: string }> = []
+    for (const link of diagramState.links) {
+      if (!link.via?.includes(nodeId)) continue
+      out.push({
+        a: endpointSummary(link.from.node, link.from.port),
+        b: endpointSummary(link.to.node, link.to.port),
+      })
+    }
+    return out
+  }
+
   // ── Svelte Flow nodes/edges (derived) ────────────────────────────
   const sfNodes = $derived.by<SfNode[]>(() => {
     const out: SfNode[] = []
@@ -181,6 +210,13 @@
       const { w, h } = effSize(n.id)
       const isEps = n.termination?.role === 'eps'
       const isDevice = !n.termination
+      const isTransit = !!n.termination && !isBend
+      // For terminations (EPS / Outlet / Panel), look up every wire
+      // whose `via` chain includes this node and emit one "peer pair"
+      // per wire — e.g. `switch-A(Gi1/1) ↔ ap-2(eth0)`. Gives the
+      // user at-a-glance context for what the termination is wired
+      // between, without opening the routing modal.
+      const transitPeers = isTransit ? peersForTransit(n.id) : undefined
       out.push({
         id: n.id,
         type: 'scene',
@@ -197,6 +233,7 @@
           editableLabel: isBend ? '' : baseLabel,
           spec: n.spec,
           termination: n.termination,
+          transitPeers,
           baseW: base.w,
           baseH: base.h,
           onOpenRouting: isDevice
@@ -532,7 +569,7 @@
 
 <style>
   /* Soften Svelte Flow's default dotted background when no floor
-                                       plan is set, but otherwise let its theming through. */
+                                         plan is set, but otherwise let its theming through. */
   :global(.svelte-flow__background) {
     background: #f8fafc;
   }
@@ -540,8 +577,8 @@
     stroke-linecap: round;
   }
   /* Make connection handles visible on hover so users can see where
-                                     to drag from. Otherwise the fully-transparent handles leave the
-                                     "how do I draw a wire" UX a guess. */
+                                       to drag from. Otherwise the fully-transparent handles leave the
+                                       "how do I draw a wire" UX a guess. */
   :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 1 !important;
@@ -551,15 +588,15 @@
     height: 8px;
   }
   /* Read-only cue: don't reveal connection handles on hover in view
-                           mode. Keep size + DOM presence so Svelte Flow can still resolve
-                           edge endpoint positions from each handle's bounding rect — only
-                           opacity is dropped. */
+                             mode. Keep size + DOM presence so Svelte Flow can still resolve
+                             edge endpoint positions from each handle's bounding rect — only
+                             opacity is dropped. */
   .scene-canvas-readonly :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 0 !important;
   }
   /* Placement-pending: crosshair cursor on the pane so users see
-                           "click somewhere to drop the item". */
+                             "click somewhere to drop the item". */
   .scene-canvas-placing :global(.svelte-flow__pane) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     cursor: crosshair !important;

--- a/apps/editor/src/lib/components/scene/SceneNode.svelte
+++ b/apps/editor/src/lib/components/scene/SceneNode.svelte
@@ -33,6 +33,12 @@
       spec?: NodeSpec
       isExternal?: boolean
       termination?: Termination
+      /** For transit terminations (EPS / Outlet / Panel) — one entry
+       *  per wire whose `via` chain includes this node, as the two
+       *  device endpoints formatted `device(port)`. Surfaced below
+       *  the label so the user can see what the termination wires
+       *  between without opening the routing modal. */
+      transitPeers?: Array<{ a: string; b: string }>
       /** Toolbar callbacks routed back to SceneCanvas. The canvas
        *  owns modal state and undo bookkeeping; the node just
        *  surfaces the action. */
@@ -304,21 +310,43 @@
       class="nodrag absolute left-1/2 top-full max-w-[200px] -translate-x-1/2 rounded-[3px] border border-blue-500 bg-white px-1 text-[10px] leading-[14px] text-slate-900 outline-none focus:ring-1 focus:ring-blue-400"
       style="margin-top: 2px; box-shadow: 0 0 0 1.5px rgba(255,255,255,0.9), 0 1px 2px rgba(0,0,0,0.2);"
     >
-  {:else if data.label}
-    <!-- Label floats beneath the icon, absolutely positioned so it
-         doesn't extend the node's hit area — handles + wires stay
-         locked to the icon. Double-click opens the rename input
-         (same handler as the toolbar Rename button). -->
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
+  {:else if data.label || data.transitPeers?.length}
+    <!-- Label + transit-peer sub-lines float beneath the icon,
+         absolutely positioned so they don't extend the node's hit
+         area — handles + wires stay locked to the icon. The label
+         is double-clickable to rename; the peer lines are static
+         info (auto-derived from each link's `via` chain). -->
     <div
-      class="absolute left-1/2 top-full max-w-[160px] -translate-x-1/2 truncate rounded-[3px] border border-black/15 bg-white px-1 text-[10px] leading-[14px] text-slate-900"
-      style="margin-top: 2px; pointer-events: auto; cursor: text; box-shadow: 0 0 0 1.5px rgba(255,255,255,0.9), 0 1px 2px rgba(0,0,0,0.2);"
-      ondblclick={(e) => {
-        e.stopPropagation()
-        startRename()
-      }}
+      class="absolute left-1/2 top-full flex -translate-x-1/2 flex-col items-center gap-[2px]"
+      style="margin-top: 2px; pointer-events: none;"
     >
-      {data.label}
+      {#if data.label}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="max-w-[200px] truncate rounded-[3px] border border-black/15 bg-white px-1 text-[10px] leading-[14px] text-slate-900"
+          style="pointer-events: auto; cursor: text; box-shadow: 0 0 0 1.5px rgba(255,255,255,0.9), 0 1px 2px rgba(0,0,0,0.2);"
+          ondblclick={(e) => {
+            e.stopPropagation()
+            startRename()
+          }}
+        >
+          {data.label}
+        </div>
+      {/if}
+      {#if data.transitPeers?.length}
+        <div
+          class="flex max-w-[260px] flex-col items-center gap-[1px] rounded-[3px] border border-black/10 bg-white/95 px-1 py-[1px] text-[9px] leading-[12px] text-slate-600"
+          style="box-shadow: 0 0 0 1.5px rgba(255,255,255,0.85), 0 1px 2px rgba(0,0,0,0.15);"
+        >
+          {#each data.transitPeers as peer (peer.a + '∷' + peer.b)}
+            <div class="truncate font-mono">
+              <span>{peer.a}</span>
+              <span class="text-slate-400">↔</span>
+              <span>{peer.b}</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## Summary

EPSs and Outlets had no on-canvas indication of what they wired between. Users had to open the \"Wires through…\" modal to see the endpoints, which made it hard to scan a floor plan and understand the cabling at a glance.

Adds a small auto-derived sub-block under each termination's label (except bends) showing one \`device(port) ↔ device(port)\` line per wire whose \`via\` chain includes this node. Pulled directly from \`Link.via\` so it stays in sync with the routing dialog.

## Implementation

- **SceneCanvas** computes \`transitPeers\` per visible termination via \`peersForTransit(nodeId)\`, walking \`diagramState.links\` once per node (small N — terminations are sparse). Each endpoint is formatted as \`device(port)\` using the same port label resolution as the link picker (\`label || faceplateLabel || interfaceName\`).
- **SceneNode** wraps the existing label chip and the new peer block in a shared absolute-positioned column under the icon. Rename still works on the label chip; the peer block is read-only auto-info.

## Test plan

- [x] EPS with 4 wires through it renders 4 peer lines (\`switch-A(Gi1/1) ↔ ap-2(eth0)\` style)
- [x] Outlets with multiple wires also show their peers
- [x] Labels still pencil/double-click editable; peer block not affected by rename
- [x] biome clean, svelte-check 0 errors

## Follow-ups (not in this PR)

- Truncate peer list when very long (e.g. \"+3 more\" after 5)
- Hover-tooltip with bandwidth / VLAN per wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)