### PR TITLE
fix(editor): drop far device(port) from label peer when wire has via

### DIFF
--- a/apps/editor/src/routes/project/[id]/(content)/bom/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/bom/+page.svelte
@@ -108,14 +108,16 @@
 
   /**
    * Build the "peer" cell from the perspective of one end of the wire.
-   * `viaFromThis` is the via-chain ids encountered as we travel from
-   * `this` end toward the far end; we prefix them so the tech reads
-   * "go via these terminations to reach the far device(port)".
+   * When there's a via chain, only the chain hops are shown — the tech
+   * physically connects to the next termination (wall outlet / EPS
+   * panel), not to the far device, so naming the chain matches what
+   * they actually plug into. The far device(port) is only relevant for
+   * direct (via-less) cables, where the cable terminates straight on
+   * the device.
    */
   function peerWithVia(viaFromThis: readonly string[], farEnd: string): string {
     if (viaFromThis.length === 0) return farEnd
-    const hops = viaFromThis.map((id) => nodeLabelOf(id)).join(' / ')
-    return `${hops}: ${farEnd}`
+    return viaFromThis.map((id) => nodeLabelOf(id)).join(' / ')
   }
 
   function buildLabelCsv(): string {


### PR DESCRIPTION
## Summary

Field feedback after #213 landed: when a cable physically transits through a wall outlet / EPS panel, the technician labelling that end connects to the *next termination*, not to the wire's far switch. Including the far device(port) on the printed label was redundant and made the label chip text uncomfortably long.

```
Before: \"EPS / Outlet: lobby-sw02 (port1.0.1)\"
After:  \"EPS / Outlet\"
```

Direct (via-less) cables still show the far device(port) — there's no termination between the ends, so the device name is the only meaningful peer.

## Test plan

- [x] Direct: \`peer = \"room1-ap04 (E0)\"\` (verified via Label CSV download)
- [x] Via EPS+Outlet: \`peer = \"EPS / Outlet\"\` for both A and B rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)