### PR TITLE
fix(editor): skip bend waypoints when building BOM rows

### DIFF
--- a/apps/editor/src/lib/state/bom.ts
+++ b/apps/editor/src/lib/state/bom.ts
@@ -71,6 +71,12 @@ export function buildAssignmentRows(args: {
   const rows: AssignmentRow[] = []
 
   for (const [nodeId, node] of nodes) {
+    // Bend waypoints are wire-path artifacts (a click-place to push a
+    // wire around an obstacle), not procurement items — skip them so
+    // the BOM doesn't fill up with phantom "Bend, incomplete" rows.
+    // EPS / Outlet / Panel terminations DO map to physical procured
+    // items (wall plates, riser panels, patch panels), so they stay.
+    if (node.termination?.role === 'bend') continue
     rows.push({
       id: `node:${nodeId}`,
       target: { kind: 'node', nodeId },


### PR DESCRIPTION
## Summary

Bend nodes are wire-path artifacts (click-place waypoints that push a wire around an obstacle on the floor plan), not physical items the customer procures. The BOM was emitting one row per bend in the Equipment section — \`Bend, incomplete\` — polluting the procurement list and flagging dozens of phantom items as \"needs review\".

Filter bends out at the bom row builder. EPS / Outlet / Panel stay — those map to real physical items (wall plates, riser panels, patch panels) the installer actually buys.

## Test plan

- [x] Live BOM verified: 0 Bend rows after filter (was 30+ before)
- [x] EPS / Outlet rows still appear in Equipment section
- [x] biome clean, svelte-check 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)