### PR TITLE
fix(editor+core): diagram layout — strip termination from layout/bounds + sort ports by peer position

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -756,7 +756,10 @@ export const diagramState = {
       sheetStore.setCurrentSheetId(null)
       return
     }
-    const { resolved } = await computeNetworkLayout(childGraph)
+    // Same reason as applyGraph: termination nodes belong to scene,
+    // not diagram. Strip before layout so they don't distort Sugiyama
+    // or inflate the resulting bounds.
+    const { resolved } = await computeNetworkLayout(stripTerminationFromGraph(childGraph))
 
     if (sheetStore.currentSheetId !== id || generation !== currentSheetCacheGeneration()) return
 
@@ -1552,8 +1555,12 @@ export const diagramState = {
         nodes: [...diagram.nodes.values()].map((n) => ({ ...n, position: undefined })),
         subgraphs: [...diagram.subgraphs.values()].map((s) => ({ ...s, bounds: undefined })),
       }
-      const { resolved } = await computeNetworkLayout(graph)
-      replaceMap(diagram.nodes, resolved.nodes)
+      const { resolved } = await computeNetworkLayout(stripTerminationFromGraph(graph))
+      const finalNodes = new Map(resolved.nodes)
+      for (const n of diagram.nodes.values()) {
+        if (n.termination) finalNodes.set(n.id, n)
+      }
+      replaceMap(diagram.nodes, finalNodes)
       replaceMap(diagram.subgraphs, resolved.subgraphs)
       replaceMap(diagram.ports, resolved.ports)
       replaceMap(diagram.edges, resolved.edges)
@@ -1906,14 +1913,27 @@ async function applyGraph(graph: NetworkGraph) {
   const allPositioned = hasAnyNode && [...nodes.values()].every((n) => n.position)
 
   if (hasAnyNode && !allPositioned) {
-    const reconstructed: NetworkGraph = {
+    // Lay out the LOGICAL subset only — termination nodes (bends,
+    // outlets, EPS, panels) live in the scene's physical coordinate
+    // system and are hidden from the diagram view (see PR #194).
+    // Feeding them to Sugiyama drags the layout into weird shapes
+    // and inflates bounds with positions that point at scene pixels
+    // far outside the diagram extent.
+    const logical = stripTerminationFromGraph({
       ...graph,
       nodes: [...nodes.values()],
       subgraphs: [...subgraphs.values()],
       links,
+    })
+    const { resolved } = await computeNetworkLayout(logical)
+    // Merge laid-out logical nodes back with the untouched termination
+    // nodes so the store still holds every Node — scene canvas needs
+    // them, just diagram doesn't.
+    const finalNodes = new Map(resolved.nodes)
+    for (const n of nodes.values()) {
+      if (n.termination) finalNodes.set(n.id, n)
     }
-    const { resolved } = await computeNetworkLayout(reconstructed)
-    replaceMap(diagram.nodes, resolved.nodes)
+    replaceMap(diagram.nodes, finalNodes)
     replaceMap(diagram.subgraphs, resolved.subgraphs)
     replaceMap(diagram.ports, resolved.ports)
     replaceMap(diagram.edges, resolved.edges)
@@ -1930,6 +1950,28 @@ async function applyGraph(graph: NetworkGraph) {
   await rerouteEdges()
 }
 
+/**
+ * Drop termination nodes from a graph for diagram-side layout.
+ * Termination nodes only appear as link `via` waypoints (never as
+ * `from` / `to` endpoints, by construction), so stripping them from
+ * `nodes` and from `link.via` keeps the topology intact for Sugiyama.
+ */
+function stripTerminationFromGraph(graph: NetworkGraph): NetworkGraph {
+  const termIds = new Set(graph.nodes.filter((n) => n.termination).map((n) => n.id))
+  if (termIds.size === 0) return graph
+  return {
+    ...graph,
+    nodes: graph.nodes.filter((n) => !n.termination),
+    links: graph.links.map((l) => {
+      if (!l.via?.length) return l
+      const nextVia = l.via.filter((id) => !termIds.has(id))
+      return nextVia.length === l.via.length
+        ? l
+        : { ...l, via: nextVia.length > 0 ? nextVia : undefined }
+    }),
+  }
+}
+
 function boundsOfPositionedGraph(
   nodes: Map<string, Node>,
   subgraphs: Map<string, Subgraph>,
@@ -1941,6 +1983,12 @@ function boundsOfPositionedGraph(
 
   for (const n of nodes.values()) {
     if (!n.position) continue
+    // Termination nodes (bend / outlet / EPS / panel) hold scene-side
+    // pixel positions, not logical-diagram coords. The diagram hides
+    // them from rendering; their positions must not influence bounds
+    // or the viewBox stretches to encompass scene pixels far outside
+    // the diagram extent.
+    if (n.termination) continue
     const size = computeNodeSize(n)
     minX = Math.min(minX, n.position.x - size.width / 2)
     minY = Math.min(minY, n.position.y - size.height / 2)

--- a/libs/@shumoku/core/src/layout/port-placement.ts
+++ b/libs/@shumoku/core/src/layout/port-placement.ts
@@ -30,6 +30,10 @@ interface PortAssignment {
   nodeId: string
   portId: string
   side: Side
+  /** The peer node id on the other end of this port's link — used to
+   *  sort ports along the side so adjacent peers don't force edges to
+   *  cross over each other. */
+  peerNodeId: string
 }
 
 function getNodePortLabel(node: Node | undefined, portId: string): string {
@@ -105,13 +109,19 @@ function assignPortSides(links: Link[], direction: Direction): PortAssignment[] 
         nodeId: fromNode,
         portId: link.from.port,
         side: sides.sourceSide,
+        peerNodeId: toNode,
       })
     }
 
     const toKey = `${toNode}:${link.to.port}`
     if (!seen.has(toKey)) {
       seen.add(toKey)
-      assignments.push({ nodeId: toNode, portId: link.to.port, side: sides.destSide })
+      assignments.push({
+        nodeId: toNode,
+        portId: link.to.port,
+        side: sides.destSide,
+        peerNodeId: fromNode,
+      })
     }
   }
 
@@ -188,6 +198,20 @@ export function placePorts(
     const side = first.side
     const node = nodes.get(nodeId)
     if (!node?.position) continue
+
+    // Sort ports along the side by their peer node's position so an
+    // edge going to a left-side peer ends up on the left port and one
+    // going to a right-side peer ends up on the right port. Without
+    // this the ports stay in the order they appeared in `links`, and
+    // edges to peers further along the side cross over each other in
+    // an "X" shape between the node and its neighbours.
+    const isHorizontalSide = side === 'top' || side === 'bottom'
+    sideAssignments.sort((a, b) => {
+      const pa = nodes.get(a.peerNodeId)?.position
+      const pb = nodes.get(b.peerNodeId)?.position
+      if (!pa || !pb) return 0
+      return isHorizontalSide ? pa.x - pb.x : pa.y - pb.y
+    })
 
     for (const [i, a] of sideAssignments.entries()) {
       const portId = `${a.nodeId}:${a.portId}`


### PR DESCRIPTION
## Two related diagram-layout bugs in one PR

### Bug 1: termination nodes distort layout and bounds

User report: diagram looks "broken" — most of the canvas is empty space and the topology is squished into a corner.

Termination nodes (\`bend\` / \`outlet\` / \`eps\` / \`panel\`) carry positions from **scene placement** (floor-plan pixel coords). PR #194 hid them from the diagram render via \`hideNode\`, but they kept participating in:

1. **Sugiyama layout** — fed to \`computeNetworkLayout\` as nodes with no edges (they appear only in \`Link.via\`, never as \`from\`/\`to\`), so the engine treated them as disconnected islands and shoved them around, distorting the visible topology.
2. **Bounds calculation** — a bend at scene y=-2500 dragged the diagram bounds up to y=-2652, leaving 2500px of empty whitespace above the actual diagram.

**Fix**: \`stripTerminationFromGraph(graph)\` removes termination nodes (and prunes them from \`Link.via\`) before \`computeNetworkLayout\` runs (three call sites: \`applyGraph\`, \`switchSheet\`, \`autoArrange\`). Termination nodes get merged back into the store afterwards so the scene canvas still sees them. \`boundsOfPositionedGraph\` skips them too.

### Bug 2: ports placed in declaration order, edges cross

After Bug 1 was fixed, \`noc01-rt01\` still had its GE1 and GE3 edges crossing under the router: GE1 was on the right side of the router but its peer (\`noc-sw01\`) sat to the left, and GE3 was the inverse.

**Root cause**: \`placePorts\` in \`@shumoku/core\` distributed ports along each side in the order links appeared in the input, ignoring where the peer node lived.

**Fix**: sort each side's port assignments by the peer node's coordinate (x for top/bottom, y for left/right) before laying them out. The port closest to the peer ends up closest to the peer.

## Concrete impact (proj-WS6KCI_cxs: 50 logical nodes, 53 termination nodes)

| | Before | After |
|---|---|---|
| diagram bounds height | 4222 | **1620** |
| viewBox empty space above | ~2600px | 50px (the pad) |
| auto-arrange shape | APs scattered to corners | clean Sugiyama hierarchy |
| rt01 GE1/GE3 edges | crossed | parallel |

## Test plan

- [x] core tests pass (134/134)
- [x] reload diagram for proj-WS6KCI_cxs — fills viewport
- [x] auto-arrange produces sensible Sugiyama
- [x] rt01 GE1 lands on the left side (peer to left), GE3 on right (peer to right)
- [ ] sheet drilldown (sub-graph view) still works
- [ ] scene mode unaffected (termination nodes still in store with original positions)