### PR TITLE
feat(core): port placement.side acts as a layout direction hint

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1328,6 +1328,47 @@ export const diagramState = {
     })
   },
   /**
+   * Persist a user override for where this port sits on its node.
+   * `placement.side` pins the edge; `placement.order` (not yet
+   * surfaced by drag — follow-up) pins the slot within the side.
+   * Passing `null` for either field clears that override so the
+   * port falls back to the auto rules.
+   *
+   * The override lives on `NodePort.placement` so it round-trips
+   * through save / load and survives auto-relayout.
+   */
+  setPortPlacement(
+    nodeId: string,
+    portId: string,
+    placement: { side?: 'top' | 'bottom' | 'left' | 'right' | null; order?: number | null },
+  ) {
+    commit('Move port', () => {
+      const node = diagram.nodes.get(nodeId)
+      if (!node) return
+      const ports = node.ports
+      if (!ports?.length) return
+      const idx = ports.findIndex((p) => p.id === portId)
+      if (idx < 0) return
+      const port = ports[idx]
+      if (!port) return
+      const prev = port.placement
+      const nextSide = placement.side === null ? undefined : (placement.side ?? prev?.side)
+      const nextOrder = placement.order === null ? undefined : (placement.order ?? prev?.order)
+      // No-op early-out — nothing changed.
+      if (nextSide === prev?.side && nextOrder === prev?.order) return
+      const nextPlacement =
+        nextSide === undefined && nextOrder === undefined
+          ? undefined
+          : { side: nextSide, order: nextOrder }
+      const nextPort = { ...port, placement: nextPlacement }
+      const nextPorts = [...ports]
+      nextPorts[idx] = nextPort
+      diagram.nodes.set(nodeId, { ...node, ports: nextPorts })
+      // Recompute port positions so the move is reflected immediately.
+      rebuildPortsAndEdges()
+    })
+  },
+  /**
    * Remove a port by its raw NodePort.id (not the ResolvedPort form).
    * Use this when the port may have no layout entry — e.g. an unwired
    * custom port the user added but never connected. Falls back to the

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -225,6 +225,9 @@
         oncreatelink={(from: LinkEndpoint, to: LinkEndpoint) => {
           diagramState.addLink({ id: newId('link'), from, to })
         }}
+        onportmove={(nodeId: string, portId: string, side: 'top' | 'bottom' | 'left' | 'right') => {
+          diagramState.setPortPlacement(nodeId, portId, { side })
+        }}
       />
     {:else}
       <div class="flex items-center justify-center h-full text-neutral-400 dark:text-neutral-500">

--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -202,7 +202,61 @@ function buildParentOf(graph: NetworkGraph): Map<string, string | null> {
  * direction, so we don't want them driving layer assignment. Their
  * port sides are still handled separately by `placePorts`.
  */
-function buildCompoundEdges(graph: NetworkGraph, parentOf: Map<string, string | null>): Edge[] {
+/**
+ * Direction-derived "this side means upstream" map. Sugiyama lays
+ * out the flow along this axis, so a port pinned to the dest side
+ * of a source node (or vice versa) is the user telling layout that
+ * the link should run the other way.
+ */
+type Side = 'top' | 'bottom' | 'left' | 'right'
+
+function flowSides(direction: 'TB' | 'BT' | 'LR' | 'RL'): { source: Side; dest: Side } {
+  switch (direction) {
+    case 'TB':
+      return { source: 'bottom', dest: 'top' }
+    case 'BT':
+      return { source: 'top', dest: 'bottom' }
+    case 'LR':
+      return { source: 'right', dest: 'left' }
+    case 'RL':
+      return { source: 'left', dest: 'right' }
+  }
+}
+
+/**
+ * For a single link, decide whether the user-placed port sides
+ * disagree with the direction-derived defaults strongly enough to
+ * flip the link's layer ordering for layout purposes. Returns
+ * `false` (no flip) for perpendicular / HA-side placements — those
+ * carry no flow information.
+ *
+ * The actual `Link.from` / `Link.to` records are not mutated; only
+ * the (source, target) pair used to feed Sugiyama is swapped.
+ */
+function shouldFlipForLayout(
+  link: NetworkGraph['links'][number],
+  nodes: Map<string, Node>,
+  direction: 'TB' | 'BT' | 'LR' | 'RL',
+): boolean {
+  const sides = flowSides(direction)
+  const fromNode = nodes.get(link.from.node)
+  const toNode = nodes.get(link.to.node)
+  const fromSide = fromNode?.ports?.find((p) => p.id === link.from.port)?.placement?.side
+  const toSide = toNode?.ports?.find((p) => p.id === link.to.port)?.placement?.side
+  // From port pinned to the dest side → "from" wants to live downstream.
+  // To port pinned to the source side → "to" wants to live upstream.
+  // Either alone is enough to flip; both agreeing also flips (idempotent).
+  if (fromSide === sides.dest) return true
+  if (toSide === sides.source) return true
+  return false
+}
+
+function buildCompoundEdges(
+  graph: NetworkGraph,
+  parentOf: Map<string, string | null>,
+  direction: 'TB' | 'BT' | 'LR' | 'RL',
+  nodesById: Map<string, Node>,
+): Edge[] {
   const commonAncestor = (a: string, b: string): string | null => {
     const aChain = new Set<string | null>()
     let cur: string | null = a
@@ -236,8 +290,11 @@ function buildCompoundEdges(graph: NetworkGraph, parentOf: Map<string, string | 
   const edges: Edge[] = []
   for (const [i, link] of graph.links.entries()) {
     if (link.redundancy) continue
-    const s = epId(link.from)
-    const t = epId(link.to)
+    const flip = shouldFlipForLayout(link, nodesById, direction)
+    const from = flip ? link.to : link.from
+    const to = flip ? link.from : link.to
+    const s = epId(from)
+    const t = epId(to)
     const level = commonAncestor(s, t)
     const srcAtLevel = resolveChild(s, level)
     const tgtAtLevel = resolveChild(t, level)
@@ -334,7 +391,8 @@ export function layoutNetwork(
     parent: s.parent ?? null,
   }))
   const parentOf = buildParentOf(graph)
-  const edges = buildCompoundEdges(graph, parentOf)
+  const nodesById = new Map(graph.nodes.map((n) => [n.id, n]))
+  const edges = buildCompoundEdges(graph, parentOf, opts.direction, nodesById)
 
   // Compound Sugiyama: positions every node, bounds every subgraph.
   const result = layoutCompound(compoundNodes, compoundSubgraphs, edges, {

--- a/libs/@shumoku/core/src/layout/port-placement.test.ts
+++ b/libs/@shumoku/core/src/layout/port-placement.test.ts
@@ -128,4 +128,125 @@ describe('placePorts', () => {
     const ports = placePorts(nodes, links, 'TB')
     expect(ports.size).toBe(0)
   })
+
+  describe('placement overrides', () => {
+    it('honours per-port side override', () => {
+      const nodes = makeNodes()
+      // Pin sw1's port to top even though it's the source in TB.
+      nodes.set('sw1', {
+        ...nodes.get('sw1'),
+        ports: [
+          {
+            id: 'eth0',
+            label: 'eth0',
+            connectors: [],
+            placement: { side: 'top' },
+          },
+        ],
+      })
+      const links: Link[] = [
+        { from: { node: 'sw1', port: 'eth0' }, to: { node: 'sw2', port: 'eth0' } },
+      ]
+
+      const ports = placePorts(nodes, links, 'TB')
+      expect(ports.get('sw1:eth0').side).toBe('top')
+      // sw2 stays auto (destination → top)
+      expect(ports.get('sw2:eth0').side).toBe('top')
+    })
+
+    it('orders auto ports by peer position to avoid crossings', () => {
+      // sw1 has two bottom ports going to peers at different x — the
+      // port whose peer is on the left should land on the left side.
+      const nodes = new Map([
+        [
+          'sw1',
+          { id: 'sw1', label: 'Switch 1', shape: 'rounded' as const, position: { x: 300, y: 100 } },
+        ],
+        [
+          'left',
+          { id: 'left', label: 'Left', shape: 'rounded' as const, position: { x: 100, y: 300 } },
+        ],
+        [
+          'right',
+          { id: 'right', label: 'Right', shape: 'rounded' as const, position: { x: 500, y: 300 } },
+        ],
+      ])
+      // Declare in "wrong" insertion order (right peer first) — the
+      // sort must put the left-peer port first.
+      const links: Link[] = [
+        { from: { node: 'sw1', port: 'A' }, to: { node: 'right', port: 'eth0' } },
+        { from: { node: 'sw1', port: 'B' }, to: { node: 'left', port: 'eth0' } },
+      ]
+      const ports = placePorts(nodes, links, 'TB')
+      const pa = ports.get('sw1:A')
+      const pb = ports.get('sw1:B')
+      // B's peer (x=100) is left of A's peer (x=500), so B should be
+      // on the left side of sw1.
+      expect(pb.absolutePosition.x).toBeLessThan(pa.absolutePosition.x)
+    })
+
+    it('respects explicit order override regardless of peer position', () => {
+      const nodes = new Map([
+        [
+          'sw1',
+          { id: 'sw1', label: 'Switch 1', shape: 'rounded' as const, position: { x: 300, y: 100 } },
+        ],
+        [
+          'left',
+          { id: 'left', label: 'Left', shape: 'rounded' as const, position: { x: 100, y: 300 } },
+        ],
+        [
+          'right',
+          { id: 'right', label: 'Right', shape: 'rounded' as const, position: { x: 500, y: 300 } },
+        ],
+      ])
+      // Pin A (peer on right) to order=0 (first) and B (peer on left)
+      // to order=1 (second). The peer-position auto-sort would put B
+      // first; the override should override that.
+      nodes.set('sw1', {
+        ...nodes.get('sw1'),
+        ports: [
+          { id: 'A', label: 'A', connectors: [], placement: { order: 0 } },
+          { id: 'B', label: 'B', connectors: [], placement: { order: 1 } },
+        ],
+      })
+      const links: Link[] = [
+        { from: { node: 'sw1', port: 'A' }, to: { node: 'right', port: 'eth0' } },
+        { from: { node: 'sw1', port: 'B' }, to: { node: 'left', port: 'eth0' } },
+      ]
+      const ports = placePorts(nodes, links, 'TB')
+      const pa = ports.get('sw1:A')
+      const pb = ports.get('sw1:B')
+      expect(pa.absolutePosition.x).toBeLessThan(pb.absolutePosition.x)
+    })
+
+    it('mixes pinned and auto ports — pinned first, auto fills the rest', () => {
+      const nodes = new Map([
+        [
+          'sw1',
+          { id: 'sw1', label: 'Switch 1', shape: 'rounded' as const, position: { x: 300, y: 100 } },
+        ],
+        ['p1', { id: 'p1', label: 'P1', shape: 'rounded' as const, position: { x: 100, y: 300 } }],
+        ['p2', { id: 'p2', label: 'P2', shape: 'rounded' as const, position: { x: 200, y: 300 } }],
+        ['p3', { id: 'p3', label: 'P3', shape: 'rounded' as const, position: { x: 500, y: 300 } }],
+      ])
+      // Only C is pinned (order=0); A and B auto-sort by peer x.
+      nodes.set('sw1', {
+        ...nodes.get('sw1'),
+        ports: [{ id: 'C', label: 'C', connectors: [], placement: { order: 0 } }],
+      })
+      const links: Link[] = [
+        { from: { node: 'sw1', port: 'A' }, to: { node: 'p3', port: 'eth0' } }, // peer x=500
+        { from: { node: 'sw1', port: 'B' }, to: { node: 'p1', port: 'eth0' } }, // peer x=100
+        { from: { node: 'sw1', port: 'C' }, to: { node: 'p2', port: 'eth0' } }, // peer x=200, pinned first
+      ]
+      const ports = placePorts(nodes, links, 'TB')
+      const pc = ports.get('sw1:C')
+      const pb = ports.get('sw1:B')
+      const pa = ports.get('sw1:A')
+      // C pinned first (leftmost), then B (smaller peer x), then A (larger peer x).
+      expect(pc.absolutePosition.x).toBeLessThan(pb.absolutePosition.x)
+      expect(pb.absolutePosition.x).toBeLessThan(pa.absolutePosition.x)
+    })
+  })
 })

--- a/libs/@shumoku/core/src/layout/port-placement.ts
+++ b/libs/@shumoku/core/src/layout/port-placement.ts
@@ -5,16 +5,29 @@
 /**
  * Port Placement
  *
- * Determines the absolute position of each port on a node, based on:
- * - Which side of the node the port is on (top/bottom/left/right)
- * - How many ports are on that side (evenly distributed)
- * - The node's absolute position and size
+ * Computes the absolute position of each port on each node. The
+ * pipeline factors into three pure phases that the public
+ * `placePorts` composes; each phase is exported so callers (and
+ * tests) can reach into the intermediate state.
  *
- * Port side assignment rules (for TB direction):
- * - Normal links: source ports → bottom, destination ports → top
- * - HA/redundancy links: source ports → right, destination ports → left
- * - For LR direction: source → right, destination → left (normal);
- *   HA → bottom/top
+ *   1. `decidePortSides`     — pick which edge of the node each
+ *      port lives on. Defaults follow direction + HA rules; the
+ *      per-port `placement.side` override wins when set.
+ *
+ *   2. `orderPortsOnSide`    — order ports along a single side.
+ *      Ports with a `placement.order` lock to that slot in
+ *      ascending order; the rest fill the remaining slots sorted
+ *      by their peer node's position so adjacent edges don't
+ *      cross under the node.
+ *
+ *   3. `computePortPosition` — distribute N indexed ports evenly
+ *      along the side and return absolute coordinates.
+ *
+ * Default side rules (TB direction):
+ *   - Normal link  → source: bottom, destination: top
+ *   - HA / redundancy → source: right, destination: left
+ *   (LR direction swaps the axis; HA always runs perpendicular to
+ *   the main flow.)
  */
 
 import type { Direction, Link, Node, Position } from '../models/types.js'
@@ -26,13 +39,14 @@ const PORT_SIZE = { width: 8, height: 8 }
 
 type Side = 'top' | 'bottom' | 'left' | 'right'
 
-interface PortAssignment {
+/** One port's assignment after phase 1 (`decidePortSides`). */
+export interface PortAssignment {
   nodeId: string
+  /** Local port id on the node (the side-of-colon part of ResolvedPort.id). */
   portId: string
   side: Side
-  /** The peer node id on the other end of this port's link — used to
-   *  sort ports along the side so adjacent peers don't force edges to
-   *  cross over each other. */
+  /** Peer node id on the other end of this port's link. Used by
+   *  `orderPortsOnSide` to put each port closest to its peer. */
   peerNodeId: string
 }
 
@@ -41,9 +55,14 @@ function getNodePortLabel(node: Node | undefined, portId: string): string {
   return port?.label ?? portId
 }
 
-/**
- * Detect HA pairs from links with redundancy field.
- */
+function getPortPlacement(
+  node: Node | undefined,
+  portId: string,
+): { side?: Side; order?: number } | undefined {
+  return node?.ports?.find((p) => p.id === portId)?.placement
+}
+
+/** True if the two nodes form an HA pair via at least one redundant link. */
 function detectHAPairs(links: Link[]): Set<string> {
   const pairs = new Set<string>()
   for (const link of links) {
@@ -53,9 +72,6 @@ function detectHAPairs(links: Link[]): Set<string> {
   return pairs
 }
 
-/**
- * Get the source/destination sides for normal links based on layout direction.
- */
 function getNormalSides(direction: Direction): { sourceSide: Side; destSide: Side } {
   switch (direction) {
     case 'TB':
@@ -69,10 +85,6 @@ function getNormalSides(direction: Direction): { sourceSide: Side; destSide: Sid
   }
 }
 
-/**
- * Get the source/destination sides for HA links based on layout direction.
- * HA pairs should be laid out perpendicular to the main flow.
- */
 function getHASides(direction: Direction): { sourceSide: Side; destSide: Side } {
   switch (direction) {
     case 'TB':
@@ -85,12 +97,23 @@ function getHASides(direction: Direction): { sourceSide: Side; destSide: Side } 
 }
 
 /**
- * Assign each port to a side of its node based on link connections.
+ * Phase 1 — decide which edge each port lives on.
+ *
+ * Auto rule: source ports go on `sourceSide`, destination ports on
+ * `destSide`, with HA links perpendicular to the main flow.
+ *
+ * Override: if the corresponding `NodePort.placement.side` is set,
+ * it wins. The peer node id stays whatever the link says so phase 2
+ * can still sort by peer position.
  */
-function assignPortSides(links: Link[], direction: Direction): PortAssignment[] {
+export function decidePortSides(
+  links: Link[],
+  nodes: Map<string, Node>,
+  direction: Direction,
+): PortAssignment[] {
   const haPairs = detectHAPairs(links)
   const assignments: PortAssignment[] = []
-  const seen = new Set<string>() // "nodeId:portName" dedup
+  const seen = new Set<string>()
 
   const normalSides = getNormalSides(direction)
   const haSides = getHASides(direction)
@@ -98,17 +121,17 @@ function assignPortSides(links: Link[], direction: Direction): PortAssignment[] 
   for (const link of links) {
     const fromNode = link.from.node
     const toNode = link.to.node
-
     const isHA = haPairs.has([fromNode, toNode].sort().join(':'))
     const sides = isHA ? haSides : normalSides
 
     const fromKey = `${fromNode}:${link.from.port}`
     if (!seen.has(fromKey)) {
       seen.add(fromKey)
+      const override = getPortPlacement(nodes.get(fromNode), link.from.port)?.side
       assignments.push({
         nodeId: fromNode,
         portId: link.from.port,
-        side: sides.sourceSide,
+        side: override ?? sides.sourceSide,
         peerNodeId: toNode,
       })
     }
@@ -116,10 +139,11 @@ function assignPortSides(links: Link[], direction: Direction): PortAssignment[] 
     const toKey = `${toNode}:${link.to.port}`
     if (!seen.has(toKey)) {
       seen.add(toKey)
+      const override = getPortPlacement(nodes.get(toNode), link.to.port)?.side
       assignments.push({
         nodeId: toNode,
         portId: link.to.port,
-        side: sides.destSide,
+        side: override ?? sides.destSide,
         peerNodeId: fromNode,
       })
     }
@@ -129,13 +153,66 @@ function assignPortSides(links: Link[], direction: Direction): PortAssignment[] 
 }
 
 /**
- * Compute the absolute position of a port on a given side of a node.
+ * Phase 2 — order ports along a single side.
  *
- * Ports are evenly distributed along the side edge.
- * For example, 3 ports on the bottom of a 120px-wide node:
- *   positions at x = 30, 60, 90 (= width * 1/4, 2/4, 3/4)
+ * Two-tier sort:
+ *   1. Ports with a `placement.order` lock to that slot in ascending
+ *      order. Sparse values stay sparse — we don't renumber.
+ *   2. The rest interleave in peer-position order (x for horizontal
+ *      sides, y for vertical) so the edge to a left peer ends up on
+ *      the leftmost free port and vice versa.
+ *
+ * Returns the assignments in the final order. The caller treats the
+ * returned array index as the port's position on the side.
  */
-function computePortPosition(
+export function orderPortsOnSide(
+  assignments: PortAssignment[],
+  nodes: Map<string, Node>,
+): PortAssignment[] {
+  if (assignments.length <= 1) return assignments
+
+  const first = assignments[0]
+  if (!first) return assignments
+  const isHorizontalSide = first.side === 'top' || first.side === 'bottom'
+
+  // Split: explicit order vs auto.
+  const explicit: Array<{ a: PortAssignment; order: number }> = []
+  const auto: PortAssignment[] = []
+  for (const a of assignments) {
+    const ord = getPortPlacement(nodes.get(a.nodeId), a.portId)?.order
+    if (typeof ord === 'number' && Number.isFinite(ord)) {
+      explicit.push({ a, order: ord })
+    } else {
+      auto.push(a)
+    }
+  }
+
+  explicit.sort((p, q) => p.order - q.order)
+  auto.sort((a, b) => {
+    const pa = nodes.get(a.peerNodeId)?.position
+    const pb = nodes.get(b.peerNodeId)?.position
+    if (!pa || !pb) return 0
+    return isHorizontalSide ? pa.x - pb.x : pa.y - pb.y
+  })
+
+  // Merge: explicit ports keep their conceptual "order rank"; auto
+  // ports flow between them. Concretely, we treat each explicit
+  // port's `order` as a target slot fraction (low → first, high →
+  // last) and slot auto ports between them by peer position.
+  // Simple approximation that works well in practice: just put all
+  // explicit-ordered first (already sorted), then auto. Users who
+  // want fine control will set order on every port. This keeps the
+  // algorithm O(n log n) and behaviour predictable.
+  return [...explicit.map((e) => e.a), ...auto]
+}
+
+/**
+ * Phase 3 — absolute position of port[index] of [total] on a node's side.
+ *
+ * Ports are spread evenly: position = (index + 1) / (total + 1) along
+ * the side edge. 3 ports on a 120px-wide bottom → 30, 60, 90.
+ */
+export function computePortPosition(
   node: Node & { position: { x: number; y: number } },
   side: Side,
   index: number,
@@ -145,8 +222,6 @@ function computePortPosition(
   const { x: cx, y: cy } = node.position
   const halfW = size.width / 2
   const halfH = size.height / 2
-
-  // Distribute evenly: position = (index + 1) / (total + 1)
   const ratio = (index + 1) / (total + 1)
 
   switch (side) {
@@ -162,72 +237,43 @@ function computePortPosition(
 }
 
 /**
- * Place all ports with absolute coordinates.
- *
- * @param nodes - Positioned nodes (from node placement step)
- * @param links - Link definitions (determine which ports exist and their sides)
- * @param direction - Layout direction (affects port side assignment)
- * @returns Map of portId → ResolvedPort with absolute positions
+ * Compose the three phases: decide sides → order each side → compute
+ * absolute coordinates → emit `ResolvedPort`s keyed by `nodeId:portId`.
  */
 export function placePorts(
   nodes: Map<string, Node>,
   links: Link[],
   direction: Direction = 'TB',
 ): Map<string, ResolvedPort> {
-  const assignments = assignPortSides(links, direction)
+  const assignments = decidePortSides(links, nodes, direction)
 
-  // Group by node+side to determine order and count
   const bySide = new Map<string, PortAssignment[]>()
   for (const a of assignments) {
     const key = `${a.nodeId}:${a.side}`
     const list = bySide.get(key)
-    if (list) {
-      list.push(a)
-    } else {
-      bySide.set(key, [a])
-    }
+    if (list) list.push(a)
+    else bySide.set(key, [a])
   }
 
-  // Compute absolute positions
   const ports = new Map<string, ResolvedPort>()
-
   for (const [_key, sideAssignments] of bySide) {
     const first = sideAssignments[0]
     if (!first) continue
-    const nodeId = first.nodeId
-    const side = first.side
-    const node = nodes.get(nodeId)
+    const node = nodes.get(first.nodeId)
     if (!node?.position) continue
 
-    // Sort ports along the side by their peer node's position so an
-    // edge going to a left-side peer ends up on the left port and one
-    // going to a right-side peer ends up on the right port. Without
-    // this the ports stay in the order they appeared in `links`, and
-    // edges to peers further along the side cross over each other in
-    // an "X" shape between the node and its neighbours.
-    const isHorizontalSide = side === 'top' || side === 'bottom'
-    sideAssignments.sort((a, b) => {
-      const pa = nodes.get(a.peerNodeId)?.position
-      const pb = nodes.get(b.peerNodeId)?.position
-      if (!pa || !pb) return 0
-      return isHorizontalSide ? pa.x - pb.x : pa.y - pb.y
-    })
+    const ordered = orderPortsOnSide(sideAssignments, nodes)
+    const positioned = node as Node & { position: { x: number; y: number } }
 
-    for (const [i, a] of sideAssignments.entries()) {
+    for (const [i, a] of ordered.entries()) {
       const portId = `${a.nodeId}:${a.portId}`
-      const absolutePosition = computePortPosition(
-        node as Node & { position: { x: number; y: number } },
-        side,
-        i,
-        sideAssignments.length,
-      )
-
+      const absolutePosition = computePortPosition(positioned, a.side, i, ordered.length)
       ports.set(portId, {
         id: portId,
         nodeId: a.nodeId,
         label: getNodePortLabel(node, a.portId),
         absolutePosition,
-        side,
+        side: a.side,
         size: PORT_SIZE,
       })
     }

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -130,6 +130,24 @@ export interface NodePort {
   source?: 'catalog' | 'custom'
   disabled?: boolean
   notes?: string
+  /**
+   * User override for where this port lives on the node, used when
+   * the default rules (side from link direction, order from peer
+   * position) place it somewhere the user doesn't want. Either
+   * field can be set independently:
+   *
+   *   - `side` — pin the port to a specific edge; overrides the
+   *     direction-derived default. Absent → side is auto.
+   *   - `order` — index along the side, low → first. Ports with an
+   *     `order` lock to their position; ports without one fill the
+   *     remaining slots in their default peer-position order.
+   *     Sparse / non-integer values are fine (10, 20, 25, 30…) so
+   *     inserting between two pinned ports doesn't have to renumber.
+   */
+  placement?: {
+    side?: 'top' | 'bottom' | 'left' | 'right'
+    order?: number
+  }
 }
 
 /**

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -16,6 +16,7 @@
     addPort,
     collectObstacles,
     computeNodeSize,
+    detectClickSide,
     linkExists,
     moveNode,
     moveSubgraph,
@@ -89,6 +90,14 @@
      * its choosing) and either push it via `bind:links` or call `appendLink()`.
      */
     oncreatelink?: (from: LinkEndpoint, to: LinkEndpoint) => void
+    /**
+     * User dragged an existing (linked) port to a new location on the
+     * same node. Renderer computes the target side from the drop
+     * coords; the host stores it as the port's `placement.side` so
+     * the next layout pass keeps it there. `order` is currently not
+     * computed by the renderer — order-within-side is a follow-up.
+     */
+    onportmove?: (nodeId: string, portId: string, side: 'top' | 'bottom' | 'left' | 'right') => void
   }
 
   let {
@@ -112,6 +121,7 @@
     ondragend,
     hideNode,
     oncreatelink,
+    onportmove,
     subgraphOverlay,
     linkOverlay,
     nodeOverlay,
@@ -493,6 +503,35 @@
    * Used by the WebComponent wrapper, which owns its link state internally.
    * Editor apps should prefer mutating their own state via `bind:links`.
    */
+  /**
+   * Translate screen coords to SVG coords, decide which edge of the
+   * port's node the drop landed nearest to, and tell the host to
+   * persist the placement. If the side didn't actually change we
+   * skip the callback so the host's commit() doesn't dirty undo /
+   * cache for a no-op.
+   */
+  function handlePortDragEnd(portId: string, screenX: number, screenY: number) {
+    if (!onportmove) return
+    const port = ports.get(portId)
+    if (!port) return
+    const node = nodes.get(port.nodeId)
+    if (!node?.position) return
+    const { x, y } = screenToSvg(screenX, screenY)
+    const newSide = detectClickSide(
+      x,
+      y,
+      node as typeof node & { position: { x: number; y: number } },
+    )
+    if (newSide === port.side) return
+    // Bare port id used by external API — SvgPort sees the resolved
+    // `nodeId:portId` form; strip the prefix back to the raw port id
+    // that lives on `NodePort.id`.
+    const rawPortId = portId.startsWith(`${port.nodeId}:`)
+      ? portId.slice(port.nodeId.length + 1)
+      : portId
+    onportmove(port.nodeId, rawPortId, newSide)
+  }
+
   export async function appendLink(link: Link) {
     if (linkExists(links, link.from.node, link.from.port, link.to.node, link.to.port)) return
     links = [...links, link]
@@ -527,6 +566,7 @@
     onaddport={handleAddPort}
     onlinkstart={handleLinkStart}
     onlinkend={handleLinkEnd}
+    onportdragend={handlePortDragEnd}
     {onlabeledit}
     oncontextmenu={handleContextMenu}
     onbackgroundclick={handleBackgroundClick}

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -39,6 +39,8 @@
     onaddport,
     onlinkstart,
     onlinkend,
+    onportdragmove,
+    onportdragend,
     onlabeledit,
     oncontextmenu: onctx,
     onbackgroundclick,
@@ -63,6 +65,8 @@
     onaddport?: (nodeId: string, side: 'top' | 'bottom' | 'left' | 'right') => void
     onlinkstart?: (portId: string, x: number, y: number) => void
     onlinkend?: (portId: string) => void
+    onportdragmove?: (portId: string, screenX: number, screenY: number) => void
+    onportdragend?: (portId: string, screenX: number, screenY: number) => void
     onlabeledit?: (portId: string, label: string, screenX: number, screenY: number) => void
     oncontextmenu?: (id: string, type: string, e: MouseEvent) => void
     onbackgroundclick?: () => void
@@ -203,6 +207,8 @@
         overlay={portOverlay}
         {onlinkstart}
         {onlinkend}
+        {onportdragmove}
+        {onportdragend}
         {onselect}
         {onlabeledit}
         oncontextmenu={(id, e) => onctx?.(id, 'port', e)}

--- a/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
@@ -18,6 +18,8 @@
     onselect,
     onlabeledit,
     oncontextmenu: onctx,
+    onportdragmove,
+    onportdragend,
   }: {
     port: ResolvedPort
     colors: RenderColors
@@ -31,6 +33,12 @@
     onselect?: (portId: string) => void
     onlabeledit?: (portId: string, label: string, screenX: number, screenY: number) => void
     oncontextmenu?: (portId: string, e: MouseEvent) => void
+    /** Drag a linked port to a different placement on the same node.
+     *  Fires after a small movement threshold so a plain click still
+     *  selects without entering drag mode. Coordinates are screen pixels
+     *  (clientX/clientY); host translates and computes the target side. */
+    onportdragmove?: (portId: string, screenX: number, screenY: number) => void
+    onportdragend?: (portId: string, screenX: number, screenY: number) => void
   } = $props()
 
   const px = $derived(port.absolutePosition.x)
@@ -60,18 +68,58 @@
 
   let hovered = $state(false)
 
+  // Port-move drag state. A linked port enters drag mode if the user
+  // moves more than DRAG_THRESHOLD px after pressing it; otherwise the
+  // pointerdown was just a click for selection. Unlinked ports keep
+  // the link-draw behaviour (pointerdown immediately starts a link).
+  const DRAG_THRESHOLD = 5
+  let dragPointerId: number | null = null
+  let dragStartX = 0
+  let dragStartY = 0
+  let dragging = $state(false)
+
   function onpointerdown(e: PointerEvent) {
     if (e.button !== 0) return
     e.stopPropagation()
     e.preventDefault()
-    // Select always; link-start only in edit mode
     onselect?.(port.id)
-    if (interactive && !linked) {
+    if (!interactive) return
+
+    if (linked && onportdragend) {
+      dragPointerId = e.pointerId
+      dragStartX = e.clientX
+      dragStartY = e.clientY
+      const el = e.currentTarget as Element
+      el.setPointerCapture?.(e.pointerId)
+    } else {
       onlinkstart?.(port.id, px, py)
     }
   }
 
+  function onpointermove(e: PointerEvent) {
+    if (dragPointerId === null || e.pointerId !== dragPointerId) return
+    if (!dragging) {
+      const dx = e.clientX - dragStartX
+      const dy = e.clientY - dragStartY
+      if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return
+      dragging = true
+    }
+    onportdragmove?.(port.id, e.clientX, e.clientY)
+  }
+
   function onpointerup(e: PointerEvent) {
+    if (dragPointerId !== null && e.pointerId === dragPointerId) {
+      const el = e.currentTarget as Element
+      el.releasePointerCapture?.(e.pointerId)
+      const wasDragging = dragging
+      dragPointerId = null
+      dragging = false
+      if (wasDragging) {
+        e.stopPropagation()
+        onportdragend?.(port.id, e.clientX, e.clientY)
+        return
+      }
+    }
     if (!interactive) return
     e.stopPropagation()
     onlinkend?.(port.id)
@@ -95,13 +143,14 @@
 >
   <!-- Hit area (CSS controls pointer-events via .interactive) -->
   <rect
-    class="port-hit {linked ? 'linked' : ''}"
+    class="port-hit {linked ? 'linked' : ''} {dragging ? 'dragging' : ''}"
     x={px - 12}
     y={py - 12}
     width={24}
     height={24}
     fill="transparent"
     {onpointerdown}
+    {onpointermove}
     {onpointerup}
   />
 


### PR DESCRIPTION
## Why

User feedback on #219: \"in/out が変わったから auto 押したら配置変わるはずじゃないの？\"

Dragging a port to a different side persists \`placement.side\` (#218) and the port renders there (#219), but auto-arrange ignored the override — Sugiyama still consumed raw \`link.from / link.to\` for layer ordering. So the port flipped but the node stayed in the wrong layer.

## Fix

In \`buildCompoundEdges\`, check each link's endpoint port placement. If the user has pinned a port to the side that semantically means \"opposite of default flow\", swap the (source, target) pair fed to Sugiyama. The \`Link\` record is untouched — only the layer-ordering hint changes.

Rules (TB direction):

| from port pin | to port pin | flip layout? |
|---|---|---|
| bottom (default src) | top (default dst) | no |
| top (= dst side) | * | **yes** |
| * | bottom (= src side) | **yes** |
| left/right (HA) | left/right (HA) | no (no flow info) |

LR/BT/RL flip the axis but keep the same logic.

## Verified

End-to-end with a real project (proj-WS6KCI_cxs):

1. Drag \`room3-ap01\`'s E0 port from bottom → top. \`placement.side = "top"\` persists, port renders on top edge.
2. Click **Auto-arrange**. \`room3-ap01\` moves from the top row (y=40) to the bottom row (y=1480), matching the new flow direction.
3. Sibling APs without overrides stay where they were.

## Stacks on

- #218 (placement field + phase split)
- #219 (port-drag UX)

This is the third PR in the port-placement chain. Open after #218 and #219 merge.