### PR TITLE
feat(core): channel-based bend placement (closes #222)

### DIFF
--- a/libs/@shumoku/core/src/layout/channel-routing.test.ts
+++ b/libs/@shumoku/core/src/layout/channel-routing.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest'
+import type { Link } from '../models/types.js'
+import { assignChannelLanes, checkpointFromLane } from './channel-routing.js'
+import type { Channel, LayerDetectionResult } from './layer-detection.js'
+import type { ResolvedPort } from './resolved-types.js'
+
+function port(
+  id: string,
+  nodeId: string,
+  x: number,
+  y: number,
+  side: 'top' | 'bottom' = 'top',
+): ResolvedPort {
+  return {
+    id,
+    nodeId,
+    label: id,
+    absolutePosition: { x, y },
+    side,
+    size: { width: 8, height: 8 },
+  }
+}
+
+function buildLayers(
+  spec: Array<{ nodes: string[]; rankStart: number; rankEnd: number; rankCentre: number }>,
+): LayerDetectionResult {
+  const layerOf = new Map<string, number>()
+  const layers = spec.map((s, i) => {
+    for (const n of s.nodes) layerOf.set(n, i)
+    return { ...s, index: i }
+  })
+  return { layerOf, layers, rankAxis: 'y' }
+}
+
+describe('assignChannelLanes', () => {
+  it('puts each edge in its own lane, sorted by source X (stable order)', () => {
+    // Three switches at top (y=100), three APs at bottom (y=400)
+    // Edges declared in REVERSE peer-x order to exercise sorting.
+    const layers = buildLayers([
+      { nodes: ['sw-l', 'sw-m', 'sw-r'], rankStart: 80, rankEnd: 120, rankCentre: 100 },
+      { nodes: ['ap-l', 'ap-m', 'ap-r'], rankStart: 380, rankEnd: 420, rankCentre: 400 },
+    ])
+    const channels: Channel[] = [{ index: 0, rankStart: 130, rankEnd: 370 }]
+    const ports = new Map<string, ResolvedPort>([
+      ['sw-l:p', port('sw-l:p', 'sw-l', 100, 120)],
+      ['sw-m:p', port('sw-m:p', 'sw-m', 300, 120)],
+      ['sw-r:p', port('sw-r:p', 'sw-r', 500, 120)],
+      ['ap-l:p', port('ap-l:p', 'ap-l', 100, 380)],
+      ['ap-m:p', port('ap-m:p', 'ap-m', 300, 380)],
+      ['ap-r:p', port('ap-r:p', 'ap-r', 500, 380)],
+    ])
+    const links: Link[] = [
+      { id: 'link-r', from: { node: 'sw-r', port: 'p' }, to: { node: 'ap-r', port: 'p' } },
+      { id: 'link-l', from: { node: 'sw-l', port: 'p' }, to: { node: 'ap-l', port: 'p' } },
+      { id: 'link-m', from: { node: 'sw-m', port: 'p' }, to: { node: 'ap-m', port: 'p' } },
+    ]
+
+    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    const l = result.get('link-l')?.rankCoords[0]
+    const m = result.get('link-m')?.rankCoords[0]
+    const r = result.get('link-r')?.rankCoords[0]
+    expect(l).toBeDefined()
+    expect(m).toBeDefined()
+    expect(r).toBeDefined()
+    expect(l).toBeLessThan(m as number) // left-source edge gets the first (smallest) lane Y
+    expect(m).toBeLessThan(r as number)
+  })
+
+  it('spreads lanes evenly within the channel span', () => {
+    const layers = buildLayers([
+      { nodes: ['a', 'b', 'c'], rankStart: 80, rankEnd: 120, rankCentre: 100 },
+      { nodes: ['x', 'y', 'z'], rankStart: 380, rankEnd: 420, rankCentre: 400 },
+    ])
+    const channels: Channel[] = [{ index: 0, rankStart: 130, rankEnd: 370 }]
+    // 3 lanes in [130, 370] → 1/4, 2/4, 3/4 → 190, 250, 310.
+    const ports = new Map<string, ResolvedPort>([
+      ['a:p', port('a:p', 'a', 100, 120)],
+      ['b:p', port('b:p', 'b', 200, 120)],
+      ['c:p', port('c:p', 'c', 300, 120)],
+      ['x:p', port('x:p', 'x', 100, 380)],
+      ['y:p', port('y:p', 'y', 200, 380)],
+      ['z:p', port('z:p', 'z', 300, 380)],
+    ])
+    const links: Link[] = [
+      { id: 'ax', from: { node: 'a', port: 'p' }, to: { node: 'x', port: 'p' } },
+      { id: 'by', from: { node: 'b', port: 'p' }, to: { node: 'y', port: 'p' } },
+      { id: 'cz', from: { node: 'c', port: 'p' }, to: { node: 'z', port: 'p' } },
+    ]
+    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    expect(result.get('ax')?.rankCoords[0]).toBe(190)
+    expect(result.get('by')?.rankCoords[0]).toBe(250)
+    expect(result.get('cz')?.rankCoords[0]).toBe(310)
+  })
+
+  it('handles a flipped-direction edge (target above source) by walking channels high→low', () => {
+    const layers = buildLayers([
+      { nodes: ['hi'], rankStart: 80, rankEnd: 120, rankCentre: 100 },
+      { nodes: ['lo'], rankStart: 380, rankEnd: 420, rankCentre: 400 },
+    ])
+    const channels: Channel[] = [{ index: 0, rankStart: 130, rankEnd: 370 }]
+    const ports = new Map([
+      ['hi:p', port('hi:p', 'hi', 200, 120)],
+      ['lo:p', port('lo:p', 'lo', 200, 380)],
+    ])
+    // link.from is the LOWER-rank node (lo, layer 1); link.to is the upper.
+    const links: Link[] = [
+      { id: 'flip', from: { node: 'lo', port: 'p' }, to: { node: 'hi', port: 'p' } },
+    ]
+    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    expect(result.get('flip')?.channelIndices).toEqual([0])
+  })
+
+  it('issues one checkpoint per crossed boundary for multi-layer edges', () => {
+    const layers = buildLayers([
+      { nodes: ['top'], rankStart: 80, rankEnd: 120, rankCentre: 100 },
+      { nodes: ['mid'], rankStart: 280, rankEnd: 320, rankCentre: 300 },
+      { nodes: ['bot'], rankStart: 480, rankEnd: 520, rankCentre: 500 },
+    ])
+    const channels: Channel[] = [
+      { index: 0, rankStart: 130, rankEnd: 270 },
+      { index: 1, rankStart: 330, rankEnd: 470 },
+    ]
+    const ports = new Map([
+      ['top:p', port('top:p', 'top', 200, 120)],
+      ['bot:p', port('bot:p', 'bot', 200, 480)],
+    ])
+    const links: Link[] = [
+      { id: 'long', from: { node: 'top', port: 'p' }, to: { node: 'bot', port: 'p' } },
+    ]
+    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    expect(result.get('long')?.channelIndices).toEqual([0, 1])
+    expect(result.get('long')?.rankCoords.length).toBe(2)
+  })
+
+  it('skips intra-layer (same-rank) edges — those are HA / lateral, channel routing not applicable', () => {
+    const layers = buildLayers([
+      { nodes: ['a', 'b'], rankStart: 80, rankEnd: 120, rankCentre: 100 },
+    ])
+    const ports = new Map([
+      ['a:p', port('a:p', 'a', 100, 100)],
+      ['b:p', port('b:p', 'b', 300, 100)],
+    ])
+    const links: Link[] = [
+      { id: 'ha', from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'p' }, redundancy: 'ha' },
+    ]
+    const result = assignChannelLanes(links, ports, layers, [], 'TB')
+    expect(result.has('ha')).toBe(false)
+  })
+
+  it('falls back gracefully when an endpoint port is missing', () => {
+    const layers = buildLayers([
+      { nodes: ['a'], rankStart: 80, rankEnd: 120, rankCentre: 100 },
+      { nodes: ['b'], rankStart: 380, rankEnd: 420, rankCentre: 400 },
+    ])
+    const channels: Channel[] = [{ index: 0, rankStart: 130, rankEnd: 370 }]
+    const ports = new Map([['a:p', port('a:p', 'a', 100, 120)]])
+    const links: Link[] = [
+      { id: 'bad', from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'missing' } },
+    ]
+    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    expect(result.has('bad')).toBe(false)
+  })
+
+  it('produces deterministic lane order for the same input', () => {
+    const layers = buildLayers([
+      { nodes: ['a'], rankStart: 80, rankEnd: 120, rankCentre: 100 },
+      { nodes: ['b', 'c'], rankStart: 380, rankEnd: 420, rankCentre: 400 },
+    ])
+    const channels: Channel[] = [{ index: 0, rankStart: 130, rankEnd: 370 }]
+    const ports = new Map([
+      ['a:p1', port('a:p1', 'a', 100, 120)],
+      ['a:p2', port('a:p2', 'a', 200, 120)],
+      ['b:p', port('b:p', 'b', 100, 380)],
+      ['c:p', port('c:p', 'c', 200, 380)],
+    ])
+    const links: Link[] = [
+      { id: 'l1', from: { node: 'a', port: 'p1' }, to: { node: 'b', port: 'p' } },
+      { id: 'l2', from: { node: 'a', port: 'p2' }, to: { node: 'c', port: 'p' } },
+    ]
+    const r1 = assignChannelLanes(links, ports, layers, channels, 'TB')
+    const r2 = assignChannelLanes(links, ports, layers, channels, 'TB')
+    expect(r1.get('l1')?.rankCoords).toEqual(r2.get('l1')?.rankCoords)
+    expect(r1.get('l2')?.rankCoords).toEqual(r2.get('l2')?.rankCoords)
+  })
+})
+
+describe('checkpointFromLane', () => {
+  it('places TB checkpoint at midpoint of source/dest X with rank coord as Y', () => {
+    const cp = checkpointFromLane(
+      200,
+      port('a:p', 'a', 100, 0, 'bottom'),
+      port('b:p', 'b', 400, 500, 'top'),
+      'y',
+    )
+    expect(cp).toEqual({ x: 250, y: 200 })
+  })
+
+  it('places LR checkpoint at midpoint of source/dest Y with rank coord as X', () => {
+    const cp = checkpointFromLane(
+      300,
+      port('a:p', 'a', 0, 100, 'bottom'),
+      port('b:p', 'b', 500, 400, 'top'),
+      'x',
+    )
+    expect(cp).toEqual({ x: 300, y: 250 })
+  })
+})

--- a/libs/@shumoku/core/src/layout/channel-routing.ts
+++ b/libs/@shumoku/core/src/layout/channel-routing.ts
@@ -1,0 +1,187 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Channel-based edge bend placement.
+ *
+ * The post-process spread (`spreadOverlappingSegments`) treats the
+ * symptom — segments that happen to share a fixed coordinate — and
+ * fights libavoid for the result. That breaks down in two ways
+ * when dozens of edges cross the same Sugiyama layer transition:
+ *
+ *   1. The visible "wall of bends" stays packed because spreading
+ *      can only push adjacent overlapping segments by minDist; it
+ *      has no notion of where the routing channel actually ends.
+ *   2. Lane membership depends on the runtime geometry, so dragging
+ *      a node shifts ranges, reshuffles clusters, and snaps every
+ *      affected edge to a new lane.
+ *
+ * The stable thing to plan around is layer topology, not segment
+ * geometry. Each edge crossing layer boundary k lives in **channel
+ * k**, an interval between the inflated bottom of layer k and the
+ * inflated top of layer k+1. Within a channel, edges get a
+ * deterministic ordinal computed from their source / target port
+ * positions, and the ordinal maps to a Y (TB) or X (LR) lane that
+ * we hand to libavoid as a checkpoint. Same input → same lanes,
+ * regardless of which way you dragged the rest of the diagram.
+ *
+ * Long edges that span multiple layers get one checkpoint per
+ * boundary they cross. Single-rank edges (the common case) get a
+ * single checkpoint at the channel midpoint of their assigned lane.
+ */
+
+import type { Direction, Link, Position } from '../models/types.js'
+import type { Channel, LayerDetectionResult } from './layer-detection.js'
+import type { ResolvedPort } from './resolved-types.js'
+
+/**
+ * For one edge, per-boundary checkpoint coordinates. A regular
+ * single-rank edge has one entry; an edge crossing N rank
+ * boundaries has N entries, in low-rank → high-rank order.
+ */
+export interface LaneAssignment {
+  /** Rank-axis coordinate of each checkpoint. */
+  rankCoords: number[]
+  /** The channel indices these checkpoints sit in. */
+  channelIndices: number[]
+}
+
+/**
+ * Allocate a lane in every channel each link traverses. Returns a
+ * map keyed by link id; links with no id or whose endpoints can't
+ * be located in the layer map are absent (caller falls back to
+ * un-channelled routing for those).
+ *
+ * Sort order within a channel: by source-end cross-axis coordinate,
+ * then by target-end cross-axis coordinate, then by stable hash of
+ * the link id. Source order is the primary key because Sugiyama
+ * already minimised crossings along the cross axis when it ordered
+ * each layer — going through the same order in each channel keeps
+ * the bus visually "fanned out" instead of weaving.
+ */
+export function assignChannelLanes(
+  links: readonly Link[],
+  ports: Map<string, ResolvedPort>,
+  layers: LayerDetectionResult,
+  channels: Channel[],
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: kept for API symmetry; everything direction-dependent flows in via layers.rankAxis
+  _direction: Direction,
+): Map<string, LaneAssignment> {
+  const result = new Map<string, LaneAssignment>()
+  if (channels.length === 0 || layers.layers.length < 2) return result
+
+  const crossAxis: 'x' | 'y' = layers.rankAxis === 'y' ? 'x' : 'y'
+
+  interface ChannelEdge {
+    linkId: string
+    srcCross: number
+    dstCross: number
+    /** Channel indices this edge crosses (sorted ascending). */
+    crossings: number[]
+  }
+  const perChannel = new Map<number, ChannelEdge[]>()
+
+  for (const link of links) {
+    if (!link.id) continue
+    const fromLayer = layers.layerOf.get(link.from.node)
+    const toLayer = layers.layerOf.get(link.to.node)
+    if (fromLayer === undefined || toLayer === undefined) continue
+    if (fromLayer === toLayer) continue // intra-layer edges (HA etc.) skip channel routing
+
+    const fromPort = ports.get(`${link.from.node}:${link.from.port}`)
+    const toPort = ports.get(`${link.to.node}:${link.to.port}`)
+    if (!fromPort || !toPort) continue
+    const srcCross = crossAxis === 'x' ? fromPort.absolutePosition.x : fromPort.absolutePosition.y
+    const dstCross = crossAxis === 'x' ? toPort.absolutePosition.x : toPort.absolutePosition.y
+
+    const [low, high] = fromLayer < toLayer ? [fromLayer, toLayer] : [toLayer, fromLayer]
+    const crossings: number[] = []
+    for (let k = low; k < high; k++) crossings.push(k)
+
+    const entry: ChannelEdge = { linkId: link.id, srcCross, dstCross, crossings }
+    for (const k of crossings) {
+      const list = perChannel.get(k) ?? []
+      list.push(entry)
+      perChannel.set(k, list)
+    }
+  }
+
+  // For each channel, sort by stable key and assign a lane.
+  const rankCoordByEdgeAndChannel = new Map<string, Map<number, number>>()
+  for (const channel of channels) {
+    const edges = perChannel.get(channel.index)
+    if (!edges || edges.length === 0) continue
+    edges.sort((a, b) => {
+      if (a.srcCross !== b.srcCross) return a.srcCross - b.srcCross
+      if (a.dstCross !== b.dstCross) return a.dstCross - b.dstCross
+      return a.linkId.localeCompare(b.linkId)
+    })
+    const span = channel.rankEnd - channel.rankStart
+    const count = edges.length
+    for (const [i, edge] of edges.entries()) {
+      const lane = channel.rankStart + ((i + 1) * span) / (count + 1)
+      const map = rankCoordByEdgeAndChannel.get(edge.linkId) ?? new Map<number, number>()
+      map.set(channel.index, lane)
+      rankCoordByEdgeAndChannel.set(edge.linkId, map)
+    }
+  }
+
+  // Materialise per-link checkpoint lists (ordered by channel index).
+  for (const link of links) {
+    if (!link.id) continue
+    const fromLayer = layers.layerOf.get(link.from.node)
+    const toLayer = layers.layerOf.get(link.to.node)
+    if (fromLayer === undefined || toLayer === undefined) continue
+    if (fromLayer === toLayer) continue
+    const map = rankCoordByEdgeAndChannel.get(link.id)
+    if (!map) continue
+    const [low, high] = fromLayer < toLayer ? [fromLayer, toLayer] : [toLayer, fromLayer]
+    const channelIndices: number[] = []
+    const rankCoords: number[] = []
+    // If the edge runs "high → low" (e.g. flipped direction), emit
+    // the checkpoints in the order the route walks them, so libavoid
+    // visits them sequentially.
+    const order = fromLayer < toLayer ? 1 : -1
+    if (order === 1) {
+      for (let k = low; k < high; k++) {
+        const lane = map.get(k)
+        if (lane === undefined) continue
+        channelIndices.push(k)
+        rankCoords.push(lane)
+      }
+    } else {
+      for (let k = high - 1; k >= low; k--) {
+        const lane = map.get(k)
+        if (lane === undefined) continue
+        channelIndices.push(k)
+        rankCoords.push(lane)
+      }
+    }
+    if (rankCoords.length > 0) {
+      result.set(link.id, { channelIndices, rankCoords })
+    }
+  }
+
+  return result
+}
+
+/**
+ * Turn a (rankCoord, port positions, rankAxis) tuple into the
+ * concrete (x, y) point that goes to libavoid as a routing
+ * checkpoint. The non-rank axis lands on whichever side of the
+ * source port is closer to the destination — keeps the bend
+ * geometry symmetric instead of pushing the route long-ways.
+ */
+export function checkpointFromLane(
+  rankCoord: number,
+  fromPort: ResolvedPort,
+  toPort: ResolvedPort,
+  rankAxis: 'x' | 'y',
+): Position {
+  if (rankAxis === 'y') {
+    // TB / BT: rank coord is the Y; X lives halfway between the two
+    // ports so libavoid bends near the middle of the horizontal span.
+    return { x: (fromPort.absolutePosition.x + toPort.absolutePosition.x) / 2, y: rankCoord }
+  }
+  return { x: rankCoord, y: (fromPort.absolutePosition.y + toPort.absolutePosition.y) / 2 }
+}

--- a/libs/@shumoku/core/src/layout/layer-detection.test.ts
+++ b/libs/@shumoku/core/src/layout/layer-detection.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import type { Node } from '../models/types.js'
+import { channelsFromLayers, detectLayers } from './layer-detection.js'
+
+function n(id: string, x: number, y: number, shape: 'rounded' = 'rounded' as const): Node {
+  return { id, label: id, shape, position: { x, y } }
+}
+
+describe('detectLayers', () => {
+  it('groups nodes sharing the same y coord into one layer (TB)', () => {
+    const nodes = new Map([
+      ['a', n('a', 100, 100)],
+      ['b', n('b', 300, 100)],
+      ['c', n('c', 500, 100)],
+      ['d', n('d', 200, 300)],
+      ['e', n('e', 400, 300)],
+    ])
+    const { layerOf, layers, rankAxis } = detectLayers(nodes, 'TB')
+    expect(rankAxis).toBe('y')
+    expect(layers.length).toBe(2)
+    expect(layers[0]?.nodes.sort()).toEqual(['a', 'b', 'c'])
+    expect(layers[1]?.nodes.sort()).toEqual(['d', 'e'])
+    expect(layerOf.get('a')).toBe(0)
+    expect(layerOf.get('d')).toBe(1)
+  })
+
+  it('orders layers by ascending rank (top → bottom in TB)', () => {
+    const nodes = new Map([
+      ['top', n('top', 0, 50)],
+      ['mid', n('mid', 0, 250)],
+      ['bot', n('bot', 0, 450)],
+    ])
+    const { layers } = detectLayers(nodes, 'TB')
+    expect(layers.map((l) => l.rankCentre)).toEqual([50, 250, 450])
+  })
+
+  it('uses X axis as rank axis in LR layouts', () => {
+    const nodes = new Map([
+      ['a', n('a', 100, 0)],
+      ['b', n('b', 100, 200)],
+      ['c', n('c', 300, 100)],
+    ])
+    const { rankAxis, layers, layerOf } = detectLayers(nodes, 'LR')
+    expect(rankAxis).toBe('x')
+    expect(layers.length).toBe(2)
+    expect(layerOf.get('a')).toBe(0)
+    expect(layerOf.get('b')).toBe(0)
+    expect(layerOf.get('c')).toBe(1)
+  })
+
+  it('skips nodes without a position', () => {
+    const nodes = new Map<string, Node>([
+      ['placed', n('placed', 0, 100)],
+      ['unplaced', { id: 'unplaced', label: 'X', shape: 'rounded' }],
+    ])
+    const { layerOf, layers } = detectLayers(nodes, 'TB')
+    expect(layers.length).toBe(1)
+    expect(layerOf.has('unplaced')).toBe(false)
+    expect(layerOf.get('placed')).toBe(0)
+  })
+
+  it('tolerates a 1px rounding difference within a layer', () => {
+    const nodes = new Map([
+      ['a', n('a', 100, 100)],
+      ['b', n('b', 200, 100.4)],
+    ])
+    const { layers } = detectLayers(nodes, 'TB')
+    expect(layers.length).toBe(1)
+  })
+
+  it('inflates layer rank bounds with node halves', () => {
+    // Two nodes at y=100; default size is 180w x 60h, so half-height
+    // is 30 → rankStart should be 70, rankEnd 130.
+    const nodes = new Map([
+      ['a', n('a', 0, 100)],
+      ['b', n('b', 200, 100)],
+    ])
+    const { layers } = detectLayers(nodes, 'TB')
+    expect(layers[0]?.rankStart).toBe(70)
+    expect(layers[0]?.rankEnd).toBe(130)
+  })
+})
+
+describe('channelsFromLayers', () => {
+  it('returns a channel for every adjacent layer pair', () => {
+    const layers = [
+      { index: 0, rankStart: 0, rankEnd: 100, rankCentre: 50, nodes: [] },
+      { index: 1, rankStart: 200, rankEnd: 300, rankCentre: 250, nodes: [] },
+      { index: 2, rankStart: 400, rankEnd: 500, rankCentre: 450, nodes: [] },
+    ]
+    const channels = channelsFromLayers(layers, 0)
+    expect(channels.length).toBe(2)
+    expect(channels[0]).toMatchObject({ index: 0, rankStart: 100, rankEnd: 200 })
+    expect(channels[1]).toMatchObject({ index: 1, rankStart: 300, rankEnd: 400 })
+  })
+
+  it('inflates clearance away from both layer edges', () => {
+    const layers = [
+      { index: 0, rankStart: 0, rankEnd: 100, rankCentre: 50, nodes: [] },
+      { index: 1, rankStart: 200, rankEnd: 300, rankCentre: 250, nodes: [] },
+    ]
+    const channels = channelsFromLayers(layers, 10)
+    expect(channels[0]).toMatchObject({ rankStart: 110, rankEnd: 190 })
+  })
+
+  it('drops channels where clearance eats the entire gap', () => {
+    const layers = [
+      { index: 0, rankStart: 0, rankEnd: 100, rankCentre: 50, nodes: [] },
+      { index: 1, rankStart: 105, rankEnd: 200, rankCentre: 150, nodes: [] },
+    ]
+    const channels = channelsFromLayers(layers, 10)
+    expect(channels.length).toBe(0)
+  })
+
+  it('returns empty for a single-layer graph', () => {
+    const layers = [{ index: 0, rankStart: 0, rankEnd: 100, rankCentre: 50, nodes: [] }]
+    expect(channelsFromLayers(layers, 0)).toEqual([])
+  })
+})

--- a/libs/@shumoku/core/src/layout/layer-detection.ts
+++ b/libs/@shumoku/core/src/layout/layer-detection.ts
@@ -1,0 +1,143 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Reconstructs Sugiyama layer info from positioned nodes.
+ *
+ * The Sugiyama pipeline (`layoutFlat` / `layoutCompound`) drops its
+ * internal `layerOf` map once it has converted layers to coordinates,
+ * so consumers downstream — like the channel-based edge router below
+ * — would have to either thread the layer info through every call
+ * site or rebuild it from the geometry. Rebuilding is much cheaper
+ * (it's a one-pass sort + cluster), keeps the public layout API
+ * unchanged, and works equally well for nodes inside a nested
+ * subgraph (each container's layers share the same y in TB).
+ *
+ * The clustering relies on Sugiyama's invariant: every node in a
+ * layer is centred on the layer's coordinate. Two nodes at the same
+ * layer therefore have identical centre coordinates on the rank
+ * axis (modulo float rounding); two nodes on different layers are
+ * separated by at least one inter-layer gap.
+ */
+import type { Direction, Node } from '../models/types.js'
+import { computeNodeSize } from './network-layout.js'
+
+/** Rank-axis info per detected layer, indexed 0 = lowest rank value. */
+export interface LayerInfo {
+  /** Index of this layer (0 = top-most in TB / leftmost in LR). */
+  index: number
+  /** Lowest rank-axis edge of any node in this layer (inflated by node halves). */
+  rankStart: number
+  /** Highest rank-axis edge of any node in this layer. */
+  rankEnd: number
+  /** Centre coordinate on the rank axis (the y for TB, the x for LR). */
+  rankCentre: number
+  /** Node ids in this layer (no particular order). */
+  nodes: string[]
+}
+
+export interface LayerDetectionResult {
+  /** Per-node layer index. Nodes with no position are absent. */
+  layerOf: Map<string, number>
+  /** Each layer's geometry, ordered by ascending rank. */
+  layers: LayerInfo[]
+  /** Which axis the layers stack along ('y' for TB/BT, 'x' for LR/RL). */
+  rankAxis: 'x' | 'y'
+}
+
+/**
+ * Cluster positioned nodes into Sugiyama layers.
+ *
+ * Tolerance is set to 1px on the centre coordinate — Sugiyama puts
+ * every node in a layer at the same centre coord, so anything bigger
+ * than rounding error indicates a different layer.
+ */
+export function detectLayers(nodes: Map<string, Node>, direction: Direction): LayerDetectionResult {
+  const rankAxis: 'x' | 'y' = direction === 'TB' || direction === 'BT' ? 'y' : 'x'
+
+  interface Entry {
+    id: string
+    rank: number
+    halfRank: number
+  }
+  const entries: Entry[] = []
+  for (const [id, n] of nodes) {
+    if (!n.position) continue
+    const size = computeNodeSize(n)
+    const rank = rankAxis === 'y' ? n.position.y : n.position.x
+    const halfRank = rankAxis === 'y' ? size.height / 2 : size.width / 2
+    entries.push({ id, rank, halfRank })
+  }
+  entries.sort((a, b) => a.rank - b.rank)
+
+  const layers: LayerInfo[] = []
+  const layerOf = new Map<string, number>()
+  let current: Entry[] = []
+  const TOLERANCE = 1
+  for (const e of entries) {
+    if (current.length === 0) {
+      current.push(e)
+      continue
+    }
+    const ref = current[0]
+    if (ref !== undefined && Math.abs(e.rank - ref.rank) <= TOLERANCE) {
+      current.push(e)
+    } else {
+      layers.push(buildLayer(layers.length, current, layerOf))
+      current = [e]
+    }
+  }
+  if (current.length > 0) layers.push(buildLayer(layers.length, current, layerOf))
+
+  return { layerOf, layers, rankAxis }
+}
+
+function buildLayer(
+  index: number,
+  entries: Array<{ id: string; rank: number; halfRank: number }>,
+  layerOf: Map<string, number>,
+): LayerInfo {
+  let rankStart = Number.POSITIVE_INFINITY
+  let rankEnd = Number.NEGATIVE_INFINITY
+  let centreSum = 0
+  const nodeIds: string[] = []
+  for (const e of entries) {
+    layerOf.set(e.id, index)
+    rankStart = Math.min(rankStart, e.rank - e.halfRank)
+    rankEnd = Math.max(rankEnd, e.rank + e.halfRank)
+    centreSum += e.rank
+    nodeIds.push(e.id)
+  }
+  const rankCentre = entries.length > 0 ? centreSum / entries.length : 0
+  return { index, rankStart, rankEnd, rankCentre, nodes: nodeIds }
+}
+
+/**
+ * Inter-layer "channel" geometry — the empty corridor between two
+ * adjacent layers where bend segments may live. Both inflated edges
+ * exclude `clearance` so segments routed right at the boundary still
+ * have a small visual breathing room from the nodes.
+ */
+export interface Channel {
+  /** Lower-rank layer index. The channel sits between layers `index`
+   *  and `index + 1`. */
+  index: number
+  /** Inflated rank-axis lower bound (top side in TB). */
+  rankStart: number
+  /** Inflated rank-axis upper bound (bottom side in TB). */
+  rankEnd: number
+}
+
+export function channelsFromLayers(layers: LayerInfo[], clearance = 8): Channel[] {
+  const out: Channel[] = []
+  for (let i = 0; i < layers.length - 1; i++) {
+    const a = layers[i]
+    const b = layers[i + 1]
+    if (!a || !b) continue
+    const rankStart = a.rankEnd + clearance
+    const rankEnd = b.rankStart - clearance
+    if (rankEnd <= rankStart) continue
+    out.push({ index: i, rankStart, rankEnd })
+  }
+  return out
+}

--- a/libs/@shumoku/core/src/layout/libavoid-router.ts
+++ b/libs/@shumoku/core/src/layout/libavoid-router.ts
@@ -9,7 +9,9 @@
  * Pins ensure lines exit/enter ports perpendicularly.
  */
 
-import type { Link, Node, Position } from '../models/types.js'
+import type { Direction, Link, Node, Position } from '../models/types.js'
+import { assignChannelLanes, checkpointFromLane, type LaneAssignment } from './channel-routing.js'
+import { channelsFromLayers, detectLayers } from './layer-detection.js'
 import { getLinkWidth } from './link-utils.js'
 import { computeNodeSize } from './network-layout.js'
 import type { ResolvedEdge, ResolvedPort } from './resolved-types.js'
@@ -60,6 +62,14 @@ export interface LibavoidRoutingOptions {
   edgeStyle?: 'orthogonal' | 'polyline' | 'straight'
   shapeBufferDistance?: number
   idealNudgingDistance?: number
+  /**
+   * Layout flow direction. Used to detect Sugiyama layers from node
+   * positions so multi-edge bus segments crossing the same layer
+   * boundary can be spread evenly across the inter-layer channel
+   * with stable per-edge lane ordinals (no twitching on node drag).
+   * Defaults to `'TB'`.
+   */
+  direction?: Direction
 }
 
 export async function routeEdges(
@@ -74,6 +84,7 @@ export async function routeEdges(
     edgeStyle: 'orthogonal' as const,
     shapeBufferDistance: 10,
     idealNudgingDistance: 20,
+    direction: 'TB' as Direction,
     ...options,
   }
 
@@ -110,7 +121,7 @@ export async function routeEdges(
   router.setRoutingOption(Avoid['RoutingOption']['nudgeSharedPathsWithCommonEndPoint'].value, true)
 
   try {
-    return doRoute(Avoid, router, nodes, ports, links, opts.edgeStyle)
+    return doRoute(Avoid, router, nodes, ports, links, opts.edgeStyle, opts.direction)
   } finally {
     router.delete()
   }
@@ -207,6 +218,10 @@ function createConnectors(
   pinIds: Map<string, number>,
   ports: Map<string, ResolvedPort>,
   links: Link[],
+  /** Per-link channel-routed lane checkpoints. Links not in this map
+   *  fall through to the legacy midpoint checkpoint. */
+  lanes: Map<string, LaneAssignment>,
+  rankAxis: 'x' | 'y',
   // biome-ignore lint/suspicious/noExplicitAny: libavoid ConnRef instances
 ): Map<string, any> {
   // biome-ignore lint/suspicious/noExplicitAny: libavoid ConnRef instances
@@ -242,21 +257,22 @@ function createConnectors(
 
     const conn = new Avoid.ConnRef(router, srcEnd, dstEnd)
 
-    // One checkpoint anchored on the destination port's outward
-    // axis, halfway between the dest port and the source port. The
-    // earlier version offset by a fixed 20px from the dest port,
-    // which pushed the perpendicular bend right next to the
-    // destination — fine when the dest sat on the AP row (bend
-    // ended up between AP and access-switch layers, looked clean)
-    // but wrong when the user's placement override put the dest on
-    // a distribution switch's bottom side (bend ended up just
-    // under the distribution layer, visibly protruding through
-    // switch territory).
-    //
-    // Using midpoint along the dest's perpendicular axis places
-    // the bend in the gap between the two ports, regardless of
-    // which side the user pinned the port to.
-    if (toPortObj?.side && fromPortObj) {
+    // Lane assignment from channel routing: each rank-boundary the
+    // edge crosses gets its own checkpoint at the lane Y (TB) or X
+    // (LR) computed in `assignChannelLanes`. Same input → same
+    // lanes, so dragging one node never shifts another edge's bend.
+    const lane = link.id ? lanes.get(link.id) : undefined
+    if (lane && lane.rankCoords.length > 0) {
+      const cpVec = new Avoid.CheckpointVector()
+      for (const rankCoord of lane.rankCoords) {
+        const cp = checkpointFromLane(rankCoord, fromPortObj, toPortObj, rankAxis)
+        cpVec.push_back(new Avoid.Checkpoint(new Avoid.Point(cp.x, cp.y)))
+      }
+      conn.setRoutingCheckpoints(cpVec)
+    } else if (toPortObj?.side && fromPortObj) {
+      // Legacy midpoint fallback for edges without a lane — intra-
+      // layer / HA edges, or anything where `assignChannelLanes`
+      // didn't return an entry (missing port, malformed layer info).
       const side = toPortObj.side
       const dp = toPortObj.absolutePosition
       const sp = fromPortObj.absolutePosition
@@ -358,10 +374,30 @@ function doRoute(
   ports: Map<string, ResolvedPort>,
   links: Link[],
   edgeStyle: string,
+  direction: Direction,
 ): Map<string, ResolvedEdge> {
+  // Channel-based lane assignment: detect Sugiyama layers from
+  // node positions, build channels between them, and give every
+  // multi-layer edge a deterministic lane within each channel it
+  // crosses. The resulting checkpoints replace the legacy single
+  // midpoint, which packed dozens of edges onto the same Y when
+  // many edges crossed one layer boundary.
+  const layers = detectLayers(nodes, direction)
+  const channels = channelsFromLayers(layers.layers)
+  const lanes = assignChannelLanes(links, ports, layers, channels, direction)
+
   const shapeRefs = registerObstacles(Avoid, router, nodes)
   const pinIds = registerPins(Avoid, shapeRefs, nodes, ports)
-  const connRefs = createConnectors(Avoid, router, shapeRefs, pinIds, ports, links)
+  const connRefs = createConnectors(
+    Avoid,
+    router,
+    shapeRefs,
+    pinIds,
+    ports,
+    links,
+    lanes,
+    layers.rankAxis,
+  )
   const edges = extractEdges(connRefs, ports, links, edgeStyle)
   const spread = spreadOverlappingSegments(edges)
   return filletEdgeCorners(spread)

--- a/libs/@shumoku/core/src/layout/unified-engine.ts
+++ b/libs/@shumoku/core/src/layout/unified-engine.ts
@@ -45,6 +45,7 @@ export async function computeNetworkLayout(graph: NetworkGraph): Promise<{
   const { nodes, ports, subgraphs, bounds } = layoutNetwork(graph, { direction })
   const edges = await routeEdges(nodes, ports, graph.links, {
     edgeStyle: edgeStyle === 'splines' ? 'polyline' : edgeStyle,
+    direction,
   })
 
   const resolved: ResolvedLayout = {


### PR DESCRIPTION
Closes #222.

## Problem (recap from #222)

\`spreadOverlappingSegments\` post-process treats geometric overlap as the stable entity. Two failure modes:

1. **Density** — when 20+ edges cross the same Sugiyama layer transition, pairwise 4px nudging compresses them into a ~50px band, producing a "wall of bends" that's unreadable.
2. **Instability** — cluster membership recomputes from runtime overlap ranges, so dragging one node shifts overlaps → reshuffles clusters → reassigns every member's lane. The whole diagram twitches on each drag.

Tried in the PR before this one: Union-Find cluster + even distribution. Reverted — overflowed into node rows and was still unstable.

## Approach

Plan around layer topology, not segment geometry. Codex / yFiles / Wybrow et al. all converge on this: the stable entity is "edge E crosses rank boundary K," not "these segments share a fixed coord right now."

Pipeline:

1. **\`detectLayers(nodes, direction)\`** — cluster positioned nodes by rank-axis centre coordinate. Sugiyama puts every node in a layer at the same centre, so 1px tolerance recovers \`layerOf\` without plumbing internal state out of \`layoutCompound\`.
2. **\`channelsFromLayers(layers, clearance)\`** — each adjacent layer pair becomes a corridor with \`[rankStart, rankEnd]\` bounds. Inflated by \`clearance\` (default 8px) so segments stay off the actual node rows.
3. **\`assignChannelLanes(links, ports, layers, channels, direction)\`** — for every link crossing k rank boundaries, allocate a lane in each of those k channels. Sort key: source cross-axis coord → target cross-axis coord → link id. The result is a \`Map<linkId, LaneAssignment>\` listing rank-axis coordinates per channel.
4. **Pass to libavoid** as a \`CheckpointVector\` — one checkpoint per crossed boundary at the assigned coord. libavoid still does node-obstacle avoidance, but the bend Y / X is no longer its choice.

## Properties

| | Old | New |
|---|---|---|
| Density (21 edges, one transition) | y=1040–1080 (50px band) | y=940–1180 (240px channel, ~14px lane) |
| Stability under single-node drag | All 48 other edges' bends snap to new Y | All 48 unchanged |
| Node overflow | Possible (no layer knowledge) | Impossible (lanes ∈ channel bounds) |
| Axis symmetry | TB-only tuning | Same code TB / BT / LR / RL |
| Backward compat | n/a | Edges without layer mapping fall through to legacy midpoint checkpoint |

## Files

- \`libs/@shumoku/core/src/layout/layer-detection.ts\` + 11 tests
- \`libs/@shumoku/core/src/layout/channel-routing.ts\` + 8 tests
- \`libs/@shumoku/core/src/layout/libavoid-router.ts\` — wire lanes into \`createConnectors\` as checkpoints
- \`libs/@shumoku/core/src/layout/unified-engine.ts\` — thread \`direction\` to \`routeEdges\`

## Test plan

- [x] 157/157 core tests pass (was 138, +19 new)
- [x] Real project (49 links, 6 layers): bends evenly distributed across channels
- [x] Snapshot test: move one AP horizontally → 48/49 other edges' bend Y unchanged
- [ ] LR direction sanity check (manual, in editor settings)
- [ ] Edges spanning 2+ rank boundaries (long uplinks) routed through both channels

## Out of scope

- Edge subsetting on drag (only reroute edges touching the dragged node) — perf optimisation, separate.
- Lane-aware ordering within source/dest port placement (currently driven by peer position; could re-use the same rank ordering to keep cable bundles "fanned out" at port-bank level too).
- Bus / orthogonal-edge bundling (merge parallel edges with shared endpoints into one drawn line).