### PR TITLE
fix(core): bend ordering + leaf clustering for network layout

### DIFF
--- a/libs/@shumoku/core/src/layout/channel-routing.test.ts
+++ b/libs/@shumoku/core/src/layout/channel-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { Link } from '../models/types.js'
+import type { Link, Node } from '../models/types.js'
 import { assignChannelLanes, checkpointFromLane } from './channel-routing.js'
 import type { Channel, LayerDetectionResult } from './layer-detection.js'
 import type { ResolvedPort } from './resolved-types.js'
@@ -21,6 +21,24 @@ function port(
   }
 }
 
+/** Build a minimal Node map from port positions — the channel router
+ *  reads node centres to group fan-out edges, so every test needs at
+ *  least a position per node id. The y is irrelevant for our TB tests
+ *  (the router uses crossAxis = x); we just need a defined position. */
+function nodesFromPorts(ports: Map<string, ResolvedPort>): Map<string, Node> {
+  const nodes = new Map<string, Node>()
+  for (const p of ports.values()) {
+    if (nodes.has(p.nodeId)) continue
+    nodes.set(p.nodeId, {
+      id: p.nodeId,
+      label: p.nodeId,
+      shape: 'rounded',
+      position: { x: p.absolutePosition.x, y: p.absolutePosition.y },
+    })
+  }
+  return nodes
+}
+
 function buildLayers(
   spec: Array<{ nodes: string[]; rankStart: number; rankEnd: number; rankCentre: number }>,
 ): LayerDetectionResult {
@@ -33,9 +51,10 @@ function buildLayers(
 }
 
 describe('assignChannelLanes', () => {
-  it('puts each edge in its own lane, sorted by source X (stable order)', () => {
-    // Three switches at top (y=100), three APs at bottom (y=400)
-    // Edges declared in REVERSE peer-x order to exercise sorting.
+  it('groups by source x; within a source, far peers get shallower lanes than near peers', () => {
+    // Three switches at top (y=100), three APs at bottom (y=400).
+    // Each switch fans to its OWN AP at matching x, so distances are
+    // all zero — the outer source-x ordering decides lane Y.
     const layers = buildLayers([
       { nodes: ['sw-l', 'sw-m', 'sw-r'], rankStart: 80, rankEnd: 120, rankCentre: 100 },
       { nodes: ['ap-l', 'ap-m', 'ap-r'], rankStart: 380, rankEnd: 420, rankCentre: 400 },
@@ -54,16 +73,42 @@ describe('assignChannelLanes', () => {
       { id: 'link-l', from: { node: 'sw-l', port: 'p' }, to: { node: 'ap-l', port: 'p' } },
       { id: 'link-m', from: { node: 'sw-m', port: 'p' }, to: { node: 'ap-m', port: 'p' } },
     ]
-
-    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    const result = assignChannelLanes(links, nodesFromPorts(ports), ports, layers, channels, 'TB')
     const l = result.get('link-l')?.rankCoords[0]
     const m = result.get('link-m')?.rankCoords[0]
     const r = result.get('link-r')?.rankCoords[0]
-    expect(l).toBeDefined()
-    expect(m).toBeDefined()
-    expect(r).toBeDefined()
-    expect(l).toBeLessThan(m as number) // left-source edge gets the first (smallest) lane Y
+    expect(l).toBeLessThan(m as number)
     expect(m).toBeLessThan(r as number)
+  })
+
+  it('fan-out: same source, far targets bend at shallower lanes than near targets', () => {
+    // One switch at x=500, three APs scattered left/right.
+    // Distances: ap-near at x=480 (Δ=20), ap-mid at x=300 (Δ=200), ap-far at x=900 (Δ=400).
+    // Expected lane order (low → high rank coord): ap-far, ap-mid, ap-near.
+    const layers = buildLayers([
+      { nodes: ['sw'], rankStart: 80, rankEnd: 120, rankCentre: 100 },
+      { nodes: ['ap-far', 'ap-mid', 'ap-near'], rankStart: 380, rankEnd: 420, rankCentre: 400 },
+    ])
+    const channels: Channel[] = [{ index: 0, rankStart: 130, rankEnd: 370 }]
+    const ports = new Map<string, ResolvedPort>([
+      ['sw:a', port('sw:a', 'sw', 500, 120)],
+      ['sw:b', port('sw:b', 'sw', 500, 120)],
+      ['sw:c', port('sw:c', 'sw', 500, 120)],
+      ['ap-far:p', port('ap-far:p', 'ap-far', 900, 380)],
+      ['ap-mid:p', port('ap-mid:p', 'ap-mid', 300, 380)],
+      ['ap-near:p', port('ap-near:p', 'ap-near', 480, 380)],
+    ])
+    const links: Link[] = [
+      { id: 'near', from: { node: 'sw', port: 'a' }, to: { node: 'ap-near', port: 'p' } },
+      { id: 'mid', from: { node: 'sw', port: 'b' }, to: { node: 'ap-mid', port: 'p' } },
+      { id: 'far', from: { node: 'sw', port: 'c' }, to: { node: 'ap-far', port: 'p' } },
+    ]
+    const result = assignChannelLanes(links, nodesFromPorts(ports), ports, layers, channels, 'TB')
+    const farY = result.get('far')?.rankCoords[0] as number
+    const midY = result.get('mid')?.rankCoords[0] as number
+    const nearY = result.get('near')?.rankCoords[0] as number
+    expect(farY).toBeLessThan(midY) // far peels off first (shallow lane = small Y in TB)
+    expect(midY).toBeLessThan(nearY) // near stays deep
   })
 
   it('spreads lanes evenly within the channel span', () => {
@@ -86,7 +131,7 @@ describe('assignChannelLanes', () => {
       { id: 'by', from: { node: 'b', port: 'p' }, to: { node: 'y', port: 'p' } },
       { id: 'cz', from: { node: 'c', port: 'p' }, to: { node: 'z', port: 'p' } },
     ]
-    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    const result = assignChannelLanes(links, nodesFromPorts(ports), ports, layers, channels, 'TB')
     expect(result.get('ax')?.rankCoords[0]).toBe(190)
     expect(result.get('by')?.rankCoords[0]).toBe(250)
     expect(result.get('cz')?.rankCoords[0]).toBe(310)
@@ -106,7 +151,7 @@ describe('assignChannelLanes', () => {
     const links: Link[] = [
       { id: 'flip', from: { node: 'lo', port: 'p' }, to: { node: 'hi', port: 'p' } },
     ]
-    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    const result = assignChannelLanes(links, nodesFromPorts(ports), ports, layers, channels, 'TB')
     expect(result.get('flip')?.channelIndices).toEqual([0])
   })
 
@@ -127,7 +172,7 @@ describe('assignChannelLanes', () => {
     const links: Link[] = [
       { id: 'long', from: { node: 'top', port: 'p' }, to: { node: 'bot', port: 'p' } },
     ]
-    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    const result = assignChannelLanes(links, nodesFromPorts(ports), ports, layers, channels, 'TB')
     expect(result.get('long')?.channelIndices).toEqual([0, 1])
     expect(result.get('long')?.rankCoords.length).toBe(2)
   })
@@ -143,7 +188,7 @@ describe('assignChannelLanes', () => {
     const links: Link[] = [
       { id: 'ha', from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'p' }, redundancy: 'ha' },
     ]
-    const result = assignChannelLanes(links, ports, layers, [], 'TB')
+    const result = assignChannelLanes(links, nodesFromPorts(ports), ports, layers, [], 'TB')
     expect(result.has('ha')).toBe(false)
   })
 
@@ -157,7 +202,7 @@ describe('assignChannelLanes', () => {
     const links: Link[] = [
       { id: 'bad', from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'missing' } },
     ]
-    const result = assignChannelLanes(links, ports, layers, channels, 'TB')
+    const result = assignChannelLanes(links, nodesFromPorts(ports), ports, layers, channels, 'TB')
     expect(result.has('bad')).toBe(false)
   })
 
@@ -177,8 +222,8 @@ describe('assignChannelLanes', () => {
       { id: 'l1', from: { node: 'a', port: 'p1' }, to: { node: 'b', port: 'p' } },
       { id: 'l2', from: { node: 'a', port: 'p2' }, to: { node: 'c', port: 'p' } },
     ]
-    const r1 = assignChannelLanes(links, ports, layers, channels, 'TB')
-    const r2 = assignChannelLanes(links, ports, layers, channels, 'TB')
+    const r1 = assignChannelLanes(links, nodesFromPorts(ports), ports, layers, channels, 'TB')
+    const r2 = assignChannelLanes(links, nodesFromPorts(ports), ports, layers, channels, 'TB')
     expect(r1.get('l1')?.rankCoords).toEqual(r2.get('l1')?.rankCoords)
     expect(r1.get('l2')?.rankCoords).toEqual(r2.get('l2')?.rankCoords)
   })

--- a/libs/@shumoku/core/src/layout/channel-routing.ts
+++ b/libs/@shumoku/core/src/layout/channel-routing.ts
@@ -30,7 +30,7 @@
  * single checkpoint at the channel midpoint of their assigned lane.
  */
 
-import type { Direction, Link, Position } from '../models/types.js'
+import type { Direction, Link, Node, Position } from '../models/types.js'
 import type { Channel, LayerDetectionResult } from './layer-detection.js'
 import type { ResolvedPort } from './resolved-types.js'
 
@@ -52,15 +52,29 @@ export interface LaneAssignment {
  * be located in the layer map are absent (caller falls back to
  * un-channelled routing for those).
  *
- * Sort order within a channel: by source-end cross-axis coordinate,
- * then by target-end cross-axis coordinate, then by stable hash of
- * the link id. Source order is the primary key because Sugiyama
- * already minimised crossings along the cross axis when it ordered
- * each layer — going through the same order in each channel keeps
- * the bus visually "fanned out" instead of weaving.
+ * Sort order within a channel:
+ *
+ *   1. **Source cross-axis coordinate** (ascending) — groups edges
+ *      coming from the same source switch contiguously and keeps
+ *      the global left-to-right reading order Sugiyama already
+ *      established for its layers.
+ *   2. **Distance from source to target** (descending, within a
+ *      source group) — for a switch fanning out to multiple peers,
+ *      this puts the FARTHEST peer at the shallowest lane (just
+ *      below the source) and the CLOSEST peer at the deepest lane
+ *      (just above the target row). Visually the route turns into
+ *      a tree silhouette with the trunk anchored under the source
+ *      as long as possible, instead of all lines weaving past each
+ *      other. The closest-first order produced a bend right next to
+ *      the source for the closest target, which forced every other
+ *      cable to cross over it on the way out.
+ *   3. **Target cross-axis coordinate** (ascending) — tie-break for
+ *      same-source same-distance edges; reads left-to-right.
+ *   4. **Link id** (string compare) — final deterministic tiebreak.
  */
 export function assignChannelLanes(
   links: readonly Link[],
+  nodes: Map<string, Node>,
   ports: Map<string, ResolvedPort>,
   layers: LayerDetectionResult,
   channels: Channel[],
@@ -72,8 +86,24 @@ export function assignChannelLanes(
 
   const crossAxis: 'x' | 'y' = layers.rankAxis === 'y' ? 'x' : 'y'
 
+  /** Cross-axis coord of a node's CENTRE — used to group fan-out
+   *  edges by their source node. Falls back to 0 if the node has
+   *  no position (shouldn't happen at routing time but be safe). */
+  const nodeCenter = (nodeId: string): number => {
+    const n = nodes.get(nodeId)
+    const p = n?.position
+    if (!p) return 0
+    return crossAxis === 'x' ? p.x : p.y
+  }
+
   interface ChannelEdge {
     linkId: string
+    /** Source NODE centre cross-axis coord — groups all fan-out
+     *  edges from the same node into a single sort cluster. The
+     *  port coord (`srcCross`) varies per port, which would split
+     *  one fan-out into several "groups" of size 1 and disable the
+     *  same-source far-first rule. */
+    srcNodeCross: number
     srcCross: number
     dstCross: number
     /** Channel indices this edge crosses (sorted ascending). */
@@ -93,12 +123,17 @@ export function assignChannelLanes(
     if (!fromPort || !toPort) continue
     const srcCross = crossAxis === 'x' ? fromPort.absolutePosition.x : fromPort.absolutePosition.y
     const dstCross = crossAxis === 'x' ? toPort.absolutePosition.x : toPort.absolutePosition.y
+    // Pick the "upstream" node (lower rank) for fan-out grouping —
+    // a switch's downstream APs all share the switch's centre as
+    // their srcNodeCross even if the link is declared reversed.
+    const srcNodeId = fromLayer < toLayer ? link.from.node : link.to.node
+    const srcNodeCross = nodeCenter(srcNodeId)
 
     const [low, high] = fromLayer < toLayer ? [fromLayer, toLayer] : [toLayer, fromLayer]
     const crossings: number[] = []
     for (let k = low; k < high; k++) crossings.push(k)
 
-    const entry: ChannelEdge = { linkId: link.id, srcCross, dstCross, crossings }
+    const entry: ChannelEdge = { linkId: link.id, srcNodeCross, srcCross, dstCross, crossings }
     for (const k of crossings) {
       const list = perChannel.get(k) ?? []
       list.push(entry)
@@ -112,8 +147,18 @@ export function assignChannelLanes(
     const edges = perChannel.get(channel.index)
     if (!edges || edges.length === 0) continue
     edges.sort((a, b) => {
-      if (a.srcCross !== b.srcCross) return a.srcCross - b.srcCross
+      // Primary: source NODE x — groups same-source fan-outs together
+      // and keeps overall left-to-right reading order.
+      if (a.srcNodeCross !== b.srcNodeCross) return a.srcNodeCross - b.srcNodeCross
+      // Within one fan-out, far peers branch off at shallower lanes
+      // (Codex / yFiles convention). Distance measured against the
+      // source node's centre, not the port, so paired ports on the
+      // same node don't fight for the same priority.
+      const aDist = Math.abs(a.dstCross - a.srcNodeCross)
+      const bDist = Math.abs(b.dstCross - b.srcNodeCross)
+      if (aDist !== bDist) return bDist - aDist
       if (a.dstCross !== b.dstCross) return a.dstCross - b.dstCross
+      if (a.srcCross !== b.srcCross) return a.srcCross - b.srcCross
       return a.linkId.localeCompare(b.linkId)
     })
     const span = channel.rankEnd - channel.rankStart

--- a/libs/@shumoku/core/src/layout/libavoid-router.ts
+++ b/libs/@shumoku/core/src/layout/libavoid-router.ts
@@ -384,7 +384,7 @@ function doRoute(
   // many edges crossed one layer boundary.
   const layers = detectLayers(nodes, direction)
   const channels = channelsFromLayers(layers.layers)
-  const lanes = assignChannelLanes(links, ports, layers, channels, direction)
+  const lanes = assignChannelLanes(links, nodes, ports, layers, channels, direction)
 
   const shapeRefs = registerObstacles(Avoid, router, nodes)
   const pinIds = registerPins(Avoid, shapeRefs, nodes, ports)

--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -224,14 +224,57 @@ function flowSides(direction: 'TB' | 'BT' | 'LR' | 'RL'): { source: Side; dest: 
 }
 
 /**
- * For a single link, decide whether the user-placed port sides
- * disagree with the direction-derived defaults strongly enough to
- * flip the link's layer ordering for layout purposes. Returns
- * `false` (no flip) for perpendicular / HA-side placements — those
- * carry no flow information.
+ * Device types that should always be downstream (leaf side) of any
+ * connection to an intermediate device, regardless of how the link
+ * was declared. APs / IoT / printers / servers usually only have
+ * one uplink and belong visually at the bottom of a TB diagram —
+ * users routinely create `ap → switch` links in input forms and
+ * expect the layout to do the right thing.
+ */
+const LEAF_DEVICE_TYPES: ReadonlySet<string> = new Set([
+  'access-point',
+  'cpe',
+  'server',
+  'database',
+  'console-server',
+])
+
+/**
+ * Device types that anchor at the upstream edge of the network
+ * (WAN side in TB). `Internet` and `Cloud` represent the outside
+ * world and should sit at the top.
+ */
+const UPSTREAM_DEVICE_TYPES: ReadonlySet<string> = new Set(['internet', 'cloud'])
+
+function deviceType(node: Node | undefined): string | undefined {
+  const spec = node?.spec
+  if (!spec) return undefined
+  if (spec.kind === 'hardware' || spec.kind === 'compute') return spec.type
+  return undefined
+}
+
+/**
+ * For a single link, decide whether the layout should swap its
+ * (source, target) pair when feeding Sugiyama. Two signals, in
+ * priority order:
  *
- * The actual `Link.from` / `Link.to` records are not mutated; only
- * the (source, target) pair used to feed Sugiyama is swapped.
+ *   1. **Per-port placement** — if the user has pinned a port to
+ *      the opposite of the direction-derived default (e.g. a
+ *      source port on the dest side in TB), respect that override.
+ *      This is the manual escape hatch from PR #220.
+ *   2. **Device-type heuristic** — if neither port has an explicit
+ *      placement, look at `Node.spec.type`. A leaf-type endpoint
+ *      (AccessPoint / CPE / Server / Database / ConsoleServer) on
+ *      the `from` side, paired with an intermediate `to`, is the
+ *      "AP → switch" reversal pattern users routinely create
+ *      without realising. Flipping puts the leaf back at the
+ *      downstream layer where network engineers expect it.
+ *      An upstream-type endpoint (Internet / Cloud) on `to`
+ *      similarly flips to keep WAN edges at the top.
+ *
+ * The actual `Link.from` / `Link.to` records are never mutated;
+ * only the (source, target) pair used inside `buildCompoundEdges`
+ * is swapped, so user-facing data stays exactly as authored.
  */
 function shouldFlipForLayout(
   link: NetworkGraph['links'][number],
@@ -243,11 +286,30 @@ function shouldFlipForLayout(
   const toNode = nodes.get(link.to.node)
   const fromSide = fromNode?.ports?.find((p) => p.id === link.from.port)?.placement?.side
   const toSide = toNode?.ports?.find((p) => p.id === link.to.port)?.placement?.side
-  // From port pinned to the dest side → "from" wants to live downstream.
-  // To port pinned to the source side → "to" wants to live upstream.
-  // Either alone is enough to flip; both agreeing also flips (idempotent).
+  // 1. Explicit placement override — wins over everything.
   if (fromSide === sides.dest) return true
   if (toSide === sides.source) return true
+  // Honour the opposite intent too: if either port is pinned to the
+  // expected source/dest side, the link as authored is already
+  // correctly oriented for layout — skip the type-based check so we
+  // never undo a deliberate placement.
+  if (fromSide === sides.source) return false
+  if (toSide === sides.dest) return false
+  // 2. Device-type heuristic. Only flips when both ports are
+  //    placement-neutral, so a single manual pin always wins.
+  const fromType = deviceType(fromNode)
+  const toType = deviceType(toNode)
+  if (fromType && LEAF_DEVICE_TYPES.has(fromType) && toType && !LEAF_DEVICE_TYPES.has(toType)) {
+    return true
+  }
+  if (
+    toType &&
+    UPSTREAM_DEVICE_TYPES.has(toType) &&
+    fromType &&
+    !UPSTREAM_DEVICE_TYPES.has(fromType)
+  ) {
+    return true
+  }
   return false
 }
 

--- a/libs/@shumoku/core/src/layout/sugiyama/layers.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/layers.ts
@@ -4,23 +4,41 @@
 /**
  * Layer assignment for Sugiyama-style layered layout.
  *
- * Given a DAG, assign each node an integer layer index so every edge
- * goes from a lower layer to a higher one. We use the longest-path
- * method: layer(v) = max over all predecessors u of layer(u) + 1.
+ * Two modes:
  *
- * Longest-path is O(V + E), trivially correct, and produces
- * layer-compact layouts for the small-to-medium graphs typical of
- * network topologies. Coffman-Graham or network-simplex would give
- * tighter width bounds but aren't justified here.
+ *  - **ASAP** ("As Soon As Possible") — `layer(v) = max(layer(u)) + 1`
+ *    over predecessors. Each node sits at the *shallowest* layer
+ *    compatible with the DAG. Leaves end up at varying depths
+ *    depending on how long their longest path from a root is.
+ *    Standard Sugiyama default.
  *
- * Disconnected components are all laid out with their longest-path
- * layers starting at 0; the caller can shift or pack them in a later
- * step if needed.
+ *  - **ALAP** ("As Late As Possible") — each node sits at the
+ *    *deepest* layer compatible with the DAG, computed as
+ *    `layer(v) = totalDepth - longestPathToLeaf(v)`. Every leaf
+ *    lands on the bottom row regardless of how it got there, which
+ *    matches what network-engineer users expect from a topology
+ *    diagram (APs at the bottom, ONU at the top, etc.). One
+ *    drawback: edges crossing many ranks become longer; with no
+ *    dummy-node insertion they remain direct straight bends.
+ *
+ * The longest-path implementations are O(V + E); the choice is a
+ * single boolean knob, so we pay nothing for keeping both around.
  */
 
 import type { Edge, LayerAssignment, NodeId } from './types.js'
 
-export function assignLayers(nodes: NodeId[], dag: Edge[]): LayerAssignment {
+export interface AssignLayersOptions {
+  /** 'asap' = leaves spread by depth; 'alap' = all leaves at the
+   *  bottom. Default 'alap' — better suited to network diagrams. */
+  mode?: 'asap' | 'alap'
+}
+
+export function assignLayers(
+  nodes: NodeId[],
+  dag: Edge[],
+  options: AssignLayersOptions = {},
+): LayerAssignment {
+  const mode = options.mode ?? 'alap'
   // Build predecessor list. In a DAG this lets us compute
   // layer(v) = 1 + max(layer(u) for u in preds(v)) via topological order.
   const preds = new Map<NodeId, NodeId[]>()
@@ -64,19 +82,50 @@ export function assignLayers(nodes: NodeId[], dag: Edge[]): LayerAssignment {
     }
   }
 
-  // If topo length < nodes length we have a cycle the caller forgot to
-  // remove — treat remaining nodes as layer 0 rather than crashing.
-  const layerOf = new Map<NodeId, number>()
+  // Forward longest path from any root (ASAP layer).
+  const asap = new Map<NodeId, number>()
   for (const u of topo) {
     let maxPred = -1
     for (const p of preds.get(u) ?? []) {
-      const lp = layerOf.get(p)
+      const lp = asap.get(p)
       if (lp !== undefined && lp > maxPred) maxPred = lp
     }
-    layerOf.set(u, maxPred + 1)
+    asap.set(u, maxPred + 1)
   }
   for (const n of nodes) {
-    if (!layerOf.has(n)) layerOf.set(n, 0)
+    if (!asap.has(n)) asap.set(n, 0)
+  }
+
+  let layerOf: Map<NodeId, number>
+  if (mode === 'alap') {
+    // Reverse longest path: distance from each node to its furthest
+    // leaf. Walk topo in reverse so successors are resolved first.
+    const reverseDepth = new Map<NodeId, number>()
+    for (let i = topo.length - 1; i >= 0; i--) {
+      const u = topo[i]
+      if (u === undefined) continue
+      let maxSucc = -1
+      for (const v of succ.get(u) ?? []) {
+        const lv = reverseDepth.get(v)
+        if (lv !== undefined && lv > maxSucc) maxSucc = lv
+      }
+      reverseDepth.set(u, maxSucc + 1)
+    }
+    for (const n of nodes) {
+      if (!reverseDepth.has(n)) reverseDepth.set(n, 0)
+    }
+    let totalDepth = 0
+    for (const n of nodes) {
+      const d = (asap.get(n) ?? 0) + (reverseDepth.get(n) ?? 0)
+      if (d > totalDepth) totalDepth = d
+    }
+    layerOf = new Map<NodeId, number>()
+    for (const n of nodes) {
+      const layer = totalDepth - (reverseDepth.get(n) ?? 0)
+      layerOf.set(n, layer)
+    }
+  } else {
+    layerOf = asap
   }
 
   // Bucket into layers[i].


### PR DESCRIPTION
## Summary

Follow-up to PR #223 (channel routing). Two coupled fixes for the diagram readability complaints raised after that merged:

1. **Far-first bend ordering inside a fan-out** (commit 8e7ca4c). When one switch fans out to N peers, the closest peer's bend now sits at the *deepest* lane (right above the target row) and far peers peel off at shallower lanes. Before, the closest peer's lane was just under the source so every other cable had to weave past it. Grouping is by source *node centre*, not source port — paired ports on the same switch don't fight for the same priority.

2. **Cluster leaves at the bottom row** (commit 5be1c7e). Two changes that go together:
   - `assignLayers` now defaults to ALAP (`layer(v) = totalDepth − longestPathToLeaf(v)`) instead of ASAP. Every leaf lands on the bottom row regardless of how short its cable run from a root is. ASAP is preserved behind a `mode` option.
   - `shouldFlipForLayout` now considers `Node.spec.type` as a soft layout hint: leaf-type endpoints (access-point / cpe / server / database / console-server) on the `from` side, and upstream-type endpoints (internet / cloud) on the `to` side, drive the (source, target) swap inside `buildCompoundEdges`. Explicit per-port placement overrides from #220 still win in both directions — a manual pin can both trigger and veto the heuristic.

Net effect on the reported diagram (103 nodes / 49 links): hall-sw01's APs now sit directly under hall-sw01, no longer interleaved with eps-sw02's subtree; all APs cluster on the bottom row at the same Y; ONU and the WAN router sit at the top.

## Test plan

- [x] `bun run --filter '@shumoku/core' test` — 158/158 passing
- [x] `bun run typecheck` — clean across all 17 packages
- [x] `bun x biome check` — clean on modified files
- [x] Browser probe on the problem project: APs all at y=1480, access switches at y=1240, ONU at y=40, router at y=220
- [x] Visual: tree silhouette under each fan-out source, no AP stranded mid-diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)