### PR TITLE
feat(core): subtree-aware coord assignment — full Brandes-Köpf 4-alignment

### DIFF
--- a/libs/@shumoku/core/src/layout/sugiyama/coords.test.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/coords.test.ts
@@ -260,6 +260,57 @@ describe('assignCoordinates', () => {
     expect(xs).toEqual([-120, 0, 120])
   })
 
+  it('parent sits above the centroid of its children after refinement', () => {
+    // Tree fragment:
+    //   root          ← layer 0
+    //   / | \
+    //  a  b  c        ← layer 1 (intermediate switches)
+    //  |  |   \
+    //  l1 l2  l3 l4   ← layer 2 (leaves, c has 2 children)
+    //
+    // The leaf layer is *wider* than the middle layer: the four
+    // leaves stretch wider than three siblings could on the same
+    // pitch. Without subtree-aware refinement, a/b/c stay evenly
+    // spaced above their (single) parent and c ends up off to the
+    // side of its two leaves. With refinement, c should sit at
+    // the centroid of l3 and l4.
+    const layers: LayerAssignment = {
+      layers: [['root'], ['a', 'b', 'c'], ['l1', 'l2', 'l3', 'l4']],
+      layerOf: new Map([
+        ['root', 0],
+        ['a', 1],
+        ['b', 1],
+        ['c', 1],
+        ['l1', 2],
+        ['l2', 2],
+        ['l3', 2],
+        ['l4', 2],
+      ]),
+    }
+    const positions = assignCoordinates(layers, {
+      defaultSize: uniformSize,
+      nodeGap: 20,
+      edges: [
+        { id: 'e1', source: 'root', target: 'a' },
+        { id: 'e2', source: 'root', target: 'b' },
+        { id: 'e3', source: 'root', target: 'c' },
+        { id: 'e4', source: 'a', target: 'l1' },
+        { id: 'e5', source: 'b', target: 'l2' },
+        { id: 'e6', source: 'c', target: 'l3' },
+        { id: 'e7', source: 'c', target: 'l4' },
+      ],
+    })
+    const l3 = positions.get('l3')?.x ?? 0
+    const l4 = positions.get('l4')?.x ?? 0
+    const cx = positions.get('c')?.x ?? 0
+    // c should be within one node-width of its children's centroid.
+    // (Exact equality is too strict — collision packing in the parent
+    // layer can shift c by up to one gap to avoid hitting b.)
+    expect(Math.abs(cx - (l3 + l4) / 2)).toBeLessThanOrEqual(uniformSize.width + 20)
+    // Sanity: c is to the right of b (preserves layer ordering).
+    expect(cx).toBeGreaterThan(positions.get('b')?.x ?? 0)
+  })
+
   it('falls back to defaultSize when sizes map is missing a node', () => {
     const layers = makeLayers([['a', 'b']])
     const sizes = new Map<string, Size>([['a', { width: 100, height: 50 }]])

--- a/libs/@shumoku/core/src/layout/sugiyama/coords.ts
+++ b/libs/@shumoku/core/src/layout/sugiyama/coords.ts
@@ -8,36 +8,77 @@
  * compute absolute (x, y) for every node.
  *
  * The y axis is the easy part: stack layers along the secondary axis
- * with `layerGap` spacing, each layer's thickness matching its tallest
- * node.
+ * with `layerGap` spacing, each layer's thickness matching its
+ * tallest node.
  *
- * The x axis has two modes:
+ * The x axis uses **Brandes-Köpf 4-alignment** (the textbook algorithm
+ * also used by dagre / ELK Layered / graphviz). The earlier hand-
+ * rolled 2-pass average only computed `up-left` + `up-right`
+ * alignments and averaged them, which meant a node's preferred x was
+ * only ever derived from its parents in the layer above. For mostly-
+ * tree network topology DAGs that produces a "narrow stalk above,
+ * wide canopy below" layout where parents stay clustered while leaves
+ * fan out, leaving every parent off-centre from its own subtree. The
+ * full BK additionally runs `down-left` + `down-right` alignments
+ * that align each node toward the median of its **successors** in the
+ * layer below, and the median-of-4 balance recovers symmetry.
  *
- *   - **Barycenter-aligned (default when `edges` are supplied).**
- *     Each non-source node's preferred x is the mean x of its
- *     predecessors in the layer above. A single forward (left-
- *     anchored) pack would put the first sibling at its preferred x
- *     and shove later siblings right — so two children of the same
- *     parent end up with one under the parent and one off to the
- *     side. Running both a forward and a backward (right-anchored)
- *     pack and averaging the two produces the visually balanced
- *     "siblings centred around their shared parent" result while
- *     still snapping single-parent children directly under their
- *     parent. This is the same trick Brandes-Köpf uses with four
- *     alignments, reduced to two passes.
+ * Pipeline:
  *
- *   - **Centred (fallback when no edges).**
- *     Layer is laid out left-to-right and shifted so its span
- *     straddles x = 0. Used for the top layer (no predecessors) and
- *     when the caller doesn't provide connectivity.
+ *   1. (Optional) mark type-1 / type-2 edge-segment conflicts.
+ *      Standard Sugiyama subdivides long edges into dummy nodes;
+ *      type-1 conflicts are non-inner segments crossing inner (dummy-
+ *      dummy) segments. We don't currently insert dummies — every
+ *      edge spans exactly one layer pair — so the conflicts set is
+ *      always empty. The plumbing is kept so a future dummy-node
+ *      phase can wire it up without restructuring this file.
  *
- * Both averaging inputs are individually valid non-overlapping
- * layouts, so their average is too: for adjacent nodes `a`, `b`, the
- * gap constraint holds in each input, and linearity preserves it
- * under averaging.
+ *   2. For each of 4 alignments `{up, down} × {left, right}`:
+ *      a. **Vertical alignment** — build "blocks" of nodes that want
+ *         to share an x coordinate. Walking each layer in the
+ *         configured horizontal direction, each node tries to align
+ *         with its **median neighbour** (predecessor for `up`,
+ *         successor for `down`). The `prevIdx` guard refuses any
+ *         alignment that would cross an earlier-in-layer alignment,
+ *         preventing tangled blocks.
+ *      b. **Horizontal compaction** — solve for each block's x given
+ *         minimum-separation constraints, by building a block-graph
+ *         (blocks as nodes, in-layer adjacency as constraint edges)
+ *         and running a two-sweep relaxation: first sweep pushes
+ *         blocks as far left as possible, second sweep relaxes each
+ *         block as far right as its downstream blocks allow. This is
+ *         the dagre-style compaction that sidesteps the two flaws in
+ *         the original BK paper's `sink/shift` scheme (one well-
+ *         known, one documented only in the 2020 erratum
+ *         arXiv:2008.01252).
+ *
+ *   3. **Width-minimum selection** — pick the alignment with the
+ *      smallest total drawing width (max-x − min-x including half
+ *      node widths) as the reference layout.
+ *
+ *   4. **Shift to the reference** — translate each non-reference
+ *      alignment so its left edge (for `*l` alignments) or right
+ *      edge (for `*r` alignments) lines up with the reference. This
+ *      keeps the four candidates comparable when balancing.
+ *
+ *   5. **Median-balanced output** — for every node, sort its four
+ *      candidate x's and emit the **average of the middle two**. The
+ *      extreme alignments cancel out and a node ends up between its
+ *      "as-far-left-as-possible from parents" and "as-far-right-as-
+ *      possible from children" positions.
  *
  * Direction handling rotates the output after the TB computation —
- * keeps the core layout code as a single implementation.
+ * keeps the core algorithm as a single implementation.
+ *
+ * **Centred fallback (no edges supplied).** Callers that skip the
+ * `edges` option get a simple centred layout per layer. Used by
+ * unit tests that exercise `assignCoordinates` in isolation and as
+ * a safe default when the graph topology isn't available.
+ *
+ * **Hints.** A node with an explicit hint in `options.hints` keeps
+ * its hinted x as the final value — applied after the BK balance —
+ * so callers can pin individual nodes without disabling layout for
+ * the rest of the graph.
  */
 
 import type { Direction, Position, Size } from '../../models/types.js'
@@ -55,33 +96,25 @@ export interface AssignCoordinatesOptions {
   /** Which way the edges flow. Defaults to TB. */
   direction?: Direction
   /**
-   * Edges between nodes in the layered graph. When supplied, each
-   * non-source node is placed near the mean x of its predecessors in
-   * the layer above (barycenter alignment). Falling back to centred
-   * layout when absent keeps unit tests that only care about a single
-   * layer unchanged.
+   * Edges between nodes in the layered graph. When supplied, BK
+   * 4-alignment runs over them. When absent, every layer is laid out
+   * centred (no parent / child awareness).
    */
   edges?: Edge[]
   /**
-   * Soft per-node x hints. When a node has an entry, the forward and
-   * backward packs both treat it as the node's preferred x — packed
-   * against neighbours in the usual way but anchored at the hint
-   * instead of the barycenter of its parents. Hints win over parent-
-   * derived preferences when both exist. The `y` field of the hint is
-   * **ignored**: layer assignment already owns the secondary axis.
-   *
-   * Hints are interpreted in whatever coordinate system the caller
-   * supplied; inside `layoutCompound` that's each container's local
-   * frame, so global-coord hints for deeply nested nodes won't land
-   * where you'd expect. Use hard-pinning (`fixed`) for that case.
+   * Hard per-node x hints. When a node has an entry, BK still runs
+   * normally but the final emitted x is replaced by the hint. Useful
+   * for pinning a small subset of nodes while leaving the rest to
+   * layout. The `y` field is **ignored**: layer assignment owns the
+   * secondary axis.
    */
   hints?: Map<NodeId, { x: number }>
 }
 
 /**
  * Compute absolute centre positions for every node in the layer
- * assignment. The returned map is keyed by NodeId and independent of
- * the input (safe to mutate).
+ * assignment. The returned map is keyed by NodeId and independent
+ * of the input (safe to mutate).
  */
 export function assignCoordinates(
   layerAssignment: LayerAssignment,
@@ -92,20 +125,9 @@ export function assignCoordinates(
   const sizes = options.sizes ?? new Map<NodeId, Size>()
   const defaultSize = options.defaultSize ?? { width: 160, height: 60 }
   const direction: Direction = options.direction ?? 'TB'
-  const sizeOf = (n: NodeId) => sizes.get(n) ?? defaultSize
+  const sizeOf = (n: NodeId): Size => sizes.get(n) ?? defaultSize
 
-  // Predecessor lookup for barycenter refinement. Built once.
-  const preds = new Map<NodeId, NodeId[]>()
-  if (options.edges) {
-    for (const e of options.edges) {
-      if (e.source === e.target) continue
-      const list = preds.get(e.target)
-      if (list) list.push(e.source)
-      else preds.set(e.target, [e.source])
-    }
-  }
-
-  // Layer y up front so barycenter doesn't need to recompute it.
+  // Layer y up front so the x pass doesn't need to recompute it.
   const layerYCenter: number[] = []
   let yCursor = 0
   for (const layer of layerAssignment.layers) {
@@ -114,53 +136,31 @@ export function assignCoordinates(
     yCursor += layerHeight + layerGap
   }
 
-  const tbPositions = new Map<NodeId, Position>()
-
-  if (!options.edges) {
-    // No connectivity → centred layout per layer (the original simple
-    // algorithm). Used by unit tests that exercise `assignCoordinates`
-    // in isolation and by layers that happen to be edgeless.
-    for (const [i, layer] of layerAssignment.layers.entries()) {
-      const y = layerYCenter[i] ?? 0
-      const xs = centredLayer(layer, sizeOf, nodeGap)
-      for (const [j, n] of layer.entries()) {
-        tbPositions.set(n, { x: xs[j] ?? 0, y })
-      }
-    }
+  // x coordinates per node.
+  let xByNode: Map<NodeId, number>
+  if (!options.edges || options.edges.length === 0) {
+    xByNode = centredAllLayers(layerAssignment.layers, sizeOf, nodeGap)
   } else {
-    // Two passes: forward (left-anchored) and backward (right-anchored),
-    // then average. Layer 0 is centred in both passes (no predecessors),
-    // so it stays centred after averaging.
-    const forwardByLayer: Map<NodeId, number>[] = []
-    const backwardByLayer: Map<NodeId, number>[] = []
+    xByNode = brandesKopf(layerAssignment, options.edges, sizeOf, nodeGap)
+  }
 
-    for (const [i, layer] of layerAssignment.layers.entries()) {
-      const y = layerYCenter[i] ?? 0
-      if (i === 0) {
-        const xs = centredLayer(layer, sizeOf, nodeGap)
-        const m = new Map<NodeId, number>()
-        for (const [j, n] of layer.entries()) m.set(n, xs[j] ?? 0)
-        forwardByLayer.push(m)
-        backwardByLayer.push(new Map(m))
-        for (const n of layer) tbPositions.set(n, { x: m.get(n) ?? 0, y })
-        continue
-      }
-
-      const forwardX = forwardPack(layer, preds, forwardByLayer, sizeOf, nodeGap, options.hints)
-      const backwardX = backwardPack(layer, preds, backwardByLayer, sizeOf, nodeGap, options.hints)
-      forwardByLayer.push(forwardX)
-      backwardByLayer.push(backwardX)
-      for (const n of layer) {
-        const fx = forwardX.get(n) ?? 0
-        const bx = backwardX.get(n) ?? 0
-        tbPositions.set(n, { x: (fx + bx) / 2, y })
-      }
+  // Apply hard hints. The hint wins regardless of what BK produced
+  // — callers asking for a hint are explicitly overriding layout.
+  if (options.hints) {
+    for (const [id, hint] of options.hints) {
+      xByNode.set(id, hint.x)
     }
+  }
+
+  const tbPositions = new Map<NodeId, Position>()
+  for (const [i, layer] of layerAssignment.layers.entries()) {
+    const y = layerYCenter[i] ?? 0
+    for (const n of layer) tbPositions.set(n, { x: xByNode.get(n) ?? 0, y })
   }
 
   if (direction === 'TB') return tbPositions
 
-  // Rotate / flip.
+  // Rotate / flip into the requested orientation.
   const result = new Map<NodeId, Position>()
   for (const [id, { x, y }] of tbPositions) {
     switch (direction) {
@@ -178,116 +178,392 @@ export function assignCoordinates(
   return result
 }
 
-/**
- * Lay out a single layer left-to-right and shift so its span is
- * centred on x = 0. Returns the per-node centre x, in the same order
- * as `layer`.
- */
-function centredLayer(layer: NodeId[], sizeOf: (n: NodeId) => Size, nodeGap: number): number[] {
-  const xs: number[] = []
-  let xCursor = 0
-  for (const n of layer) {
-    const { width } = sizeOf(n)
-    xs.push(xCursor + width / 2)
-    xCursor += width + nodeGap
+// ---------------------------------------------------------------------------
+// Fallback: no-edges layout. Lay each layer out left-to-right and shift so
+// its span is centred on x = 0. Used by tests that don't supply edges and as
+// a safe default when topology isn't available.
+// ---------------------------------------------------------------------------
+
+function centredAllLayers(
+  layers: NodeId[][],
+  sizeOf: (n: NodeId) => Size,
+  nodeGap: number,
+): Map<NodeId, number> {
+  const out = new Map<NodeId, number>()
+  for (const layer of layers) {
+    const xs: number[] = []
+    let xCursor = 0
+    for (const n of layer) {
+      const { width } = sizeOf(n)
+      xs.push(xCursor + width / 2)
+      xCursor += width + nodeGap
+    }
+    const span = layer.length === 0 ? 0 : xCursor - nodeGap
+    const shiftX = -span / 2
+    for (const [j, n] of layer.entries()) out.set(n, (xs[j] ?? 0) + shiftX)
   }
-  const span = layer.length === 0 ? 0 : xCursor - nodeGap
-  const shiftX = -span / 2
-  return xs.map((x) => x + shiftX)
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Brandes-Köpf 4-alignment.
+// ---------------------------------------------------------------------------
+
+/**
+ * Returned by `verticalAlignment`. For each node v:
+ *   - `root[v]` = the block root v belongs to (a representative node id)
+ *   - `align[v]` = the next node in the block's circular alignment list
+ * The block-membership graph forms one cycle per block when you
+ * follow `align`; the root has the lowest "preferred" index in the
+ * walked direction.
+ */
+interface AlignmentResult {
+  root: Map<NodeId, NodeId>
+  align: Map<NodeId, NodeId>
+}
+
+type Conflicts = Map<NodeId, Set<NodeId>>
+type AlignmentKey = 'ul' | 'ur' | 'dl' | 'dr'
+
+function brandesKopf(
+  layerAssignment: LayerAssignment,
+  edges: Edge[],
+  sizeOf: (n: NodeId) => Size,
+  nodeGap: number,
+): Map<NodeId, number> {
+  const layers = layerAssignment.layers
+  if (layers.length === 0) return new Map()
+
+  // Adjacency. We treat the layered graph as a DAG flowing source → target
+  // and read predecessors / successors directly off the edge list.
+  const preds = new Map<NodeId, NodeId[]>()
+  const succs = new Map<NodeId, NodeId[]>()
+  for (const e of edges) {
+    if (e.source === e.target) continue
+    const pl = preds.get(e.target)
+    if (pl) pl.push(e.source)
+    else preds.set(e.target, [e.source])
+    const sl = succs.get(e.source)
+    if (sl) sl.push(e.target)
+    else succs.set(e.source, [e.target])
+  }
+
+  // Conflict map. Empty for now — we don't subdivide long edges so
+  // there are no inner segments to mark. The plumbing is here so a
+  // future dummy-node phase can populate it without restructuring.
+  const conflicts: Conflicts = new Map()
+
+  const xss: Record<AlignmentKey, Map<NodeId, number>> = {
+    ul: new Map(),
+    ur: new Map(),
+    dl: new Map(),
+    dr: new Map(),
+  }
+
+  for (const vert of ['u', 'd'] as const) {
+    // For `d` alignments, reverse the layer order so the walk goes
+    // bottom → top; `verticalAlignment` still iterates "first layer
+    // first", which corresponds to leaves first in this orientation.
+    const vertLayers = vert === 'u' ? layers : [...layers].reverse()
+    const neighborFn = (v: NodeId): NodeId[] => (vert === 'u' ? preds.get(v) : succs.get(v)) ?? []
+
+    for (const horiz of ['l', 'r'] as const) {
+      // For `r` alignments, reverse within-layer order so the walk
+      // goes right → left; combined with sign-flip after compaction
+      // this produces a right-anchored layout.
+      const oriented = horiz === 'l' ? vertLayers : vertLayers.map((layer) => [...layer].reverse())
+
+      const alignment = verticalAlignment(oriented, neighborFn, conflicts)
+      const xs = horizontalCompaction(oriented, alignment, sizeOf, nodeGap)
+      if (horiz === 'r') {
+        for (const [k, v] of xs) xs.set(k, -v)
+      }
+      xss[(vert + horiz) as AlignmentKey] = xs
+    }
+  }
+
+  const reference = findSmallestWidthAlignment(xss, sizeOf)
+  alignCoordinates(xss, reference)
+  return balance(xss)
 }
 
 /**
- * Preferred x for a node, priority:
- *   1. Hint (explicit caller override)
- *   2. Barycenter of its predecessors in the layers above
- *   3. undefined (packing fallback takes over)
+ * Build vertical alignment blocks. For each layer (in the supplied
+ * walking direction), each node tries to align with its median
+ * neighbour in the previously-processed adjacent layer, subject to:
+ *   - the node hasn't already been claimed by an earlier-in-layer
+ *     neighbour (`align[v] === v` check),
+ *   - aligning here wouldn't cross an earlier alignment in this
+ *     layer (`prevIdx < posW`),
+ *   - the edge is not marked as a type-1 conflict.
  */
-function preferredX(
-  node: NodeId,
-  preds: Map<NodeId, NodeId[]>,
-  layerX: Map<NodeId, number>[],
-  hints: Map<NodeId, { x: number }> | undefined,
-): number | undefined {
-  const hint = hints?.get(node)
-  if (hint !== undefined) return hint.x
+function verticalAlignment(
+  layers: NodeId[][],
+  neighborFn: (v: NodeId) => NodeId[],
+  conflicts: Conflicts,
+): AlignmentResult {
+  const root = new Map<NodeId, NodeId>()
+  const align = new Map<NodeId, NodeId>()
+  const pos = new Map<NodeId, number>()
 
-  const parents = preds.get(node) ?? []
-  if (parents.length === 0) return undefined
-  let sum = 0
-  let count = 0
-  for (const p of parents) {
-    // Walk layers from most recent back to find the predecessor. In
-    // a proper Sugiyama DAG, preds live in the immediately-preceding
-    // layer, but walking lets us tolerate skipped layers if they show
-    // up later.
-    for (let li = layerX.length - 1; li >= 0; li--) {
-      const map = layerX[li]
-      if (!map) continue
-      const x = map.get(p)
-      if (x !== undefined) {
-        sum += x
-        count++
-        break
+  // Initialise blocks: each node starts as its own root, aligned to
+  // itself, with a position equal to its index in the current layer
+  // (which encodes both the horizontal reversal and the in-layer
+  // ordering produced by crossing reduction).
+  for (const layer of layers) {
+    for (const [order, v] of layer.entries()) {
+      root.set(v, v)
+      align.set(v, v)
+      pos.set(v, order)
+    }
+  }
+
+  for (const layer of layers) {
+    let prevIdx = -1
+    for (const v of layer) {
+      const neighbours = neighborFn(v)
+      if (neighbours.length === 0) continue
+      // Sort neighbours by their position in the adjacent layer so
+      // the median lookup uses in-layer order.
+      const ws = neighbours.slice().sort((a, b) => (pos.get(a) ?? 0) - (pos.get(b) ?? 0))
+      const mp = (ws.length - 1) / 2
+      for (let i = Math.floor(mp); i <= Math.ceil(mp); i++) {
+        const w = ws[i]
+        if (w === undefined) continue
+        if (align.get(v) !== v) continue // already claimed by an earlier node
+        const posW = pos.get(w) ?? 0
+        if (prevIdx >= posW) continue // would cross an earlier alignment
+        if (hasConflict(conflicts, v, w)) continue
+        // Insert v into the block w belongs to. `align` forms a
+        // ring: w → ... → root → ... → w, and inserting v before w's
+        // successor sets w.align = v and v.align = root[w].
+        const rootW = root.get(w)
+        if (rootW === undefined) continue
+        align.set(w, v)
+        align.set(v, rootW)
+        root.set(v, rootW)
+        prevIdx = posW
       }
     }
   }
-  if (count === 0) return undefined
-  return sum / count
+
+  return { root, align }
 }
 
 /**
- * Forward (left-anchored) pack. Each node's x is the max of its
- * preferred x and the leftmost it can sit without overlapping the
- * previous node's right edge + nodeGap.
+ * Solve x coordinates given the block decomposition. We model the
+ * non-overlap constraints as a block-graph: each block is a node,
+ * each adjacent (left, right) pair in a layer contributes an edge
+ * (root(left) → root(right)) with weight = the minimum gap that
+ * pair needs.
+ *
+ * Two passes:
+ *
+ *   1. Sweep predecessors → successors, assigning each block the
+ *      smallest x that satisfies all incoming constraints. (Pushes
+ *      everything as far left as possible.)
+ *   2. Sweep successors → predecessors. For each block, check the
+ *      tightest constraint from a downstream block; if there's room
+ *      between the current x and that bound, slide right. This
+ *      removes spurious gaps the first sweep introduced.
+ *
+ * Block roots get the final x. Every other node in a block inherits
+ * its root's x — that's what makes the block visually vertical.
  */
-function forwardPack(
-  layer: NodeId[],
-  preds: Map<NodeId, NodeId[]>,
-  previousLayers: Map<NodeId, number>[],
+function horizontalCompaction(
+  layers: NodeId[][],
+  alignment: AlignmentResult,
   sizeOf: (n: NodeId) => Size,
   nodeGap: number,
-  hints: Map<NodeId, { x: number }> | undefined,
 ): Map<NodeId, number> {
+  const { root, align } = alignment
+
+  /** For each block root b, list of (left-neighbour-root, weight). */
+  const blockIn = new Map<NodeId, { u: NodeId; w: number }[]>()
+  /** For each block root b, list of (right-neighbour-root, weight). */
+  const blockOut = new Map<NodeId, { v: NodeId; w: number }[]>()
+  const blockNodes = new Set<NodeId>()
+
+  const sepBetween = (left: NodeId, right: NodeId): number =>
+    sizeOf(left).width / 2 + sizeOf(right).width / 2 + nodeGap
+
+  for (const layer of layers) {
+    let prev: NodeId | undefined
+    for (const v of layer) {
+      const vRoot = root.get(v) ?? v
+      blockNodes.add(vRoot)
+      if (prev !== undefined) {
+        const prevRoot = root.get(prev) ?? prev
+        const w = sepBetween(prev, v)
+        // Merge with existing constraint if any — two pairs that
+        // happen to span the same block boundary keep the max.
+        const inList = blockIn.get(vRoot) ?? []
+        const existing = inList.find((e) => e.u === prevRoot)
+        if (existing) {
+          existing.w = Math.max(existing.w, w)
+        } else {
+          inList.push({ u: prevRoot, w })
+          blockIn.set(vRoot, inList)
+        }
+        const outList = blockOut.get(prevRoot) ?? []
+        const existingOut = outList.find((e) => e.v === vRoot)
+        if (existingOut) {
+          existingOut.w = Math.max(existingOut.w, w)
+        } else {
+          outList.push({ v: vRoot, w })
+          blockOut.set(prevRoot, outList)
+        }
+      }
+      prev = v
+    }
+  }
+
+  // Pass 1: tight-left. Visit each block after all its predecessors
+  // (DFS post-order over the block-graph). Each block's x is the max
+  // over incoming edges of (predecessor x + weight).
+  const xsBlock = new Map<NodeId, number>()
+  const visited1 = new Set<NodeId>()
+  const stack: NodeId[] = [...blockNodes]
+  while (stack.length > 0) {
+    const top = stack[stack.length - 1]
+    if (top === undefined) {
+      stack.pop()
+      continue
+    }
+    if (visited1.has(top)) {
+      stack.pop()
+      const incoming = blockIn.get(top) ?? []
+      let best = 0
+      for (const { u, w } of incoming) {
+        best = Math.max(best, (xsBlock.get(u) ?? 0) + w)
+      }
+      xsBlock.set(top, best)
+    } else {
+      visited1.add(top)
+      const incoming = blockIn.get(top) ?? []
+      for (const { u } of incoming) {
+        if (!visited1.has(u)) stack.push(u)
+      }
+    }
+  }
+
+  // Pass 2: slack-right. Visit each block after all its successors
+  // (post-order over reversed block-graph). Slide each block right as
+  // far as its downstream-most constraint allows.
+  const visited2 = new Set<NodeId>()
+  const stack2: NodeId[] = [...blockNodes]
+  while (stack2.length > 0) {
+    const top = stack2[stack2.length - 1]
+    if (top === undefined) {
+      stack2.pop()
+      continue
+    }
+    if (visited2.has(top)) {
+      stack2.pop()
+      const outgoing = blockOut.get(top) ?? []
+      let bound = Number.POSITIVE_INFINITY
+      for (const { v, w } of outgoing) {
+        const xv = xsBlock.get(v)
+        if (xv !== undefined) bound = Math.min(bound, xv - w)
+      }
+      if (bound !== Number.POSITIVE_INFINITY) {
+        xsBlock.set(top, Math.max(xsBlock.get(top) ?? 0, bound))
+      }
+    } else {
+      visited2.add(top)
+      const outgoing = blockOut.get(top) ?? []
+      for (const { v } of outgoing) {
+        if (!visited2.has(v)) stack2.push(v)
+      }
+    }
+  }
+
+  // Propagate root x to every aligned node.
+  const xs = new Map<NodeId, number>()
+  for (const v of align.keys()) {
+    const vRoot = root.get(v) ?? v
+    xs.set(v, xsBlock.get(vRoot) ?? 0)
+  }
+  return xs
+}
+
+/** Total drawing span (max right edge − min left edge) using node widths. */
+function findSmallestWidthAlignment(
+  xss: Record<AlignmentKey, Map<NodeId, number>>,
+  sizeOf: (n: NodeId) => Size,
+): Map<NodeId, number> {
+  let minWidth = Number.POSITIVE_INFINITY
+  let best: Map<NodeId, number> = xss.ul
+  for (const xs of Object.values(xss)) {
+    let max = Number.NEGATIVE_INFINITY
+    let min = Number.POSITIVE_INFINITY
+    for (const [v, x] of xs) {
+      const hw = sizeOf(v).width / 2
+      max = Math.max(max, x + hw)
+      min = Math.min(min, x - hw)
+    }
+    const width = max - min
+    if (width < minWidth) {
+      minWidth = width
+      best = xs
+    }
+  }
+  return best
+}
+
+/**
+ * Translate each non-reference alignment so that its left edge (for
+ * `*l` alignments) or right edge (for `*r` alignments) lines up with
+ * the reference alignment's corresponding edge. This makes the four
+ * x candidates comparable when the median balance averages them.
+ */
+function alignCoordinates(
+  xss: Record<AlignmentKey, Map<NodeId, number>>,
+  reference: Map<NodeId, number>,
+): void {
+  const refVals = Array.from(reference.values())
+  if (refVals.length === 0) return
+  const refMin = Math.min(...refVals)
+  const refMax = Math.max(...refVals)
+
+  for (const vert of ['u', 'd'] as const) {
+    for (const horiz of ['l', 'r'] as const) {
+      const key = (vert + horiz) as AlignmentKey
+      const xs = xss[key]
+      if (xs === reference) continue
+      const vals = Array.from(xs.values())
+      if (vals.length === 0) continue
+      const delta = horiz === 'l' ? refMin - Math.min(...vals) : refMax - Math.max(...vals)
+      if (delta === 0) continue
+      const shifted = new Map<NodeId, number>()
+      for (const [k, v] of xs) shifted.set(k, v + delta)
+      xss[key] = shifted
+    }
+  }
+}
+
+/** For each node, take the average of the middle two of the four x's. */
+function balance(xss: Record<AlignmentKey, Map<NodeId, number>>): Map<NodeId, number> {
+  const reference = xss.ul
   const out = new Map<NodeId, number>()
-  let prevRight = Number.NEGATIVE_INFINITY
-  for (const [j, n] of layer.entries()) {
-    const { width } = sizeOf(n)
-    const pref = preferredX(n, preds, previousLayers, hints)
-    const minX = j === 0 ? Number.NEGATIVE_INFINITY : prevRight + nodeGap + width / 2
-    const desired = pref ?? minX
-    const x = desired < minX ? minX : desired
-    out.set(n, x)
-    prevRight = x + width / 2
+  for (const v of reference.keys()) {
+    const all = [xss.ul.get(v), xss.ur.get(v), xss.dl.get(v), xss.dr.get(v)]
+    const vals = all.filter((x): x is number => x !== undefined).sort((a, b) => a - b)
+    if (vals.length === 0) {
+      out.set(v, 0)
+      continue
+    }
+    if (vals.length < 4) {
+      // Shouldn't happen with our 4-alignment pipeline, but be safe.
+      out.set(v, vals[Math.floor(vals.length / 2)] ?? 0)
+      continue
+    }
+    out.set(v, ((vals[1] ?? 0) + (vals[2] ?? 0)) / 2)
   }
   return out
 }
 
-/**
- * Backward (right-anchored) pack. Mirror of forwardPack: we traverse
- * right-to-left, each node's x is the min of its preferred x and the
- * rightmost it can sit without overlapping the next node's left edge
- * minus nodeGap.
- */
-function backwardPack(
-  layer: NodeId[],
-  preds: Map<NodeId, NodeId[]>,
-  previousLayers: Map<NodeId, number>[],
-  sizeOf: (n: NodeId) => Size,
-  nodeGap: number,
-  hints: Map<NodeId, { x: number }> | undefined,
-): Map<NodeId, number> {
-  const out = new Map<NodeId, number>()
-  let nextLeft = Number.POSITIVE_INFINITY
-  for (let j = layer.length - 1; j >= 0; j--) {
-    const n = layer[j]
-    if (n === undefined) continue
-    const { width } = sizeOf(n)
-    const pref = preferredX(n, preds, previousLayers, hints)
-    const maxX = j === layer.length - 1 ? Number.POSITIVE_INFINITY : nextLeft - nodeGap - width / 2
-    const desired = pref ?? maxX
-    const x = desired > maxX ? maxX : desired
-    out.set(n, x)
-    nextLeft = x - width / 2
-  }
-  return out
+function hasConflict(conflicts: Conflicts, a: NodeId, b: NodeId): boolean {
+  const [lo, hi] = a < b ? [a, b] : [b, a]
+  return conflicts.get(lo)?.has(hi) ?? false
 }


### PR DESCRIPTION
## Summary

Replaces the hand-rolled 2-alignment coordinate assignment (only `up-left` + `up-right`, predecessor-only barycenter, averaged) with the textbook **Brandes-Köpf 4-alignment** used by dagre / ELK Layered / graphviz.

**Before:** parents' x came only from their predecessors. For mostly-tree network topology DAGs this produced "narrow stalk above, wide canopy below" — 14 access switches evenly spaced above x=0 while 35 leaves filled the canvas. hall-sw01 sat 1300px to the right of its three APs.

**After:** four alignments `{up, down} × {left, right}` are computed. `up` aligns each node toward its **median predecessor**, `down` aligns toward its **median successor**. Width-minimum selection picks a reference, the other three are translated to share its left/right edge, and each node's final x is the **median-balanced average** (middle two of four) of its candidates.

Mirrors dagre's `bk.ts` structure rather than the original BK paper's `sink/shift` compaction, which has two correctness flaws documented in the 2020 erratum (arXiv:2008.01252). The dagre-style block-graph + two-sweep compaction sidesteps both.

## Visual result on the problem project (103 nodes / 49 links)

Access switches now sit at **non-uniform x positions matching their subtree widths**:
- `hall-sw02 → room3-sw01` gap = 97px (both have few children)
- `room1-sw01 → hall-sw01` gap = 175px (both have wide subtrees)
- `boardroom-sw01 → room1-sw01` gap = 175px (both have wide subtrees)

Each access switch is now visibly centred over its child cluster, and each child cluster fans out cleanly without weaving past its siblings.

## Notes

- **Type-1 / type-2 conflict marking** is plumbed in but currently a no-op. Long edges aren't subdivided into dummy nodes yet, so there are no inner segments to conflict against. The conflict map stays in the API for a future dummy-node phase.
- **Hints** are now applied as a post-balance override (final emitted x = hint.x) rather than influencing alignment. Simpler and matches the existing test expectation that hints win exactly.
- Replaces the one-shot bottom-up + top-down refinement attempt from earlier on this branch (a 2-alignment + post-hoc patch approximating BK). The full algorithm is more principled and produces visibly better clustering.

## References

- Brandes & Köpf, *Fast and Simple Horizontal Coordinate Assignment* (2001)
- Brandes & Köpf, [Erratum (2020, arXiv:2008.01252)](https://arxiv.org/abs/2008.01252)
- [dagre `bk.ts`](https://github.com/dagrejs/dagre/blob/master/lib/position/bk.ts) — primary reference implementation
- [ELK Layered NodePlacementStrategy](https://eclipse.dev/elk/reference/options/org-eclipse-elk-layered-nodePlacement-strategy.html)

## Test plan

- [x] `bun run --filter '@shumoku/core' test` — 159/159 passing (existing tests + new subtree-centroid regression test)
- [x] `bun run typecheck` — clean across all 17 packages
- [x] `bun x biome check` — clean
- [x] Browser probe on the problem project — confirmed non-uniform spacing in the access-switch row, parents over their child clusters
- [x] Visual screenshot — tree silhouette restored, no stranded APs

🤖 Generated with [Claude Code](https://claude.com/claude-code)