### PR TITLE
feat(renderer): bezier edge style as default — root-cause fix for bend density

### DIFF
--- a/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
   import type { ResolvedEdge } from '@shumoku/core'
+  import { edgeStyleStore } from '../../lib/edge-style.svelte'
   import type { LinkOverlaySnippet } from '../../lib/overlays'
   import type { RenderColors } from '../../lib/render-colors'
-  import { computePortLabelPosition, getVlanStroke, pointsToPathD } from '../../lib/svg-coords'
+  import {
+    bezierEdgePath,
+    computePortLabelPosition,
+    getVlanStroke,
+    pointsToPathD,
+  } from '../../lib/svg-coords'
 
   let {
     edge,
@@ -20,7 +26,17 @@
     oncontextmenu?: (edgeId: string, e: MouseEvent) => void
   } = $props()
 
-  const pathD = $derived(pointsToPathD(edge.points))
+  // Edge rendering style. Toggle from devtools with
+  //   window.__shumoku.setEdgeStyle('bezier')   // or 'orthogonal'
+  // Bezier mode bypasses the libavoid polyline and draws a single
+  // cubic curve from the source port (with its side as the start
+  // tangent) to the dest port (with its side as the end tangent).
+  // Orthogonal mode (default) uses the routed polyline as before.
+  const pathD = $derived(
+    edgeStyleStore.current === 'bezier' && edge.fromPort && edge.toPort
+      ? bezierEdgePath(edge.fromPort, edge.toPort)
+      : pointsToPathD(edge.points),
+  )
   const link = $derived(edge.link)
   const linkType = $derived(link?.type ?? 'solid')
   const dasharray = $derived(() => {

--- a/libs/@shumoku/renderer/src/lib/edge-style.svelte.ts
+++ b/libs/@shumoku/renderer/src/lib/edge-style.svelte.ts
@@ -1,0 +1,30 @@
+/**
+ * Edge rendering style toggle (prototype).
+ *
+ * Toggle from devtools:
+ *   window.__shumoku.setEdgeStyle('bezier')
+ *   window.__shumoku.setEdgeStyle('orthogonal')
+ *
+ * Held in a module-level rune so every `SvgEdge` re-renders when it
+ * changes. Survives across renderer instances but resets on page
+ * reload — by design, this is exploratory plumbing.
+ */
+
+export type EdgeStyle = 'orthogonal' | 'bezier'
+
+class EdgeStyleStore {
+  current: EdgeStyle = $state('orthogonal')
+}
+
+export const edgeStyleStore = new EdgeStyleStore()
+
+if (typeof window !== 'undefined') {
+  const w = window as unknown as {
+    __shumoku?: { setEdgeStyle: (s: EdgeStyle) => void; getEdgeStyle: () => EdgeStyle }
+  }
+  w.__shumoku ??= {} as never
+  w.__shumoku.setEdgeStyle = (s: EdgeStyle) => {
+    edgeStyleStore.current = s
+  }
+  w.__shumoku.getEdgeStyle = () => edgeStyleStore.current
+}

--- a/libs/@shumoku/renderer/src/lib/edge-style.svelte.ts
+++ b/libs/@shumoku/renderer/src/lib/edge-style.svelte.ts
@@ -13,7 +13,10 @@
 export type EdgeStyle = 'orthogonal' | 'bezier'
 
 class EdgeStyleStore {
-  current: EdgeStyle = $state('orthogonal')
+  // Default. Bezier flows out of each port for a stalk-length then
+  // arcs to the destination — dense fan-outs no longer collapse into
+  // a wall of bends. Orthogonal stays available via setEdgeStyle().
+  current: EdgeStyle = $state('bezier')
 }
 
 export const edgeStyleStore = new EdgeStyleStore()

--- a/libs/@shumoku/renderer/src/lib/svg-coords.ts
+++ b/libs/@shumoku/renderer/src/lib/svg-coords.ts
@@ -20,17 +20,21 @@ export function pointsToPathD(points: { x: number; y: number }[]): string {
 
 /**
  * Build a cubic-Bezier SVG path that flows out of `from`'s port side and
- * into `to`'s. The control-point distance is proportional to the
- * straight-line gap between the two ports along the rank axis (the
- * normal of the source's side), clamped to [MIN, MAX] so very short
- * edges don't degenerate to overshooting curves and very long edges
- * don't get visually flat.
+ * into `to`'s.
  *
- * The curve has no notion of obstacle avoidance — by design, since we
- * trade the bend-channel correctness of libavoid for visual flow. If
- * the edge crosses an unrelated node body it just goes through it.
- * Acceptable for the network-diagram case where parent/child layers
- * are clearly stacked.
+ * Tangent magnitude scales with **the distance along the port normal**
+ * (the rank-axis gap), not the straight-line Euclidean distance. That
+ * keeps the curve "shooting straight" out of the port for a sizeable
+ * fraction of the vertical gap before bending sideways — endpoints
+ * read as straight while the curvature concentrates in the middle.
+ * Using the Euclidean distance instead made every long edge into a
+ * gentle diagonal that started turning right at the port; perpendicular
+ * gap gives the more telegraphic "stalk → arc → stalk" silhouette.
+ *
+ * No obstacle avoidance — by design, since we trade the bend-channel
+ * correctness of libavoid for visual flow. If the edge crosses an
+ * unrelated node body it just goes through it. Acceptable for the
+ * network-diagram case where parent/child layers are clearly stacked.
  */
 export function bezierEdgePath(
   from: { absolutePosition: { x: number; y: number }; side?: Side },
@@ -38,19 +42,35 @@ export function bezierEdgePath(
 ): string {
   const a = from.absolutePosition
   const b = to.absolutePosition
-  const dx = b.x - a.x
-  const dy = b.y - a.y
-  // Tangent distance: how far the curve "shoots straight" out of each
-  // port before bending. Scales with the perpendicular gap so a short
-  // edge bends tighter than a long one but never collapses to zero.
-  const reach = clamp(Math.sqrt(dx * dx + dy * dy) * 0.4, 24, 220)
-  const [ax, ay] = tangentOffset(from.side ?? 'bottom', reach)
-  const [bx, by] = tangentOffset(to.side ?? 'top', reach)
+  const fromSide = from.side ?? 'bottom'
+  const toSide = to.side ?? 'top'
+  // Distance along the source's port normal (= the "rank-axis gap"
+  // when source.side is top/bottom this is |dy|, when it's left/right
+  // this is |dx|). Long stalks come out of the port before the arc
+  // takes over.
+  const normalGap = projectAlongNormal(fromSide, b.x - a.x, b.y - a.y)
+  const reach = clamp(normalGap * 0.6, 40, 320)
+  const [ax, ay] = tangentOffset(fromSide, reach)
+  const [bx, by] = tangentOffset(toSide, reach)
   const c1x = a.x + ax
   const c1y = a.y + ay
   const c2x = b.x + bx
   const c2y = b.y + by
   return `M ${a.x} ${a.y} C ${c1x} ${c1y} ${c2x} ${c2y} ${b.x} ${b.y}`
+}
+
+/** Absolute distance from the port along its outward normal. */
+function projectAlongNormal(side: Side, dx: number, dy: number): number {
+  switch (side) {
+    case 'top':
+      return Math.abs(Math.min(0, dy))
+    case 'bottom':
+      return Math.abs(Math.max(0, dy))
+    case 'left':
+      return Math.abs(Math.min(0, dx))
+    case 'right':
+      return Math.abs(Math.max(0, dx))
+  }
 }
 
 function tangentOffset(side: Side, magnitude: number): [number, number] {

--- a/libs/@shumoku/renderer/src/lib/svg-coords.ts
+++ b/libs/@shumoku/renderer/src/lib/svg-coords.ts
@@ -18,6 +18,58 @@ export function pointsToPathD(points: { x: number; y: number }[]): string {
   return d
 }
 
+/**
+ * Build a cubic-Bezier SVG path that flows out of `from`'s port side and
+ * into `to`'s. The control-point distance is proportional to the
+ * straight-line gap between the two ports along the rank axis (the
+ * normal of the source's side), clamped to [MIN, MAX] so very short
+ * edges don't degenerate to overshooting curves and very long edges
+ * don't get visually flat.
+ *
+ * The curve has no notion of obstacle avoidance — by design, since we
+ * trade the bend-channel correctness of libavoid for visual flow. If
+ * the edge crosses an unrelated node body it just goes through it.
+ * Acceptable for the network-diagram case where parent/child layers
+ * are clearly stacked.
+ */
+export function bezierEdgePath(
+  from: { absolutePosition: { x: number; y: number }; side?: Side },
+  to: { absolutePosition: { x: number; y: number }; side?: Side },
+): string {
+  const a = from.absolutePosition
+  const b = to.absolutePosition
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  // Tangent distance: how far the curve "shoots straight" out of each
+  // port before bending. Scales with the perpendicular gap so a short
+  // edge bends tighter than a long one but never collapses to zero.
+  const reach = clamp(Math.sqrt(dx * dx + dy * dy) * 0.4, 24, 220)
+  const [ax, ay] = tangentOffset(from.side ?? 'bottom', reach)
+  const [bx, by] = tangentOffset(to.side ?? 'top', reach)
+  const c1x = a.x + ax
+  const c1y = a.y + ay
+  const c2x = b.x + bx
+  const c2y = b.y + by
+  return `M ${a.x} ${a.y} C ${c1x} ${c1y} ${c2x} ${c2y} ${b.x} ${b.y}`
+}
+
+function tangentOffset(side: Side, magnitude: number): [number, number] {
+  switch (side) {
+    case 'top':
+      return [0, -magnitude]
+    case 'bottom':
+      return [0, magnitude]
+    case 'left':
+      return [-magnitude, 0]
+    case 'right':
+      return [magnitude, 0]
+  }
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return v < lo ? lo : v > hi ? hi : v
+}
+
 type Side = 'top' | 'bottom' | 'left' | 'right'
 
 const LABEL_OFFSET = 12


### PR DESCRIPTION
## Summary

Swaps the per-edge orthogonal polyline + bend-channel routing for a single **cubic Bezier curve** from source port to dest port. Tangent magnitude is proportional to the **port-normal gap** so each curve flows straight out of its port for a stalk-length before arcing toward the destination — the "stalk → arc → stalk" silhouette network engineers expect from a cable.

**Bezier is the default in this PR.** Orthogonal remains selectable via \`window.__shumoku.setEdgeStyle('orthogonal')\` for A/B comparison and as an escape hatch.

## Why

The dense fan-out problem (one switch → 14 children) crammed all orthogonal bend points into the layer-gap channel, producing a visible \"wall of bends\" no matter how cleverly the lanes were allocated (#222, #223, #224). The problem was structural: orthogonal routing forces every edge to make its horizontal turn at *some* y, and when many edges share similar geometry they share similar bend-y → wall.

Bezier curves have no shared bend coordinate. Each edge takes its own smooth arc through the available space, so the wall **structurally cannot form**.

## Implementation

\`\`\`ts
// libs/@shumoku/renderer/src/lib/svg-coords.ts
export function bezierEdgePath(from, to) {
  // Distance along the source port's outward normal (≈ rank-axis gap).
  // For TB, this is |dy|; for LR, |dx|. Stalk length scales with it.
  const normalGap = projectAlongNormal(from.side, b.x - a.x, b.y - a.y)
  const reach = clamp(normalGap * 0.6, 40, 320)
  const c1 = a + tangentOffset(from.side, reach)
  const c2 = b + tangentOffset(to.side, reach)
  return \`M \${a.x} \${a.y} C \${c1.x} \${c1.y} \${c2.x} \${c2.y} \${b.x} \${b.y}\`
}
\`\`\`

\`SvgEdge.svelte\` switches between bezier and the existing polyline based on \`edgeStyleStore.current\`. Channel routing, libavoid output, and the bend-spread post-process are bypassed in bezier mode (currently the default).

## Visual

Verified on the problem project (103 nodes / 49 links):

| | orthogonal (was) | bezier (now) |
|---|---|---|
| eps-sw01 → 13 access switches | T-bar with 13 stacked bends | 13 individual S-curves with stalks |
| short edges | straight | tight curve, nearly straight |
| long edges | long horizontal + 2 bends | gentle S-curve with long stalks |
| node-body collisions | libavoid avoids | may pass through (deferred) |

## Defaults and toggle

The default is bezier in this PR. To switch back to orthogonal at runtime:

\`\`\`js
window.__shumoku.setEdgeStyle('orthogonal')  // use libavoid polyline + channel routing
window.__shumoku.setEdgeStyle('bezier')      // (default) smooth curve from port normals
window.__shumoku.getEdgeStyle()
\`\`\`

The toggle stays session-local for now. A real UI toggle in Settings can be added in a follow-up.

## Follow-ups (not in this PR)

- Remove or guard \`channel-routing.ts\` and the bend-spread post-process — both become dead code under the bezier default.
- Decide whether libavoid is still worth running just for obstacle avoidance, or whether we drop it entirely.
- Settings UI for the edge-style toggle.
- Optional \"Step 2\" obstacle avoidance: bbox-intersection reflection of the bezier control points so curves don't pass through unrelated node bodies.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun x biome check\` — clean
- [x] Browser visual on problem project — bend density resolved, stalks look natural
- [x] A/B toggle works (\`setEdgeStyle\` flips reactively)

🤖 Generated with [Claude Code](https://claude.com/claude-code)