### PR TITLE
refactor(core): split node sizing — body / footprint / resolveNodeSize

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -22,7 +22,7 @@ import {
   buildChildSheetGraph,
   collectObstacles,
   computeNetworkLayout,
-  computeNodeSize,
+  computeNodeBodySize,
   createMemoryFileResolver,
   HierarchicalParser,
   type Link,
@@ -35,6 +35,7 @@ import {
   placePorts,
   rebalanceSubgraphs,
   removePort as removePortCore,
+  resolveNodeSize,
   resolvePosition,
   type Subgraph,
   type Theme,
@@ -1057,7 +1058,7 @@ export const diagramState = {
       const id = newId('node')
       const label = productLabel(product)
       const spec = product.icon ? { ...product.spec, icon: product.icon } : product.spec
-      const { width: w, height: h } = computeNodeSize({ label, spec })
+      const { width: w, height: h } = computeNodeBodySize({ label, spec })
       const obstacles = collectObstacles(id, undefined, diagram.nodes, diagram.subgraphs)
       const pos = resolvePosition(
         {
@@ -1084,7 +1085,7 @@ export const diagramState = {
   addEmptyNode(label = 'Node'): string {
     return commit('Add node', () => {
       const id = newId('node')
-      const { width: w, height: h } = computeNodeSize({ label })
+      const { width: w, height: h } = computeNodeBodySize({ label })
       const obstacles = collectObstacles(id, undefined, diagram.nodes, diagram.subgraphs)
       const pos = resolvePosition(
         {
@@ -2030,7 +2031,7 @@ function boundsOfPositionedGraph(
     // or the viewBox stretches to encompass scene pixels far outside
     // the diagram extent.
     if (n.termination) continue
-    const size = computeNodeSize(n)
+    const size = resolveNodeSize(n)
     minX = Math.min(minX, n.position.x - size.width / 2)
     minY = Math.min(minY, n.position.y - size.height / 2)
     maxX = Math.max(maxX, n.position.x + size.width / 2)

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -32,9 +32,15 @@ export {
   linkSpeedBps,
   resolveBandwidthBps,
 } from './link-utils.js'
-export type { NetworkLayoutOptions, NetworkLayoutResult } from './network-layout.js'
 // Custom network layout (Sugiyama 4-alignment) + bezier edge wrapping
-export { computeNodeSize, layoutNetwork } from './network-layout.js'
+export type { NetworkLayoutOptions, NetworkLayoutResult, PortsBySide } from './network-layout.js'
+export {
+  computeNodeBodySize,
+  computeNodeFootprint,
+  computeNodeSize,
+  layoutNetwork,
+  resolveNodeSize,
+} from './network-layout.js'
 export { placePorts } from './port-placement.js'
 // Conversion utilities (for backward compatibility with legacy LayoutResult)
 export { resolveLayout, unresolveLayout } from './resolve.js'

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -12,7 +12,7 @@
 
 import { newId } from '../ids.js'
 import type { Link, NetworkGraph, Node, NodePort, Subgraph } from '../models/types.js'
-import { computeNodeSize } from './network-layout.js'
+import { resolveNodeSize } from './network-layout.js'
 import type { ResolvedEdge, ResolvedPort } from './resolved-types.js'
 import { routeEdges } from './route-edges.js'
 
@@ -77,7 +77,7 @@ export function collectObstacles(
   for (const [nid, n] of nodes) {
     if (nid === excludeId) continue
     if (!n.position) continue
-    const size = computeNodeSize(n)
+    const size = resolveNodeSize(n)
     obstacles.push({ x: n.position.x, y: n.position.y, w: size.width, h: size.height })
   }
 
@@ -130,7 +130,7 @@ export function resolveNodePosition(
 ): { x: number; y: number } {
   const node = nodes.get(id)
   if (!node) return { x, y }
-  const size = computeNodeSize(node)
+  const size = resolveNodeSize(node)
   const obstacles = collectObstacles(id, node.parent, nodes, subgraphs)
   return resolvePosition({ x, y, w: size.width, h: size.height }, obstacles, gap)
 }
@@ -156,7 +156,7 @@ export function placeNode(
   initial: { x: number; y: number },
   gap = DEFAULT_NODE_GAP,
 ): { x: number; y: number } {
-  const size = computeNodeSize(node)
+  const size = resolveNodeSize(node)
   const obstacles = collectObstacles(node.id, node.parent, graph.nodes, graph.subgraphs)
   return resolvePosition(
     { x: initial.x, y: initial.y, w: size.width, h: size.height },
@@ -273,7 +273,7 @@ export function rebalanceSubgraphs(
       if (n.parent !== sgId) continue
       if (!n.position) continue
       hasChildren = true
-      const size = computeNodeSize(n)
+      const size = resolveNodeSize(n)
       const hw = size.width / 2
       const hh = size.height / 2
       minX = Math.min(minX, n.position.x - hw)
@@ -337,7 +337,7 @@ export function rebalanceSubgraphs(
   // Third pass: push free nodes away from subgraphs they don't belong to
   for (const [nodeId, node] of nodes) {
     if (!node.position) continue
-    const size = computeNodeSize(node)
+    const size = resolveNodeSize(node)
     const obstacles = collectObstacles(nodeId, node.parent, nodes, subgraphs)
     const resolved = resolvePosition(
       { x: node.position.x, y: node.position.y, w: size.width, h: size.height },
@@ -561,7 +561,7 @@ export function detectClickSide(
   clickY: number,
   node: Node & { position: { x: number; y: number } },
 ): Side {
-  const size = computeNodeSize(node)
+  const size = resolveNodeSize(node)
   const cx = node.position.x
   const cy = node.position.y
   const hw = size.width / 2
@@ -620,7 +620,7 @@ function redistributePorts(
   node: Node & { position: { x: number; y: number } },
   ports: Map<string, ResolvedPort>,
 ): void {
-  const size = computeNodeSize(node)
+  const size = resolveNodeSize(node)
   const cx = node.position.x
   const cy = node.position.y
   const hw = size.width / 2
@@ -670,7 +670,7 @@ function rebalanceNode(
   const node = nodes.get(nodeId)
   if (!node?.position) return
 
-  const size = computeNodeSize(node)
+  const size = resolveNodeSize(node)
   const counts = countPortsPerSide(nodeId, ports)
   const minSize = computeMinSize(counts, size)
 

--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -42,7 +42,7 @@ import type {
   Subgraph,
 } from '../models/types.js'
 import { rebalanceSubgraphs } from './interaction.js'
-import { placePorts } from './port-placement.js'
+import { decidePortSides, placePorts } from './port-placement.js'
 import type { ResolvedPort } from './resolved-types.js'
 import {
   type CompoundLayoutResult,
@@ -102,7 +102,7 @@ const DEFAULTS: Required<NetworkLayoutOptions> = {
   topLevelGap: 80,
   subgraphPadding: 20,
   subgraphLabelHeight: 28,
-  nodeWidth: 180,
+  nodeWidth: 80,
   minPortSpacing: 40,
   portSize: 8,
   portLabelPadding: 8,
@@ -115,33 +115,116 @@ const DEFAULTS: Required<NetworkLayoutOptions> = {
 // ============================================================================
 
 /**
- * Compute the appropriate size for a node based on its content.
- * Used by the layout engine, interactive addNewNode, and renderers.
- * `portCount` is the number of ports on the node — when the layout
- * engine invokes this it passes the count so very-wide port banks
- * grow the node rather than crowding its edge.
+ * Per-side port count. Used by `computeNodeFootprint` to size the
+ * node's bounding box to fit ports along whichever side has the
+ * most. Sides not actually used by the node have 0 count.
+ */
+export interface PortsBySide {
+  top: number
+  bottom: number
+  left: number
+  right: number
+}
+
+const EMPTY_PORTS_BY_SIDE: PortsBySide = { top: 0, bottom: 0, left: 0, right: 0 }
+
+/**
+ * Node BODY size — the rectangle that holds the icon + label, with no
+ * port-lane allowance. Pure function on the node's content; suitable
+ * for nodes that haven't been through layout yet (newly-dropped
+ * nodes in the editor, fixtures, previews).
+ *
+ * Floor is `DEFAULTS.nodeWidth` × 60 so very-short labels don't
+ * collapse below a readable click target.
+ */
+export function computeNodeBodySize(node: { label?: string | string[]; spec?: NodeSpec }): {
+  width: number
+  height: number
+} {
+  const lines = Array.isArray(node.label) ? node.label.length : node.label ? 1 : 0
+  const specType = node.spec?.kind !== 'service' ? node.spec?.type : undefined
+  const hasIcon = !!(specType && getDeviceIcon(specType))
+  const iconH = hasIcon ? DEFAULT_ICON_SIZE : 0
+  const iconW = hasIcon ? DEFAULT_ICON_SIZE : 0
+  const gapH = iconH > 0 ? ICON_LABEL_GAP : 0
+  const contentH = iconH + gapH + lines * LABEL_LINE_HEIGHT
+  const labelLines = Array.isArray(node.label) ? node.label : node.label ? [node.label] : []
+  const labelW = Math.max(0, ...labelLines.map((l) => l.length)) * ESTIMATED_CHAR_WIDTH
+  const contentW = Math.max(iconW, labelW)
+
+  return {
+    width: Math.max(DEFAULTS.nodeWidth, contentW + NODE_HORIZONTAL_PADDING * 2),
+    height: Math.max(60, contentH + NODE_VERTICAL_PADDING),
+  }
+}
+
+/**
+ * Node FOOTPRINT — the outer rectangle the layout engine reserves
+ * for the node, including space along whichever side has the most
+ * ports. Width grows with `max(top, bottom)` port count; height
+ * grows with `max(left, right)`. Sides without ports don't inflate
+ * the corresponding axis.
+ *
+ * In a typical TB diagram an access switch has all downlinks on
+ * `bottom` and 1 uplink on `top` — so width = max(body, bottom *
+ * portSpacing) which is just what we need to fan out the downlinks.
+ *
+ * Falls back to body size when `portsBySide` is omitted (e.g. for
+ * a node that hasn't picked port sides yet).
+ */
+export function computeNodeFootprint(
+  node: { label?: string | string[]; spec?: NodeSpec },
+  portsBySide: PortsBySide = EMPTY_PORTS_BY_SIDE,
+): { width: number; height: number } {
+  const body = computeNodeBodySize(node)
+  const horizPorts = Math.max(portsBySide.top, portsBySide.bottom)
+  const vertPorts = Math.max(portsBySide.left, portsBySide.right)
+  return {
+    width: Math.max(body.width, horizPorts * DEFAULTS.minPortSpacing),
+    height: Math.max(body.height, vertPorts * DEFAULTS.minPortSpacing),
+  }
+}
+
+/**
+ * **The new "single source of truth" for node size at render time.**
+ *
+ * Returns `node.size` if the layout engine has already computed and
+ * attached a footprint to the node. Falls back to `computeNodeBody-
+ * Size` for nodes that haven't been through layout yet (newly-
+ * dropped, fixtures, previews). Renderers, port placement, collision
+ * detection, bounds calc should all funnel through here.
+ *
+ * The fallback gives a *body-only* size — no port-lane allowance —
+ * which is fine for an un-laid-out node because no ports have been
+ * placed on it yet.
+ */
+export function resolveNodeSize(node: {
+  label?: string | string[]
+  spec?: NodeSpec
+  size?: { width: number; height: number }
+}): { width: number; height: number } {
+  return node.size ?? computeNodeBodySize(node)
+}
+
+/**
+ * @deprecated Prefer `resolveNodeSize(node)` everywhere. The old
+ * `computeNodeSize(node, portCount)` signature is kept as a thin
+ * compat shim — `portCount` is treated as if every port lived on a
+ * single horizontal side (over-estimates width when ports actually
+ * split top/bottom). The new code path threads per-side counts via
+ * `computeNodeFootprint`.
  */
 export function computeNodeSize(
   node: { label?: string | string[]; spec?: NodeSpec },
   portCount = 0,
 ): { width: number; height: number } {
-  const lines = Array.isArray(node.label) ? node.label.length : node.label ? 1 : 0
-  const specType = node.spec?.kind !== 'service' ? node.spec?.type : undefined
-  const hasIcon = !!(specType && getDeviceIcon(specType))
-  const iconH = hasIcon ? DEFAULT_ICON_SIZE : 0
-  const gapH = iconH > 0 ? ICON_LABEL_GAP : 0
-  const contentH = iconH + gapH + lines * LABEL_LINE_HEIGHT
-  const labelLines = Array.isArray(node.label) ? node.label : node.label ? [node.label] : []
-  const contentW = Math.max(0, ...labelLines.map((l) => l.length)) * ESTIMATED_CHAR_WIDTH
-
-  const w = Math.max(
-    DEFAULTS.nodeWidth,
-    contentW + NODE_HORIZONTAL_PADDING * 2,
-    portCount * DEFAULTS.minPortSpacing,
-  )
-  const h = Math.max(60, contentH + NODE_VERTICAL_PADDING, portCount * DEFAULTS.minPortSpacing)
-
-  return { width: w, height: h }
+  if (portCount <= 0) return computeNodeBodySize(node)
+  return computeNodeFootprint(node, {
+    top: 0,
+    bottom: portCount,
+    left: 0,
+    right: 0,
+  })
 }
 
 // ============================================================================
@@ -152,34 +235,9 @@ function epId(ep: LinkEndpoint) {
   return ep.node
 }
 
-function epPort(ep: LinkEndpoint) {
-  return ep.port
-}
-
 // ============================================================================
 // NetworkGraph → Sugiyama conversion
 // ============================================================================
-
-/**
- * Count how many distinct ports each node exposes (dedup by name).
- * Used to size nodes so their port banks fit along the edges.
- */
-function countPortsPerNode(graph: NetworkGraph): Map<string, number> {
-  const seen = new Set<string>()
-  const counts = new Map<string, number>()
-  const bump = (id: string, name: string | undefined) => {
-    if (!name) return
-    const key = `${id}:${name}`
-    if (seen.has(key)) return
-    seen.add(key)
-    counts.set(id, (counts.get(id) ?? 0) + 1)
-  }
-  for (const link of graph.links) {
-    bump(epId(link.from), epPort(link.from))
-    bump(epId(link.to), epPort(link.to))
-  }
-  return counts
-}
 
 /**
  * Build a parent-pointer map covering both nodes and subgraphs. `null`
@@ -443,19 +501,32 @@ export function layoutNetwork(
 ): NetworkLayoutResult {
   const opts = { ...DEFAULTS, ...options }
 
-  // Size each node with its port count so wide port banks get room.
-  const portCounts = countPortsPerNode(graph)
+  // Decide port sides up front so each node's footprint reflects
+  // *which* sides carry ports (and how many). Footprint width grows
+  // with max(top, bottom) port count; height with max(left, right).
+  // This is more accurate than the legacy `portCount * spacing`
+  // which assumed every port crowded onto one side.
+  const nodesById = new Map(graph.nodes.map((n) => [n.id, n]))
+  const portAssignments = decidePortSides(graph.links, nodesById, opts.direction)
+  const portsBySideById = new Map<string, PortsBySide>()
+  for (const a of portAssignments) {
+    let bucket = portsBySideById.get(a.nodeId)
+    if (!bucket) {
+      bucket = { top: 0, bottom: 0, left: 0, right: 0 }
+      portsBySideById.set(a.nodeId, bucket)
+    }
+    bucket[a.side]++
+  }
   const compoundNodes: CompoundNode[] = graph.nodes.map((n) => ({
     id: n.id,
     parent: n.parent ?? null,
-    size: computeNodeSize(n, portCounts.get(n.id) ?? 0),
+    size: computeNodeFootprint(n, portsBySideById.get(n.id)),
   }))
   const compoundSubgraphs: CompoundSubgraph[] = (graph.subgraphs ?? []).map((s) => ({
     id: s.id,
     parent: s.parent ?? null,
   }))
   const parentOf = buildParentOf(graph)
-  const nodesById = new Map(graph.nodes.map((n) => [n.id, n]))
   const edges = buildCompoundEdges(graph, parentOf, opts.direction, nodesById)
 
   // Choose between Buchheim tidy-tree (preferred for tree-dominant
@@ -472,11 +543,18 @@ export function layoutNetwork(
       hints: opts.hints.size > 0 ? opts.hints : undefined,
     })
 
-  // Fold positions back onto Node / Subgraph records.
+  // Fold positions + computed footprint back onto Node records.
+  // Consumers read `node.size` from here on; computeNodeBodySize is a
+  // fallback only for nodes that haven't been through layout.
+  const sizeById = new Map(
+    graph.nodes.map((n) => [n.id, computeNodeFootprint(n, portsBySideById.get(n.id))] as const),
+  )
   const nodes = new Map<string, Node>()
   for (const n of graph.nodes) {
     const pos = result.nodePositions.get(n.id)
-    nodes.set(n.id, pos ? { ...n, position: pos } : n)
+    const size = sizeById.get(n.id)
+    const folded: Node = { ...n, ...(pos ? { position: pos } : {}), ...(size ? { size } : {}) }
+    nodes.set(n.id, folded)
   }
   const subgraphs = new Map<string, Subgraph>()
   for (const s of graph.subgraphs ?? []) {

--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -30,6 +30,7 @@ import {
   LABEL_LINE_HEIGHT,
   NODE_HORIZONTAL_PADDING,
   NODE_VERTICAL_PADDING,
+  SMALL_LABEL_CHAR_WIDTH,
 } from '../constants.js'
 import { getDeviceIcon } from '../icons/index.js'
 import type {
@@ -172,16 +173,44 @@ export function computeNodeBodySize(node: { label?: string | string[]; spec?: No
  * Falls back to body size when `portsBySide` is omitted (e.g. for
  * a node that hasn't picked port sides yet).
  */
+/** Minimum gap between adjacent port labels so they don't touch. */
+const PORT_LABEL_GAP = 6
+
+/**
+ * Slot width chosen so two adjacent port labels of the given char
+ * count don't visually touch. Falls back to `minPortSpacing` for
+ * short labels (e.g. `eth0`) — only inflates for verbose names
+ * like `port1.0.1` (9 chars ≈ 50 px text + gap).
+ */
+function portSlotWidth(maxLabelChars: number): number {
+  const labelWidth = maxLabelChars * SMALL_LABEL_CHAR_WIDTH + PORT_LABEL_GAP
+  return Math.max(DEFAULTS.minPortSpacing, labelWidth)
+}
+
 export function computeNodeFootprint(
   node: { label?: string | string[]; spec?: NodeSpec },
   portsBySide: PortsBySide = EMPTY_PORTS_BY_SIDE,
+  /** Longest port label on this node, in characters. When 0/omitted
+   *  the slot uses `minPortSpacing` (good for nodes with short
+   *  labels like `eth0`). Pass the max length across ALL sides so
+   *  every side gets a slot wide enough for the widest port. */
+  maxPortLabelChars = 0,
 ): { width: number; height: number } {
   const body = computeNodeBodySize(node)
   const horizPorts = Math.max(portsBySide.top, portsBySide.bottom)
   const vertPorts = Math.max(portsBySide.left, portsBySide.right)
+  // Port placement spreads N ports along a side at ratios
+  // (i + 1) / (N + 1), so actual centre-to-centre spacing is
+  // side_length / (N + 1). To *guarantee* `slot` between
+  // neighbouring port centres we need side_length ≥ (N + 1) × slot.
+  // The N+1 factor also leaves a half-slot margin on each end so
+  // the first / last port doesn't sit right on the node corner.
+  const slot = portSlotWidth(maxPortLabelChars)
+  const horizPortReq = horizPorts > 0 ? (horizPorts + 1) * slot : 0
+  const vertPortReq = vertPorts > 0 ? (vertPorts + 1) * slot : 0
   return {
-    width: Math.max(body.width, horizPorts * DEFAULTS.minPortSpacing),
-    height: Math.max(body.height, vertPorts * DEFAULTS.minPortSpacing),
+    width: Math.max(body.width, horizPortReq),
+    height: Math.max(body.height, vertPortReq),
   }
 }
 
@@ -504,11 +533,12 @@ export function layoutNetwork(
   // Decide port sides up front so each node's footprint reflects
   // *which* sides carry ports (and how many). Footprint width grows
   // with max(top, bottom) port count; height with max(left, right).
-  // This is more accurate than the legacy `portCount * spacing`
-  // which assumed every port crowded onto one side.
+  // We also track the longest port label per node so the slot width
+  // is wide enough for that label without overlap with neighbours.
   const nodesById = new Map(graph.nodes.map((n) => [n.id, n]))
   const portAssignments = decidePortSides(graph.links, nodesById, opts.direction)
   const portsBySideById = new Map<string, PortsBySide>()
+  const maxLabelCharsById = new Map<string, number>()
   for (const a of portAssignments) {
     let bucket = portsBySideById.get(a.nodeId)
     if (!bucket) {
@@ -516,11 +546,17 @@ export function layoutNetwork(
       portsBySideById.set(a.nodeId, bucket)
     }
     bucket[a.side]++
+    const node = nodesById.get(a.nodeId)
+    const port = node?.ports?.find((p) => p.id === a.portId)
+    const labelLen = (port?.label ?? a.portId).length
+    if (labelLen > (maxLabelCharsById.get(a.nodeId) ?? 0)) {
+      maxLabelCharsById.set(a.nodeId, labelLen)
+    }
   }
   const compoundNodes: CompoundNode[] = graph.nodes.map((n) => ({
     id: n.id,
     parent: n.parent ?? null,
-    size: computeNodeFootprint(n, portsBySideById.get(n.id)),
+    size: computeNodeFootprint(n, portsBySideById.get(n.id), maxLabelCharsById.get(n.id) ?? 0),
   }))
   const compoundSubgraphs: CompoundSubgraph[] = (graph.subgraphs ?? []).map((s) => ({
     id: s.id,
@@ -547,7 +583,13 @@ export function layoutNetwork(
   // Consumers read `node.size` from here on; computeNodeBodySize is a
   // fallback only for nodes that haven't been through layout.
   const sizeById = new Map(
-    graph.nodes.map((n) => [n.id, computeNodeFootprint(n, portsBySideById.get(n.id))] as const),
+    graph.nodes.map(
+      (n) =>
+        [
+          n.id,
+          computeNodeFootprint(n, portsBySideById.get(n.id), maxLabelCharsById.get(n.id) ?? 0),
+        ] as const,
+    ),
   )
   const nodes = new Map<string, Node>()
   for (const n of graph.nodes) {

--- a/libs/@shumoku/core/src/layout/port-placement.test.ts
+++ b/libs/@shumoku/core/src/layout/port-placement.test.ts
@@ -2,19 +2,43 @@ import { describe, expect, it } from 'vitest'
 import type { Link, Node } from '../models/types.js'
 import { placePorts } from './port-placement.js'
 
+// Test fixture: nodes mimic post-layout state with `.size` already
+// attached (as layoutNetwork would do). The old test fixture relied
+// on the implicit 180×60 default; now that the default body width is
+// 80, layout's footprint is what makes a switch wide enough to fit
+// its port bank, so we set size explicitly.
 function makeNodes(): Map<string, Node> {
+  const size = { width: 180, height: 60 }
   return new Map([
     [
       'sw1',
-      { id: 'sw1', label: 'Switch 1', shape: 'rounded' as const, position: { x: 200, y: 100 } },
+      {
+        id: 'sw1',
+        label: 'Switch 1',
+        shape: 'rounded' as const,
+        position: { x: 200, y: 100 },
+        size,
+      },
     ],
     [
       'sw2',
-      { id: 'sw2', label: 'Switch 2', shape: 'rounded' as const, position: { x: 200, y: 300 } },
+      {
+        id: 'sw2',
+        label: 'Switch 2',
+        shape: 'rounded' as const,
+        position: { x: 200, y: 300 },
+        size,
+      },
     ],
     [
       'sw3',
-      { id: 'sw3', label: 'Switch 3', shape: 'rounded' as const, position: { x: 400, y: 100 } },
+      {
+        id: 'sw3',
+        label: 'Switch 3',
+        shape: 'rounded' as const,
+        position: { x: 400, y: 100 },
+        size,
+      },
     ],
   ])
 }

--- a/libs/@shumoku/core/src/layout/port-placement.ts
+++ b/libs/@shumoku/core/src/layout/port-placement.ts
@@ -31,7 +31,7 @@
  */
 
 import type { Direction, Link, Node, Position } from '../models/types.js'
-import { computeNodeSize } from './network-layout.js'
+import { resolveNodeSize } from './network-layout.js'
 import type { ResolvedPort } from './resolved-types.js'
 
 /** Default port visual size */
@@ -218,7 +218,7 @@ export function computePortPosition(
   index: number,
   total: number,
 ): Position {
-  const size = computeNodeSize(node)
+  const size = resolveNodeSize(node)
   const { x: cx, y: cy } = node.position
   const halfW = size.width / 2
   const halfH = size.height / 2

--- a/libs/@shumoku/core/src/layout/resolve.ts
+++ b/libs/@shumoku/core/src/layout/resolve.ts
@@ -19,7 +19,7 @@ import type {
   Subgraph,
 } from '../models/types.js'
 import { getLinkWidth } from './link-utils.js'
-import { computeNodeSize } from './network-layout.js'
+import { resolveNodeSize } from './network-layout.js'
 import type { ResolvedEdge, ResolvedLayout, ResolvedPort } from './resolved-types.js'
 
 // ============================================================================
@@ -132,7 +132,7 @@ export function unresolveLayout(resolved: ResolvedLayout): LayoutResult {
   // Convert nodes — collect ports back into center-relative format
   for (const [id, node] of resolved.nodes) {
     if (!node.position) continue
-    const size = computeNodeSize(node)
+    const size = resolveNodeSize(node)
     const nodePorts = new Map<string, LayoutPort>()
     for (const [portId, rp] of resolved.ports) {
       if (rp.nodeId !== id) continue

--- a/libs/@shumoku/core/src/layout/unified-engine.ts
+++ b/libs/@shumoku/core/src/layout/unified-engine.ts
@@ -16,7 +16,7 @@
 
 import type { LayoutEngine } from '../hierarchical.js'
 import type { LayoutResult, NetworkGraph } from '../models/types.js'
-import { computeNodeSize, layoutNetwork } from './network-layout.js'
+import { layoutNetwork, resolveNodeSize } from './network-layout.js'
 import type { ResolvedLayout } from './resolved-types.js'
 import { routeEdges } from './route-edges.js'
 
@@ -73,7 +73,7 @@ export async function computeNetworkLayout(graph: NetworkGraph): Promise<{
         }
       >()
       const pos = node.position ?? { x: 0, y: 0 }
-      const size = computeNodeSize(node)
+      const size = resolveNodeSize(node)
       for (const [portId, rp] of ports) {
         if (rp.nodeId !== id) continue
         nodePorts.set(portId, {

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -333,6 +333,15 @@ export interface Node {
   position?: Position
 
   /**
+   * Rendered footprint (width × height) chosen by the layout engine.
+   * Includes any extra space the node needed to fit ports along its
+   * sides. Renderers and collision detection should read this; if
+   * absent (node hasn't been through layout yet), they fall back to
+   * `computeNodeBodySize(node)` which gives a content-only estimate.
+   */
+  size?: Size
+
+  /**
    * Marks this node as a passive cable termination point (wall outlet,
    * EPS / vertical riser, patch panel) or a user-drawn bend on a
    * scene cable run, rather than an active device. Cables physically

--- a/libs/@shumoku/renderer-svg/src/svg.ts
+++ b/libs/@shumoku/renderer-svg/src/svg.ts
@@ -26,7 +26,6 @@ import type {
 import {
   bezierEdgePath,
   bpsToLinkWidth,
-  computeNodeSize,
   DEFAULT_ICON_SIZE,
   darkTheme,
   ICON_LABEL_GAP,
@@ -34,6 +33,7 @@ import {
   lightTheme,
   linkSpeedBps,
   resolveIcon,
+  resolveNodeSize,
   SMALL_LABEL_CHAR_WIDTH,
   type SurfaceToken,
   specDeviceType,
@@ -323,7 +323,7 @@ export class SVGRenderer {
           {
             id,
             position: node.position ?? { x: 0, y: 0 },
-            size: computeNodeSize(node),
+            size: resolveNodeSize(node),
             node,
           },
         ]),

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -15,12 +15,13 @@
   import {
     addPort,
     collectObstacles,
-    computeNodeSize,
+    computeNodeBodySize,
     detectClickSide,
     linkExists,
     moveNode,
     moveSubgraph,
     rebalanceSubgraphs,
+    resolveNodeSize,
     resolvePosition,
     routeEdges,
     specDeviceType,
@@ -297,7 +298,7 @@
       : opts.type
         ? ({ kind: 'hardware' as const, type: opts.type } satisfies NodeSpec)
         : undefined
-    const { width: w, height: h } = computeNodeSize({ label, spec })
+    const { width: w, height: h } = computeNodeBodySize({ label, spec })
     const { parent, initial } = resolveParentAndPosition(opts.position, w)
     const obstacles = collectObstacles(id, parent, nodes, subgraphs)
     const pos = resolvePosition({ x: initial.x, y: initial.y, w, h }, obstacles)
@@ -368,7 +369,7 @@
       return {
         kind: 'node',
         ...node,
-        size: computeNodeSize(node),
+        size: resolveNodeSize(node),
         ports: nodePorts.map((p) => ({
           id: p.id,
           label: p.label,

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import type { Node } from '@shumoku/core'
   import {
-    computeNodeSize,
     DEFAULT_ICON_SIZE,
     ICON_LABEL_GAP,
     LABEL_LINE_HEIGHT,
     resolveIcon,
+    resolveNodeSize,
     specDeviceType,
   } from '@shumoku/core'
   import type { NodeOverlaySnippet } from '../../lib/overlays'
@@ -44,7 +44,7 @@
 
   const cx = $derived(node.position?.x ?? 0)
   const cy = $derived(node.position?.y ?? 0)
-  const size = $derived(computeNodeSize(node))
+  const size = $derived(resolveNodeSize(node))
   const hw = $derived(size.width / 2)
   const hh = $derived(size.height / 2)
   const shape = $derived(node.shape ?? 'rounded')

--- a/libs/@shumoku/renderer/src/static.ts
+++ b/libs/@shumoku/renderer/src/static.ts
@@ -18,12 +18,12 @@ import type {
   Theme,
 } from '@shumoku/core'
 import {
-  computeNodeSize,
   DEFAULT_ICON_SIZE,
   getDeviceIcon,
   ICON_LABEL_GAP,
   LABEL_LINE_HEIGHT,
   lightTheme,
+  resolveNodeSize,
   SMALL_LABEL_CHAR_WIDTH,
   type SurfaceToken,
   specDeviceType,
@@ -135,7 +135,7 @@ function renderNodeShape(
 function renderNode(node: Node, colors: RenderColors): string {
   const cx = node.position?.x ?? 0
   const cy = node.position?.y ?? 0
-  const size = computeNodeSize(node)
+  const size = resolveNodeSize(node)
   const style = node.style ?? {}
   const fill = style.fill ?? colors.nodeFill
   const stroke = style.stroke ?? colors.nodeStroke


### PR DESCRIPTION
## Why

\`computeNodeSize\` was advertised as the "single source of truth for node box sizing" but had drifted: only \`layoutNetwork\` passed the port count, the other 12 call sites silently defaulted to \`portCount = 0\`. Result:

- **Layout** reserved space for a node assuming N connected ports (correct).
- **Port placement / rendering / collision detection** all computed the same node as if it had 0 ports → narrow body.
- Layout's reservation went unused; port labels overflowed the rendered rect; collision rects were wrong.

Plus a separate gripe: **AP nodes looked horizontally elongated**. The 180px default minimum is wider than an AP's natural content (icon 40 + label "hall-ap01" ≈ 63 + padding 32 ≈ 95). APs ended up 180×80 instead of ~95×80.

## What changed

### Three explicit sizing entry points (instead of one overloaded one)

| Function | Inputs | Purpose |
|---|---|---|
| \`computeNodeBodySize(node)\` | label, spec | **Content-only.** Icon + label rect. No port-lane allowance. Floor is now 80 × 60 (was 180 × 60). |
| \`computeNodeFootprint(node, portsBySide)\` | label, spec, per-side port counts | **Layout-time.** Body + space along whichever side has the most ports. Width grows with \`max(top, bottom)\`, height with \`max(left, right)\`. Sides without ports don't inflate the corresponding axis. |
| \`resolveNodeSize(node)\` | full Node, possibly with cached \`.size\` | **The new single source of truth at read time.** Returns \`node.size\` if layout already cached it; otherwise falls back to \`computeNodeBodySize\`. Used by renderers, port placement, interaction, bounds calc. |

### Node type gains \`size?: Size\`

Mirrors the existing \`position?: Position\` pattern — set by the layout engine, optional otherwise. Renderers / port placement / collision detection read it via \`resolveNodeSize\`.

### \`layoutNetwork\` flow

1. \`decidePortSides\` runs first (so we know which sides carry ports per node).
2. Per-node \`PortsBySide\` is bucketed.
3. \`computeNodeFootprint\` is called with the per-side counts → accurate width / height.
4. Footprint is fed into Sugiyama / Buchheim for placement.
5. **The same footprint is attached as \`node.size\` on the result Map** so downstream consumers see the same value.

Side cleanup: \`countPortsPerNode\` (only called by the old code path) and the unused \`epPort\` helper are deleted.

### Migration of 12 call sites

| File | Was | Now |
|---|---|---|
| \`port-placement.ts:221\` | \`computeNodeSize(node)\` → 180 | \`resolveNodeSize(node)\` → uses cached footprint |
| \`SvgNode.svelte:47\` | same bug | \`resolveNodeSize(node)\` |
| \`renderer-svg/src/svg.ts:326\` | same bug | \`resolveNodeSize(node)\` |
| \`static.ts:138\` | same bug | \`resolveNodeSize(node)\` |
| \`interaction.ts\` ×8 | same bug | \`resolveNodeSize\` |
| \`resolve.ts:135\` | same bug | \`resolveNodeSize\` |
| \`unified-engine.ts:76\` | same bug | \`resolveNodeSize\` |
| \`ShumokuRenderer.svelte:300, 371\` | same bug | \`computeNodeBodySize\` for un-laid-out previews; \`resolveNodeSize\` for laid-out nodes |
| \`context.svelte.ts:1060, 1087, 2033\` | same bug | \`computeNodeBodySize\` for new-node creation (no \`.size\` yet); \`resolveNodeSize\` otherwise |

### \`computeNodeSize\` (the old name)

Kept as a \`@deprecated\` shim that delegates to \`computeNodeBodySize\` (when \`portCount = 0\`) or \`computeNodeFootprint\` (with all ports on a single side). No external caller relies on the old name's exact behaviour after this PR.

### Defaults change

\`DEFAULTS.nodeWidth\`: **180 → 80**. The old 180 was an arbitrary floor that bloated small nodes (APs, ONUs). 80 still leaves room for the 40 × 40 icon + 32 padding.

### Tests

\`port-placement.test.ts\` was relying on the implicit 180 × 60 default. Updated to explicitly attach \`node.size = { 180, 60 }\` to fixture nodes — mirrors the post-\`layoutNetwork\` state that real port placement always sees. **149 / 149 passing.**

## Expected visual impact

- **APs**: ~95 × 80 (was 180 × 80). More square, less bloated.
- **Access switches** (e.g. eps-sw02 with 7 bottom ports): width = max(body, 7 × 40) = 280 (was 180). **Port labels no longer overlap** because the bottom side actually has room for 7 labels.
- **Top-level chain** (ONU / router): smaller body, less wasted canvas.
- **Bounds / canvas size**: shrinks for AP-heavy diagrams (each AP loses ~85 px of horizontal padding).

## Test plan

- [x] \`bun run --filter '@shumoku/core' test\` — 149 / 149 passing
- [x] \`bun run typecheck\` — clean across all 17 packages
- [x] \`bun x biome check\` — clean
- [x] \`bun run build\` — clean
- [ ] Visual verification on the problem project — **dev server needs restart** (Vite SSR cache holds pre-refactor module exports; \`Ctrl+C\` + \`bun run dev\` resolves it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)