### PR TITLE
feat(editor): scene labels scale with node size, drop white halo

### DIFF
--- a/apps/editor/src/lib/components/scene/SceneEdge.svelte
+++ b/apps/editor/src/lib/components/scene/SceneEdge.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { BaseEdge, type Edge, EdgeLabel, type EdgeProps, useSvelteFlow } from '@xyflow/svelte'
+  import { BaseEdge, type Edge, type EdgeProps, useSvelteFlow } from '@xyflow/svelte'
   import { editorState } from '$lib/context.svelte'
   import { formatMeters } from '$lib/scene/cable-length'
   import { WIRE_CORNER_RADIUS } from '$lib/scene/node-geometry'
@@ -119,10 +119,22 @@
   />
 {/if}
 
+<!-- Cable-length pill uses BaseEdge's built-in `label` prop instead
+     of a separate EdgeLabel block. Same DOM result (Svelte Flow
+     portals it into the edge-labels layer), but no double-wrapping
+     <span> and no custom halo box-shadow — the white fill + thin
+     border gives enough contrast on its own. Hidden while selected
+     to keep wire-edit space uncluttered. -->
 <BaseEdge
   path={pathD}
   {markerEnd}
   interactionWidth={0}
+  label={!selected && labelAnchor && data?.lengthMeters != null
+    ? `${formatMeters(data.lengthMeters)}m`
+    : undefined}
+  labelX={labelAnchor?.x}
+  labelY={labelAnchor?.y}
+  labelStyle="background:white;padding:0 6px;border-radius:3px;border:1px solid rgba(0,0,0,0.15);font-size:10px;line-height:14px;font-weight:500;color:#1e293b;box-shadow:0 1px 2px rgba(0,0,0,0.15);"
   style="stroke: {selected ? '#3b82f6' : '#475569'}; stroke-width: {(selected ? 3.5 : 3) *
     (data?.wireScale ?? 1)}; stroke-linecap: round; stroke-linejoin: round; {style ?? ''}"
 />
@@ -138,16 +150,3 @@
   style="cursor: grab; pointer-events: stroke;"
   onpointerdown={onLinePointerDown}
 />
-
-<!-- Cable length pill, hidden while selected to keep the
-     wire-edit space uncluttered. -->
-{#if !selected && labelAnchor && data?.lengthMeters !== null && data?.lengthMeters !== undefined}
-  <EdgeLabel x={labelAnchor.x} y={labelAnchor.y}>
-    <span
-      class="block rounded-[3px] border border-black/15 bg-white px-1.5 text-[10px] leading-[14px] font-medium text-slate-800 shadow-[0_0_0_1.5px_rgba(255,255,255,0.9),0_1px_2px_rgba(0,0,0,0.2)]"
-      style="transform: translate(-50%, -50%); pointer-events: none;"
-    >
-      {formatMeters(data.lengthMeters)}m
-    </span>
-  </EdgeLabel>
-{/if}

--- a/apps/editor/src/lib/components/scene/SceneNode.svelte
+++ b/apps/editor/src/lib/components/scene/SceneNode.svelte
@@ -55,7 +55,18 @@
     'scene'
   >
 
-  let { data, selected }: NodeProps<SceneNodeT> = $props()
+  let { data, selected, width }: NodeProps<SceneNodeT> = $props()
+
+  // Label font scales with the node width so per-element / per-scene
+  // display scale carries the typography along with the icon. A 52 px
+  // base node renders 10 px text; bigger nodes get proportionally
+  // larger labels, clamped so the extremes stay readable. Matches the
+  // ratio used by NodeResizer's baseW / scale math.
+  const labelFontSize = $derived.by(() => {
+    const w = width ?? 52
+    return Math.max(8, Math.min(24, w / 5.2))
+  })
+  const labelMaxWidth = $derived((width ?? 52) * 3)
 
   // Inline rename state. While editing we swap the read-only label
   // chip for an <input>; on commit we route through `data.onRename`
@@ -294,25 +305,30 @@
     <!-- Inline rename input. Replaces the read-only label chip while
          editing; commits on Enter / blur, cancels on Escape. The
          outer `nodrag` class keeps Svelte Flow from interpreting
-         pointer drags inside the input as a node move. -->
+         pointer drags inside the input as a node move. Font size
+         tracks `labelFontSize` so the input chip matches what the
+         label was just showing — no jump when you double-click in. -->
     <input
       bind:this={inputEl}
       bind:value={editValue}
       onkeydown={onRenameKey}
       onblur={commitRename}
       type="text"
-      class="nodrag absolute left-1/2 top-full max-w-[200px] -translate-x-1/2 rounded-[3px] border border-blue-500 bg-white px-1 text-[10px] leading-[14px] text-slate-900 outline-none focus:ring-1 focus:ring-blue-400"
-      style="margin-top: 2px; box-shadow: 0 0 0 1.5px rgba(255,255,255,0.9), 0 1px 2px rgba(0,0,0,0.2);"
+      class="nodrag absolute left-1/2 top-full -translate-x-1/2 rounded-[3px] border border-blue-500 bg-white px-1 text-slate-900 outline-none focus:ring-1 focus:ring-blue-400"
+      style="margin-top: 2px; font-size: {labelFontSize}px; line-height: 1.4em; max-width: {labelMaxWidth +
+        40}px; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);"
     >
   {:else if data.label}
     <!-- Label floats beneath the icon, absolutely positioned so it
          doesn't extend the node's hit area — handles + wires stay
          locked to the icon. Double-click opens the rename input
-         (same handler as the toolbar Rename button). -->
+         (same handler as the toolbar Rename button). Font size and
+         max-width scale with the node — see `labelFontSize` /
+         `labelMaxWidth` derivations above. -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
-      class="absolute left-1/2 top-full max-w-[160px] -translate-x-1/2 truncate rounded-[3px] border border-black/15 bg-white px-1 text-[10px] leading-[14px] text-slate-900"
-      style="margin-top: 2px; pointer-events: auto; cursor: text; box-shadow: 0 0 0 1.5px rgba(255,255,255,0.9), 0 1px 2px rgba(0,0,0,0.2);"
+      class="absolute left-1/2 top-full -translate-x-1/2 truncate rounded-[3px] border border-black/15 bg-white px-1 text-slate-900"
+      style="margin-top: 2px; font-size: {labelFontSize}px; line-height: 1.4em; max-width: {labelMaxWidth}px; pointer-events: auto; cursor: text; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);"
       ondblclick={(e) => {
         e.stopPropagation()
         startRename()


### PR DESCRIPTION
## Summary

Two related cleanups for scene-mode labels.

### `SceneNode`: label scales with node width

- Pull `width` from `NodeProps`, derive `labelFontSize = clamp(8, w / 5.2, 24)` and `labelMaxWidth = w * 3`
- Apply to both the read-only label chip and the inline rename input — no jump when double-clicking in
- Per-element / per-scene display scale now carries the typography along with the icon; a 2× node renders 2× text instead of staying stuck at 10 px

### `SceneEdge`: cable-length pill via built-in API

- Migrated to `BaseEdge`'s built-in `label` / `labelX` / `labelY` / `labelStyle` props
- Removed the separate `<EdgeLabel>` block and the custom `<span>` wrapper
- Same rendered DOM (Svelte Flow still portals `EdgeLabel` into the edge-labels layer), but the label string now flows through the standard API — matches the `{ id, source, target, label: '...' }` idiom from React Flow docs

### Both surfaces: drop the white halo

`box-shadow: 0 0 0 1.5px rgba(255,255,255,0.9), 0 1px 2px rgba(0,0,0,0.2)` →
`box-shadow: 0 1px 2px rgba(0,0,0,0.15)`

The halo was making the pills look like they had a "backdrop" piece floating behind them. White fill + 1 px black/15 border already gives enough contrast over busy floor plans.

**Kept** the halo on termination glyphs (outlet / EPS / panel) — those are small functional icons (not text backgrounds), and they really do lose contrast without it.

## Test plan

- [ ] Open a scene with calibrated `pxPerMeter`. Cable-length pills appear at edge midpoints, single layered look (no halo backdrop)
- [ ] Select a wire. Pill hides for the wire-edit gesture
- [ ] Open a scene, drag-resize a device pin. Label text grows / shrinks proportionally; `max-width` follows so longer labels gain room
- [ ] Double-click a label to rename. Input chip matches the label's current font-size (no jump)
- [ ] Try light + dark editor themes; pills + labels readable against floor-plan + plain backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)