### PR TITLE
fix(editor): cable length measures icon-center → icon-center (with effective-size helper dedup)

### DIFF
--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -10,7 +10,12 @@
   import { onDestroy, onMount } from 'svelte'
   import { diagramState, editorState } from '$lib/context.svelte'
   import { cableSegmentLengths, visibleCableSegments } from '$lib/scene/cable-length'
-  import { pickSideForDirection, sceneNodeSize } from '$lib/scene/node-geometry'
+  import {
+    effectiveNodeSize,
+    nodeCenterFromTopLeft,
+    pickSideForDirection,
+    sceneNodeSize,
+  } from '$lib/scene/node-geometry'
   import { nodesInScope } from '$lib/scene/scope'
   import type { Scene } from '$lib/types'
   import EpsRoutingModal from './EpsRoutingModal.svelte'
@@ -113,42 +118,33 @@
     return node?.position ?? { x: 100, y: 100 }
   }
 
-  // Per-scene visual tuning. The scene-level multipliers are the
-  // baseline; individual nodes / wires can override them via
-  // `Node.metadata.displayScale` and `Link.metadata.wireScale`.
-  const sceneNodeScale = $derived(scene.display?.nodeScale ?? 1)
+  // Per-scene visual tuning. Node size is computed via the shared
+  // `effectiveNodeSize` helper so length math sees identical
+  // dimensions; here we just keep the wire-scale resolver (no
+  // analogous helper in node-geometry — wires aren't placeable
+  // shapes, so the scale lookup lives at the call site).
   const sceneWireScale = $derived(scene.display?.wireScale ?? 1)
 
-  function effectiveNodeScale(nodeId: string): number {
-    const ov = diagramState.nodes.get(nodeId)?.metadata?.displayScale
-    if (typeof ov === 'number' && ov > 0) return ov
-    return sceneNodeScale
-  }
   function effectiveWireScale(link: { metadata?: Record<string, unknown> }): number {
     const ov = link.metadata?.wireScale
     if (typeof ov === 'number' && ov > 0) return ov
     return sceneWireScale
   }
 
-  // Effective rendered dimensions for a node — base role size times
-  // its effective scale. We pass these to Svelte Flow as
-  // `Node.width`/`Node.height` so the library positions handles
-  // and computes sourceX/Y / targetX/Y itself; SceneNode just fills
-  // the wrapper with `w-full h-full`.
+  // Effective rendered dimensions for a node. We pass these to Svelte
+  // Flow as `Node.width`/`Node.height` so the library positions
+  // handles and computes sourceX/Y / targetX/Y itself; SceneNode just
+  // fills the wrapper with `w-full h-full`.
   function effSize(nodeId: string): { w: number; h: number } {
-    const base = sceneNodeSize(diagramState.nodes.get(nodeId))
-    const s = effectiveNodeScale(nodeId)
-    return { w: base.w * s, h: base.h * s }
+    return effectiveNodeSize(scene, diagramState.nodes.get(nodeId))
   }
 
   // Center of a node's icon in flow coords. Used for via TP positions
   // — Svelte Flow doesn't expose those automatically (they're not
   // edge endpoints). Reads the same effective size we hand to Svelte
-  // Flow for the node, so layouts stay in sync.
+  // Flow for the node, so layouts stay in sync with length math.
   function centerOf(nodeId: string): { x: number; y: number } {
-    const tl = positionFor(nodeId)
-    const { w, h } = effSize(nodeId)
-    return { x: tl.x + w / 2, y: tl.y + h / 2 }
+    return nodeCenterFromTopLeft(scene, diagramState.nodes.get(nodeId), positionFor(nodeId))
   }
 
   // ── Svelte Flow nodes/edges (derived) ────────────────────────────

--- a/apps/editor/src/lib/scene/cable-length.ts
+++ b/apps/editor/src/lib/scene/cable-length.ts
@@ -3,6 +3,7 @@
 
 import type { Link, Node } from '@shumoku/core'
 import type { Scene } from '../types'
+import { nodeCenterFromTopLeft } from './node-geometry'
 
 /**
  * Single source of truth for cable length number formatting:
@@ -14,7 +15,13 @@ export function formatMeters(m: number): string {
 }
 
 /**
- * Endpoint position in a scene. Order:
+ * Endpoint position in a scene as the **icon center** — matches
+ * exactly where SceneCanvas anchors wires. Without the center
+ * offset, two different-sized nodes would have their length-math
+ * endpoints at mismatched corners, putting the reported cable length
+ * out of sync with the polyline that's actually drawn.
+ *
+ * Top-left priority:
  *   1. explicit placement (user dragged the pin somewhere)
  *   2. Node.position fallback (auto-layout coords)
  *
@@ -30,9 +37,11 @@ function endpointPos(
   nodeId: string,
   nodes: Map<string, Node>,
 ): { x: number; y: number } | null {
+  const node = nodes.get(nodeId)
   const placement = scene.nodePlacements.find((p) => p.nodeId === nodeId)
-  if (placement) return placement.position
-  return nodes.get(nodeId)?.position ?? null
+  const tl = placement?.position ?? node?.position
+  if (!tl) return null
+  return nodeCenterFromTopLeft(scene, node, tl)
 }
 
 /** Pixel distance between two scene endpoints, or null if either

--- a/apps/editor/src/lib/scene/node-geometry.ts
+++ b/apps/editor/src/lib/scene/node-geometry.ts
@@ -2,9 +2,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { Position } from '@xyflow/svelte'
+import type { Scene } from '../types'
 
 export type TerminationRole = 'outlet' | 'eps' | 'panel' | 'bend'
 export type WithTermination = { termination?: { role: TerminationRole } }
+export type WithScaleOverride = { metadata?: Record<string, unknown> }
+export type SceneSizedNode = WithTermination & WithScaleOverride
+
+/**
+ * Path corner radius for a polyline that bends through Nodes. The
+ * bend dot is sized at 2x this so its footprint exactly matches the
+ * arc the path cuts at each corner — visually the bend covers the
+ * rounded corner rather than floating beside it.
+ */
+export const WIRE_CORNER_RADIUS = 8
 
 /**
  * Pixel dimensions of a SceneNode for its role. Devices are larger
@@ -14,14 +25,6 @@ export type WithTermination = { termination?: { role: TerminationRole } }
  * compute correct centers, hit areas, and wire endpoint anchors
  * without re-deriving sizes.
  */
-/**
- * Path corner radius for a polyline that bends through Nodes. The
- * bend dot is sized at 2x this so its footprint exactly matches the
- * arc the path cuts at each corner — visually the bend covers the
- * rounded corner rather than floating beside it.
- */
-export const WIRE_CORNER_RADIUS = 8
-
 export function sceneNodeSize(node: WithTermination | undefined): { w: number; h: number } {
   const role = node?.termination?.role
   if (role === 'bend') return { w: WIRE_CORNER_RADIUS * 2, h: WIRE_CORNER_RADIUS * 2 }
@@ -29,6 +32,52 @@ export function sceneNodeSize(node: WithTermination | undefined): { w: number; h
   if (role === 'eps') return { w: 22, h: 32 }
   if (role === 'panel') return { w: 44, h: 22 }
   return { w: 52, h: 52 }
+}
+
+/**
+ * Effective display scale a node renders at: a per-element override
+ * (`Node.metadata.displayScale`) wins, falling back to the per-scene
+ * default. This is the multiplier applied on top of `sceneNodeSize`'s
+ * base role dimensions.
+ */
+export function effectiveNodeScale(scene: Scene, node: SceneSizedNode | undefined): number {
+  const override = node?.metadata?.displayScale
+  if (typeof override === 'number' && override > 0) return override
+  return scene.display?.nodeScale ?? 1
+}
+
+/**
+ * Effective rendered size for a node in a given scene — base role
+ * size times its effective scale. Both SceneCanvas (which hands these
+ * to Svelte Flow as `Node.width` / `Node.height`) and cable-length
+ * math (which adds half-w / half-h to recover the icon center) read
+ * from this single source so the visual line and the reported length
+ * stay in sync.
+ */
+export function effectiveNodeSize(
+  scene: Scene,
+  node: SceneSizedNode | undefined,
+): { w: number; h: number } {
+  const base = sceneNodeSize(node)
+  const s = effectiveNodeScale(scene, node)
+  return { w: base.w * s, h: base.h * s }
+}
+
+/**
+ * Icon center given a top-left point. Convenience over inlining
+ * `tl.x + w/2, tl.y + h/2` at every call site, and keeps the
+ * top-left → center conversion paired with the size math it depends
+ * on. Pass whatever you already have for the top-left — SceneCanvas
+ * uses a derived Map for hot-path performance, cable-length walks
+ * `nodePlacements` directly, both feed in here.
+ */
+export function nodeCenterFromTopLeft(
+  scene: Scene,
+  node: SceneSizedNode | undefined,
+  topLeft: { x: number; y: number },
+): { x: number; y: number } {
+  const { w, h } = effectiveNodeSize(scene, node)
+  return { x: topLeft.x + w / 2, y: topLeft.y + h / 2 }
 }
 
 /**


### PR DESCRIPTION
## Problem

The visual wire in SceneCanvas runs from one icon **center** to another (`centerOf` adds the node's effective `w/2`, `h/2` to its top-left). But the length math in \`cable-length.ts\` was reading \`scene.nodePlacements[i].position\` directly — Svelte Flow's **top-left** convention. Same-size nodes worked by accident (the center offset cancels in the subtraction), but the moment a scene mixed sizes — per-element \`displayScale\`, per-scene \`nodeScale\`, or two different termination roles back-to-back — the reported cable length drifted from the polyline that was actually drawn.

## Fix

\`endpointPos\` now resolves the icon **center** (top-left + w/2, h/2 of the effective render size) so length matches what's on screen.

## Refactor

The size math was duplicated across SceneCanvas (\`effectiveNodeScale\`, \`effSize\`, \`centerOf\`) and \`cable-length.ts\` (the new \`effSizeFor\`). Lifted to \`node-geometry.ts\`:

- \`effectiveNodeScale(scene, node)\` — per-element \`displayScale\` override or scene \`nodeScale\` fallback
- \`effectiveNodeSize(scene, node)\` — base role size × effective scale, the single source of truth for "how big is this node?"
- \`nodeCenterFromTopLeft(scene, node, tl)\` — pairs the size math with the top-left → center conversion

SceneCanvas keeps its derived \`placementById\` Map for hot-path performance — it just feeds the top-left into the shared helper now. \`cable-length.ts\` no longer carries its own \`effSizeFor\` copy.

## Test plan

- [ ] Open a scene with mixed-size nodes (e.g. device pin + EPS, or device with a per-element scale override). Cable-length pill now matches the visible polyline distance ÷ \`pxPerMeter\`
- [ ] Pure same-size scenes: lengths unchanged (the fix is a no-op there)
- [ ] LinkProperties detail panel still shows "from scene" tag for scene-derived lengths
- [ ] BOM tab + Connections page reflect the corrected lengths
- [ ] Drag-resize a pin: handles + wires still terminate at the icon edges (no regression in SceneCanvas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)