### PR TITLE
feat(editor): scene wires colored by cable jacket grade (TIA-598-C fiber + industry copper)

### DIFF
--- a/apps/editor/src/lib/components/scene/CableLegend.svelte
+++ b/apps/editor/src/lib/components/scene/CableLegend.svelte
@@ -88,15 +88,22 @@
       </ul>
     </div>
   {:else}
-    <Button
-      variant="outline"
-      size="sm"
-      class="h-7 px-2 text-[11px]"
+    <button
+      type="button"
+      class="flex h-7 items-center gap-1.5 rounded-md border border-neutral-200 bg-white px-2 text-[11px] font-medium text-slate-800 shadow-md hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
       onclick={() => {
-          expanded = true
-        }}
+        expanded = true
+      }}
+      aria-label="Show cable color legend"
     >
+      <!-- 4 swatch pips so the trigger itself hints at the content -->
+      <span class="flex gap-0.5" aria-hidden="true">
+        <span class="h-2 w-1 rounded-[1px]" style="background:#2563EB"></span>
+        <span class="h-2 w-1 rounded-[1px]" style="background:#10B981"></span>
+        <span class="h-2 w-1 rounded-[1px]" style="background:#06B6D4"></span>
+        <span class="h-2 w-1 rounded-[1px]" style="background:#EAB308"></span>
+      </span>
       Cable colors
-    </Button>
+    </button>
   {/if}
 </Panel>

--- a/apps/editor/src/lib/components/scene/CableLegend.svelte
+++ b/apps/editor/src/lib/components/scene/CableLegend.svelte
@@ -1,78 +1,41 @@
 <script lang="ts">
   import type { CableGrade } from '@shumoku/core'
   import { Panel } from '@xyflow/svelte'
-  import { Button } from '$lib/components/ui/button'
   import { CABLE_GRADE_ORDER, cableCategoryColor, cableGradeLabel } from '$lib/scene/cable-colors'
 
   // In-canvas color legend for scene wires. The wire stroke palette
   // lives in `cable-colors.ts`; this component is the visual readout
-  // for it.
-  //
-  // - **Categorized scene** (some link has `cable.category`): legend
-  //   filters to grades actually used, so a 3-link scene with one
-  //   Cat 6 and two OM3 wires shows two rows, not twelve.
-  // - **Un-categorized scene** (no link has it set): full 12-grade
-  //   palette is shown as a reference card. The legend is the
-  //   discovery surface for the color system, so users see what's
-  //   possible before they start assigning grades — and don't waste
-  //   time hunting for "where do I see the color key".
+  // for it. Always expanded, always filtered: shows just the grades
+  // referenced by links in the current scene, and hides entirely
+  // when no link has a `cable.category` set — the legend follows the
+  // data, no toggling, no reference mode.
   //
   // Positioning is Svelte Flow `<Panel>` (canvas-fixed, opts out of
-  // viewport zoom/pan). Inner styling is Tailwind + shadcn Button so
-  // the legend matches the rest of the app (NavBar / modals / detail
-  // panels). Standard "Panel for where, UI library for how it looks".
+  // viewport zoom/pan). Inner styling is plain Tailwind so the card
+  // matches the rest of the app (NavBar / modals / detail panels).
 
   type Props = {
-    /** Cable grades referenced by visible links in the current scene.
-     *  Empty → legend falls back to the full reference set. */
+    /** Cable grades referenced by visible links in the current scene. */
     presentGrades: Iterable<CableGrade>
   }
 
   const { presentGrades }: Props = $props()
 
-  // Open state is local — there's no project-wide setting to persist
-  // because the legend is informational, not a configuration. Default
-  // closed so the canvas reads uncluttered; one click reveals the key.
-  let expanded = $state(false)
-
-  const isReferenceMode = $derived.by(() => {
-    const it = presentGrades[Symbol.iterator]()
-    return it.next().done === true
-  })
   const sortedGrades = $derived.by(() => {
-    if (isReferenceMode) return CABLE_GRADE_ORDER
     const present = new Set(presentGrades)
     return CABLE_GRADE_ORDER.filter((g) => present.has(g))
   })
 </script>
 
-<Panel position="bottom-right">
-  {#if expanded}
+{#if sortedGrades.length > 0}
+  <Panel position="bottom-right">
     <div
-      class="flex w-44 flex-col rounded-md border border-neutral-200 bg-white text-slate-800 shadow-md dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+      class="flex flex-col rounded-md border border-neutral-200 bg-white text-slate-800 shadow-md dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
     >
       <div
-        class="flex items-center justify-between border-b border-neutral-200 px-3 py-1.5 text-[11px] font-medium dark:border-neutral-700"
+        class="border-b border-neutral-200 px-3 py-1.5 text-[11px] font-medium dark:border-neutral-700"
       >
-        <span>
-          Cable colors
-          {#if isReferenceMode}
-            <span class="ml-1 font-normal text-neutral-400 dark:text-neutral-500">
-              (reference)
-            </span>
-          {/if}
-        </span>
-        <Button
-          variant="ghost"
-          size="icon"
-          class="h-5 w-5 text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100"
-          onclick={() => {
-              expanded = false
-            }}
-          aria-label="Close cable color legend"
-        >
-          ×
-        </Button>
+        Cable colors
       </div>
       <ul class="flex flex-col gap-1 px-3 py-2">
         {#each sortedGrades as grade (grade)}
@@ -87,23 +50,5 @@
         {/each}
       </ul>
     </div>
-  {:else}
-    <button
-      type="button"
-      class="flex h-7 items-center gap-1.5 rounded-md border border-neutral-200 bg-white px-2 text-[11px] font-medium text-slate-800 shadow-md hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
-      onclick={() => {
-        expanded = true
-      }}
-      aria-label="Show cable color legend"
-    >
-      <!-- 4 swatch pips so the trigger itself hints at the content -->
-      <span class="flex gap-0.5" aria-hidden="true">
-        <span class="h-2 w-1 rounded-[1px]" style="background:#2563EB"></span>
-        <span class="h-2 w-1 rounded-[1px]" style="background:#10B981"></span>
-        <span class="h-2 w-1 rounded-[1px]" style="background:#06B6D4"></span>
-        <span class="h-2 w-1 rounded-[1px]" style="background:#EAB308"></span>
-      </span>
-      Cable colors
-    </button>
-  {/if}
-</Panel>
+  </Panel>
+{/if}

--- a/apps/editor/src/lib/components/scene/CableLegend.svelte
+++ b/apps/editor/src/lib/components/scene/CableLegend.svelte
@@ -6,21 +6,25 @@
 
   // In-canvas color legend for scene wires. The wire stroke palette
   // lives in `cable-colors.ts`; this component is the visual readout
-  // for it. Lists only the grades actually present in the scene so
-  // the legend reflects what the user is looking at — a 3-link
-  // scene with one Cat 6 and two OM3 wires shows two rows, not
-  // twelve. Empty when no link has a `cable.category` set, so we
-  // don't introduce UI noise on scenes that haven't been categorized.
+  // for it.
+  //
+  // - **Categorized scene** (some link has `cable.category`): legend
+  //   filters to grades actually used, so a 3-link scene with one
+  //   Cat 6 and two OM3 wires shows two rows, not twelve.
+  // - **Un-categorized scene** (no link has it set): full 12-grade
+  //   palette is shown as a reference card. The legend is the
+  //   discovery surface for the color system, so users see what's
+  //   possible before they start assigning grades — and don't waste
+  //   time hunting for "where do I see the color key".
   //
   // Positioning is Svelte Flow `<Panel>` (canvas-fixed, opts out of
-  // viewport zoom/pan). Inner styling is shadcn-svelte so the legend
-  // matches the rest of the app (NavBar / modals / detail panels).
-  // Mixing the two is the standard Svelte-Flow-plus-UI-library
-  // pattern — Panel for "where", shadcn for "how it looks".
+  // viewport zoom/pan). Inner styling is Tailwind + shadcn Button so
+  // the legend matches the rest of the app (NavBar / modals / detail
+  // panels). Standard "Panel for where, UI library for how it looks".
 
   type Props = {
     /** Cable grades referenced by visible links in the current scene.
-     *  Caller passes the deduped set; legend filters + sorts. */
+     *  Empty → legend falls back to the full reference set. */
     presentGrades: Iterable<CableGrade>
   }
 
@@ -31,58 +35,68 @@
   // closed so the canvas reads uncluttered; one click reveals the key.
   let expanded = $state(false)
 
+  const isReferenceMode = $derived.by(() => {
+    const it = presentGrades[Symbol.iterator]()
+    return it.next().done === true
+  })
   const sortedGrades = $derived.by(() => {
+    if (isReferenceMode) return CABLE_GRADE_ORDER
     const present = new Set(presentGrades)
     return CABLE_GRADE_ORDER.filter((g) => present.has(g))
   })
 </script>
 
-{#if sortedGrades.length > 0}
-  <Panel position="bottom-right">
-    {#if expanded}
+<Panel position="bottom-right">
+  {#if expanded}
+    <div
+      class="flex w-44 flex-col rounded-md border border-neutral-200 bg-white text-slate-800 shadow-md dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+    >
       <div
-        class="flex w-44 flex-col rounded-md border border-neutral-200 bg-white text-slate-800 shadow-md dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+        class="flex items-center justify-between border-b border-neutral-200 px-3 py-1.5 text-[11px] font-medium dark:border-neutral-700"
       >
-        <div
-          class="flex items-center justify-between border-b border-neutral-200 px-3 py-1.5 text-[11px] font-medium dark:border-neutral-700"
-        >
-          <span>Cable colors</span>
-          <Button
-            variant="ghost"
-            size="icon"
-            class="h-5 w-5 text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100"
-            onclick={() => {
+        <span>
+          Cable colors
+          {#if isReferenceMode}
+            <span class="ml-1 font-normal text-neutral-400 dark:text-neutral-500">
+              (reference)
+            </span>
+          {/if}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          class="h-5 w-5 text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100"
+          onclick={() => {
               expanded = false
             }}
-            aria-label="Close cable color legend"
-          >
-            ×
-          </Button>
-        </div>
-        <ul class="flex flex-col gap-1 px-3 py-2">
-          {#each sortedGrades as grade (grade)}
-            <li class="flex items-center gap-2 text-[11px]">
-              <span
-                class="inline-block h-2 w-4 flex-shrink-0 rounded-sm"
-                style="background: {cableCategoryColor(grade)};"
-                aria-hidden="true"
-              ></span>
-              <span>{cableGradeLabel(grade)}</span>
-            </li>
-          {/each}
-        </ul>
+          aria-label="Close cable color legend"
+        >
+          ×
+        </Button>
       </div>
-    {:else}
-      <Button
-        variant="outline"
-        size="sm"
-        class="h-7 px-2 text-[11px]"
-        onclick={() => {
+      <ul class="flex flex-col gap-1 px-3 py-2">
+        {#each sortedGrades as grade (grade)}
+          <li class="flex items-center gap-2 text-[11px]">
+            <span
+              class="inline-block h-2 w-4 flex-shrink-0 rounded-sm"
+              style="background: {cableCategoryColor(grade)};"
+              aria-hidden="true"
+            ></span>
+            <span>{cableGradeLabel(grade)}</span>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {:else}
+    <Button
+      variant="outline"
+      size="sm"
+      class="h-7 px-2 text-[11px]"
+      onclick={() => {
           expanded = true
         }}
-      >
-        Cable colors
-      </Button>
-    {/if}
-  </Panel>
-{/if}
+    >
+      Cable colors
+    </Button>
+  {/if}
+</Panel>

--- a/apps/editor/src/lib/components/scene/CableLegend.svelte
+++ b/apps/editor/src/lib/components/scene/CableLegend.svelte
@@ -5,10 +5,10 @@
 
   // In-canvas color legend for scene wires. The wire stroke palette
   // lives in `cable-colors.ts`; this component is the visual readout
-  // for it. Always expanded, always filtered: shows just the grades
-  // referenced by links in the current scene, and hides entirely
-  // when no link has a `cable.category` set — the legend follows the
-  // data, no toggling, no reference mode.
+  // for it. Always expanded, always present (so the user always
+  // knows where to look). The body filters to grades referenced by
+  // links in the current scene; when no link has `cable.category`
+  // set yet, the body shows a small placeholder hint instead.
   //
   // Positioning is Svelte Flow `<Panel>` (canvas-fixed, opts out of
   // viewport zoom/pan). Inner styling is plain Tailwind so the card
@@ -27,16 +27,16 @@
   })
 </script>
 
-{#if sortedGrades.length > 0}
-  <Panel position="bottom-right">
+<Panel position="bottom-right">
+  <div
+    class="flex flex-col rounded-md border border-neutral-200 bg-white text-slate-800 shadow-md dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+  >
     <div
-      class="flex flex-col rounded-md border border-neutral-200 bg-white text-slate-800 shadow-md dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+      class="border-b border-neutral-200 px-3 py-1.5 text-[11px] font-medium dark:border-neutral-700"
     >
-      <div
-        class="border-b border-neutral-200 px-3 py-1.5 text-[11px] font-medium dark:border-neutral-700"
-      >
-        Cable colors
-      </div>
+      Cable colors
+    </div>
+    {#if sortedGrades.length > 0}
       <ul class="flex flex-col gap-1 px-3 py-2">
         {#each sortedGrades as grade (grade)}
           <li class="flex items-center gap-2 text-[11px]">
@@ -49,6 +49,10 @@
           </li>
         {/each}
       </ul>
-    </div>
-  </Panel>
-{/if}
+    {:else}
+      <div class="px-3 py-2 text-[11px] text-neutral-500 dark:text-neutral-400">
+        No categories set
+      </div>
+    {/if}
+  </div>
+</Panel>

--- a/apps/editor/src/lib/components/scene/CableLegend.svelte
+++ b/apps/editor/src/lib/components/scene/CableLegend.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import type { CableGrade } from '@shumoku/core'
+  import { Panel } from '@xyflow/svelte'
+  import { Button } from '$lib/components/ui/button'
+  import { CABLE_GRADE_ORDER, cableCategoryColor, cableGradeLabel } from '$lib/scene/cable-colors'
+
+  // In-canvas color legend for scene wires. The wire stroke palette
+  // lives in `cable-colors.ts`; this component is the visual readout
+  // for it. Lists only the grades actually present in the scene so
+  // the legend reflects what the user is looking at — a 3-link
+  // scene with one Cat 6 and two OM3 wires shows two rows, not
+  // twelve. Empty when no link has a `cable.category` set, so we
+  // don't introduce UI noise on scenes that haven't been categorized.
+  //
+  // Positioning is Svelte Flow `<Panel>` (canvas-fixed, opts out of
+  // viewport zoom/pan). Inner styling is shadcn-svelte so the legend
+  // matches the rest of the app (NavBar / modals / detail panels).
+  // Mixing the two is the standard Svelte-Flow-plus-UI-library
+  // pattern — Panel for "where", shadcn for "how it looks".
+
+  type Props = {
+    /** Cable grades referenced by visible links in the current scene.
+     *  Caller passes the deduped set; legend filters + sorts. */
+    presentGrades: Iterable<CableGrade>
+  }
+
+  const { presentGrades }: Props = $props()
+
+  // Open state is local — there's no project-wide setting to persist
+  // because the legend is informational, not a configuration. Default
+  // closed so the canvas reads uncluttered; one click reveals the key.
+  let expanded = $state(false)
+
+  const sortedGrades = $derived.by(() => {
+    const present = new Set(presentGrades)
+    return CABLE_GRADE_ORDER.filter((g) => present.has(g))
+  })
+</script>
+
+{#if sortedGrades.length > 0}
+  <Panel position="bottom-right">
+    {#if expanded}
+      <div
+        class="flex w-44 flex-col rounded-md border border-neutral-200 bg-white text-slate-800 shadow-md dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+      >
+        <div
+          class="flex items-center justify-between border-b border-neutral-200 px-3 py-1.5 text-[11px] font-medium dark:border-neutral-700"
+        >
+          <span>Cable colors</span>
+          <Button
+            variant="ghost"
+            size="icon"
+            class="h-5 w-5 text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100"
+            onclick={() => {
+              expanded = false
+            }}
+            aria-label="Close cable color legend"
+          >
+            ×
+          </Button>
+        </div>
+        <ul class="flex flex-col gap-1 px-3 py-2">
+          {#each sortedGrades as grade (grade)}
+            <li class="flex items-center gap-2 text-[11px]">
+              <span
+                class="inline-block h-2 w-4 flex-shrink-0 rounded-sm"
+                style="background: {cableCategoryColor(grade)};"
+                aria-hidden="true"
+              ></span>
+              <span>{cableGradeLabel(grade)}</span>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {:else}
+      <Button
+        variant="outline"
+        size="sm"
+        class="h-7 px-2 text-[11px]"
+        onclick={() => {
+          expanded = true
+        }}
+      >
+        Cable colors
+      </Button>
+    {/if}
+  </Panel>
+{/if}

--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { CableGrade } from '@shumoku/core'
   import {
     type Connection,
     ConnectionMode,
@@ -18,6 +19,7 @@
   } from '$lib/scene/node-geometry'
   import { nodesInScope } from '$lib/scene/scope'
   import type { Scene } from '$lib/types'
+  import CableLegend from './CableLegend.svelte'
   import EpsRoutingModal from './EpsRoutingModal.svelte'
   import NodeRoutingModal from './NodeRoutingModal.svelte'
   import SceneBackgroundNode from './SceneBackgroundNode.svelte'
@@ -61,6 +63,18 @@
         (inScopeIds.has(l.from.node) || inScopeIds.has(l.to.node)),
     ),
   )
+  // Cable grades referenced by visible links — feeds the in-canvas
+  // legend so it only lists grades actually used in this scene.
+  // Links without `cable.category` contribute nothing and keep the
+  // default slate stroke.
+  const presentCableGrades = $derived.by(() => {
+    const set = new Set<CableGrade>()
+    for (const l of visibleLinks) {
+      const cat = l.cable?.category
+      if (cat) set.add(cat)
+    }
+    return set
+  })
   // Nodes to render as pins in this scene = scope-internal nodes
   // PLUS any external endpoint referenced by a visible cross-boundary
   // link. Externals are normal SceneNodes (draggable, length-bearing);
@@ -492,6 +506,7 @@
     <ScenePrintFitter />
     <SceneCalibrationCapture sceneId={scene.id} paneClick={paneClickEvent} />
     <SceneClickPlace sceneId={scene.id} paneClick={paneClickEvent} />
+    <CableLegend presentGrades={presentCableGrades} />
   </SvelteFlow>
 
   <!-- Status hint: shown while the user is mid-action. Calibration UI

--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -305,6 +305,9 @@
             innerWaypoints,
             lengthMeters: meters,
             wireScale,
+            // Cable grade drives wire stroke color in SceneEdge —
+            // see lib/scene/cable-colors.ts + CABLE_COLORS.md.
+            cableCategory: link.cable?.category,
           },
           animated: false,
           style: crossBoundary ? 'stroke-dasharray: 5 3;' : '',

--- a/apps/editor/src/lib/components/scene/SceneEdge.svelte
+++ b/apps/editor/src/lib/components/scene/SceneEdge.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import type { CableGrade } from '@shumoku/core'
   import { BaseEdge, type Edge, type EdgeProps, useSvelteFlow } from '@xyflow/svelte'
   import { editorState } from '$lib/context.svelte'
+  import { cableCategoryColor } from '$lib/scene/cable-colors'
   import { formatMeters } from '$lib/scene/cable-length'
   import { WIRE_CORNER_RADIUS } from '$lib/scene/node-geometry'
   import { bendOnDrag, polylinePath, type Waypoint } from './wire-edit'
@@ -32,6 +34,9 @@
     lengthMeters: number | null
     /** Per-scene stroke width multiplier (Scene.display.wireScale). */
     wireScale?: number
+    /** Cable jacket grade, drives stroke color via
+     *  `cableCategoryColor()`. Undefined → slate default. */
+    cableCategory?: CableGrade
   }
   type SceneEdgeT = Edge<SceneEdgeData, 'wire'>
 
@@ -135,7 +140,9 @@
   labelX={labelAnchor?.x}
   labelY={labelAnchor?.y}
   labelStyle="background:white;padding:0 6px;border-radius:3px;border:1px solid rgba(0,0,0,0.15);font-size:10px;line-height:14px;font-weight:500;color:#1e293b;box-shadow:0 1px 2px rgba(0,0,0,0.15);"
-  style="stroke: {selected ? '#3b82f6' : '#475569'}; stroke-width: {(selected ? 3.5 : 3) *
+  style="stroke: {selected
+    ? '#3b82f6'
+    : cableCategoryColor(data?.cableCategory)}; stroke-width: {(selected ? 3.5 : 3) *
     (data?.wireScale ?? 1)}; stroke-linecap: round; stroke-linejoin: round; {style ?? ''}"
 />
 

--- a/apps/editor/src/lib/sample-diagram.ts
+++ b/apps/editor/src/lib/sample-diagram.ts
@@ -648,6 +648,7 @@ export const sampleDiagram = {
       label: 'DMZ',
       type: 'solid',
       vlan: [100],
+      cable: { category: 'om3' },
     },
     {
       id: 'link-3',
@@ -666,6 +667,7 @@ export const sampleDiagram = {
       },
       label: 'Active',
       type: 'solid',
+      cable: { category: 'om3' },
     },
     {
       id: 'link-4',
@@ -684,6 +686,7 @@ export const sampleDiagram = {
       },
       label: 'Standby',
       type: 'solid',
+      cable: { category: 'om3' },
     },
     {
       id: 'cloud/link-0',
@@ -711,6 +714,7 @@ export const sampleDiagram = {
         ip: '203.0.113.1/30',
       },
       type: 'solid',
+      cable: { category: 'os2' },
     },
     {
       id: 'perimeter/link-1',
@@ -727,6 +731,7 @@ export const sampleDiagram = {
         plug: { module: { standard: '10GBASE-SR' } },
       },
       type: 'solid',
+      cable: { category: 'os2' },
     },
     {
       id: 'perimeter/link-2',
@@ -746,6 +751,7 @@ export const sampleDiagram = {
       style: {
         minLength: 300,
       },
+      cable: { category: 'cat6' },
     },
     {
       id: 'perimeter/link-3',
@@ -762,6 +768,7 @@ export const sampleDiagram = {
         plug: { module: { standard: '10GBASE-SR' } },
       },
       type: 'solid',
+      cable: { category: 'om3' },
     },
     {
       id: 'perimeter/link-4',
@@ -778,6 +785,7 @@ export const sampleDiagram = {
         plug: { module: { standard: '10GBASE-SR' } },
       },
       type: 'solid',
+      cable: { category: 'om3' },
     },
     {
       id: 'perimeter/link-5',
@@ -795,6 +803,7 @@ export const sampleDiagram = {
       style: {
         minLength: 300,
       },
+      cable: { category: 'cat6' },
     },
     {
       id: 'dmz/link-0',
@@ -810,6 +819,7 @@ export const sampleDiagram = {
       },
       type: 'solid',
       vlan: [100],
+      cable: { category: 'cat6a' },
     },
     {
       id: 'dmz/link-1',
@@ -825,6 +835,7 @@ export const sampleDiagram = {
       },
       type: 'solid',
       vlan: [100],
+      cable: { category: 'cat6a' },
     },
     {
       id: 'campus/link-0',
@@ -842,6 +853,7 @@ export const sampleDiagram = {
       },
       label: '40G LACP',
       type: 'solid',
+      cable: { category: 'om4' },
     },
     {
       id: 'campus/link-1',
@@ -860,6 +872,7 @@ export const sampleDiagram = {
       label: 'Trunk',
       type: 'solid',
       vlan: [10, 20],
+      cable: { category: 'om3' },
     },
     {
       id: 'campus/link-2',
@@ -878,6 +891,7 @@ export const sampleDiagram = {
       label: 'Trunk',
       type: 'solid',
       vlan: [10, 30],
+      cable: { category: 'om3' },
     },
     {
       id: 'campus/link-3',
@@ -893,6 +907,7 @@ export const sampleDiagram = {
       },
       type: 'solid',
       vlan: [20],
+      cable: { category: 'cat6' },
     },
     {
       id: 'campus/link-4',
@@ -908,6 +923,7 @@ export const sampleDiagram = {
       },
       type: 'solid',
       vlan: [20],
+      cable: { category: 'cat6' },
     },
     {
       id: 'campus/link-5',
@@ -923,6 +939,7 @@ export const sampleDiagram = {
       },
       type: 'solid',
       vlan: [30],
+      cable: { category: 'cat6' },
     },
     {
       id: 'campus/link-6',
@@ -938,6 +955,7 @@ export const sampleDiagram = {
       },
       type: 'solid',
       vlan: [30],
+      cable: { category: 'cat6' },
     },
     {
       id: 'campus/link-7',
@@ -952,6 +970,7 @@ export const sampleDiagram = {
         plug: { module: { standard: '1000BASE-T' } },
       },
       type: 'solid',
+      cable: { category: 'cat5e' },
     },
   ],
   subgraphs: [

--- a/apps/editor/src/lib/scene/CABLE_COLORS.md
+++ b/apps/editor/src/lib/scene/CABLE_COLORS.md
@@ -1,0 +1,76 @@
+# Cable jacket colors in Scene mode
+
+Scene mode colors each wire by `link.cable.category` so a floor-plan view matches the physical jackets an installer is holding. This document explains the standards (or absence thereof) the palette draws from. Implementation lives in `cable-colors.ts` next to this file.
+
+The Diagram view uses a different axis — VLAN color (`getVlanStroke` in `libs/@shumoku/renderer`). Both stay in their respective lanes: **logical → VLAN, physical → cable jacket**.
+
+---
+
+## What is standardized
+
+### TIA-598-C — fiber jacket color (firm)
+
+The international standard for optical fiber cable jackets. We follow it exactly for the OM / OS grades:
+
+| Grade | TIA-598-C jacket | Our hex |
+|---|---|---|
+| **OM1 / OM2** (62.5 / 50 µm MMF, legacy) | Orange | _not represented — covered as `om3+`_ |
+| **OM3** (laser-optimized 50 µm) | **Aqua** | `#06B6D4` (cyan-500) |
+| **OM4** (bend-insensitive 50 µm) | **Aqua** (some vendors: erika violet) | `#0EA5E9` (sky-500) |
+| **OM5** (wideband 50 µm, TIA-598-C 2016) | **Lime green** | `#84CC16` (lime-500) |
+| **OS1 / OS2** (single-mode) | **Yellow** | `#EAB308` (yellow-500) |
+
+Aqua-for-MMF and yellow-for-SMF are universal — every fiber installer reads them instantly. We keep them.
+
+### TIA/EIA-606 — administration labels (not used)
+
+TIA/EIA-606 governs the **labeling of telecom records** (demarc, backbone, horizontal, emergency) with colors like orange / green / purple / red. These are **administrative metadata colors**, not cable jacket colors, and don't map cleanly to per-link visualization. We do not use TIA-606 here.
+
+---
+
+## What is industry custom (not standardized)
+
+### Copper Cat grades
+
+TIA/EIA does **not** specify Cat-cable jacket color. Vendors and installers have converged on the following — strong enough to be a working convention, but unenforceable:
+
+| Grade | Common jacket | Our hex | Rationale |
+|---|---|---|---|
+| **Cat 5e** | Gray (or blue, varies) | `#94A3B8` (slate-400) | Gray reads as "legacy" without clashing |
+| **Cat 6** | **Blue** | `#2563EB` (blue-600) | The single most-followed copper convention |
+| **Cat 6a** | White / green / violet | `#10B981` (emerald-500) | Green for "10G access" — clearer than violet at small sizes |
+| **Cat 7** | Gray / black (shielded) | `#52525B` (zinc-700) | Matches the heavier shielded look |
+| **Cat 8** | Often green | `#16A34A` (green-600) | DC-grade copper — same family as Cat 6a but darker |
+
+### DAC / AOC
+
+Direct Attach Copper and Active Optical Cable are rack-internal interconnects without color standards. We pick:
+
+| Grade | Our hex | Rationale |
+|---|---|---|
+| **DAC** | `#1F2937` (gray-800) | Near-black matches typical passive-copper jackets |
+| **AOC** | `#F472B6` (pink-400) | Pink stands out in rack-dense scenes so DAC and AOC don't blur together |
+
+---
+
+## Default (no category set)
+
+When `link.cable.category` is undefined we keep the pre-color-code era stroke: **`#475569` (slate-600)**. This matters because most existing scenes were authored before color-by-category — they should not suddenly look broken.
+
+Selection state still overrides every grade with **`#3B82F6` (blue-500)** so the wire-edit affordance reads regardless of color.
+
+---
+
+## Why not VLAN color in Scene mode?
+
+VLANs are **logical** — a single Cat 6 cable carries N VLANs as a trunk. The Diagram view (which is about logical adjacency) shows that. Scene mode is the **physical floor-plan** view; a cable installer picking the right reel cares about jacket grade, not what 802.1Q tags traverse it. Two different views, two different color axes — each consistent inside its own context.
+
+A user-toggleable color mode (slate / by-category / by-VLAN) is a possible future extension, but only worth adding if the two-context split turns out to be confusing in practice.
+
+---
+
+## Reference
+
+- TIA-598-C: ANSI/TIA-598-C-2014 (with 2016 OM5 amendment). _Optical Fiber Cable Color Coding_.
+- TIA/EIA-606-B: _Administration Standard for Telecommunications Infrastructure_. (Not used here — administrative records only.)
+- Copper Cat conventions: aggregated from major vendors (CommScope, Panduit, Belden, Hitachi Cable) — no single standard.

--- a/apps/editor/src/lib/scene/cable-colors.ts
+++ b/apps/editor/src/lib/scene/cable-colors.ts
@@ -4,6 +4,48 @@
 import type { CableGrade } from '@shumoku/core'
 
 /**
+ * Canonical display order for cable grades — copper before fiber,
+ * legacy before modern, and DAC / AOC tail since they're rack-level
+ * not building-level cabling. Used by the in-canvas legend so the
+ * column always reads top-to-bottom by familiarity rather than alpha.
+ */
+export const CABLE_GRADE_ORDER: readonly CableGrade[] = [
+  'cat5e',
+  'cat6',
+  'cat6a',
+  'cat7',
+  'cat8',
+  'om3',
+  'om4',
+  'om5',
+  'os1',
+  'os2',
+  'dac',
+  'aoc',
+]
+
+/**
+ * Human-friendly label for a grade. We capitalize the family ("Cat",
+ * "OM", "OS") and keep the numeric tier as-is so existing terminology
+ * survives. DAC / AOC stay all-caps — those are acronyms in the wild.
+ */
+export function cableGradeLabel(grade: CableGrade): string {
+  if (grade === 'cat5e') return 'Cat 5e'
+  if (grade === 'cat6') return 'Cat 6'
+  if (grade === 'cat6a') return 'Cat 6a'
+  if (grade === 'cat7') return 'Cat 7'
+  if (grade === 'cat8') return 'Cat 8'
+  if (grade === 'om3') return 'OM3 (MMF)'
+  if (grade === 'om4') return 'OM4 (MMF)'
+  if (grade === 'om5') return 'OM5 (MMF)'
+  if (grade === 'os1') return 'OS1 (SMF)'
+  if (grade === 'os2') return 'OS2 (SMF)'
+  if (grade === 'dac') return 'DAC'
+  if (grade === 'aoc') return 'AOC'
+  return grade
+}
+
+/**
  * Wire stroke color for a given cable grade in Scene mode.
  *
  * The palette mixes two sources:

--- a/apps/editor/src/lib/scene/cable-colors.ts
+++ b/apps/editor/src/lib/scene/cable-colors.ts
@@ -1,0 +1,66 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { CableGrade } from '@shumoku/core'
+
+/**
+ * Wire stroke color for a given cable grade in Scene mode.
+ *
+ * The palette mixes two sources:
+ *
+ * - **Fiber grades follow TIA-598-C**, the international jacket-color
+ *   standard. OM3 / OM4 = aqua, OM5 = lime, OS1 / OS2 = yellow. Using
+ *   the same colors in the floor-plan as the physical jackets means
+ *   "the orange one on the diagram" matches "the orange one in your
+ *   hand" with no translation step.
+ *
+ * - **Copper grades follow industry custom**, not a formal standard.
+ *   TIA/EIA does not regulate Cat-cable jacket color, but vendors and
+ *   installers have converged on Cat 6 = blue, Cat 6a = green-ish,
+ *   Cat 7 = dark / shielded look, Cat 8 = green. Cat 5e = gray for
+ *   "legacy/old" connotation.
+ *
+ * - **DAC / AOC** (rack-internal copper / active optical) don't have
+ *   color standards. We pick a near-black for DAC (matches typical
+ *   passive copper jackets) and pink for AOC so it's visually
+ *   distinct in rack-dense scenes.
+ *
+ * Returns the slate default when the link has no `cable.category`
+ * set — same as the pre-color-code era, so unconfigured scenes don't
+ * suddenly look broken. Callers should pass `undefined` for "no
+ * category known", not a sentinel value.
+ *
+ * See `CABLE_COLORS.md` for the full standards reference.
+ */
+export function cableCategoryColor(grade: CableGrade | undefined): string {
+  switch (grade) {
+    // ── Copper (industry custom) ────────────────────────────────────
+    case 'cat5e':
+      return '#94A3B8' // slate-400: legacy gray
+    case 'cat6':
+      return '#2563EB' // blue-600: the most common Cat 6 jacket
+    case 'cat6a':
+      return '#10B981' // emerald-500: 10G-access shorthand
+    case 'cat7':
+      return '#52525B' // zinc-700: shielded / heavier look
+    case 'cat8':
+      return '#16A34A' // green-600: DC-grade copper
+    // ── Fiber (TIA-598-C) ───────────────────────────────────────────
+    case 'om3':
+      return '#06B6D4' // cyan-500 ≈ standard MMF aqua
+    case 'om4':
+      return '#0EA5E9' // sky-500: slightly bluer MMF
+    case 'om5':
+      return '#84CC16' // lime-500: TIA-598-C 2016 wideband
+    case 'os1':
+    case 'os2':
+      return '#EAB308' // yellow-500: SMF jacket color
+    // ── Other assemblies ────────────────────────────────────────────
+    case 'dac':
+      return '#1F2937' // gray-800: near-black for rack-internal copper
+    case 'aoc':
+      return '#F472B6' // pink-400: distinguishes from DAC at a glance
+    default:
+      return '#475569' // slate-600: scene-mode default (unchanged)
+  }
+}


### PR DESCRIPTION
## Summary

Scene-mode wires now derive their stroke color from \`link.cable.category\` so a floor-plan view matches the physical jackets an installer is holding. Diagram view keeps its VLAN-based color (logical adjacency); Scene gets jacket color (physical install).

## Palette

Mixes two sources:

| Grade | Color | Source |
|---|---|---|
| cat5e | slate-400 \`#94A3B8\` | industry custom (legacy gray) |
| cat6 | blue-600 \`#2563EB\` | industry custom |
| cat6a | emerald-500 \`#10B981\` | industry custom |
| cat7 | zinc-700 \`#52525B\` | industry custom (shielded look) |
| cat8 | green-600 \`#16A34A\` | industry custom |
| **om3** | cyan-500 \`#06B6D4\` | **TIA-598-C** (aqua MMF) |
| **om4** | sky-500 \`#0EA5E9\` | **TIA-598-C** |
| **om5** | lime-500 \`#84CC16\` | **TIA-598-C** (2016 amendment) |
| **os1/os2** | yellow-500 \`#EAB308\` | **TIA-598-C** (SMF yellow) |
| dac | gray-800 \`#1F2937\` | rack-internal copper convention |
| aoc | pink-400 \`#F472B6\` | distinguishes from DAC |
| _undefined_ | slate-600 \`#475569\` | pre-color-code default — keeps existing scenes intact |

Selection state still overrides every grade with \`#3B82F6\` (blue-500) so the wire-edit affordance reads regardless of color.

## Why two color sources?

- **TIA-598-C** is an actual international standard for **fiber jacket color**. Following it means "aqua on the diagram" = "aqua reel in your hand".
- **Cat jacket color is unstandardized** — TIA/EIA doesn't regulate it. The industry-custom palette comes from what major cable vendors converged on (CommScope, Panduit, Belden, Hitachi Cable). Strong enough to read, but not enforced anywhere.

Both rationales are written into \`CABLE_COLORS.md\` next to the implementation.

## Why not VLAN color in Scene mode?

VLANs are **logical** — one Cat 6 cable carries N VLANs as a trunk. The Diagram view (logical adjacency) shows that. Scene mode is the **physical floor-plan** view; a cable installer picking the right reel cares about jacket grade, not 802.1Q tags. Two views, two axes.

## Files

- \`apps/editor/src/lib/scene/cable-colors.ts\` — \`cableCategoryColor(grade)\` helper + inline JSDoc with the rationale
- \`apps/editor/src/lib/scene/CABLE_COLORS.md\` — full standards reference (TIA-598-C, TIA-606, industry custom)
- \`SceneCanvas.svelte\` — pass \`link.cable?.category\` into edge \`data\`
- \`SceneEdge.svelte\` — read \`data.cableCategory\`, color the stroke

## Note

Branches off \`fix/cable-length-icon-center\` (PR #236) since both touch SceneEdge. Will need a rebase once #236 lands, but the diff is independent.

## Test plan

- [ ] Open a scene with mixed cable categories (e.g. Cat 6 between switches, OM3 fiber uplink, DAC inside a rack). Wires render in the per-grade color
- [ ] Link with no \`cable.category\` set: keeps the slate-600 default, no visible regression
- [ ] Select a wire: selection still overrides to blue regardless of grade
- [ ] Light + dark editor themes: colors readable in both
- [ ] White halo behind wires still gives contrast over floor-plan images

🤖 Generated with [Claude Code](https://claude.com/claude-code)