### PR TITLE
refactor(server): weathermap lanes via analytic bezier offset

### DIFF
--- a/apps/server/docs/topology-rendering.md
+++ b/apps/server/docs/topology-rendering.md
@@ -443,7 +443,8 @@ flowchart LR
     CAM["attachCamera 関数<br/>renderer/lib/camera.ts"]
   end
 
-  WML -->|createOffsetPathD<br/>getUtilizationColor<br/>bpsToDurationMs| WMG
+  WML -->|getUtilizationColor<br/>bpsToDurationMs<br/>utilizationToDurationMs| WMG
+  WML -->|bezierOffsetPath| BEZ["@shumoku/core<br/>layout/bezier-path.ts"]
   TTO -. addEventListener .-> SVG[svgElement]
   HLO -. classList + querySelector .-> SVG
   NSO -. classList + querySelector .-> SVG

--- a/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
+++ b/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import type { LinkOverlayContext } from '@shumoku/renderer'
+  import { bezierOffsetPath } from '@shumoku/renderer'
   import {
     bpsToDurationMs,
-    createOffsetPathD,
     DOWN_COLOR,
     getUtilizationColor,
     type LinkFlowMetrics,
+    utilizationToDurationMs,
   } from '$lib/weathermap'
 
   export type WeathermapAnimation = 'full' | 'reduced' | 'off'
@@ -23,18 +24,50 @@
   const down = $derived(metrics?.status === 'down')
   const inUtil = $derived(metrics?.inUtilization ?? metrics?.utilization ?? 0)
   const outUtil = $derived(metrics?.outUtilization ?? metrics?.utilization ?? 0)
+  // Lane geometry: keep half-stroke + a 0.5px gap between lanes so the
+  // two colored streams never collide regardless of `context.width`.
+  // The previous `width/4` offset overlapped at width ≤ 4, masking the
+  // in lane behind the out lane.
+  const LANE_GAP = 0.5
   const laneWidth = $derived(Math.max(context.width / 2, 2))
-  const laneOffset = $derived(context.width / 4)
+  const laneOffset = $derived(laneWidth / 2 + LANE_GAP)
   const baseColor = $derived(down ? DOWN_COLOR : getUtilizationColor(Math.max(inUtil, outUtil)))
   const inColor = $derived(down ? DOWN_COLOR : getUtilizationColor(inUtil))
   const outColor = $derived(down ? DOWN_COLOR : getUtilizationColor(outUtil))
-  const inDuration = $derived(bpsToDurationMs(metrics?.inBps ?? 0))
-  const outDuration = $derived(bpsToDurationMs(metrics?.outBps ?? 0))
+  // Prefer bps for animation speed; fall back to utilization% when the
+  // data source only reports a percentage (legacy / partial plugins).
+  const inDuration = $derived(
+    (metrics?.inBps ?? 0) > 0
+      ? bpsToDurationMs(metrics?.inBps ?? 0)
+      : utilizationToDurationMs(inUtil),
+  )
+  const outDuration = $derived(
+    (metrics?.outBps ?? 0) > 0
+      ? bpsToDurationMs(metrics?.outBps ?? 0)
+      : utilizationToDurationMs(outUtil),
+  )
+  // Lane geometry is computed analytically from port positions/sides,
+  // so we don't need a mounted SVGPathElement and don't pay for any
+  // DOM sampling. When port data is missing (degenerate / non-port
+  // edges) we collapse to a single combined overlay — see template —
+  // because there's no geometric anchor to split lanes from.
+  const hasPorts = $derived(!!(context.fromPort && context.toPort))
   const inPathD = $derived(
-    context.pathElement ? createOffsetPathD(context.pathElement, laneOffset) : context.pathD,
+    hasPorts && context.fromPort && context.toPort
+      ? bezierOffsetPath(context.fromPort, context.toPort, laneOffset)
+      : context.pathD,
   )
   const outPathD = $derived(
-    context.pathElement ? createOffsetPathD(context.pathElement, -laneOffset) : context.pathD,
+    hasPorts && context.fromPort && context.toPort
+      ? bezierOffsetPath(context.fromPort, context.toPort, -laneOffset)
+      : context.pathD,
+  )
+  // Combined-lane duration for the port-less fallback: pick whichever
+  // direction is moving fastest so the user still sees activity.
+  const combinedDuration = $derived(
+    inDuration > 0 && outDuration > 0
+      ? Math.min(inDuration, outDuration)
+      : Math.max(inDuration, outDuration),
   )
 
   $effect(() => {
@@ -58,30 +91,46 @@
 </script>
 
 {#if active}
-  <path
-    class="wm-overlay"
-    class:wm-static={animation === 'reduced'}
-    data-direction="in"
-    d={inPathD}
-    style:--wm-color={inColor}
-    style:--wm-width={String(laneWidth)}
-    style:--wm-dash={down ? '8 4' : '3 21'}
-    style:--wm-opacity={down ? '0.5' : '0.9'}
-    style:--wm-play={down || inDuration <= 0 ? 'paused' : 'running'}
-    style:--wm-duration={down || inDuration <= 0 ? '0ms' : `${inDuration}ms`}
-  />
-  <path
-    class="wm-overlay"
-    class:wm-static={animation === 'reduced'}
-    data-direction="out"
-    d={outPathD}
-    style:--wm-color={outColor}
-    style:--wm-width={String(laneWidth)}
-    style:--wm-dash={down ? '8 4' : '3 21'}
-    style:--wm-opacity={down ? '0.5' : '0.9'}
-    style:--wm-play={down || outDuration <= 0 ? 'paused' : 'running'}
-    style:--wm-duration={down || outDuration <= 0 ? '0ms' : `${outDuration}ms`}
-  />
+  {#if hasPorts}
+    <path
+      class="wm-overlay"
+      class:wm-static={animation === 'reduced'}
+      data-direction="in"
+      d={inPathD}
+      style:--wm-color={inColor}
+      style:--wm-width={String(laneWidth)}
+      style:--wm-dash={down ? '8 4' : '3 21'}
+      style:--wm-opacity={down ? '0.5' : '0.9'}
+      style:--wm-play={down || inDuration <= 0 ? 'paused' : 'running'}
+      style:--wm-duration={down || inDuration <= 0 ? '0ms' : `${inDuration}ms`}
+    />
+    <path
+      class="wm-overlay"
+      class:wm-static={animation === 'reduced'}
+      data-direction="out"
+      d={outPathD}
+      style:--wm-color={outColor}
+      style:--wm-width={String(laneWidth)}
+      style:--wm-dash={down ? '8 4' : '3 21'}
+      style:--wm-opacity={down ? '0.5' : '0.9'}
+      style:--wm-play={down || outDuration <= 0 ? 'paused' : 'running'}
+      style:--wm-duration={down || outDuration <= 0 ? '0ms' : `${outDuration}ms`}
+    />
+  {:else}
+    <!-- Port-less edge: render one combined lane (no direction split). -->
+    <path
+      class="wm-overlay"
+      class:wm-static={animation === 'reduced'}
+      data-direction="in"
+      d={context.pathD}
+      style:--wm-color={baseColor}
+      style:--wm-width={String(laneWidth)}
+      style:--wm-dash={down ? '8 4' : '3 21'}
+      style:--wm-opacity={down ? '0.5' : '0.9'}
+      style:--wm-play={down || combinedDuration <= 0 ? 'paused' : 'running'}
+      style:--wm-duration={down || combinedDuration <= 0 ? '0ms' : `${combinedDuration}ms`}
+    />
+  {/if}
 {/if}
 
 <style>
@@ -141,7 +190,9 @@
 
   @media (prefers-reduced-motion: reduce) {
     .wm-overlay {
+      stroke-dasharray: none;
       animation: none !important;
+      opacity: 0.7;
     }
   }
 </style>

--- a/apps/server/web/src/lib/weathermap/index.ts
+++ b/apps/server/web/src/lib/weathermap/index.ts
@@ -2,6 +2,13 @@
  * Structural shape accepted by WeathermapLinkOverlay. Looser than
  * `@shumoku/core`'s `LinkMetrics` so the dashboard's richer statuses
  * (e.g. 'degraded') flow through — we only branch on 'down'.
+ *
+ * Direction note: `inBps` / `outBps` (and the `*Utilization` variants)
+ * are data-source-defined. The overlay renders them as two visually
+ * distinct lanes flowing in opposite directions, but does NOT claim
+ * either lane corresponds to `fromPort → toPort`. Plugins are expected
+ * to be consistent within themselves; cross-plugin direction semantics
+ * are not unified.
  */
 export interface LinkFlowMetrics {
   status: string
@@ -24,59 +31,45 @@ const UTILIZATION_COLORS: readonly (readonly [number, string])[] = [
   [100, '#dc2626'],
 ]
 export const DOWN_COLOR = '#ef4444'
+const NO_DATA_COLOR = '#6b7280'
 
 export function getUtilizationColor(utilization: number): string {
+  // NaN/Infinity would silently fall through every `<=` comparison and
+  // land on DOWN_COLOR (red). Treat bad input as "no data" (gray).
+  if (!Number.isFinite(utilization)) return NO_DATA_COLOR
+  const u = Math.max(0, Math.min(100, utilization))
   for (const [max, color] of UTILIZATION_COLORS) {
-    if (utilization <= max) return color
+    if (u <= max) return color
   }
+  // Unreachable given the clamp + 100 ceiling, but keeps the return type total.
   return DOWN_COLOR
 }
 
-export function bpsToDurationMs(bps: number): number {
-  if (bps <= 0) return 0
-  const speed = Math.min(1, Math.log10(bps + 1) / 9)
-  return Math.max(300, (2 - speed * 1.5) * 1000)
+// --- Bandwidth/utilization → animation duration ---
+
+// log10(bps) denominator: 11 puts 100 Gbps at full speed, covering modern
+// link rates. Previously 9 saturated at ~1 Gbps so 10G/100G all looked alike.
+const BPS_LOG_DENOM = 11
+const DURATION_MIN_MS = 400
+const DURATION_MAX_MS = 2000
+
+function speedToDurationMs(speed01: number): number {
+  const s = Math.max(0, Math.min(1, speed01))
+  return DURATION_MIN_MS + (DURATION_MAX_MS - DURATION_MIN_MS) * (1 - s)
 }
 
-// --- Offset-path geometry (sample path normals to build parallel in/out lanes) ---
+export function bpsToDurationMs(bps: number): number {
+  if (!Number.isFinite(bps) || bps <= 0) return 0
+  const speed = Math.log10(bps + 1) / BPS_LOG_DENOM
+  return speedToDurationMs(speed)
+}
 
-export function createOffsetPathD(path: SVGPathElement, offset: number): string {
-  const len = path.getTotalLength()
-  if (len === 0) return path.getAttribute('d') ?? ''
-
-  const start = path.getPointAtLength(0)
-  const end = path.getPointAtLength(len)
-  const angle = Math.atan2(end.y - start.y, end.x - start.x)
-  const nx = -Math.sin(angle) * offset
-  const ny = Math.cos(angle) * offset
-
-  // Straight segment fast path — no sampling needed.
-  const mid = path.getPointAtLength(len / 2)
-  const deviation =
-    Math.abs(mid.x - (start.x + end.x) / 2) + Math.abs(mid.y - (start.y + end.y) / 2)
-  if (deviation < 1) {
-    return (
-      `M ${(start.x + nx).toFixed(2)} ${(start.y + ny).toFixed(2)}` +
-      ` L ${(end.x + nx).toFixed(2)} ${(end.y + ny).toFixed(2)}`
-    )
-  }
-
-  // Curved path: sample along normals.
-  const numSamples = Math.max(30, Math.ceil(len / 4))
-  const pts: string[] = []
-  for (let i = 0; i <= numSamples; i++) {
-    const t = (i / numSamples) * len
-    const p = path.getPointAtLength(t)
-    const dt = Math.min(1, len * 0.001)
-    const p1 = path.getPointAtLength(Math.max(0, t - dt))
-    const p2 = path.getPointAtLength(Math.min(len, t + dt))
-    const a = Math.atan2(p2.y - p1.y, p2.x - p1.x)
-    pts.push(
-      `${(p.x - Math.sin(a) * offset).toFixed(2)} ${(p.y + Math.cos(a) * offset).toFixed(2)}`,
-    )
-  }
-  return `M ${pts[0]}${pts
-    .slice(1)
-    .map((p) => ` L ${p}`)
-    .join('')}`
+/**
+ * Fallback for data sources that report utilization but not bps. Maps
+ * 0–100% to the same duration band as `bpsToDurationMs`, so the visual
+ * speed scale stays comparable.
+ */
+export function utilizationToDurationMs(util: number): number {
+  if (!Number.isFinite(util) || util <= 0) return 0
+  return speedToDurationMs(util / 100)
 }

--- a/libs/@shumoku/core/src/layout/bezier-path.ts
+++ b/libs/@shumoku/core/src/layout/bezier-path.ts
@@ -55,6 +55,69 @@ export function bezierEdgePath(
   return `M ${a.x} ${a.y} C ${a.x + ax} ${a.y + ay} ${b.x + bx} ${b.y + by} ${b.x} ${b.y}`
 }
 
+/**
+ * `bezierEdgePath` translated as a whole by `offset` SVG units along the
+ * chord-perpendicular direction. Used to draw parallel "in" / "out"
+ * lanes for weathermap-style flow overlays.
+ *
+ * This is a *parallel translate*, NOT a true cubic offset curve (which
+ * cannot in general be represented exactly as another cubic). All four
+ * control points shift by the same vector, so:
+ *   • lane spacing is exactly `2 * |offset|` everywhere along the curve,
+ *   • the offset curve never crosses the base curve or the opposite lane
+ *     regardless of port-side configuration (incl. same-side U-turns
+ *     and adjacent-side L-turns),
+ *   • tangents are preserved at every point — but the lane endpoint is
+ *     shifted off the port by `(nx, ny)`. Lanes are decorative; they
+ *     are not meant to "connect to" the port.
+ *
+ * The shift direction is the chord normal (perpendicular to b-a). Sign
+ * convention: in screen coordinates (y-down), `+offset` shifts to the
+ * right-hand side of the chord A→B, `-offset` to the left. Pass
+ * `+offset` and `-offset` for the two lanes; which one ends up labelled
+ * "in" is a data-source semantic, not enforced here.
+ *
+ * Computed analytically — no DOM measurement, so callers don't need a
+ * mounted SVGPathElement.
+ */
+export function bezierOffsetPath(
+  from: { absolutePosition: { x: number; y: number }; side?: PortSide },
+  to: { absolutePosition: { x: number; y: number }; side?: PortSide },
+  offset: number,
+): string {
+  if (!Number.isFinite(offset) || offset === 0) return bezierEdgePath(from, to)
+
+  const a = from.absolutePosition
+  const b = to.absolutePosition
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  const chordLen = Math.hypot(dx, dy)
+  // Degenerate (coincident endpoints): no meaningful chord direction.
+  if (chordLen === 0) return bezierEdgePath(from, to)
+
+  // Right-hand chord normal × offset → uniform translation vector.
+  const nx = -(dy / chordLen) * offset
+  const ny = (dx / chordLen) * offset
+
+  const fromSide = from.side ?? 'bottom'
+  const toSide = to.side ?? 'top'
+  const normalGap = projectAlongNormal(fromSide, dx, dy)
+  const reach = clamp(normalGap * REACH_RATIO, MIN_REACH, MAX_REACH)
+  const [ax, ay] = tangentOffset(fromSide, reach)
+  const [bx, by] = tangentOffset(toSide, reach)
+
+  const p0x = a.x + nx
+  const p0y = a.y + ny
+  const p1x = a.x + ax + nx
+  const p1y = a.y + ay + ny
+  const p2x = b.x + bx + nx
+  const p2y = b.y + by + ny
+  const p3x = b.x + nx
+  const p3y = b.y + ny
+
+  return `M ${p0x} ${p0y} C ${p1x} ${p1y} ${p2x} ${p2y} ${p3x} ${p3y}`
+}
+
 /** Absolute distance from a port along its outward normal direction. */
 function projectAlongNormal(side: PortSide, dx: number, dy: number): number {
   switch (side) {

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -7,7 +7,7 @@
  */
 
 // Bezier edge geometry (shared by interactive renderer + SSR renderer-svg)
-export { bezierEdgePath, type PortSide } from './bezier-path.js'
+export { bezierEdgePath, bezierOffsetPath, type PortSide } from './bezier-path.js'
 // Interactive operations (node move, collision detection)
 export {
   addLink,

--- a/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
@@ -99,6 +99,7 @@
     {@const gap = Math.max(3, Math.round(edge.width * 0.9))}
     <path
       bind:this={basePathElement}
+      class="link"
       d={pathD}
       fill="none"
       stroke={strokeColor}

--- a/libs/@shumoku/renderer/src/index.ts
+++ b/libs/@shumoku/renderer/src/index.ts
@@ -27,6 +27,7 @@ export {
 } from './lib/serialization'
 export {
   bezierEdgePath,
+  bezierOffsetPath,
   computePortLabelPosition,
   getNodeLabel,
   getVlanStroke,

--- a/libs/@shumoku/renderer/src/lib/svg-coords.ts
+++ b/libs/@shumoku/renderer/src/lib/svg-coords.ts
@@ -8,7 +8,7 @@
 
 import type { PortSide } from '@shumoku/core'
 
-export { bezierEdgePath } from '@shumoku/core'
+export { bezierEdgePath, bezierOffsetPath } from '@shumoku/core'
 
 type Side = PortSide
 


### PR DESCRIPTION
## Summary

- Replace DOM measurement (`getTotalLength` / `getPointAtLength` polyline sampling) with an analytic `bezierOffsetPath` in `@shumoku/core`. Lanes are now a pure parallel translate of the base cubic Bezier along the chord-perpendicular axis.
- Fix the geometric issue behind \"2 レーンあるはずなのに色が分かれて見えない\": the previous `laneOffset = width/4` overlapped both lanes whenever `edge.width ≤ 4`, masking the in lane behind the out lane. Lanes now sit at `laneWidth/2 + 0.5px` so they never touch.
- Fix latent lane-crossing for same-side / adjacent-side ports. Local-tangent normals flipped between endpoints, so `+offset` / `-offset` collapsed at the curve midpoint. Chord-normal translate gives constant `2 × |offset|` separation regardless of port-side configuration.
- Plus a handful of smaller weathermap bugs (NaN color, bps duration saturating at 1 Gbps, reduced-motion inconsistency, port-less fallback hiding the in lane, double-link missing `class=\"link\"`).

## Why the refactor

The overlay was reaching into the rendered `SVGPathElement` to call `getTotalLength` / `getPointAtLength`, then approximating a parallel curve with a 30–160-point polyline. That was conceptually wrong for a library renderer that's meant to be black-box (and unusable for SSR / static SVG / web-component output). All the data needed to build the lane geometry already lives on `context.fromPort` / `context.toPort`.

The new `bezierOffsetPath` is a uniform translation of all four cubic control points along the chord normal. It's not a true cubic offset curve (which cannot in general be represented as another cubic), but for the weathermap purpose — parallel decorative lanes — it's strictly better than the DOM-sampling approximation:

- O(1) per link instead of O(N) with N capped at 160
- Constant lane separation everywhere along the curve
- Lanes never cross themselves or the base curve for any port-side combination
- Tangent at every point is preserved (because the curve is translated as a whole)
- No DOM dependency

## Changes

**New / API:**
- `bezierOffsetPath(from, to, offset)` in `@shumoku/core/layout/bezier-path.ts`, re-exported from `@shumoku/renderer`.

**Removed:**
- `createOffsetPathD` (and its sampling / clamping infrastructure) from `apps/server/web/src/lib/weathermap/index.ts`.

**Bug fixes:**
- `getUtilizationColor`: NaN / Infinity → \"no data\" gray instead of falling through to down-state red.
- `bpsToDurationMs`: widen log denominator so 10G / 100G no longer all saturate at the same duration.
- `utilizationToDurationMs`: new fallback so animation doesn't freeze when a data source reports util% but not bps.
- `laneOffset` widened to `laneWidth / 2 + 0.5px` (no more in-lane occlusion on thin links).
- `@media (prefers-reduced-motion: reduce)` now kills `stroke-dasharray` in addition to the animation, matching `animation=\"reduced\"`.
- `LinkFlowMetrics`' `in*` / `out*` direction semantics documented as data-source-defined.
- Port-less edges render a single combined overlay rather than two stacked identical lanes.
- `class=\"link\"` added to the outer base path of double-style edges (otherwise `:global(.wm-active > path.link)` was a no-op for double links).

## Test plan

- [ ] Open a topology with mixed `bottom→top`, `left→right` and `bottom→bottom` (same-side) link configurations and confirm both in/out lanes are visible side by side along the entire curve.
- [ ] Confirm the in lane is no longer hidden by the out lane on thin links (`edge.width ≤ 4`).
- [ ] Toggle `WeathermapAnimation` through `full` / `reduced` / `off` and confirm visuals match expectations in each mode.
- [ ] OS-level `prefers-reduced-motion: reduce` should produce the same look as `animation=\"reduced\"` (no dasharray, no motion).
- [ ] Confirm a 10G mock link and a 100M mock link animate at visibly different speeds.
- [ ] Render a snapshot of a static SVG export (`@shumoku/renderer-svg`) — the bezier path geometry should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)