### PR TITLE
feat(editor): multi-select foundation (PR 1/2)

### DIFF
--- a/apps/editor/src/lib/components/StatusBadge.svelte
+++ b/apps/editor/src/lib/components/StatusBadge.svelte
@@ -3,10 +3,14 @@
     status = 'Ready',
     stats = { nodes: 0, links: 0, subgraphs: 0 },
     selected = null,
+    selectionCount = 0,
   }: {
     status: string
     stats: { nodes: number; links: number; subgraphs: number }
+    /** First selected element for label/id display (single-target detail). */
     selected: { id: string; type: string } | null
+    /** Total size of the selection set. >1 means multi-select active. */
+    selectionCount?: number
   } = $props()
 </script>
 
@@ -30,8 +34,11 @@
     <span>{stats.subgraphs}G</span>
   </div>
 
-  <!-- Selection -->
-  {#if selected}
+  <!-- Selection: show id when single, count when multi. -->
+  {#if selectionCount > 1}
+    <div class="text-neutral-300 dark:text-neutral-600">|</div>
+    <div class="font-medium text-blue-600 dark:text-blue-400">{selectionCount} selected</div>
+  {:else if selected}
     <div class="text-neutral-300 dark:text-neutral-600">|</div>
     <div class="flex items-center gap-1 text-blue-600 dark:text-blue-400 font-medium">
       <span class="capitalize">{selected.type}</span>

--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -68,13 +68,18 @@
       diagramState.setCurrentScene(null)
     }
   })
-  let selected = $state<{ id: string; type: string } | null>(null)
-  // Canvas right-click menu — registry-driven for both empty canvas
-  // and per-element clicks. The renderer's per-element handler sets
-  // `selected = { id, type }` before the contextmenu event bubbles
-  // to the shadcn ContextMenu wrapper (`CanvasContextMenu`); the
-  // wrapper then opens at the actual cursor position and reads the
-  // current selection for action gating.
+  // Multi-selection state. The renderer drives this via
+  // `onselectionchange`; the page just mirrors it so the action
+  // registry / status bar / detail panel can react. `selected`
+  // (singular) is a derived convenience for surfaces that only care
+  // about the focused single item (StatusBadge, double-click detail).
+  type SelType = ActionContext['selection']['types'][number]
+  let selection = $state<{ ids: string[]; types: SelType[] }>({ ids: [], types: [] })
+  const selected = $derived<{ id: string; type: string } | null>(
+    selection.ids[0] && selection.types[0]
+      ? { id: selection.ids[0], type: selection.types[0] }
+      : null,
+  )
 
   // Adapter that lets registry-side actions (copy / paste) talk to
   // the renderer instance without each action grabbing the bound
@@ -97,12 +102,7 @@
 
   const actionCtx = $derived<ActionContext>({
     mode: 'diagram',
-    selection: selected
-      ? {
-          ids: [selected.id],
-          types: [selected.type as ActionContext['selection']['types'][number]],
-        }
-      : { ids: [], types: [] },
+    selection,
     // canvasPos is filled in by `CanvasContextMenu` from the live
     // contextmenu event, since shadcn ContextMenu handles its own
     // positioning. The page-level ctx is just the rest of the state.
@@ -202,15 +202,16 @@
           hideNode={(n) => !!n.termination}
           ondragstart={() => diagramState.beginTx('Move node')}
           ondragend={() => diagramState.endTx()}
-          onselect={(id: string | null, type: string | null) => { selected = id ? { id, type: type ?? 'node' } : null }}
+          onselectionchange={(ids: string[], types: string[]) => {
+            // Mirror the renderer's selection set so the action
+            // registry / status bar see the live state. Fires
+            // synchronously inside the renderer's click /
+            // right-click handler, so the ContextMenu wrapper
+            // sees the right selection when it opens.
+            selection = { ids, types: types as SelType[] }
+          }}
           onchange={() => {}}
           onlabeledit={(portId: string, label: string, screenX: number, screenY: number) => { labelEdit = { portId, label, x: screenX, y: screenY } }}
-          oncontextmenu={(id: string, type: string) => {
-            // Update selection before the contextmenu event bubbles
-            // up to the ContextMenu trigger so action gating sees
-            // the right item when the menu opens.
-            selected = { id, type }
-          }}
           onnodeadd={(_id: string) => {
             // The renderer mutated diagram.nodes directly (via $bindable)
             // before emitting this event — invalidate cached sheets now.
@@ -255,7 +256,12 @@
 
   <!-- Bottom-left: Status -->
   <div data-print-hide class="fixed bottom-3 left-3 z-20">
-    <StatusBadge status={diagramState.status} stats={diagramState.stats} {selected} />
+    <StatusBadge
+      status={diagramState.status}
+      stats={diagramState.stats}
+      {selected}
+      selectionCount={selection.ids.length}
+    />
   </div>
 
   <!-- Left side: Code panel (slide-out) -->

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -66,7 +66,21 @@
      */
     svgElement?: SVGSVGElement | null
     onchange?: (links: Link[]) => void
+    /**
+     * Single-selection callback. Fires whenever the selection changes,
+     * with the first selected element's id/type (or null/null on clear).
+     * Kept stable for backward-compat with consumers that only care
+     * about a single item (e.g. server/web TopologyViewer). For the
+     * full selection set use `onselectionchange`.
+     */
     onselect?: (id: string | null, type: string | null) => void
+    /**
+     * Multi-selection callback. Fires whenever the selection set
+     * changes, with parallel `ids` / `types` arrays (empty when cleared).
+     * Hosts that support multi-select (editor) listen here; viewer-only
+     * surfaces can ignore it.
+     */
+    onselectionchange?: (ids: string[], types: string[]) => void
     onlabeledit?: (portId: string, label: string, screenX: number, screenY: number) => void
     oncontextmenu?: (id: string, type: string, screenX: number, screenY: number) => void
     onnodeadd?: (id: string) => void
@@ -125,6 +139,7 @@
     svgElement = $bindable<SVGSVGElement | null>(null),
     onchange,
     onselect,
+    onselectionchange,
     onlabeledit,
     oncontextmenu: onctx,
     onnodeadd,
@@ -209,35 +224,87 @@
     return () => el.removeEventListener('keydown', handleKeyDown)
   })
 
+  function classifyId(id: string): 'node' | 'edge' | 'subgraph' | 'port' {
+    if (edges.has(id)) return 'edge'
+    if (ports.has(id)) return 'port'
+    if (subgraphs.has(id)) return 'subgraph'
+    return 'node'
+  }
+
+  /** Emit both callbacks in lockstep after a selection mutation.
+   *  Called synchronously inside event handlers so consumers' state
+   *  is up to date before the event finishes bubbling — important
+   *  for context-menu wrappers that read selection on right-click. */
+  function emitSelection() {
+    const ids = [...selection]
+    const types = ids.map(classifyId)
+    onselectionchange?.(ids, types)
+    onselect?.(ids[0] ?? null, types[0] ?? null)
+  }
+
+  // Drop selection entries whose target was removed from the model
+  // (e.g. after multi-delete or undo). Without this, StatusBadge would
+  // keep showing a stale "N selected" until the user clicks elsewhere.
   $effect(() => {
-    if (selection.size === 0) {
-      onselect?.(null, null)
-    } else {
-      const id = [...selection][0] ?? null
-      if (!id) return
-      let type: string = 'node'
-      if (edges.has(id)) type = 'edge'
-      else if (ports.has(id)) type = 'port'
-      else if (subgraphs.has(id)) type = 'subgraph'
-      onselect?.(id, type)
+    let changed = false
+    const next = new Set<string>()
+    for (const id of selection) {
+      if (nodes.has(id) || edges.has(id) || subgraphs.has(id) || ports.has(id)) {
+        next.add(id)
+      } else {
+        changed = true
+      }
+    }
+    if (changed) {
+      selection = next
+      emitSelection()
     }
   })
 
-  function handleSelect(id: string) {
-    selection = new Set([id])
+  function handleSelect(id: string, ev?: MouseEvent) {
+    // Shift / Cmd (macOS) / Ctrl (Windows-Linux) → additive toggle.
+    // Plain click → replace.
+    const additive = !!ev && (ev.shiftKey || ev.metaKey || ev.ctrlKey)
+    if (additive) {
+      const next = new Set(selection)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      selection = next
+    } else {
+      selection = new Set([id])
+    }
+    emitSelection()
   }
   function handleBackgroundClick() {
     selection = new Set()
+    emitSelection()
   }
   function handleContextMenu(id: string, type: string, e: MouseEvent) {
-    selection = new Set([id])
+    // Right-click on an unselected item reduces the selection to that
+    // single item; right-click on something already selected keeps the
+    // existing multi-selection so the menu applies to the whole set.
+    if (!selection.has(id)) {
+      selection = new Set([id])
+      emitSelection()
+    }
     onctx?.(id, type, e.clientX, e.clientY)
   }
 
   function handleKeyDown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
       selection = new Set()
+      emitSelection()
       linkDrag = null
+    } else if ((e.metaKey || e.ctrlKey) && (e.key === 'a' || e.key === 'A')) {
+      // Cmd/Ctrl+A → select every node + subgraph. Edges and ports
+      // intentionally excluded; they're rarely the target of bulk
+      // operations and including them clutters Delete behavior.
+      e.preventDefault()
+      const next = new Set<string>()
+      for (const id of nodes.keys()) next.add(id)
+      for (const id of subgraphs.keys()) next.add(id)
+      selection = next
+      emitSelection()
     }
   }
 
@@ -292,6 +359,7 @@
     // we now use a SvelteMap the mutations are picked up without any reassign.
     rebalanceSubgraphs(nodes, subgraphs, ports)
     selection = new Set([id])
+    emitSelection()
   }
 
   export function addNewNode(opts: {

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -62,7 +62,7 @@
     ondragstart?: (id: string) => void
     ondragmove?: (id: string, x: number, y: number) => void
     ondragend?: (id: string) => void
-    onselect?: (id: string) => void
+    onselect?: (id: string, e?: MouseEvent) => void
     onaddport?: (nodeId: string, side: 'top' | 'bottom' | 'left' | 'right') => void
     onlinkstart?: (portId: string, x: number, y: number) => void
     onlinkend?: (portId: string) => void

--- a/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
@@ -17,7 +17,9 @@
     colors: RenderColors
     selected?: boolean
     overlay?: LinkOverlaySnippet
-    onselect?: (edgeId: string) => void
+    /** Click / right-click on this edge. Receives the original event so the
+     *  renderer can read modifier keys for additive multi-selection. */
+    onselect?: (edgeId: string, e?: MouseEvent) => void
     oncontextmenu?: (edgeId: string, e: MouseEvent) => void
     preventContextMenuDefault?: boolean
   } = $props()
@@ -85,12 +87,12 @@
 
   function onclick(e: MouseEvent) {
     e.stopPropagation()
-    onselect?.(edge.id)
+    onselect?.(edge.id, e)
   }
 
   function handleContextMenu(e: MouseEvent) {
     if (preventContextMenuDefault) e.preventDefault()
-    onselect?.(edge.id)
+    onselect?.(edge.id, e)
     onctx?.(edge.id, e)
   }
 </script>

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -39,7 +39,10 @@
     /** Fires once on release — host closes the transaction (undo push + DB sync). */
     ondragend?: (id: string) => void
     onaddport?: (nodeId: string, side: 'top' | 'bottom' | 'left' | 'right') => void
-    onselect?: (id: string) => void
+    /** Click / right-click on this node. Receives the original event so the
+     *  renderer can read modifier keys (shift / cmd / ctrl) for additive
+     *  multi-selection. */
+    onselect?: (id: string, e?: MouseEvent) => void
     oncontextmenu?: (id: string, e: MouseEvent) => void
     /** Suppress browser native menu via preventDefault. See ShumokuRenderer. */
     preventContextMenuDefault?: boolean
@@ -158,7 +161,7 @@
     onDrag: (dx, dy) => ondragmove?.(node.id, (node.position?.x ?? 0) + dx, (node.position?.y ?? 0) + dy),
     onEnd: () => ondragend?.(node.id),
   })}
-  onclick={(e) => { e.stopPropagation(); onselect?.(node.id) }}
+  onclick={(e) => { e.stopPropagation(); onselect?.(node.id, e) }}
   onpointerenter={() => { if (interactive) hovered = true }}
   onpointerleave={() => { hovered = false }}
   oncontextmenu={handleContextMenu}

--- a/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
@@ -31,7 +31,9 @@
     overlay?: PortOverlaySnippet
     onlinkstart?: (portId: string, x: number, y: number) => void
     onlinkend?: (portId: string) => void
-    onselect?: (portId: string) => void
+    /** Click on this port. Receives the original event so the renderer can
+     *  read modifier keys for additive multi-selection. */
+    onselect?: (portId: string, e?: MouseEvent) => void
     onlabeledit?: (portId: string, label: string, screenX: number, screenY: number) => void
     oncontextmenu?: (portId: string, e: MouseEvent) => void
     /** Drag a linked port to a different placement on the same node.
@@ -84,7 +86,7 @@
     if (e.button !== 0) return
     e.stopPropagation()
     e.preventDefault()
-    onselect?.(port.id)
+    onselect?.(port.id, e)
     if (!interactive) return
 
     if (linked && onportdragend) {
@@ -129,7 +131,7 @@
 
   function handleContextMenu(e: MouseEvent) {
     if (preventContextMenuDefault) e.preventDefault()
-    onselect?.(port.id)
+    onselect?.(port.id, e)
     onctx?.(port.id, e)
   }
 </script>

--- a/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
@@ -27,7 +27,9 @@
     ondragstart?: (sgId: string) => void
     ondragmove?: (sgId: string, x: number, y: number) => void
     ondragend?: (sgId: string) => void
-    onselect?: (sgId: string) => void
+    /** Click / right-click on this subgraph. Receives the original event so
+     *  the renderer can read modifier keys for additive multi-selection. */
+    onselect?: (sgId: string, e?: MouseEvent) => void
     oncontextmenu?: (id: string, e: MouseEvent) => void
     preventContextMenuDefault?: boolean
   } = $props()
@@ -86,8 +88,8 @@
     stroke={selected ? '#3b82f6' : resolved().stroke}
     stroke-width={selected ? 3 : strokeWidth}
     stroke-dasharray={selected ? undefined : (strokeDasharray || undefined)}
-    onclick={(e) => { e.stopPropagation(); onselect?.(subgraph.id) }}
-    oncontextmenu={(e) => { if (preventContextMenuDefault) e.preventDefault(); onselect?.(subgraph.id); onctx?.(subgraph.id, e) }}
+    onclick={(e) => { e.stopPropagation(); onselect?.(subgraph.id, e) }}
+    oncontextmenu={(e) => { if (preventContextMenuDefault) e.preventDefault(); onselect?.(subgraph.id, e); onctx?.(subgraph.id, e) }}
     use:elementDrag={() => ({
       filter: (e) => e.button === 0 && interactive,
       onStart: () => ondragstart?.(subgraph.id),


### PR DESCRIPTION
## Summary
First of two PRs adding diagram multi-selection. This one wires up the selection model + interaction primitives; PR 2 will add marquee + multi-node drag + multi-target actions.

- Shift / Cmd / Ctrl + click → additive toggle. Plain click → replace.
- Cmd / Ctrl + A → select every node + subgraph.
- Right-click on a selected item keeps the multi-selection so the menu applies to the whole set.
- Multi-delete works via the existing \`edit.delete\` action (it already iterated \`selection.ids\`).
- StatusBadge shows \"N selected\" when multi, falls back to id/type for single.
- Renderer \`onselectionchange(ids, types)\` callback added alongside the existing \`onselect\` (kept for back-compat with server/web TopologyViewer).

## What's deferred to PR 2
- Marquee (drag empty canvas to box-select).
- Multi-node drag (moving any selected node moves them all together).
- Copy / Duplicate / Move-to-group on multi-selection (currently gated to single).

## Test plan
- [x] Click → replaces selection (single)
- [x] Shift+click → adds to selection
- [x] Shift+click on already-selected → toggles off
- [x] Cmd / Ctrl + A → all nodes + subgraphs (28 in sample)
- [x] Delete with N selected → removes all N, StatusBadge clears
- [x] Right-click selected item → menu stays multi-aware
- [x] Right-click unselected item → reduces to that one item
- [x] Scene view unaffected (Svelte Flow handles its own multi-select)
- [x] typecheck / biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)