### PR TITLE
feat(editor): marquee + multi-node drag + bulk move-to-group

### DIFF
--- a/apps/editor/src/lib/actions/builtin.ts
+++ b/apps/editor/src/lib/actions/builtin.ts
@@ -255,36 +255,45 @@ const builtinActions: Action[] = [
     icon: FolderSimplePlus,
     group: 'arrange',
     when: inDiagram,
-    enabled: (ctx) =>
-      ctx.selection.ids.length === 1 &&
-      ctx.selection.types[0] === 'node' &&
-      diagramState.subgraphs.size > 0,
+    // Available when at least one node is selected. Multi-selection is
+    // OK — the submenu iterates over every selected node id.
+    enabled: (ctx) => {
+      if (diagramState.subgraphs.size === 0) return false
+      const nodeIds = ctx.selection.ids.filter((_id, i) => ctx.selection.types[i] === 'node')
+      return nodeIds.length > 0
+    },
     // Parent-only entry. `run` is unused on menu surfaces that
     // recognise `submenu`, but registry types still require it —
     // wire it to a no-op so keyboard / palette invocations don't
     // misfire.
     run: () => {},
     submenu: (ctx) => {
-      const nodeId = ctx.selection.ids[0]
-      if (!nodeId) return []
-      const currentParent = diagramState.nodes.get(nodeId)?.parent
+      const nodeIds = ctx.selection.ids.filter((_id, i) => ctx.selection.types[i] === 'node')
+      if (nodeIds.length === 0) return []
+      // Multi-selection: "(top level)" stays available whenever any
+      // selected node is nested somewhere. Subgraphs are excluded from
+      // the choices only if every selected node already lives there.
+      const parents = new Set(nodeIds.map((id) => diagramState.nodes.get(id)?.parent))
+      const move = async (target: string | undefined) => {
+        for (const id of nodeIds) await diagramState.moveNodeToGroup(id, target)
+      }
       const items = [
         {
           id: '__top__',
           label: '(top level)',
           muted: true,
-          enabled: currentParent !== undefined,
-          pick: () => diagramState.moveNodeToGroup(nodeId, undefined),
+          enabled: !(parents.size === 1 && parents.has(undefined)),
+          pick: () => move(undefined),
         },
       ]
       for (const sg of diagramState.subgraphs.values()) {
-        if (sg.id === currentParent) continue
+        if (parents.size === 1 && parents.has(sg.id)) continue
         items.push({
           id: sg.id,
           label: sg.label ?? sg.id,
           muted: false,
           enabled: true,
-          pick: () => diagramState.moveNodeToGroup(nodeId, sg.id),
+          pick: () => move(sg.id),
         })
       }
       return items

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -309,8 +309,40 @@
   }
 
   // =========================================================================
-  // Drag (unified for nodes and subgraphs)
+  // Drag (unified for nodes and subgraphs; supports multi-selection)
   // =========================================================================
+  //
+  // Multi-drag strategy: when the user starts dragging a node that's part
+  // of a multi-selection, snapshot every selected element's origin at
+  // dragstart. On every tick, compute how far the *dragged* element
+  // actually moved (after its own collision resolution), then translate
+  // the other selected elements by that delta. This keeps the group
+  // visually rigid — drag two nodes apart, both move together; bump into
+  // an obstacle, the entire group is held back by the dragged one.
+  let multiDragOrigin: Map<string, { x: number; y: number }> | null = null
+
+  function handleDragStart(id: string) {
+    if (selection.has(id) && selection.size > 1) {
+      multiDragOrigin = new Map()
+      for (const sid of selection) {
+        if (nodes.has(sid)) {
+          const p = nodes.get(sid)?.position
+          if (p) multiDragOrigin.set(sid, { x: p.x, y: p.y })
+        } else if (subgraphs.has(sid)) {
+          const b = subgraphs.get(sid)?.bounds
+          if (b) multiDragOrigin.set(sid, { x: b.x, y: b.y })
+        }
+      }
+    } else {
+      multiDragOrigin = null
+    }
+    ondragstart?.(id)
+  }
+
+  function handleDragEnd(id: string) {
+    multiDragOrigin = null
+    ondragend?.(id)
+  }
 
   async function handleDragMove(id: string, x: number, y: number) {
     const state = { nodes, ports, subgraphs }
@@ -324,6 +356,56 @@
     replaceMap(ports, result.ports)
     replaceMap(edges, result.edges)
     if (result.subgraphs) replaceMap(subgraphs, result.subgraphs)
+
+    if (!multiDragOrigin || !multiDragOrigin.has(id)) return
+    // Where the dragged element ended up after collision resolution.
+    const draggedNow = nodes.get(id)?.position ?? subgraphs.get(id)?.bounds
+    const origin = multiDragOrigin.get(id)
+    if (!draggedNow || !origin) return
+    const dx = draggedNow.x - origin.x
+    const dy = draggedNow.y - origin.y
+    for (const [sid, sorigin] of multiDragOrigin) {
+      if (sid === id) continue
+      const tx = sorigin.x + dx
+      const ty = sorigin.y + dy
+      const st = { nodes, ports, subgraphs }
+      const r = nodes.has(sid)
+        ? await moveNode(sid, tx, ty, st, links)
+        : subgraphs.has(sid)
+          ? await moveSubgraph(sid, tx, ty, st, links)
+          : null
+      if (!r) continue
+      replaceMap(nodes, r.nodes)
+      replaceMap(ports, r.ports)
+      replaceMap(edges, r.edges)
+      if (r.subgraphs) replaceMap(subgraphs, r.subgraphs)
+    }
+  }
+
+  function handleMarquee(rect: { x: number; y: number; w: number; h: number }, additive: boolean) {
+    const hits = new Set<string>()
+    const rx1 = rect.x
+    const ry1 = rect.y
+    const rx2 = rect.x + rect.w
+    const ry2 = rect.y + rect.h
+    const intersects = (ex1: number, ey1: number, ex2: number, ey2: number) =>
+      ex1 < rx2 && ex2 > rx1 && ey1 < ry2 && ey2 > ry1
+    for (const [id, node] of nodes) {
+      if (hideNode?.(node)) continue
+      const p = node.position
+      if (!p) continue
+      const size = resolveNodeSize(node)
+      const hw = size.width / 2
+      const hh = size.height / 2
+      if (intersects(p.x - hw, p.y - hh, p.x + hw, p.y + hh)) hits.add(id)
+    }
+    for (const [id, sg] of subgraphs) {
+      const b = sg.bounds
+      if (!b) continue
+      if (intersects(b.x, b.y, b.x + b.width, b.y + b.height)) hits.add(id)
+    }
+    selection = additive ? new Set([...selection, ...hits]) : hits
+    emitSelection()
   }
 
   // =========================================================================
@@ -638,9 +720,9 @@
     {portOverlay}
     linkPreview={linkDrag}
     bind:svgEl={svgElement}
-    {ondragstart}
+    ondragstart={handleDragStart}
     ondragmove={handleDragMove}
-    {ondragend}
+    ondragend={handleDragEnd}
     {hideNode}
     onselect={handleSelect}
     onaddport={handleAddPort}
@@ -650,6 +732,7 @@
     {onlabeledit}
     oncontextmenu={handleContextMenu}
     onbackgroundclick={handleBackgroundClick}
+    onmarquee={handleMarquee}
     {preventContextMenuDefault}
   />
 </div>

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -2,6 +2,7 @@
   import type { Node, ResolvedEdge, ResolvedPort, Subgraph, Theme } from '@shumoku/core'
   import type { RendererOverlaySnippets } from '../../lib/overlays'
   import type { RenderColors } from '../../lib/render-colors'
+  import { screenToSvg } from '../../lib/svg-coords'
   import SvgEdge from './SvgEdge.svelte'
   import SvgLinkPreview from './SvgLinkPreview.svelte'
   import SvgNode from './SvgNode.svelte'
@@ -44,6 +45,7 @@
     onlabeledit,
     oncontextmenu: onctx,
     onbackgroundclick,
+    onmarquee,
     preventContextMenuDefault = true,
   }: RendererOverlaySnippets & {
     nodes: Map<string, Node>
@@ -71,6 +73,11 @@
     onlabeledit?: (portId: string, label: string, screenX: number, screenY: number) => void
     oncontextmenu?: (id: string, type: string, e: MouseEvent) => void
     onbackgroundclick?: () => void
+    /** Marquee rectangle drag finished on empty canvas. The rect is in SVG
+     *  world coords (post-camera transform). `additive` is true when the
+     *  user held Shift/Cmd/Ctrl, so the host should merge with the existing
+     *  selection rather than replace. */
+    onmarquee?: (rect: { x: number; y: number; w: number; h: number }, additive: boolean) => void
     /** Suppress browser native menu via `e.preventDefault()`. See ShumokuRenderer. */
     preventContextMenuDefault?: boolean
   } = $props()
@@ -88,6 +95,61 @@
   // Per-node d3-drag still lives inside each SvgNode/SvgSubgraph via
   // the `use:elementDrag` directive — it only fires in edit mode and
   // concerns element manipulation rather than viewport camera.
+
+  // =========================================================================
+  // Marquee (drag empty canvas to box-select)
+  // =========================================================================
+  // Plain left-click + drag on the background creates a selection rectangle.
+  // Alt+drag is reserved for camera panning (camera.ts's filter), so we
+  // explicitly skip those events. Shift / Cmd / Ctrl held at the start
+  // makes the marquee additive (merge with existing selection).
+  let marquee = $state<{
+    x0: number
+    y0: number
+    x1: number
+    y1: number
+    additive: boolean
+  } | null>(null)
+
+  function bgPointerDown(e: PointerEvent) {
+    if (e.button !== 0 || e.altKey || !svgEl) return
+    const p = screenToSvg(svgEl, e.clientX, e.clientY)
+    marquee = {
+      x0: p.x,
+      y0: p.y,
+      x1: p.x,
+      y1: p.y,
+      additive: e.shiftKey || e.metaKey || e.ctrlKey,
+    }
+    ;(e.currentTarget as Element).setPointerCapture(e.pointerId)
+  }
+
+  function bgPointerMove(e: PointerEvent) {
+    if (!marquee || !svgEl) return
+    const p = screenToSvg(svgEl, e.clientX, e.clientY)
+    marquee = { ...marquee, x1: p.x, y1: p.y }
+  }
+
+  function bgPointerUp(_e: PointerEvent) {
+    if (!marquee) return
+    const w = Math.abs(marquee.x1 - marquee.x0)
+    const h = Math.abs(marquee.y1 - marquee.y0)
+    // Drags shorter than a couple of world units are treated as background
+    // clicks — let the click handler clear the selection instead. 3 is a
+    // bit arbitrary but it matches the visual feedback threshold.
+    if (w > 3 || h > 3) {
+      onmarquee?.(
+        {
+          x: Math.min(marquee.x0, marquee.x1),
+          y: Math.min(marquee.y0, marquee.y1),
+          w,
+          h,
+        },
+        marquee.additive,
+      )
+    }
+    marquee = null
+  }
 </script>
 
 <svg
@@ -142,7 +204,8 @@
 
   <!-- Viewport group: d3-zoom applies transform here -->
   <g class="viewport">
-    <!-- Background: grid in edit mode, transparent in view mode -->
+    <!-- Background: grid in edit mode, transparent in view mode.
+         Plain click clears selection; drag starts a marquee box-select. -->
     <rect
       class="canvas-bg"
       x="-99999"
@@ -152,6 +215,9 @@
       fill="url(#grid)"
       pointer-events="fill"
       onclick={() => onbackgroundclick?.()}
+      onpointerdown={bgPointerDown}
+      onpointermove={bgPointerMove}
+      onpointerup={bgPointerUp}
     />
     {#each subgraphs.values() as subgraph (subgraph.id)}
       <SvgSubgraph
@@ -228,6 +294,25 @@
         fromY={linkPreview.fromY}
         toX={linkPreview.toX}
         toY={linkPreview.toY}
+      />
+    {/if}
+
+    {#if marquee}
+      <!-- Marquee overlay. Lives inside the viewport group so it scales
+           with the camera transform. pointer-events:none lets the
+           background rect keep receiving pointer events for drag. -->
+      <rect
+        class="marquee"
+        x={Math.min(marquee.x0, marquee.x1)}
+        y={Math.min(marquee.y0, marquee.y1)}
+        width={Math.abs(marquee.x1 - marquee.x0)}
+        height={Math.abs(marquee.y1 - marquee.y0)}
+        fill={colors.selection}
+        fill-opacity="0.1"
+        stroke={colors.selection}
+        stroke-width="1"
+        stroke-dasharray="3 2"
+        pointer-events="none"
       />
     {/if}
   </g>


### PR DESCRIPTION
Re-opening #241 onto main — it merged into the foundation branch (which got squashed into main as #240) so its commits never reached main directly.

## Summary
Second half of diagram multi-selection. Foundation landed in #240.

- **Marquee box-select.** Plain drag on the background draws a rectangle; release adds every intersecting node + subgraph to the selection. Shift / Cmd / Ctrl at drag start makes it additive.
- **Multi-node drag.** Drag any one of a multi-selection and the whole group follows in lockstep — the actual post-collision delta of the lead node is applied to every other selected element's snapshotted origin, so collisions on the leader hold the group back rigidly.
- **Bulk Move to group.** The submenu now operates on every node in the selection, not just the first id. \"(top level)\" hides only when every selected node is already at top level.

## Test plan
- [x] Marquee on sample → status badge shows N selected
- [x] Marquee with Shift → adds to existing selection
- [x] Marquee shorter than 3 units → behaves as background click (clears)
- [x] Move to group with N > 1 selected → all move into chosen subgraph
- [ ] Multi-drag verified by code review (d3-drag rejects synthetic events; needs interactive QA before final ship)
- [x] typecheck / biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)