### PR TITLE
fix(editor): marquee follows cursor under camera zoom + stays visible

### DIFF
--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -124,6 +124,15 @@
     additive: boolean
   } | null>(null)
 
+  // After a real pointerdown→pointerup on the same element, the
+  // browser synthesises a `click` — which the canvas-bg's
+  // `onclick={onbackgroundclick}` interprets as "clear selection".
+  // For an empty (sub-threshold) drag that's correct, but for a
+  // successful marquee it would wipe the selection we just made,
+  // making the marquee look like it did nothing. Flag a recently
+  // committed marquee and suppress the click that follows it.
+  let suppressNextBgClick = false
+
   function bgPointerDown(e: PointerEvent) {
     if (e.button !== 0 || e.altKey || !svgEl) return
     const p = screenToWorld(svgEl, e.clientX, e.clientY)
@@ -160,8 +169,17 @@
         },
         marquee.additive,
       )
+      suppressNextBgClick = true
     }
     marquee = null
+  }
+
+  function bgClick() {
+    if (suppressNextBgClick) {
+      suppressNextBgClick = false
+      return
+    }
+    onbackgroundclick?.()
   }
 </script>
 
@@ -237,7 +255,7 @@
       height="199998"
       fill="url(#grid)"
       pointer-events="fill"
-      onclick={() => onbackgroundclick?.()}
+      onclick={bgClick}
       onpointerdown={bgPointerDown}
       onpointermove={bgPointerMove}
       onpointerup={bgPointerUp}

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -2,12 +2,25 @@
   import type { Node, ResolvedEdge, ResolvedPort, Subgraph, Theme } from '@shumoku/core'
   import type { RendererOverlaySnippets } from '../../lib/overlays'
   import type { RenderColors } from '../../lib/render-colors'
-  import { screenToSvg } from '../../lib/svg-coords'
   import SvgEdge from './SvgEdge.svelte'
   import SvgLinkPreview from './SvgLinkPreview.svelte'
   import SvgNode from './SvgNode.svelte'
   import SvgPort from './SvgPort.svelte'
   import SvgSubgraph from './SvgSubgraph.svelte'
+
+  // Marquee uses world-space coords: convert screen → world via the
+  // viewport <g>'s screen CTM so the camera's pan/zoom is included.
+  // The svg-coords helper's `screenToSvg` only inverts the SVG root's
+  // CTM, so it would skip d3-zoom and the marquee would lag behind the
+  // cursor whenever the canvas is panned. Mirrors the same approach
+  // ShumokuRenderer takes in its own `screenToSvg` export.
+  function screenToWorld(el: SVGSVGElement, sx: number, sy: number): { x: number; y: number } {
+    const viewport = el.querySelector('.viewport') as SVGGraphicsElement | null
+    const ctm = (viewport ?? el).getScreenCTM()
+    if (!ctm) return { x: sx, y: sy }
+    const p = new DOMPoint(sx, sy).matrixTransform(ctm.inverse())
+    return { x: p.x, y: p.y }
+  }
 
   let {
     nodes,
@@ -113,7 +126,7 @@
 
   function bgPointerDown(e: PointerEvent) {
     if (e.button !== 0 || e.altKey || !svgEl) return
-    const p = screenToSvg(svgEl, e.clientX, e.clientY)
+    const p = screenToWorld(svgEl, e.clientX, e.clientY)
     marquee = {
       x0: p.x,
       y0: p.y,
@@ -126,7 +139,7 @@
 
   function bgPointerMove(e: PointerEvent) {
     if (!marquee || !svgEl) return
-    const p = screenToSvg(svgEl, e.clientX, e.clientY)
+    const p = screenToWorld(svgEl, e.clientX, e.clientY)
     marquee = { ...marquee, x1: p.x, y1: p.y }
   }
 
@@ -298,9 +311,12 @@
     {/if}
 
     {#if marquee}
-      <!-- Marquee overlay. Lives inside the viewport group so it scales
-           with the camera transform. pointer-events:none lets the
-           background rect keep receiving pointer events for drag. -->
+      <!-- Marquee overlay. Lives inside the viewport group so its
+           position scales with the camera. `vector-effect=non-scaling-stroke`
+           keeps the outline visible at any zoom level — otherwise
+           stroke-width=1 in world coords becomes sub-pixel when the
+           camera zooms out to fit a large diagram. pointer-events:none
+           lets the background rect keep receiving pointer events. -->
       <rect
         class="marquee"
         x={Math.min(marquee.x0, marquee.x1)}
@@ -308,10 +324,11 @@
         width={Math.abs(marquee.x1 - marquee.x0)}
         height={Math.abs(marquee.y1 - marquee.y0)}
         fill={colors.selection}
-        fill-opacity="0.1"
+        fill-opacity="0.12"
         stroke={colors.selection}
-        stroke-width="1"
-        stroke-dasharray="3 2"
+        stroke-width="1.5"
+        stroke-dasharray="4 3"
+        vector-effect="non-scaling-stroke"
         pointer-events="none"
       />
     {/if}

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -213,6 +213,16 @@
 
     /* Edit-only UI (hidden in view mode) */
     .edge-zone { pointer-events: none; }
+
+    /* Selection feedback. The node/subgraph already paints a selection-coloured
+       stroke; this rule keeps that stroke visible at any camera zoom. Without
+       non-scaling-stroke the outline of icon-style nodes vanishes below 1px
+       when the camera is zoomed out to fit a busy diagram. */
+    .node.selected .node-bg > *,
+    .subgraph.selected > .subgraph-bg {
+      vector-effect: non-scaling-stroke;
+      stroke-width: 3;
+    }
   </style>`}
 
   <!-- Viewport group: d3-zoom applies transform here -->

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -148,8 +148,7 @@
 </script>
 
 <g
-  class="node"
-  class:selected
+  class={selected ? 'node selected' : 'node'}
   data-id={node.id}
   data-device-type={specDeviceType(node.spec) ?? ''}
   filter="url(#{shadowFilterId})"

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -149,6 +149,7 @@
 
 <g
   class="node"
+  class:selected
   data-id={node.id}
   data-device-type={specDeviceType(node.spec) ?? ''}
   filter="url(#{shadowFilterId})"

--- a/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
@@ -74,7 +74,7 @@
   })
 </script>
 
-<g class="subgraph" class:selected data-id={subgraph.id}>
+<g class={selected ? 'subgraph selected' : 'subgraph'} data-id={subgraph.id}>
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
   <rect
     class="subgraph-bg"

--- a/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
@@ -74,7 +74,7 @@
   })
 </script>
 
-<g class="subgraph" data-id={subgraph.id}>
+<g class="subgraph" class:selected data-id={subgraph.id}>
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
   <rect
     class="subgraph-bg"


### PR DESCRIPTION
Two bugs in #242's marquee, both spotted while QA-ing on the sample diagram.

## What was wrong
1. **Marquee lagged behind cursor when the canvas was panned/zoomed.**
   I'd used the svg-coords helper's \`screenToSvg(svg, ...)\`, which inverts only the SVG root's CTM. The marquee rect is drawn inside the viewport \`<g>\`, so d3-zoom's transform was applied on top of the supposed-cursor position — and any pan/zoom offset accumulated visibly.

2. **Outline went sub-pixel when the camera zoomed out.**
   stroke-width=1 in world coords gets divided by the camera scale; at typical \"fit-all\" zoom on a busy diagram the dashed line was effectively invisible.

## Fix
- Invert the viewport \`<g>\`'s screen CTM directly (matches ShumokuRenderer's own \`screenToSvg\` helper) so the marquee lands on the actual cursor at any camera transform.
- Mark the stroke as \`vector-effect=non-scaling-stroke\` and bump the dashed contrast slightly so the outline stays legible at every zoom.

## Test plan
- [x] Marquee at default zoom — rect tracks cursor, dashed outline visible
- [x] DOM proof: \`rect.marquee\` getBoundingClientRect = (clientX, clientY, width, height) — matches the drag span exactly
- [x] Selection result fires correctly on release (\"4 selected\" for the test span)
- [x] typecheck / biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)