### PR TITLE
fix(editor): enforce one link per port

### DIFF
--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -25,6 +25,7 @@ import {
   computeNodeBodySize,
   createMemoryFileResolver,
   HierarchicalParser,
+  isPortLinked,
   type Link,
   moveNode,
   type NetworkGraph,
@@ -559,6 +560,17 @@ export const diagramState = {
 
   // ----- Diagram mutations (commit-wrapped) ---------------------------
   addLink(link: Link) {
+    // Defensive guard. Renderer's link-creation flow already rejects
+    // drops on linked ports, but this is the canonical API every other
+    // caller (imports, scripts, future surfaces) goes through — keep
+    // the invariant enforced here so a single bypass can't corrupt the
+    // model. Either endpoint already in use → drop silently.
+    if (
+      isPortLinked(diagram.links, link.from.node, link.from.port) ||
+      isPortLinked(diagram.links, link.to.node, link.to.port)
+    ) {
+      return
+    }
     commit('Add link', () => {
       diagram.links = [...diagram.links, link]
       invalidateSheetCache()

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -14,6 +14,7 @@ export {
   addPort,
   collectObstacles,
   detectClickSide,
+  isPortLinked,
   linkExists,
   moveNode,
   movePort,

--- a/libs/@shumoku/core/src/layout/interaction.test.ts
+++ b/libs/@shumoku/core/src/layout/interaction.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { Link } from '../models/types.js'
+import { isPortLinked, linkExists } from './interaction.js'
+
+const link = (id: string, fromN: string, fromP: string, toN: string, toP: string): Link => ({
+  id,
+  from: { node: fromN, port: fromP },
+  to: { node: toN, port: toP },
+})
+
+describe('isPortLinked', () => {
+  it('returns false for an empty link set', () => {
+    expect(isPortLinked([], 'sw1', 'eth0')).toBe(false)
+  })
+
+  it('returns true when the port appears as the from endpoint', () => {
+    const links = [link('l1', 'sw1', 'eth0', 'sw2', 'eth0')]
+    expect(isPortLinked(links, 'sw1', 'eth0')).toBe(true)
+  })
+
+  it('returns true when the port appears as the to endpoint', () => {
+    const links = [link('l1', 'sw1', 'eth0', 'sw2', 'eth0')]
+    expect(isPortLinked(links, 'sw2', 'eth0')).toBe(true)
+  })
+
+  it('returns false for an unrelated port on a linked node', () => {
+    const links = [link('l1', 'sw1', 'eth0', 'sw2', 'eth0')]
+    expect(isPortLinked(links, 'sw1', 'eth1')).toBe(false)
+  })
+
+  it('returns false for the same port id on a different node', () => {
+    const links = [link('l1', 'sw1', 'eth0', 'sw2', 'eth0')]
+    expect(isPortLinked(links, 'sw3', 'eth0')).toBe(false)
+  })
+})
+
+describe('linkExists vs isPortLinked', () => {
+  // Sanity check: linkExists only guards exact-link duplicates, while
+  // isPortLinked enforces the "one link per port" invariant. The
+  // multi-link-per-port bug came from conflating the two.
+  it('linkExists is false when a port already has a different partner', () => {
+    const links = [link('l1', 'sw1', 'eth0', 'sw2', 'eth0')]
+    // Try a brand-new link from sw3 onto sw1:eth0 (already in use).
+    expect(linkExists(links, 'sw3', 'eth0', 'sw1', 'eth0')).toBe(false)
+    expect(isPortLinked(links, 'sw1', 'eth0')).toBe(true)
+  })
+})

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -502,6 +502,22 @@ export function linkExists(
 }
 
 /**
+ * Whether the given port already appears as an endpoint of any link.
+ *
+ * A physical port models one cable termination, so it can host at most
+ * one link at a time. Callers use this to reject attempts to wire a
+ * second link onto an already-connected port — `linkExists` only
+ * catches exact-duplicate links, which isn't enough for the "1 port =
+ * 1 link" invariant.
+ */
+export function isPortLinked(links: Link[], nodeId: string, portId: string): boolean {
+  return links.some(
+    ({ from, to }) =>
+      (from.node === nodeId && from.port === portId) || (to.node === nodeId && to.port === portId),
+  )
+}
+
+/**
  * Add a link between two ports (existing or new).
  *
  * If fromPortId/toPortId refer to existing ports, use them.

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -667,6 +667,10 @@
     const fromPortId = linkDrag.fromPortId
     linkCleanup?.()
     if (fromPortId === portId) return
+    // Reject drops on an already-linked target. A port is one physical
+    // termination — it can host at most one link. linkedPorts derives
+    // from the live edges set so this is in sync with what the user sees.
+    if (linkedPorts.has(portId)) return
     const fromPort = ports.get(fromPortId)
     const toPort = ports.get(portId)
     if (fromPort && toPort && fromPort.nodeId === toPort.nodeId) return


### PR DESCRIPTION
A port models a single physical termination — it can host at most one link. The user reported that the diagram view let a port carry multiple connections; tracing through the link-creation flow, the renderer's \`handleLinkEnd\` only guarded against same-port / same-node drops, and the editor's \`addLink\` had no validation at all.

## Three coordinated changes
- **Core:** new \`isPortLinked(links, nodeId, portId)\` next to \`linkExists\` in \`layout/interaction.ts\`. They answer different questions (exact-duplicate vs. port-occupancy) and were getting conflated; unit tests pin the distinction.
- **Renderer:** \`handleLinkEnd\` rejects drops where \`linkedPorts.has(portId)\` before forwarding to \`doAddLink\`. \`linkedPorts\` is already derived from the live edges, so the gate stays consistent with what the user sees.
- **Editor state:** \`diagramState.addLink\` runs \`isPortLinked\` on both endpoints before committing. This is the canonical ingress for every other surface (paste, scripts, future imports), so the invariant holds regardless of how the link is being added.

## Test plan
- [x] New \`interaction.test.ts\` covers \`isPortLinked\` and the linkExists/isPortLinked distinction (5 cases, all green)
- [x] Full \`@shumoku/core\` suite: 155/155 pass
- [x] typecheck / biome clean
- [ ] Manual: drag a fresh link onto a port that's already wired — should not create a second link

🤖 Generated with [Claude Code](https://claude.com/claude-code)