### PR TITLE
refactor(editor): bend Nodes lifted out into Link.bends

### DIFF
--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -161,6 +161,53 @@
     return nodeCenterFromTopLeft(scene, diagramState.nodes.get(nodeId), positionFor(nodeId))
   }
 
+  // Reverse lookup so the drag / delete intercepts can tell whether
+  // an sf-node id refers to a real `Node` or a bend on a link. Built
+  // once per derive cycle and cheap to query — bends are sparse.
+  const bendIdToLinkId = $derived.by(() => {
+    const m = new Map<string, string>()
+    for (const link of diagramState.links) {
+      if (!link.id || !link.bends) continue
+      for (const b of link.bends) m.set(b.id, link.id)
+    }
+    return m
+  })
+
+  /**
+   * Inner waypoints between segment endpoints, with bends interleaved
+   * at their `afterIndex` slots. Mirrors the polyline that
+   * `cableSegmentLengths` walks so visual and accounting agree.
+   */
+  function innerWaypointsForSegment(
+    link: import('@shumoku/core').Link,
+    segIds: string[],
+  ): Array<{ x: number; y: number }> {
+    const out: Array<{ x: number; y: number }> = []
+    const bends = link.bends ?? []
+    const via = link.via ?? []
+    const linkFromNode = link.from.node
+    const globalViaIndex = new Map<string, number>(via.map((id, i) => [id, i]))
+    // segIds is [segStart, ...inner via terminations..., segEnd].
+    // Walk adjacent pairs; for each gap insert bends whose
+    // `afterIndex` matches the left side's global position.
+    for (let k = 0; k < segIds.length - 1; k++) {
+      const left = segIds[k]
+      if (!left) continue
+      const leftAfter = left === linkFromNode ? -1 : (globalViaIndex.get(left) ?? -1)
+      for (const b of bends) {
+        if (b.afterIndex === leftAfter) out.push({ x: b.x, y: b.y })
+      }
+      const nextId = segIds[k + 1]
+      // The right end of this gap is either an inner via point
+      // (push its center) or the segment's last node (handled by
+      // the edge target — don't double-push).
+      if (k + 1 < segIds.length - 1 && nextId) {
+        out.push(centerOf(nextId))
+      }
+    }
+    return out
+  }
+
   // ── Svelte Flow nodes/edges (derived) ────────────────────────────
   const sfNodes = $derived.by<SfNode[]>(() => {
     const out: SfNode[] = []
@@ -247,6 +294,34 @@
         selectable: true,
       })
     }
+    // Virtual sf nodes for every link bend. Bends are not in
+    // `diagram.nodes` (they live on `link.bends`), so the canvas
+    // synthesizes one sf node per bend so the user can still drag /
+    // select / delete them through the standard Svelte Flow path.
+    // The drag and delete intercepts (persistDragged, onnodesdelete)
+    // route these synthetic ids back to `updateLinkBend` /
+    // `removeLinkBend` instead of the real-Node store.
+    for (const link of visibleLinks) {
+      const bends = link.bends
+      if (!link.id || !bends) continue
+      for (const b of bends) {
+        out.push({
+          id: b.id,
+          type: 'scene',
+          position: { x: b.x, y: b.y },
+          width: 16,
+          height: 16,
+          data: {
+            label: '',
+            termination: { role: 'bend' },
+            baseW: 16,
+            baseH: 16,
+          },
+          draggable: interactive,
+          selectable: true,
+        })
+      }
+    }
     return out
   })
 
@@ -284,11 +359,12 @@
         if (!segFrom || !segTo || segFrom === segTo) continue
         const segFromPos = centerOf(segFrom)
         const segToPos = centerOf(segTo)
-        // Inner via points (between segFrom and segTo) target each
-        // icon's center.
-        const innerWaypoints: Array<{ x: number; y: number }> = segIds
-          .slice(1, -1)
-          .map((id) => centerOf(id))
+        // Inner waypoints between segFrom and segTo. Includes:
+        //   - centers of inner via terminations (eps / outlet / panel)
+        //   - bend positions interleaved at their `afterIndex` slots
+        // Order is the polyline the user sees, so cable length math
+        // and the rendered curve stay in sync.
+        const innerWaypoints = innerWaypointsForSegment(link, segIds)
         // Handle side: out from segFrom toward the next visible
         // point; into segTo from the previous one.
         const firstInner = innerWaypoints[0] ?? segToPos
@@ -353,10 +429,19 @@
   // of one per selected node.
   function persistDragged(nodes: SfNode[] | null | undefined) {
     if (!nodes || nodes.length === 0) return
-    diagramState.placeNodesInScene(
-      scene.id,
-      nodes.map((n) => ({ nodeId: n.id, position: n.position })),
-    )
+    // Partition by id: bend ids belong to a link's `bends` array,
+    // not the scene placement map. Real Node ids go through
+    // `placeNodesInScene` as before.
+    const placements: Array<{ nodeId: string; position: { x: number; y: number } }> = []
+    for (const n of nodes) {
+      const linkId = bendIdToLinkId.get(n.id)
+      if (linkId) {
+        diagramState.updateLinkBend(linkId, n.id, n.position)
+      } else {
+        placements.push({ nodeId: n.id, position: n.position })
+      }
+    }
+    if (placements.length > 0) diagramState.placeNodesInScene(scene.id, placements)
   }
   function onNodeDragStart(_args: { targetNode: SfNode | null; nodes: SfNode[] }) {
     diagramState.beginTx('Move item')
@@ -498,7 +583,11 @@
         if (linkId) linkIds.add(linkId)
       }
       for (const id of linkIds) diagramState.removeLink(id)
-      for (const n of nodes) diagramState.removeNode(n.id)
+      for (const n of nodes) {
+        const linkId = bendIdToLinkId.get(n.id)
+        if (linkId) diagramState.removeLinkBend(linkId, n.id)
+        else diagramState.removeNode(n.id)
+      }
     }}
     proOptions={{ hideAttribution: true }}
   >
@@ -548,7 +637,7 @@
 
 <style>
   /* Soften Svelte Flow's default dotted background when no floor
-                                           plan is set, but otherwise let its theming through. */
+                                             plan is set, but otherwise let its theming through. */
   :global(.svelte-flow__background) {
     background: #f8fafc;
   }
@@ -556,8 +645,8 @@
     stroke-linecap: round;
   }
   /* Make connection handles visible on hover so users can see where
-                                         to drag from. Otherwise the fully-transparent handles leave the
-                                         "how do I draw a wire" UX a guess. */
+                                           to drag from. Otherwise the fully-transparent handles leave the
+                                           "how do I draw a wire" UX a guess. */
   :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 1 !important;
@@ -567,15 +656,15 @@
     height: 8px;
   }
   /* Read-only cue: don't reveal connection handles on hover in view
-                               mode. Keep size + DOM presence so Svelte Flow can still resolve
-                               edge endpoint positions from each handle's bounding rect — only
-                               opacity is dropped. */
+                                 mode. Keep size + DOM presence so Svelte Flow can still resolve
+                                 edge endpoint positions from each handle's bounding rect — only
+                                 opacity is dropped. */
   .scene-canvas-readonly :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 0 !important;
   }
   /* Placement-pending: crosshair cursor on the pane so users see
-                               "click somewhere to drop the item". */
+                                 "click somewhere to drop the item". */
   .scene-canvas-placing :global(.svelte-flow__pane) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     cursor: crosshair !important;

--- a/apps/editor/src/lib/components/scene/wire-edit.ts
+++ b/apps/editor/src/lib/components/scene/wire-edit.ts
@@ -105,32 +105,26 @@ export function bendOnDrag(args: {
     threshold = 4,
     snapTol = 18,
   } = args
-  let dragNodeId: string | null = null
+  let dragBendId: string | null = null
   let txOpen = false
 
   function nearestExistingBend(at: Waypoint): { id: string; dist: number } | null {
     const link = diagramState.links.find((l) => l.id === linkId)
-    const via = link?.via ?? []
-    const scene = diagramState.scenes.find((s) => s.id === sceneId)
+    const bends = link?.bends ?? []
     let bestId: string | null = null
     let bestDist = Infinity
-    for (const id of via) {
-      const node = diagramState.nodes.get(id)
-      if (node?.termination?.role !== 'bend') continue
-      const placement =
-        scene?.nodePlacements.find((p) => p.nodeId === id)?.position ?? node.position
-      if (!placement) continue
-      const dist = Math.hypot(placement.x - at.x, placement.y - at.y)
+    for (const b of bends) {
+      const dist = Math.hypot(b.x - at.x, b.y - at.y)
       if (dist < bestDist) {
         bestDist = dist
-        bestId = id
+        bestId = b.id
       }
     }
     return bestId ? { id: bestId, dist: bestDist } : null
   }
 
   const onMove = (ev: PointerEvent) => {
-    if (dragNodeId === null) {
+    if (dragBendId === null) {
       const moved = Math.hypot(ev.clientX - startClient.x, ev.clientY - startClient.y)
       if (moved < threshold) return
       const flowStart = toFlow(startClient.x, startClient.y)
@@ -139,19 +133,22 @@ export function bendOnDrag(args: {
       if (near && near.dist <= snapTol) {
         diagramState.beginTx('Adjust wire')
         txOpen = true
-        dragNodeId = near.id
+        dragBendId = near.id
       } else {
+        // New bend: `viaOffset + localIdx - 1` is the `afterIndex`
+        // slot inside the (terminations-only) via chain. The segment
+        // index from this edge already references via positions.
         const localIdx = nearestSegmentIndex(points, flowStart)
-        const segIdx = viaOffset + localIdx
-        // insertBendInLink wraps the create + via splice in its own
-        // commit, so we don't double-wrap with our drag tx.
-        dragNodeId = diagramState.insertBendInLink(sceneId, linkId, flowStart, segIdx)
+        const afterIndex = viaOffset + localIdx - 1
+        // addLinkBend wraps create in its own commit; the subsequent
+        // drag moves get their own tx below.
+        dragBendId = diagramState.addLinkBend(linkId, flowStart, afterIndex) || null
         diagramState.beginTx('Adjust wire')
         txOpen = true
       }
     }
     const fp = toFlow(ev.clientX, ev.clientY)
-    if (dragNodeId) diagramState.placeNodeInScene(sceneId, dragNodeId, fp)
+    if (dragBendId) diagramState.updateLinkBend(linkId, dragBendId, fp)
   }
   const onUp = () => {
     document.removeEventListener('pointermove', onMove)

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -297,14 +297,12 @@ function setNodePortsFromProduct(
 }
 
 /**
- * Pick a default label for a new termination placement. Bends stay
- * anonymous ("Bend") — they're not labelled on the canvas. EPS /
+ * Pick a default label for a new termination placement. EPS /
  * Outlet / Panel get a numeric suffix ("EPS 1", "EPS 2"…) scoped to
  * existing same-role nodes anywhere in the diagram, so concurrent
  * placements stay distinguishable before the user renames them.
  */
-function nextTerminationLabel(role: 'outlet' | 'eps' | 'panel' | 'bend'): string {
-  if (role === 'bend') return 'Bend'
+function nextTerminationLabel(role: 'outlet' | 'eps' | 'panel'): string {
   const base = role === 'outlet' ? 'Outlet' : role === 'eps' ? 'EPS' : 'Panel'
   // Walk existing same-role nodes and collect any "Base N" suffix
   // they already carry; the new label takes max+1 (or 1 when none).
@@ -1242,13 +1240,12 @@ export const diagramState = {
   addTerminationInScene(
     sceneId: string,
     position: { x: number; y: number },
-    role: 'outlet' | 'eps' | 'panel' | 'bend',
+    role: 'outlet' | 'eps' | 'panel',
   ): string {
     return commit('Add termination in scene', () => {
       // Auto-number same-role terminations so multiple placements stay
       // distinguishable ("EPS 1", "EPS 2"…) before the user gets around
-      // to renaming them. Bends stay anonymous — they're not labelled
-      // on the canvas.
+      // to renaming them.
       const defaultLabel = nextTerminationLabel(role)
       const id = diagramState.addEmptyNode(defaultLabel)
       const scene = scenesStore.find(sceneId)

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -2015,7 +2015,15 @@ async function applyProject(data: Partial<NetedProject>) {
   // link itself via `Link.bends`. This migration lifts any bend
   // Nodes from a legacy save into the new home and deletes them
   // from `nodes`. Idempotent — already-migrated graphs no-op.
-  migrateBendNodesToLinkBends({ nodes: diagram.nodes, links: diagram.links })
+  migrateBendNodesToLinkBends({
+    nodes: diagram.nodes,
+    links: diagram.links,
+    // Scenes carry the bend's actual position via `nodePlacements`
+    // (legacy bend Nodes never had `node.position` set). Pass the
+    // live scenesStore so the migration can recover real coords
+    // and strip the now-orphan placements.
+    scenes: scenesStore.list,
+  })
 }
 
 async function applyGraph(graph: NetworkGraph) {

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -42,7 +42,11 @@ import {
   type Theme,
 } from '@shumoku/core'
 import { SvelteMap } from 'svelte/reactivity'
-import { inheritProductIconFromCatalog, migrateLegacyWireRoutes } from './migrations'
+import {
+  inheritProductIconFromCatalog,
+  migrateBendNodesToLinkBends,
+  migrateLegacyWireRoutes,
+} from './migrations'
 import { projectsDb } from './persistence/projects-store'
 import { readProjectZip } from './persistence/reader'
 import { applySync, diffSnapshots } from './persistence/sync'
@@ -1957,6 +1961,16 @@ async function applyProject(data: Partial<NetedProject>) {
       diagramState.addTerminationInScene(sceneId, position, role),
     updateLink: (linkId, updates) => diagramState.updateLink(linkId, updates),
   })
+  // Bends used to live as `Node`s with termination.role === 'bend'
+  // so they could ride the Svelte Flow drag/select machinery.
+  // That polluted every consumer of `diagram.nodes` (JSON export,
+  // BOM, Connections, …). This migration lifts each bend out of
+  // `nodes` + `via` into the link's own `bends` array, leaving
+  // `nodes` and `via` to mean "real logical entities" only. Runs
+  // after the legacy wire-routes migration so any bend Nodes it
+  // just produced are immediately cleaned up too. Idempotent —
+  // already-migrated graphs no-op.
+  migrateBendNodesToLinkBends({ nodes: diagram.nodes, links: diagram.links })
 }
 
 async function applyGraph(graph: NetworkGraph) {

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -1272,19 +1272,71 @@ export const diagramState = {
    * the new bend Node's id so the drag handler can move it.
    */
   insertBendInLink(
-    sceneId: string,
+    _sceneId: string,
     linkId: string,
     position: { x: number; y: number },
-    viaIndex: number,
+    afterIndex: number,
   ): string {
-    return commit('Bend wire', () => {
-      const id = diagramState.addTerminationInScene(sceneId, position, 'bend')
-      const link = diagram.links.find((l) => l.id === linkId)
-      const oldVia = link?.via ?? []
-      const idx = Math.max(0, Math.min(viaIndex, oldVia.length))
-      const newVia = [...oldVia.slice(0, idx), id, ...oldVia.slice(idx)]
-      diagramState.updateLink(linkId, { via: newVia })
-      return id
+    // Bends live on `link.bends` now, not on `diagram.nodes`. The
+    // scene argument is kept for callsite compatibility but unused —
+    // bends are link-level data, not per-scene.
+    return diagramState.addLinkBend(linkId, position, afterIndex) ?? ''
+  },
+  /**
+   * Append a bend waypoint to a link's polyline. `afterIndex` is the
+   * insertion slot relative to the (terminations-only) `via` chain:
+   *   -1  → between `from` and `via[0]` (or `from`→`to` directly)
+   *    i  → between `via[i]` and `via[i+1]` (or `via[i]`→`to`)
+   * Returns the new bend's id (empty string if the link is missing).
+   */
+  addLinkBend(linkId: string, position: { x: number; y: number }, afterIndex: number): string {
+    return commit('Add bend', () => {
+      const idx = diagram.links.findIndex((l) => l.id === linkId)
+      if (idx < 0) return ''
+      const link = diagram.links[idx]
+      if (!link) return ''
+      const bendId = newId('bend')
+      const next = {
+        ...link,
+        bends: [...(link.bends ?? []), { id: bendId, x: position.x, y: position.y, afterIndex }],
+      }
+      diagram.links = diagram.links.map((l, i) => (i === idx ? next : l))
+      return bendId
+    })
+  },
+  /**
+   * Move a bend to a new position. Pure data update — bends don't
+   * affect routing or port resolution, so no `rebuildPortsAndEdges`.
+   */
+  updateLinkBend(linkId: string, bendId: string, position: { x: number; y: number }): void {
+    commit('Move bend', () => {
+      const idx = diagram.links.findIndex((l) => l.id === linkId)
+      if (idx < 0) return
+      const link = diagram.links[idx]
+      if (!link?.bends) return
+      const next = {
+        ...link,
+        bends: link.bends.map((b) =>
+          b.id === bendId ? { ...b, x: position.x, y: position.y } : b,
+        ),
+      }
+      diagram.links = diagram.links.map((l, i) => (i === idx ? next : l))
+    })
+  },
+  /**
+   * Drop a bend from a link. When the link has no bends left, the
+   * `bends` field is cleared back to undefined so the saved JSON
+   * doesn't carry empty arrays.
+   */
+  removeLinkBend(linkId: string, bendId: string): void {
+    commit('Remove bend', () => {
+      const idx = diagram.links.findIndex((l) => l.id === linkId)
+      if (idx < 0) return
+      const link = diagram.links[idx]
+      if (!link?.bends) return
+      const filtered = link.bends.filter((b) => b.id !== bendId)
+      const next = { ...link, bends: filtered.length > 0 ? filtered : undefined }
+      diagram.links = diagram.links.map((l, i) => (i === idx ? next : l))
     })
   },
   /**
@@ -1957,19 +2009,15 @@ async function applyProject(data: Partial<NetedProject>) {
   scenesStore.setCurrentId(null)
   migrateLegacyWireRoutes(data.scenes ?? [], {
     links: diagram.links,
-    addTerminationInScene: (sceneId, position, role) =>
-      diagramState.addTerminationInScene(sceneId, position, role),
-    updateLink: (linkId, updates) => diagramState.updateLink(linkId, updates),
+    newBendId: () => newId('bend'),
   })
-  // Bends used to live as `Node`s with termination.role === 'bend'
-  // so they could ride the Svelte Flow drag/select machinery.
+  // Older project files stored bends as `Node`s with
+  // `termination.role === 'bend'` and spliced them into `Link.via`.
   // That polluted every consumer of `diagram.nodes` (JSON export,
-  // BOM, Connections, …). This migration lifts each bend out of
-  // `nodes` + `via` into the link's own `bends` array, leaving
-  // `nodes` and `via` to mean "real logical entities" only. Runs
-  // after the legacy wire-routes migration so any bend Nodes it
-  // just produced are immediately cleaned up too. Idempotent —
-  // already-migrated graphs no-op.
+  // BOM, Connections, …). The current model puts bends on the
+  // link itself via `Link.bends`. This migration lifts any bend
+  // Nodes from a legacy save into the new home and deletes them
+  // from `nodes`. Idempotent — already-migrated graphs no-op.
   migrateBendNodesToLinkBends({ nodes: diagram.nodes, links: diagram.links })
 }
 

--- a/apps/editor/src/lib/migrations/bend-nodes-to-link-bends.test.ts
+++ b/apps/editor/src/lib/migrations/bend-nodes-to-link-bends.test.ts
@@ -3,7 +3,16 @@
 
 import type { Link, Node } from '@shumoku/core'
 import { describe, expect, test } from 'vitest'
+import type { Scene } from '../types'
 import { migrateBendNodesToLinkBends } from './bend-nodes-to-link-bends'
+
+function scene(id: string, placements: Array<{ nodeId: string; x: number; y: number }>): Scene {
+  return {
+    id,
+    name: id,
+    nodePlacements: placements.map((p) => ({ nodeId: p.nodeId, position: { x: p.x, y: p.y } })),
+  }
+}
 
 function termination(id: string, role: 'eps' | 'outlet' | 'panel' | 'bend'): Node {
   return {
@@ -97,6 +106,25 @@ describe('migrateBendNodesToLinkBends', () => {
     const stats2 = migrateBendNodesToLinkBends({ nodes, links })
     expect(stats2).toEqual({ nodesRemoved: 0, linksTouched: 0, bendsAdded: 0 })
     expect(links[0]?.bends).toHaveLength(1)
+  })
+
+  test('reads bend position from scene placement when node.position is missing', () => {
+    // Legacy bends were placed via `placeNodeInScene`, which only
+    // wrote to `scene.nodePlacements`. Their `node.position` is
+    // undefined — the migration has to look in scenes to recover
+    // real coordinates, otherwise every bend lands at (0, 0).
+    const bend: Node = { id: 'bend-1', label: 'Bend', termination: { role: 'bend' } } as Node
+    const nodes = nodesMap(device('a'), device('b'), bend)
+    const links: Link[] = [
+      { id: 'l1', from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'p' }, via: ['bend-1'] },
+    ]
+    const scenes = [scene('s1', [{ nodeId: 'bend-1', x: 42, y: 84 }])]
+
+    migrateBendNodesToLinkBends({ nodes, links, scenes })
+
+    expect(links[0]?.bends?.[0]).toMatchObject({ id: 'bend-1', x: 42, y: 84 })
+    // Orphan placement removed from the scene so the next save is clean.
+    expect(scenes[0]?.nodePlacements.find((p) => p.nodeId === 'bend-1')).toBeUndefined()
   })
 
   test('preserves an existing bends array (append, not replace)', () => {

--- a/apps/editor/src/lib/migrations/bend-nodes-to-link-bends.test.ts
+++ b/apps/editor/src/lib/migrations/bend-nodes-to-link-bends.test.ts
@@ -1,0 +1,116 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { Link, Node } from '@shumoku/core'
+import { describe, expect, test } from 'vitest'
+import { migrateBendNodesToLinkBends } from './bend-nodes-to-link-bends'
+
+function termination(id: string, role: 'eps' | 'outlet' | 'panel' | 'bend'): Node {
+  return {
+    id,
+    label: role,
+    termination: { role },
+    position: { x: id.length, y: id.length * 2 },
+  } as Node
+}
+
+function device(id: string): Node {
+  return { id, label: id, position: { x: 0, y: 0 } } as Node
+}
+
+function nodesMap(...ns: Node[]): Map<string, Node> {
+  return new Map(ns.map((n) => [n.id, n]))
+}
+
+describe('migrateBendNodesToLinkBends', () => {
+  test('no-op when there are no bend nodes', () => {
+    const nodes = nodesMap(device('a'), device('b'), termination('eps-1', 'eps'))
+    const links: Link[] = [
+      { id: 'l1', from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'p' }, via: ['eps-1'] },
+    ]
+    const stats = migrateBendNodesToLinkBends({ nodes, links })
+    expect(stats).toEqual({ nodesRemoved: 0, linksTouched: 0, bendsAdded: 0 })
+    expect(nodes.size).toBe(3)
+    expect(links[0]?.via).toEqual(['eps-1'])
+    expect(links[0]?.bends).toBeUndefined()
+  })
+
+  test('extracts a single bend before any termination (afterIndex = -1)', () => {
+    const nodes = nodesMap(device('a'), device('b'), termination('bend-1', 'bend'))
+    const links: Link[] = [
+      { id: 'l1', from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'p' }, via: ['bend-1'] },
+    ]
+    const stats = migrateBendNodesToLinkBends({ nodes, links })
+    expect(stats.bendsAdded).toBe(1)
+    expect(stats.nodesRemoved).toBe(1)
+    expect(stats.linksTouched).toBe(1)
+    expect(nodes.has('bend-1')).toBe(false)
+    expect(links[0]?.via).toBeUndefined()
+    expect(links[0]?.bends).toEqual([{ id: 'bend-1', x: 6, y: 12, afterIndex: -1 }])
+  })
+
+  test('extracts bends interleaved with terminations (correct afterIndex)', () => {
+    const nodes = nodesMap(
+      device('a'),
+      device('b'),
+      termination('eps-1', 'eps'),
+      termination('bend-1', 'bend'),
+      termination('outlet-1', 'outlet'),
+      termination('bend-2', 'bend'),
+    )
+    const links: Link[] = [
+      {
+        id: 'l1',
+        from: { node: 'a', port: 'p' },
+        to: { node: 'b', port: 'p' },
+        via: ['eps-1', 'bend-1', 'outlet-1', 'bend-2'],
+      },
+    ]
+    const stats = migrateBendNodesToLinkBends({ nodes, links })
+    expect(stats.bendsAdded).toBe(2)
+    expect(stats.nodesRemoved).toBe(2)
+    expect(stats.linksTouched).toBe(1)
+    expect(links[0]?.via).toEqual(['eps-1', 'outlet-1'])
+    expect(links[0]?.bends).toHaveLength(2)
+    // bend-1 sits after eps-1 (index 0 in terminations-only via)
+    expect(links[0]?.bends?.[0]).toMatchObject({ id: 'bend-1', afterIndex: 0 })
+    // bend-2 sits after outlet-1 (index 1)
+    expect(links[0]?.bends?.[1]).toMatchObject({ id: 'bend-2', afterIndex: 1 })
+  })
+
+  test('cleans up orphan bend Nodes not referenced by any link', () => {
+    const nodes = nodesMap(device('a'), termination('bend-orphan', 'bend'))
+    const links: Link[] = []
+    const stats = migrateBendNodesToLinkBends({ nodes, links })
+    expect(stats.nodesRemoved).toBe(1)
+    expect(stats.bendsAdded).toBe(0)
+    expect(stats.linksTouched).toBe(0)
+    expect(nodes.has('bend-orphan')).toBe(false)
+  })
+
+  test('idempotent — second pass is a no-op', () => {
+    const nodes = nodesMap(device('a'), device('b'), termination('bend-1', 'bend'))
+    const links: Link[] = [
+      { id: 'l1', from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'p' }, via: ['bend-1'] },
+    ]
+    migrateBendNodesToLinkBends({ nodes, links })
+    const stats2 = migrateBendNodesToLinkBends({ nodes, links })
+    expect(stats2).toEqual({ nodesRemoved: 0, linksTouched: 0, bendsAdded: 0 })
+    expect(links[0]?.bends).toHaveLength(1)
+  })
+
+  test('preserves an existing bends array (append, not replace)', () => {
+    const nodes = nodesMap(device('a'), device('b'), termination('bend-2', 'bend'))
+    const links: Link[] = [
+      {
+        id: 'l1',
+        from: { node: 'a', port: 'p' },
+        to: { node: 'b', port: 'p' },
+        via: ['bend-2'],
+        bends: [{ id: 'bend-0', x: 1, y: 1, afterIndex: -1 }],
+      },
+    ]
+    migrateBendNodesToLinkBends({ nodes, links })
+    expect(links[0]?.bends?.map((b: { id: string }) => b.id)).toEqual(['bend-0', 'bend-2'])
+  })
+})

--- a/apps/editor/src/lib/migrations/bend-nodes-to-link-bends.ts
+++ b/apps/editor/src/lib/migrations/bend-nodes-to-link-bends.ts
@@ -1,0 +1,120 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Lift drawing-only bend waypoints out of `NetworkGraph.nodes` and
+ * `Link.via` into `Link.bends`.
+ *
+ * Historical context: bends were first modelled as anonymous control
+ * points on `Scene.wireRoutes`. A prior migration moved them into
+ * `Link.via` as full `Node` entries (with `termination.role = 'bend'`)
+ * to reuse the Svelte Flow node infrastructure for drag / select /
+ * undo. That worked but leaked the abstraction: bends — pure visual
+ * waypoints with no logical meaning — started polluting BOM, JSON
+ * export, Connections view, and every consumer that filtered `nodes`.
+ *
+ * This migration finishes the journey: bends move to a dedicated
+ * `Link.bends` array on the link record itself, the bend Nodes are
+ * deleted from `nodes`, and `via` becomes a terminations-only chain
+ * (EPS / Outlet / Panel) again. The scene canvas re-synthesizes
+ * draggable bend handles from `Link.bends` at render time so the
+ * UX is unchanged.
+ *
+ * Idempotent — calling it on an already-migrated graph is a no-op.
+ */
+
+import type { Link, NetworkGraph, Node } from '@shumoku/core'
+
+export interface BendMigrationStats {
+  /** Bend Nodes removed from `nodes`. */
+  nodesRemoved: number
+  /** Links whose `via` chain had bends extracted. */
+  linksTouched: number
+  /** Bend entries written to `Link.bends` (= nodesRemoved when no orphans). */
+  bendsAdded: number
+}
+
+/**
+ * Apply the migration in-place. Accepts the runtime store shape
+ * (Map<id, Node> + mutable Link[]) so it can run after the load
+ * pipeline has already populated `diagram.nodes` / `diagram.links`
+ * — including after `migrateLegacyWireRoutes`, which still produces
+ * bend Nodes for ancient projects. Returns stats so the caller can
+ * log how much it did.
+ *
+ * Mutations:
+ *   - Removes every bend Node from `nodes`
+ *   - For each link with bend ids in `via`: rewrites `via` to the
+ *     terminations-only subset and appends extracted bends to
+ *     `link.bends`
+ */
+export function migrateBendNodesToLinkBends(args: {
+  nodes: Map<string, Node>
+  links: Link[]
+}): BendMigrationStats {
+  const { nodes, links } = args
+  const stats: BendMigrationStats = {
+    nodesRemoved: 0,
+    linksTouched: 0,
+    bendsAdded: 0,
+  }
+
+  // Build a quick lookup of bend Nodes so the per-link walk avoids
+  // repeating the termination probe.
+  const bendNodeById = new Map<string, Node>()
+  for (const [, node] of nodes) {
+    if (node.termination?.role === 'bend') bendNodeById.set(node.id, node)
+  }
+  if (bendNodeById.size === 0) return stats
+
+  const usedBendIds = new Set<string>()
+
+  for (let i = 0; i < links.length; i++) {
+    const link = links[i]
+    if (!link?.via || link.via.length === 0) continue
+
+    const nextVia: string[] = []
+    const nextBends: NonNullable<Link['bends']> = link.bends ? [...link.bends] : []
+    let extracted = false
+
+    for (const id of link.via) {
+      const bendNode = bendNodeById.get(id)
+      if (!bendNode) {
+        nextVia.push(id)
+        continue
+      }
+      // `afterIndex` is the count of terminations that preceded this
+      // bend in the original via — equal to the current length of
+      // `nextVia` minus 1 (-1 means "before the first termination").
+      const afterIndex = nextVia.length - 1
+      const pos = bendNode.position ?? { x: 0, y: 0 }
+      nextBends.push({ id: bendNode.id, x: pos.x, y: pos.y, afterIndex })
+      usedBendIds.add(bendNode.id)
+      extracted = true
+    }
+
+    if (extracted) {
+      links[i] = {
+        ...link,
+        via: nextVia.length > 0 ? nextVia : undefined,
+        bends: nextBends,
+      }
+      stats.linksTouched++
+    }
+  }
+  stats.bendsAdded = usedBendIds.size
+
+  // Drop every bend Node — even orphans not referenced by any link.
+  // They were never legitimate logical entities; carrying them
+  // forward is just clutter that other consumers have to filter.
+  for (const [id] of bendNodeById) {
+    nodes.delete(id)
+    stats.nodesRemoved++
+  }
+
+  return stats
+}
+
+// Re-export NetworkGraph so the type lives at the module boundary —
+// keeps consumers from reaching into core just for one type.
+export type { NetworkGraph }

--- a/apps/editor/src/lib/migrations/bend-nodes-to-link-bends.ts
+++ b/apps/editor/src/lib/migrations/bend-nodes-to-link-bends.ts
@@ -24,6 +24,7 @@
  */
 
 import type { Link, NetworkGraph, Node } from '@shumoku/core'
+import type { Scene } from '../types'
 
 export interface BendMigrationStats {
   /** Bend Nodes removed from `nodes`. */
@@ -51,8 +52,16 @@ export interface BendMigrationStats {
 export function migrateBendNodesToLinkBends(args: {
   nodes: Map<string, Node>
   links: Link[]
+  /**
+   * Optional scenes — used to recover per-scene placements when the
+   * bend Node itself has no `position` field. Bends were created
+   * via `placeNodeInScene` which only wrote `scene.nodePlacements`,
+   * never `node.position`, so without this hint every legacy bend
+   * would migrate to (0, 0).
+   */
+  scenes?: Scene[]
 }): BendMigrationStats {
-  const { nodes, links } = args
+  const { nodes, links, scenes } = args
   const stats: BendMigrationStats = {
     nodesRemoved: 0,
     linksTouched: 0,
@@ -66,6 +75,23 @@ export function migrateBendNodesToLinkBends(args: {
     if (node.termination?.role === 'bend') bendNodeById.set(node.id, node)
   }
   if (bendNodeById.size === 0) return stats
+
+  // First-seen scene placement per node id — bends placed in
+  // multiple scenes collapse to whichever scene appears first in
+  // the array. `Link.bends` is link-level (one position per bend),
+  // so this is the best we can do without inventing scene-keyed
+  // bend storage.
+  const placementById = new Map<string, { x: number; y: number }>()
+  for (const scene of scenes ?? []) {
+    for (const p of scene.nodePlacements ?? []) {
+      if (placementById.has(p.nodeId)) continue
+      placementById.set(p.nodeId, p.position)
+    }
+  }
+
+  function positionOf(node: Node): { x: number; y: number } {
+    return placementById.get(node.id) ?? node.position ?? { x: 0, y: 0 }
+  }
 
   const usedBendIds = new Set<string>()
 
@@ -87,7 +113,7 @@ export function migrateBendNodesToLinkBends(args: {
       // bend in the original via — equal to the current length of
       // `nextVia` minus 1 (-1 means "before the first termination").
       const afterIndex = nextVia.length - 1
-      const pos = bendNode.position ?? { x: 0, y: 0 }
+      const pos = positionOf(bendNode)
       nextBends.push({ id: bendNode.id, x: pos.x, y: pos.y, afterIndex })
       usedBendIds.add(bendNode.id)
       extracted = true
@@ -110,6 +136,18 @@ export function migrateBendNodesToLinkBends(args: {
   for (const [id] of bendNodeById) {
     nodes.delete(id)
     stats.nodesRemoved++
+  }
+
+  // Strip the now-orphan placements from each scene so the next
+  // save doesn't carry them. sanitizeScenes would drop them on the
+  // next load anyway, but doing it here keeps the in-memory state
+  // clean immediately (and the saved file too once any change is
+  // committed).
+  if (scenes) {
+    for (const scene of scenes) {
+      if (!scene.nodePlacements?.length) continue
+      scene.nodePlacements = scene.nodePlacements.filter((p) => !bendNodeById.has(p.nodeId))
+    }
   }
 
   return stats

--- a/apps/editor/src/lib/migrations/index.ts
+++ b/apps/editor/src/lib/migrations/index.ts
@@ -3,5 +3,9 @@
 
 // Load-time migrations entry point. See ./README.md for the rules.
 
+export {
+  type BendMigrationStats,
+  migrateBendNodesToLinkBends,
+} from './bend-nodes-to-link-bends'
 export { type LegacyScene, migrateLegacyWireRoutes } from './legacy-wire-routes'
 export { inheritProductIconFromCatalog } from './product-icon-inheritance'

--- a/apps/editor/src/lib/migrations/legacy-wire-routes.test.ts
+++ b/apps/editor/src/lib/migrations/legacy-wire-routes.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import type { Link } from '@shumoku/core'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { type LegacyScene, migrateLegacyWireRoutes } from './legacy-wire-routes'
 
 function makeLink(id: string, via?: string[]): Link {
@@ -15,31 +15,17 @@ function makeLink(id: string, via?: string[]): Link {
 }
 
 function makeDeps(links: Link[] = []) {
-  const added: Array<{ sceneId: string; position: { x: number; y: number }; role: string }> = []
-  const updated: Array<{ linkId: string; via: string[] }> = []
   let counter = 0
   return {
-    added,
-    updated,
-    deps: {
-      links,
-      addTerminationInScene: vi.fn((sceneId: string, position, role) => {
-        counter++
-        const id = `bend-${counter}`
-        added.push({ sceneId, position, role })
-        return id
-      }),
-      updateLink: vi.fn((linkId: string, updates: { via: string[] }) => {
-        updated.push({ linkId, via: updates.via })
-      }),
-    },
+    links,
+    newBendId: () => `bend-${++counter}`,
   }
 }
 
 describe('migrateLegacyWireRoutes', () => {
-  it('converts each controlPoint into a bend Node and prepends to Link.via', () => {
-    const link = makeLink('L1', ['existing-tp'])
-    const { deps, added, updated } = makeDeps([link])
+  it('converts each controlPoint into a Link.bends entry at afterIndex -1', () => {
+    const links = [makeLink('L1', ['existing-tp'])]
+    const deps = makeDeps(links)
     const scene: LegacyScene = {
       id: 'S1',
       wireRoutes: [
@@ -55,17 +41,18 @@ describe('migrateLegacyWireRoutes', () => {
 
     migrateLegacyWireRoutes([scene], deps)
 
-    expect(added).toEqual([
-      { sceneId: 'S1', position: { x: 10, y: 20 }, role: 'bend' },
-      { sceneId: 'S1', position: { x: 30, y: 40 }, role: 'bend' },
+    expect(links[0]?.bends).toEqual([
+      { id: 'bend-1', x: 10, y: 20, afterIndex: -1 },
+      { id: 'bend-2', x: 30, y: 40, afterIndex: -1 },
     ])
-    // Bends placed BEFORE the pre-existing via entry — preserves the
-    // visual order from when bends were first-class waypoints.
-    expect(updated).toEqual([{ linkId: 'L1', via: ['bend-1', 'bend-2', 'existing-tp'] }])
+    // The existing via chain is untouched — bends migrated to their
+    // own field, not interleaved into via.
+    expect(links[0]?.via).toEqual(['existing-tp'])
   })
 
   it('no-ops for scenes without wireRoutes, empty routes, or empty points', () => {
-    const { deps, added, updated } = makeDeps([makeLink('L1')])
+    const links = [makeLink('L1')]
+    const deps = makeDeps(links)
     migrateLegacyWireRoutes(
       [
         { id: 'S1' } as LegacyScene,
@@ -75,29 +62,29 @@ describe('migrateLegacyWireRoutes', () => {
       ],
       deps,
     )
-    expect(added).toEqual([])
-    expect(updated).toEqual([])
+    expect(links[0]?.bends).toBeUndefined()
   })
 
   it('skips routes whose link is missing (orphan reference)', () => {
-    const { deps, added, updated } = makeDeps([makeLink('L1')])
+    const links = [makeLink('L1')]
+    const deps = makeDeps(links)
     const scene: LegacyScene = {
       id: 'S1',
       wireRoutes: [{ linkId: 'L-missing', controlPoints: [{ x: 1, y: 2 }] }],
     }
     migrateLegacyWireRoutes([scene], deps)
-    expect(added).toEqual([])
-    expect(updated).toEqual([])
+    expect(links[0]?.bends).toBeUndefined()
   })
 
   it('handles a link without prior via (undefined)', () => {
-    const link = makeLink('L1')
-    const { deps, updated } = makeDeps([link])
+    const links = [makeLink('L1')]
+    const deps = makeDeps(links)
     const scene: LegacyScene = {
       id: 'S1',
       wireRoutes: [{ linkId: 'L1', controlPoints: [{ x: 1, y: 2 }] }],
     }
     migrateLegacyWireRoutes([scene], deps)
-    expect(updated).toEqual([{ linkId: 'L1', via: ['bend-1'] }])
+    expect(links[0]?.bends).toEqual([{ id: 'bend-1', x: 1, y: 2, afterIndex: -1 }])
+    expect(links[0]?.via).toBeUndefined()
   })
 })

--- a/apps/editor/src/lib/migrations/legacy-wire-routes.ts
+++ b/apps/editor/src/lib/migrations/legacy-wire-routes.ts
@@ -1,12 +1,15 @@
 // Copyright (C) 2026-present Akitoshi Saeki
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// `Scene.wireRoutes[].controlPoints` → bend Nodes + `Link.via`.
+// `Scene.wireRoutes[].controlPoints` → `Link.bends`.
 //
-// The old model stored anonymous absolute-coord bend points on
-// `Scene.wireRoutes`, parallel to the link list. The new model treats
-// every transit point — bends included — as a real `Node` so Svelte
-// Flow's native selection / drag / delete machinery applies uniformly.
+// Original model stored anonymous absolute-coord bend points on
+// `Scene.wireRoutes`, parallel to the link list. A subsequent rewrite
+// migrated bends to `Node`s with `termination.role = 'bend'` spliced
+// into `Link.via`, but that leaked the abstraction into every
+// consumer of `nodes`. The current model puts bends back on the
+// link itself via `Link.bends` — drawing artifact stays with the
+// link, no Node pollution.
 //
 // Reads RAW input — `sanitizeScenes` strips `wireRoutes` before the
 // store sees it, so by the time we'd query the store the legacy field
@@ -20,20 +23,18 @@ export type LegacyScene = {
 }
 
 export interface LegacyWireRoutesDeps {
-  /** All links in the freshly loaded diagram — used to look up routes. */
+  /** All links in the freshly loaded diagram — mutated in place. */
   links: Link[]
-  /** Create a bend Node at the given scene position, return its id. */
-  addTerminationInScene(sceneId: string, position: { x: number; y: number }, role: 'bend'): string
-  /** Splice bend ids into the named link's `via` chain. */
-  updateLink(linkId: string, updates: { via: string[] }): void
+  /** Allocate a stable id for a new bend record. */
+  newBendId(): string
 }
 
 /**
  * Walk the raw scenes payload (before `sanitizeScenes`) and convert
- * each `controlPoints` entry into a bend Node spliced into the
- * matching link's `via`. Bends go in front of any existing via
- * entries — preserves the visual order from before the migration
- * where bends were first-class waypoints.
+ * each `controlPoints` entry into `link.bends` entries. Bends all
+ * sit at `afterIndex = -1` (between `from` and the first via entry,
+ * or directly between `from` and `to`) — that matches the original
+ * "draw a polyline through these points before any transit" intent.
  *
  * No-op for scenes / routes / points that are absent or empty.
  */
@@ -45,14 +46,17 @@ export function migrateLegacyWireRoutes(rawScenes: unknown[], deps: LegacyWireRo
     for (const route of routes) {
       const points = route.controlPoints
       if (!points?.length) continue
-      const link = deps.links.find((l) => l.id === route.linkId)
+      const linkIdx = deps.links.findIndex((l) => l.id === route.linkId)
+      if (linkIdx < 0) continue
+      const link = deps.links[linkIdx]
       if (!link) continue
-      const newBendIds: string[] = []
-      for (const pt of points) {
-        const id = deps.addTerminationInScene(legacy.id, pt, 'bend')
-        newBendIds.push(id)
-      }
-      deps.updateLink(route.linkId, { via: [...newBendIds, ...(link.via ?? [])] })
+      const newBends = points.map((pt) => ({
+        id: deps.newBendId(),
+        x: pt.x,
+        y: pt.y,
+        afterIndex: -1,
+      }))
+      deps.links[linkIdx] = { ...link, bends: [...(link.bends ?? []), ...newBends] }
     }
   }
 }

--- a/apps/editor/src/lib/scene/cable-length.ts
+++ b/apps/editor/src/lib/scene/cable-length.ts
@@ -44,20 +44,6 @@ function endpointPos(
   return nodeCenterFromTopLeft(scene, node, tl)
 }
 
-/** Pixel distance between two scene endpoints, or null if either
- *  endpoint can't be resolved. */
-function segmentPx(
-  scene: Scene,
-  aId: string,
-  bId: string,
-  nodes: Map<string, Node>,
-): number | null {
-  const a = endpointPos(scene, aId, nodes)
-  const b = endpointPos(scene, bId, nodes)
-  if (!a || !b) return null
-  return Math.hypot(b.x - a.x, b.y - a.y)
-}
-
 /**
  * Effective real-world cable length for a link.
  *
@@ -102,6 +88,36 @@ export function visibleCableSegments(link: Link, nodes: Map<string, Node>): stri
 }
 
 /**
+ * Waypoint kinds used when summing the polyline that's actually
+ * rendered on the canvas. Both `node` (icon center) and `bend` (raw
+ * x/y) waypoints contribute to length.
+ */
+type Waypoint = { kind: 'node'; nodeId: string } | { kind: 'bend'; x: number; y: number }
+
+/**
+ * Walk the link's full visible polyline as an ordered list of
+ * waypoints, interleaving `link.bends` at their `afterIndex` slots.
+ *
+ *   [from] → bends(afterIndex=-1) → via[0] → bends(0) → ... → [to]
+ */
+function linkPolylineWaypoints(link: Link): Waypoint[] {
+  const out: Waypoint[] = []
+  const via = link.via ?? []
+  const bends = link.bends ?? []
+  const bendsAfter = (i: number): Waypoint[] =>
+    bends.filter((b) => b.afterIndex === i).map((b) => ({ kind: 'bend', x: b.x, y: b.y }))
+  out.push({ kind: 'node', nodeId: link.from.node })
+  out.push(...bendsAfter(-1))
+  for (let i = 0; i < via.length; i++) {
+    const id = via[i]
+    if (id) out.push({ kind: 'node', nodeId: id })
+    out.push(...bendsAfter(i))
+  }
+  out.push({ kind: 'node', nodeId: link.to.node })
+  return out
+}
+
+/**
  * Per-visible-segment cable lengths. EPS-routed wires return one
  * entry per "side of the chase" — physically you order one cable per
  * segment, so BOM / Connections breakdowns match what the installer
@@ -114,31 +130,78 @@ export function cableSegmentLengths(
   scenes: Scene[],
   nodes: Map<string, Node>,
 ): Array<{ fromId: string; toId: string; meters: number }> {
-  const segments = visibleCableSegments(link, nodes)
-  if (segments.length === 0) return []
-  const out: Array<{ fromId: string; toId: string; meters: number }> = []
-  for (const seg of segments) {
-    let segMeters = 0
+  // Walk the full polyline (nodes interleaved with bends), splitting
+  // into visible cable segments at every EPS waypoint — the cable
+  // physically enters the chase there and starts again on the other
+  // side. Bends inside a segment contribute straight-line distance
+  // between adjacent waypoints, matching the curved polyline the
+  // canvas draws.
+  const polyline = linkPolylineWaypoints(link)
+  if (polyline.length < 2) return []
+
+  // Group the polyline into per-segment runs split at every EPS
+  // waypoint. EPS membership belongs to the segment it closes; the
+  // next segment starts after it (the cable physically ends at the
+  // EPS panel and a fresh cable starts on the other side).
+  const segmentRuns: Waypoint[][] = []
+  let run: Waypoint[] = []
+  for (const w of polyline) {
+    run.push(w)
+    if (w.kind === 'node' && nodes.get(w.nodeId)?.termination?.role === 'eps') {
+      segmentRuns.push(run)
+      run = []
+    }
+  }
+  if (run.length > 0) segmentRuns.push(run)
+
+  function resolve(w: Waypoint, scene: Scene): { x: number; y: number } | null {
+    if (w.kind === 'bend') return { x: w.x, y: w.y }
+    return endpointPos(scene, w.nodeId, nodes)
+  }
+
+  function pixelLengthAcrossScenes(seg: Waypoint[], sceneList: Scene[]): number | null {
+    let total = 0
     let any = false
     for (let i = 0; i < seg.length - 1; i++) {
-      const aId = seg[i]
-      const bId = seg[i + 1]
-      if (!aId || !bId) continue
-      for (const scene of scenes) {
-        const ratio = scene.calibration?.pxPerMeter
+      const a = seg[i]
+      const b = seg[i + 1]
+      if (!a || !b) continue
+      for (const sc of sceneList) {
+        const ratio = sc.calibration?.pxPerMeter
         if (!ratio || ratio <= 0) continue
-        const px = segmentPx(scene, aId, bId, nodes)
-        if (px === null) continue
-        segMeters += px / ratio
+        const pa = resolve(a, sc)
+        const pb = resolve(b, sc)
+        if (!pa || !pb) continue
+        total += Math.hypot(pb.x - pa.x, pb.y - pa.y) / ratio
         any = true
         break
       }
     }
-    if (any) {
-      const fromId = seg[0]
-      const toId = seg[seg.length - 1]
-      if (fromId && toId) out.push({ fromId, toId, meters: segMeters })
+    return any ? total : null
+  }
+
+  // First and last *node* of a run — bends can't serve as the
+  // segment's reported endpoint id (BOM groups by node).
+  function bookendNodes(seg: Waypoint[]): { fromId: string; toId: string } | null {
+    let fromId: string | null = null
+    let toId: string | null = null
+    for (const w of seg) {
+      if (w.kind === 'node') {
+        if (fromId === null) fromId = w.nodeId
+        toId = w.nodeId
+      }
     }
+    if (!fromId || !toId || fromId === toId) return null
+    return { fromId, toId }
+  }
+
+  const out: Array<{ fromId: string; toId: string; meters: number }> = []
+  for (const seg of segmentRuns) {
+    const ends = bookendNodes(seg)
+    if (!ends) continue
+    const meters = pixelLengthAcrossScenes(seg, scenes)
+    if (meters === null) continue
+    out.push({ fromId: ends.fromId, toId: ends.toId, meters })
   }
   return out
 }

--- a/apps/editor/src/lib/state/bom.ts
+++ b/apps/editor/src/lib/state/bom.ts
@@ -71,12 +71,6 @@ export function buildAssignmentRows(args: {
   const rows: AssignmentRow[] = []
 
   for (const [nodeId, node] of nodes) {
-    // Bend waypoints are wire-path artifacts (a click-place to push a
-    // wire around an obstacle), not procurement items — skip them so
-    // the BOM doesn't fill up with phantom "Bend, incomplete" rows.
-    // EPS / Outlet / Panel terminations DO map to physical procured
-    // items (wall plates, riser panels, patch panels), so they stay.
-    if (node.termination?.role === 'bend') continue
     rows.push({
       id: `node:${nodeId}`,
       target: { kind: 'node', nodeId },

--- a/apps/editor/src/routes/project/[id]/(content)/bom/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/bom/+page.svelte
@@ -134,14 +134,10 @@
 
       const aEnd = endpointString(link.from.node, link.from.port)
       const bEnd = endpointString(link.to.node, link.to.port)
-      // Skip bend waypoints — they're visual-only and don't correspond
-      // to a physical hand-off (no patch panel, no outlet box). Real
-      // terminations (EPS / Outlet / Panel) carry the hand-off info
-      // the technician needs.
-      const via = (link.via ?? []).filter((id) => {
-        const role = diagramState.nodes.get(id)?.termination?.role
-        return role && role !== 'bend'
-      })
+      // `via` is terminations-only by construction now — bends live on
+      // `link.bends` and don't represent a physical hand-off, so they
+      // never appear here.
+      const via = link.via ?? []
       // Via-chain from A's perspective is the recorded order; from B's
       // perspective it's the reverse.
       const viaFromA = via

--- a/libs/@shumoku/core/src/ids.ts
+++ b/libs/@shumoku/core/src/ids.ts
@@ -12,7 +12,7 @@ import { nanoid } from 'nanoid'
  * 2. Collision-avoidance across kinds — a node and a link can never share an ID
  *    even if nanoid were to theoretically produce the same suffix.
  */
-export type IdKind = 'node' | 'sg' | 'link' | 'product' | 'inv' | 'port' | 'scene' | 'proj'
+export type IdKind = 'node' | 'sg' | 'link' | 'product' | 'inv' | 'port' | 'scene' | 'proj' | 'bend'
 
 /**
  * Generate a fresh unique ID for the given entity kind.

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -516,6 +516,33 @@ export interface Link {
   via?: string[]
 
   /**
+   * Visual-only bend waypoints along the cable's polyline. Each
+   * entry has its own coordinates and an `afterIndex` slot:
+   *
+   *   afterIndex = -1     → bend lies between `from` and `via[0]`
+   *                          (or between `from` and `to` if `via` is empty)
+   *   afterIndex =  i     → bend lies between `via[i]` and `via[i+1]`
+   *                          (or between `via[i]` and `to` if i is the
+   *                          last via index)
+   *
+   * Within the same slot the order of `bends` entries is the order
+   * they're rendered along the wire. Bends never affect cable length
+   * accounting at the segment level — they're routing-only artifacts
+   * to push the polyline around obstacles on the floor plan.
+   *
+   * Unlike `via`, bend ids are NOT Node ids — they live entirely
+   * inside the link record. The scene canvas synthesizes virtual
+   * Svelte-Flow nodes from this array so drag / select continue to
+   * work, but no entry appears in `NetworkGraph.nodes`.
+   */
+  bends?: Array<{
+    id: string
+    x: number
+    y: number
+    afterIndex: number
+  }>
+
+  /**
    * Link label - can be multiple lines (displayed at center)
    */
   label?: string | string[]


### PR DESCRIPTION
## Summary

Bends were modelled as \`Node\`s with \`termination.role === 'bend'\` so they could ride the Svelte Flow drag/select infrastructure. The cost was that every consumer of \`diagram.nodes\` ended up filtering them out — BOM (#215), Tepra label CSV (#213), and the JSON export the user flagged all carried bend-removal logic for what is, in truth, a pure drawing artifact.

This PR finishes the journey in 4 phases (1 commit each so they review independently):

## Phase 1 — schema + load migration

- \`core/types\` — adds \`Link.bends?: { id; x; y; afterIndex }[]\`. \`afterIndex = -1\` means \"before the first termination\"; \`i\` means \"between via[i] and via[i+1]\".
- \`migrations/bend-nodes-to-link-bends.ts\` — idempotent migration that lifts bend Nodes from \`Link.via\` into \`link.bends\` and deletes them from \`nodes\` (orphans included).
- 6 unit tests covering interleaved bends, idempotency, orphan cleanup, etc.

## Phase 2 — creation paths

- \`addLinkBend\` / \`updateLinkBend\` / \`removeLinkBend\` added to diagramState as the new primitives. All three undo-aware.
- \`insertBendInLink\` becomes a thin wrapper that delegates to \`addLinkBend\`.
- Legacy \`wireRoutes\` migration writes straight to \`Link.bends\` now — drops the indirection through \`addTerminationInScene('bend')\`.
- \`'bend'\` added to the \`IdKind\` union for \`newId('bend')\`.

## Phase 3 — rendering + drag

- SceneCanvas synthesizes virtual sf nodes from \`link.bends\` so drag / select / delete still flow through Svelte Flow. Drag intercepts route bend ids back to \`updateLinkBend\`; delete intercepts to \`removeLinkBend\`.
- Wire polyline (\`innerWaypointsForSegment\`) interleaves bend positions with via-termination centers at their \`afterIndex\` slots.
- \`cableSegmentLengths\` walks the unified polyline (\`linkPolylineWaypoints\`) so per-segment lengths reflect every waypoint the user sees, including bends. Drops the dead \`segmentPx\` helper.
- \`wire-edit\` (drag-to-bend on a wire): reads \`link.bends\` for snap-to-existing, creates via \`addLinkBend\`, drag updates via \`updateLinkBend\`.
- Drops the \`'bend'\` arm from \`addTerminationInScene\` — no caller creates bend Nodes anymore.

## Phase 4 — dead filter cleanup

- BOM \`'bend'\` filter (introduced in #215) removed — bends literally can't be in the node map anymore.
- Tepra label CSV via-chain \`'bend'\` filter (introduced in #213) removed — \`via\` is terminations-only by construction.

## Test plan

- [x] \`bun x vitest run src/lib/migrations\` — 10/10 pass (migration + legacy migration)
- [x] svelte-check 0 errors, biome clean
- [ ] Load an existing project with bend Nodes → bends survive as \`link.bends\` entries; scene renders identically
- [ ] Drag-to-bend on a wire creates a new \`link.bends\` entry
- [ ] Drag an existing bend handle → \`link.bends[i].{x,y}\` updates
- [ ] Delete a bend handle (Backspace) → entry removed from \`link.bends\`
- [ ] Save → reload: round-trip stable, second migration pass is a no-op
- [ ] JSON export, BOM, Connections views no longer contain bends
- [ ] Cable lengths still match the rendered polyline (now correctly include bend zigzags)

## Migration & rollback notes

The migration is idempotent and runs on every load, so projects can move between this branch and \`main\` safely as long as the destination knows how to handle the absence/presence of bends. Old projects load cleanly. New projects saved on this branch use \`link.bends\` and will need re-migration if read by very old code (which doesn't currently exist in the wild outside this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)