### PR TITLE
fix(server-web): prevent full-page reload when leaving topology view

### DIFF
--- a/apps/server/web/src/lib/components/topology/HighlightOverlay.svelte
+++ b/apps/server/web/src/lib/components/topology/HighlightOverlay.svelte
@@ -124,8 +124,14 @@
   })
 
   $effect(() => {
+    // Capture the svg reference at effect-run time. Reading the prop
+    // in the teardown can throw if the parent's snippet context has
+    // already been torn down (the prop getter dereferences a now-null
+    // context). An unhandled error during navigation teardown causes
+    // SvelteKit to fall back to a full page reload.
+    const svg = svgElement
     return () => {
-      if (svgElement) clear(svgElement)
+      if (svg?.isConnected) clear(svg)
     }
   })
 </script>

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -6,7 +6,7 @@
 import { NODE_MATCH_THRESHOLD, nodeNameMatchScore } from '@shumoku/core'
 import { derived, get, writable } from 'svelte/store'
 import { api } from '$lib/api'
-import type { Host, HostItem, MetricsMapping } from '$lib/types'
+import type { Host, HostItem, MetricsMapping, Topology, TopologyDataSource } from '$lib/types'
 
 interface MappingState {
   topologyId: string | null
@@ -40,7 +40,44 @@ function createMappingStore() {
     subscribe,
 
     /**
-     * Load mapping data for a topology
+     * Hydrate from already-fetched topology + sources. Use this when the
+     * caller has already fetched the data (avoids duplicate API calls).
+     * Triggers host loading in the background.
+     */
+    hydrate: (topologyId: string, topo: Topology, sources: TopologyDataSource[]) => {
+      let mapping: MetricsMapping = { nodes: {}, links: {} }
+      if (topo.mappingJson) {
+        try {
+          mapping = JSON.parse(topo.mappingJson)
+        } catch {
+          // Ignore parse error
+        }
+      }
+
+      const metricsSource = sources.find((s) => s.purpose === 'metrics')
+      const metricsSourceId = metricsSource?.dataSourceId || null
+
+      update((s) => ({
+        ...s,
+        topologyId,
+        mapping,
+        metricsSourceId,
+        loading: false,
+        error: null,
+      }))
+
+      if (metricsSourceId) {
+        update((s) => ({ ...s, hostsLoading: true }))
+        api.dataSources
+          .getHosts(metricsSourceId)
+          .then((hosts) => update((s) => ({ ...s, hosts, hostsLoading: false })))
+          .catch(() => update((s) => ({ ...s, hostsLoading: false })))
+      }
+    },
+
+    /**
+     * Load mapping data for a topology (fetches topology + sources itself).
+     * Prefer `hydrate()` when the caller already has the data.
      */
     load: async (topologyId: string, forceReload = false) => {
       const current = get({ subscribe })

--- a/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
@@ -54,11 +54,12 @@
         api.topologies.get(topologyId),
         fetch(`/api/topologies/${topologyId}/render`).then((r) => r.json()),
         api.topologies.sources.list(topologyId),
-        // Load mapping via shared store
-        mappingStore.load(topologyId),
       ])
       topology = topoData
       renderData = { nodeCount: renderResponse.nodeCount, edgeCount: renderResponse.edgeCount }
+
+      // Hand off to the shared mapping store without re-fetching
+      mappingStore.hydrate(topologyId, topoData, sources)
 
       // Find NetBox topology source for device links
       const netboxSource = sources.find(


### PR DESCRIPTION
## Summary

トポロジー詳細から戻る操作が**フルリロード**になり、ストアがリセットされて一覧が \"No topologies\" 表示になる問題の修正。

### 原因 (devtools で確認)

1. `HighlightOverlay` の \`\$effect\` クリーンアップが prop \`svgElement\` を直接読んでいた。親側 \`{#snippet children({ svgElement })}\` の context が先に teardown され、prop getter が null を参照して \`Cannot read properties of null (reading 'svgElement')\` を throw。SvelteKit はクライアントナビゲーション中の unhandled error をフルリロードへフォールバックさせる挙動なので、ブラウザの戻る毎にページ全体が再ロード → ストア初期化 → 一覧空。

2. 副次バグ：トポロジー詳細ページが \`/topologies/:id\` と \`/topologies/:id/sources\` を**2回ずつ**叩いていた。ページが直接呼び、さらに \`mappingStore.load()\` 内でも同じ2エンドポイントを再フェッチしていた。

### 変更

- \`HighlightOverlay.svelte\`: effect body で \`const svg = svgElement\` キャプチャし、teardown は \`svg?.isConnected\` で安全に参照する
- \`mapping.ts\`: \`hydrate(topologyId, topo, sources)\` を追加。既得データを渡せばホストだけバックグラウンドで取得
- \`topologies/[id]/+page.svelte\`: \`mappingStore.load()\` の代わりに \`hydrate()\` を使う

## Test plan

- [ ] 一覧→View→戻る→別Topology View→戻る を繰り返し、一覧が空にならないこと
- [ ] DevTools Console に \`Cannot read properties of null (reading 'svgElement')\` が出ないこと
- [ ] DevTools Network で View ページの \`/topologies/:id\` と \`/sources\` がそれぞれ 1 回だけ呼ばれること
- [ ] マッピングモーダルが従来通り動く (ホスト一覧表示・ホスト割当)

🤖 Generated with [Claude Code](https://claude.com/claude-code)