### PR TITLE
fix(server-web): resolve topology/dashboard IDs to names in breadcrumb

### DIFF
--- a/apps/server/web/src/lib/components/header.svelte
+++ b/apps/server/web/src/lib/components/header.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { CaretRightIcon, MoonIcon, SunIcon } from 'phosphor-svelte'
+  import { derived } from 'svelte/store'
   import { page } from '$app/stores'
+  import { dashboards } from '$lib/stores/dashboards'
   import { resolvedTheme, themeSetting } from '$lib/stores/theme'
+  import { topologiesList } from '$lib/stores/topologies'
 
   // Generate breadcrumbs from current path
   interface Breadcrumb {
@@ -14,13 +17,40 @@
     dashboards: 'Dashboards',
     topologies: 'Topologies',
     datasources: 'Data Sources',
+    plugins: 'Plugins',
     settings: 'Settings',
     edit: 'Edit',
   }
 
-  $: breadcrumbs = generateBreadcrumbs($page.url.pathname)
+  // ID-shaped segments (e.g. "msy3HM05AczI") get resolved via the
+  // matching store. Shows "…" while the entity hasn't been loaded yet.
+  const ID_PATTERN = /^[A-Za-z0-9_-]{8,}$/
 
-  function generateBreadcrumbs(pathname: string): Breadcrumb[] {
+  const idLabels = derived(
+    [topologiesList, dashboards, page],
+    ([$topologies, $dashboards, $page]) => {
+      const parts = $page.url.pathname.split('/').filter(Boolean)
+      const labels: Record<string, string> = {}
+      // Map id segments based on the parent route segment
+      for (let i = 0; i < parts.length; i++) {
+        const seg = parts[i]
+        if (!seg || !ID_PATTERN.test(seg)) continue
+        const parent = parts[i - 1]
+        if (parent === 'topologies') {
+          const t = $topologies.find((x) => x.id === seg)
+          if (t) labels[seg] = t.name
+        } else if (parent === 'dashboards') {
+          const d = $dashboards.find((x) => x.id === seg)
+          if (d) labels[seg] = d.name
+        }
+      }
+      return labels
+    },
+  )
+
+  $: breadcrumbs = generateBreadcrumbs($page.url.pathname, $idLabels)
+
+  function generateBreadcrumbs(pathname: string, labels: Record<string, string>): Breadcrumb[] {
     const parts = pathname.split('/').filter(Boolean)
 
     if (parts.length === 0) {
@@ -32,7 +62,10 @@
     let currentPath = ''
     for (const part of parts) {
       currentPath += `/${part}`
-      const label = routeLabels[part] || decodeURIComponent(part)
+      let label = routeLabels[part] ?? labels[part]
+      if (!label) {
+        label = ID_PATTERN.test(part) ? '…' : decodeURIComponent(part)
+      }
       crumbs.push({ label, href: currentPath })
     }
 

--- a/apps/server/web/src/lib/stores/dashboards.ts
+++ b/apps/server/web/src/lib/stores/dashboards.ts
@@ -73,12 +73,20 @@ function createDashboardStore() {
       try {
         const dashboard = await api.dashboards.get(id)
         const layout = parseDashboardLayout(dashboard)
-        update((s) => ({
-          ...s,
-          current: dashboard,
-          currentLayout: layout,
-          loading: false,
-        }))
+        update((s) => {
+          const idx = s.items.findIndex((d) => d.id === dashboard.id)
+          const items =
+            idx === -1
+              ? [dashboard, ...s.items]
+              : s.items.map((d, i) => (i === idx ? dashboard : d))
+          return {
+            ...s,
+            items,
+            current: dashboard,
+            currentLayout: layout,
+            loading: false,
+          }
+        })
         return dashboard
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to load dashboard'

--- a/apps/server/web/src/lib/stores/topologies.ts
+++ b/apps/server/web/src/lib/stores/topologies.ts
@@ -38,6 +38,17 @@ function createTopologiesStore() {
       return api.topologies.get(id)
     },
 
+    /** Insert or replace a topology in the cached list (used by detail pages). */
+    upsert(topology: Topology) {
+      update((s) => {
+        const idx = s.items.findIndex((t) => t.id === topology.id)
+        if (idx === -1) return { ...s, items: [topology, ...s.items] }
+        const items = s.items.slice()
+        items[idx] = topology
+        return { ...s, items }
+      })
+    },
+
     async create(input: TopologyInput) {
       const topology = await api.topologies.create(input)
       update((s) => ({ ...s, items: [topology, ...s.items] }))

--- a/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
@@ -14,7 +14,7 @@
   import ShareButton from '$lib/components/ShareButton.svelte'
   import SubgraphInfoModal from '$lib/components/SubgraphInfoModal.svelte'
   import TopologySettings from '$lib/components/TopologySettings.svelte'
-  import { mappingStore, metricsConnected } from '$lib/stores'
+  import { mappingStore, metricsConnected, topologies } from '$lib/stores'
   import type { Topology, TopologyDataSource } from '$lib/types'
 
   let topology: Topology | null = null
@@ -57,6 +57,7 @@
       ])
       topology = topoData
       renderData = { nodeCount: renderResponse.nodeCount, edgeCount: renderResponse.edgeCount }
+      topologies.upsert(topoData)
 
       // Hand off to the shared mapping store without re-fetching
       mappingStore.hydrate(topologyId, topoData, sources)

--- a/apps/server/web/src/routes/(app)/topologies/[id]/edit/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/edit/+page.svelte
@@ -5,6 +5,7 @@
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
   import { api } from '$lib/api'
+  import { topologies } from '$lib/stores'
   import type { Topology } from '$lib/types'
 
   // Get ID from route params (always defined for this route)
@@ -24,6 +25,7 @@
   onMount(async () => {
     try {
       topology = await api.topologies.get(id)
+      topologies.upsert(topology)
 
       // Parse stored JSON and display as YAML for editing
       const graph = JSON.parse(topology.contentJson)

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -31,6 +31,7 @@
     nodeMapping,
     showNodeStatus,
     showTrafficFlow,
+    topologies,
   } from '$lib/stores'
   import type {
     DataSource,
@@ -204,6 +205,7 @@
       ])
 
       topology = topoData
+      topologies.upsert(topoData)
       renderData = { nodeCount: renderResponse.nodeCount, edgeCount: renderResponse.edgeCount }
       currentSources = sources
       topologyDataSources = topoSources


### PR DESCRIPTION
## Summary

ヘッダーの breadcrumb で詳細ページの URL セグメントが ID 生 (\`msy3HM05AczI\`) のまま表示されていた問題の修正。

- detail page (\`/topologies/[id]\`, \`/edit\`, \`/settings\`, \`/dashboards/[id]\`) で取得した entity を共通ストア (\`topologiesList\` / \`dashboards\`) に upsert
- header はストアから ID → name の Map を derive、ID 形のセグメントを名前に置換
- まだロードされてない / 見つからない場合は \"…\" にフォールバック（生 ID は出さない）

## Test plan

- [ ] \`/topologies/{id}\` 直リンクで一瞬 \`…\` → topology name に解決される
- [ ] 一覧から View で遷移しても breadcrumb が name 表示
- [ ] \`/topologies/{id}/edit\` \`/settings\` でも同様
- [ ] \`/dashboards/{id}\` でも同様
- [ ] 既存ページ機能に regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)