### PR TITLE
refactor(editor): EPS / Outlet / Panel out of Nodes into NetworkGraph.terminations

### DIFF
--- a/apps/editor/src/lib/components/scene/EpsRoutingModal.svelte
+++ b/apps/editor/src/lib/components/scene/EpsRoutingModal.svelte
@@ -139,23 +139,21 @@
       let createdOutletId: string | null = null
       if (want) {
         viaTail.push(epsId)
-        let outletId = findAutoOutlet(diagramState.nodes, linkId, epsId)
+        let outletId = findAutoOutlet(diagramState.terminations, linkId, epsId)
         if (!outletId) {
-          // Pick the device-side endpoint as the outlet anchor — for
-          // an EPS-side modal that's whichever wire end isn't a TP.
-          const fromN = diagramState.nodes.get(w.from.node)
-          const toN = diagramState.nodes.get(w.to.node)
-          let farId = w.to.node
-          if (fromN?.termination && !toN?.termination) farId = w.to.node
-          else if (!fromN?.termination && toN?.termination) farId = w.from.node
+          // Pick the device-side endpoint as the outlet anchor —
+          // wire endpoints are always real Nodes (terminations are
+          // never wire endpoints), so both `from` and `to` are
+          // device-side here. Bias toward `to`.
+          const farId = w.to.node
           const farNode = diagramState.nodes.get(farId)
           const farPos =
             scene?.nodePlacements.find((p) => p.nodeId === farId)?.position ??
             farNode?.position ??
             null
           const outletPos = autoOutletPosition(epsPos, farPos)
-          outletId = diagramState.addTerminationInScene(sceneId, outletPos, 'outlet')
-          diagramState.updateNode(outletId, {
+          outletId = diagramState.addTermination('outlet', outletPos)
+          diagramState.updateTermination(outletId, {
             metadata: { autoFor: autoOutletTag(linkId, epsId) },
           })
         }
@@ -166,7 +164,7 @@
       const orphanOutlets: string[] = []
       const oldVia = w.via ?? []
       if (!want && oldVia.includes(epsId)) {
-        const tagged = findAutoOutlet(diagramState.nodes, linkId, epsId)
+        const tagged = findAutoOutlet(diagramState.terminations, linkId, epsId)
         if (tagged) orphanOutlets.push(tagged)
       }
 
@@ -175,7 +173,7 @@
       const finalVia = buildViaForLink(w, managedIds, viaTail)
       diagramState.updateLink(linkId, { via: finalVia.length > 0 ? finalVia : undefined })
 
-      for (const orphan of orphanOutlets) diagramState.removeNode(orphan)
+      for (const orphan of orphanOutlets) diagramState.removeTermination(orphan)
     }
     onclose()
   }

--- a/apps/editor/src/lib/components/scene/EpsRoutingModal.svelte
+++ b/apps/editor/src/lib/components/scene/EpsRoutingModal.svelte
@@ -9,7 +9,6 @@
     buildViaForLink,
     findAutoOutlet,
   } from '$lib/scene/auto-outlets'
-  import { descendantSubgraphIds } from '$lib/scene/scope'
 
   // Per-EPS routing modal. Progressive: shows only the nodes the user
   // has chosen to inspect (or that already have wires through this
@@ -27,31 +26,31 @@
     onclose: () => void
   } = $props()
 
-  const eps = $derived(epsId ? (diagramState.nodes.get(epsId) ?? null) : null)
-  const epsLabel = $derived.by(() => {
-    if (!eps) return ''
-    const l = eps.label
-    return Array.isArray(l) ? l[0] : (l ?? eps.id)
-  })
+  const eps = $derived(
+    epsId ? (diagramState.terminations.find((t) => t.id === epsId) ?? null) : null,
+  )
+  const epsLabel = $derived(eps?.label ?? '')
 
-  // Devices in the EPS's scope that could plausibly send wires through
-  // this chase. We exclude TPs (they're passive transit, not sources).
+  // Devices that could plausibly send wires through this chase. The
+  // previous scope filter used the EPS's `parent` subgraph; the
+  // termination registry is global (no parent), so we list every
+  // non-termination Node. The wire list itself is the more useful
+  // affordance now — users typically pick "send wires through EPS
+  // by selecting them in the wire list" rather than scrolling all
+  // candidate devices.
   const candidateNodes = $derived.by(() => {
     if (!eps) return []
-    const scopeIds = eps.parent ? descendantSubgraphIds(diagramState.subgraphs, eps.parent) : null
-    return [...diagramState.nodes.values()].filter((n) => {
-      if (n.id === epsId) return false
-      if (n.termination) return false
-      if (scopeIds === null) return !n.parent
-      return !!n.parent && scopeIds.has(n.parent)
-    })
+    return [...diagramState.nodes.values()].filter((n) => n.id !== epsId && !n.termination)
   })
 
   function nodeLabelOf(id: string): string {
     const n = diagramState.nodes.get(id)
-    if (!n) return id
-    const l = n.label
-    return Array.isArray(l) ? l[0] : (l ?? id)
+    if (n) {
+      const l = n.label
+      return Array.isArray(l) ? l[0] : (l ?? id)
+    }
+    const term = diagramState.terminations.find((t) => t.id === id)
+    return term?.label ?? id
   }
 
   // Wires touching a given node (only id-bearing).
@@ -122,9 +121,10 @@
   function save() {
     if (!epsId) return
     const scene = diagramState.scenes.find((s) => s.id === sceneId)
-    const epsNode = diagramState.nodes.get(epsId)
-    const epsPos =
-      scene?.nodePlacements.find((p) => p.nodeId === epsId)?.position ?? epsNode?.position ?? null
+    // EPS position comes from the registry now — terminations carry
+    // their own coords, no longer relying on scene placements.
+    const epsT = diagramState.terminations.find((t) => t.id === epsId)
+    const epsPos = epsT?.position ?? null
 
     // Walk every wire we have an entry for. Entries we've never
     // touched stay out of `routing` and we don't disturb them — that

--- a/apps/editor/src/lib/components/scene/NodeRoutingModal.svelte
+++ b/apps/editor/src/lib/components/scene/NodeRoutingModal.svelte
@@ -48,20 +48,21 @@
   }
 
   // Both EPS and patch panels are valid via choices for a wire from
-  // this node. We surface them in scope (ancestor or sibling of this
-  // node's parent subgraph). Outlets are excluded — they're auto-
-  // created downstream of EPS routing, never user-picked from here.
+  // this node. With terminations now living in the global registry
+  // (no `parent` subgraph), all are reachable in principle — the
+  // routing modal lists every entry of the requested role. The
+  // returned shape mirrors the old `Node`-shaped objects the rest of
+  // this component expects.
   function tpsInScope(role: 'eps' | 'panel') {
     if (!node) return []
-    const all = [...diagramState.nodes.values()].filter((n) => n.termination?.role === role)
-    if (!node.parent) return all
-    return all.filter((tp) => {
-      if (!tp.parent) return true
-      const tpScope = descendantSubgraphIds(diagramState.subgraphs, tp.parent)
-      const nodeAncestors = ancestorChain(node.parent)
-      for (const a of nodeAncestors) if (tpScope.has(a)) return true
-      return tpScope.has(node.parent ?? '')
-    })
+    return diagramState.terminations
+      .filter((t) => t.role === role)
+      .map((t) => ({
+        id: t.id,
+        label: t.label,
+        termination: { role: t.role },
+        position: t.position,
+      }))
   }
   const epsInScope = $derived.by(() => tpsInScope('eps'))
   const panelsInScope = $derived.by(() => tpsInScope('panel'))
@@ -184,16 +185,13 @@
       let createdOutletId: string | null = null
       if (wantTpId && wantRole === 'eps') {
         viaTail.push(wantTpId)
-        let outletId = findAutoOutlet(diagramState.nodes, wireId, wantTpId)
+        let outletId = findAutoOutlet(diagramState.terminations, wireId, wantTpId)
         if (!outletId) {
-          const epsNode = diagramState.nodes.get(wantTpId)
-          const epsPos =
-            scene?.nodePlacements.find((p) => p.nodeId === wantTpId)?.position ??
-            epsNode?.position ??
-            null
+          const epsT = diagramState.terminations.find((t) => t.id === wantTpId)
+          const epsPos = epsT?.position ?? null
           const outletPos = autoOutletPosition(epsPos, farPos)
-          outletId = diagramState.addTerminationInScene(sceneId, outletPos, 'outlet')
-          diagramState.updateNode(outletId, {
+          outletId = diagramState.addTermination('outlet', outletPos)
+          diagramState.updateTermination(outletId, {
             metadata: { autoFor: autoOutletTag(wireId, wantTpId) },
           })
         }
@@ -210,7 +208,7 @@
       for (const eps of epsInScope) {
         if (eps.id === wantTpId) continue
         if (oldVia.includes(eps.id)) {
-          const tagged = findAutoOutlet(diagramState.nodes, wireId, eps.id)
+          const tagged = findAutoOutlet(diagramState.terminations, wireId, eps.id)
           if (tagged) orphanOutlets.push(tagged)
         }
       }
@@ -223,7 +221,7 @@
       const finalVia = buildViaForLink(w, managedIds, viaTail)
       diagramState.updateLink(wireId, { via: finalVia.length > 0 ? finalVia : undefined })
 
-      for (const orphan of orphanOutlets) diagramState.removeNode(orphan)
+      for (const orphan of orphanOutlets) diagramState.removeTermination(orphan)
     }
     onclose()
   }

--- a/apps/editor/src/lib/components/scene/NodeRoutingModal.svelte
+++ b/apps/editor/src/lib/components/scene/NodeRoutingModal.svelte
@@ -9,7 +9,6 @@
     buildViaForLink,
     findAutoOutlet,
   } from '$lib/scene/auto-outlets'
-  import { descendantSubgraphIds } from '$lib/scene/scope'
 
   // Per-node routing modal. One row per wire incident to this node,
   // labeled by destination. Each row picks ONE EPS to route through
@@ -33,19 +32,6 @@
     const l = node.label
     return Array.isArray(l) ? l[0] : (l ?? node.id)
   })
-
-  function ancestorChain(parentId: string | undefined): string[] {
-    const out: string[] = []
-    let cur = parentId
-    const safety = 64
-    let i = 0
-    while (cur && i < safety) {
-      out.push(cur)
-      cur = diagramState.subgraphs.get(cur)?.parent
-      i++
-    }
-    return out
-  }
 
   // Both EPS and patch panels are valid via choices for a wire from
   // this node. With terminations now living in the global registry

--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { CableGrade } from '@shumoku/core'
+  import type { CableGrade, Node } from '@shumoku/core'
   import {
     type Connection,
     ConnectionMode,
@@ -153,12 +153,20 @@
     return effectiveNodeSize(scene, diagramState.nodes.get(nodeId))
   }
 
-  // Center of a node's icon in flow coords. Used for via TP positions
-  // — Svelte Flow doesn't expose those automatically (they're not
-  // edge endpoints). Reads the same effective size we hand to Svelte
-  // Flow for the node, so layouts stay in sync with length math.
+  // Center of a node-or-termination's icon in flow coords. Used for
+  // via waypoint positions — Svelte Flow doesn't expose those
+  // automatically (they're not edge endpoints). Terminations no
+  // longer live in `diagram.nodes`; resolve them through the
+  // registry and the position they carry on themselves.
   function centerOf(nodeId: string): { x: number; y: number } {
-    return nodeCenterFromTopLeft(scene, diagramState.nodes.get(nodeId), positionFor(nodeId))
+    const real = diagramState.nodes.get(nodeId)
+    if (real) return nodeCenterFromTopLeft(scene, real, positionFor(nodeId))
+    const term = diagramState.terminations.find((t) => t.id === nodeId)
+    if (term?.position) {
+      const shadow = { id: term.id, label: term.label, termination: { role: term.role } } as Node
+      return nodeCenterFromTopLeft(scene, shadow, term.position)
+    }
+    return nodeCenterFromTopLeft(scene, undefined, { x: 0, y: 0 })
   }
 
   // Reverse lookup so the drag / delete intercepts can tell whether
@@ -172,6 +180,11 @@
     }
     return m
   })
+
+  // Termination ids — used by drag / delete / rename intercepts to
+  // tell sf-node ids referring to entries in the global termination
+  // registry apart from real `Node` ids.
+  const terminationIds = $derived.by(() => new Set(diagramState.terminations.map((t) => t.id)))
 
   /**
    * Inner waypoints between segment endpoints, with bends interleaved
@@ -294,6 +307,42 @@
         selectable: true,
       })
     }
+    // Virtual sf nodes for every termination in the global registry.
+    // Terminations no longer live in `diagram.nodes`, so the canvas
+    // synthesizes one sf node per entry to keep drag / select /
+    // rename / delete flowing through Svelte Flow as before. The
+    // drag and delete intercepts route synthetic ids back to
+    // `updateTermination` / `removeTermination`. Same trick as bends
+    // below, but terminations carry shared identity so they live in
+    // their own global array rather than per-link.
+    for (const t of diagramState.terminations) {
+      if (!t.position) continue
+      const size =
+        t.role === 'eps'
+          ? { w: 22, h: 32 }
+          : t.role === 'outlet'
+            ? { w: 28, h: 28 }
+            : { w: 44, h: 22 }
+      out.push({
+        id: t.id,
+        type: 'scene',
+        position: { x: t.position.x, y: t.position.y },
+        width: size.w,
+        height: size.h,
+        data: {
+          label: t.label,
+          editableLabel: t.label,
+          termination: { role: t.role },
+          baseW: size.w,
+          baseH: size.h,
+          onDelete: () => diagramState.removeTermination(t.id),
+          onRename: (label: string) =>
+            diagramState.updateTermination(t.id, { label: label || t.label }),
+        },
+        draggable: interactive,
+        selectable: true,
+      })
+    }
     // Virtual sf nodes for every link bend. Bends are not in
     // `diagram.nodes` (they live on `link.bends`), so the canvas
     // synthesizes one sf node per bend so the user can still drag /
@@ -340,7 +389,7 @@
       const linkFrom = link.from.node
       const linkTo = link.to.node
       const crossBoundary = !inScopeIds.has(linkFrom) || !inScopeIds.has(linkTo)
-      const idSegments = visibleCableSegments(link, diagramState.nodes)
+      const idSegments = visibleCableSegments(link, diagramState.nodes, diagramState.terminations)
       // Per-segment via offset — global via index of the segment's
       // left endpoint. Source-rooted segment = 0; room-side (after
       // EPS) = (viaIndex of head) + 1. Drag-to-bend uses this to
@@ -350,7 +399,12 @@
       const viaIndexOf = new Map<string, number>(via.map((id, i) => [id, i] as const))
       // Cable length per segment (already computed by
       // cableSegmentLengths in the same order as visibleCableSegments).
-      const segParts = cableSegmentLengths(link, [scene], diagramState.nodes)
+      const segParts = cableSegmentLengths(
+        link,
+        [scene],
+        diagramState.nodes,
+        diagramState.terminations,
+      )
       const wireScale = effectiveWireScale(link)
       for (let i = 0; i < idSegments.length; i++) {
         const segIds = idSegments[i] ?? []
@@ -429,17 +483,22 @@
   // of one per selected node.
   function persistDragged(nodes: SfNode[] | null | undefined) {
     if (!nodes || nodes.length === 0) return
-    // Partition by id: bend ids belong to a link's `bends` array,
-    // not the scene placement map. Real Node ids go through
-    // `placeNodesInScene` as before.
+    // Partition by id kind:
+    //   - bend ids → link.bends array
+    //   - termination ids → global termination registry
+    //   - real Node ids → scene placement map (as before)
     const placements: Array<{ nodeId: string; position: { x: number; y: number } }> = []
     for (const n of nodes) {
       const linkId = bendIdToLinkId.get(n.id)
       if (linkId) {
         diagramState.updateLinkBend(linkId, n.id, n.position)
-      } else {
-        placements.push({ nodeId: n.id, position: n.position })
+        continue
       }
+      if (terminationIds.has(n.id)) {
+        diagramState.updateTermination(n.id, { position: n.position })
+        continue
+      }
+      placements.push({ nodeId: n.id, position: n.position })
     }
     if (placements.length > 0) diagramState.placeNodesInScene(scene.id, placements)
   }
@@ -586,6 +645,7 @@
       for (const n of nodes) {
         const linkId = bendIdToLinkId.get(n.id)
         if (linkId) diagramState.removeLinkBend(linkId, n.id)
+        else if (terminationIds.has(n.id)) diagramState.removeTermination(n.id)
         else diagramState.removeNode(n.id)
       }
     }}
@@ -637,7 +697,7 @@
 
 <style>
   /* Soften Svelte Flow's default dotted background when no floor
-                                             plan is set, but otherwise let its theming through. */
+                                               plan is set, but otherwise let its theming through. */
   :global(.svelte-flow__background) {
     background: #f8fafc;
   }
@@ -645,8 +705,8 @@
     stroke-linecap: round;
   }
   /* Make connection handles visible on hover so users can see where
-                                           to drag from. Otherwise the fully-transparent handles leave the
-                                           "how do I draw a wire" UX a guess. */
+                                             to drag from. Otherwise the fully-transparent handles leave the
+                                             "how do I draw a wire" UX a guess. */
   :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 1 !important;
@@ -656,15 +716,15 @@
     height: 8px;
   }
   /* Read-only cue: don't reveal connection handles on hover in view
-                                 mode. Keep size + DOM presence so Svelte Flow can still resolve
-                                 edge endpoint positions from each handle's bounding rect — only
-                                 opacity is dropped. */
+                                   mode. Keep size + DOM presence so Svelte Flow can still resolve
+                                   edge endpoint positions from each handle's bounding rect — only
+                                   opacity is dropped. */
   .scene-canvas-readonly :global(.svelte-flow__node:hover .svelte-flow__handle) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     opacity: 0 !important;
   }
   /* Placement-pending: crosshair cursor on the pane so users see
-                                 "click somewhere to drop the item". */
+                                   "click somewhere to drop the item". */
   .scene-canvas-placing :global(.svelte-flow__pane) {
     /* biome-ignore lint/complexity/noImportantStyles: overrides Svelte Flow defaults */
     cursor: crosshair !important;

--- a/apps/editor/src/lib/components/scene/wire-edit.ts
+++ b/apps/editor/src/lib/components/scene/wire-edit.ts
@@ -46,30 +46,6 @@ export function polylinePath(points: Waypoint[], radius = 12): string {
   return d
 }
 
-/** Index of the polyline segment closest to `p`. */
-function nearestSegmentIndex(points: Waypoint[], p: Waypoint): number {
-  let best = 0
-  let bestDist = Infinity
-  for (let i = 0; i < points.length - 1; i++) {
-    const a = points[i]
-    const b = points[i + 1]
-    if (!a || !b) continue
-    const dx = b.x - a.x
-    const dy = b.y - a.y
-    const len2 = dx * dx + dy * dy
-    const t =
-      len2 === 0 ? 0 : Math.max(0, Math.min(1, ((p.x - a.x) * dx + (p.y - a.y) * dy) / len2))
-    const px = a.x + t * dx
-    const py = a.y + t * dy
-    const d = (p.x - px) ** 2 + (p.y - py) ** 2
-    if (d < bestDist) {
-      bestDist = d
-      best = i
-    }
-  }
-  return best
-}
-
 /**
  * Drag-to-bend: pointerdown on a wire's hit path. Creates a bend
  * Node in the link's `via` chain at the right insertion index,
@@ -135,11 +111,18 @@ export function bendOnDrag(args: {
         txOpen = true
         dragBendId = near.id
       } else {
-        // New bend: `viaOffset + localIdx - 1` is the `afterIndex`
-        // slot inside the (terminations-only) via chain. The segment
-        // index from this edge already references via positions.
-        const localIdx = nearestSegmentIndex(points, flowStart)
-        const afterIndex = viaOffset + localIdx - 1
+        // New bend: stamp `afterIndex` to the segment's leading via
+        // slot. `viaOffset` is the via index AFTER which this
+        // segment lives (source-rooted = 0, post-EPS = via index of
+        // the EPS at segment head + 1), so `viaOffset - 1` is the
+        // slot for any bend inside this segment.
+        //
+        // Limitation: when a segment crosses multiple non-EPS
+        // terminations (e.g. switch → outletA → outletB → to),
+        // clicks at different positions all land in the leading
+        // slot, so a bend dragged past a via boundary won't relayer
+        // visually. Acceptable for the common single-slot segment.
+        const afterIndex = viaOffset - 1
         // addLinkBend wraps create in its own commit; the subsequent
         // drag moves get their own tx below.
         dragBendId = diagramState.addLinkBend(linkId, flowStart, afterIndex) || null

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -300,27 +300,26 @@ function setNodePortsFromProduct(
 /**
  * Pick a default label for a new termination placement. EPS /
  * Outlet / Panel get a numeric suffix ("EPS 1", "EPS 2"…) scoped to
- * existing same-role nodes anywhere in the diagram, so concurrent
+ * existing same-role terminations in the registry, so concurrent
  * placements stay distinguishable before the user renames them.
  */
 function nextTerminationLabel(role: 'outlet' | 'eps' | 'panel'): string {
   const base = role === 'outlet' ? 'Outlet' : role === 'eps' ? 'EPS' : 'Panel'
-  // Walk existing same-role nodes and collect any "Base N" suffix
-  // they already carry; the new label takes max+1 (or 1 when none).
+  // Walk existing same-role terminations and collect any "Base N"
+  // suffix they already carry; the new label takes max+1 (or 1 when
+  // none).
   const re = new RegExp(`^${base}(?:\\s+(\\d+))?$`)
   let max = 0
   let baseSeen = false
-  for (const [, node] of diagram.nodes) {
-    if (node.termination?.role !== role) continue
-    const label = Array.isArray(node.label) ? node.label[0] : node.label
-    if (typeof label !== 'string') continue
-    const m = label.match(re)
+  for (const t of diagram.terminations) {
+    if (t.role !== role) continue
+    const m = t.label.match(re)
     if (!m) continue
     if (m[1]) max = Math.max(max, Number.parseInt(m[1], 10))
     else baseSeen = true
   }
   // If a bare "EPS" exists with no number yet, the first numbered one
-  // should be "EPS 2" so the existing one effectively becomes #1.
+  // should be "EPS 2" so the existing one effectively occupies #1.
   const next = baseSeen ? Math.max(max, 1) + 1 : max + 1
   return `${base} ${next}`
 }
@@ -1239,28 +1238,68 @@ export const diagramState = {
    * renders them differently and the logical diagram filters them out.
    */
   addTerminationInScene(
-    sceneId: string,
+    _sceneId: string,
     position: { x: number; y: number },
     role: 'outlet' | 'eps' | 'panel',
   ): string {
-    return commit('Add termination in scene', () => {
-      // Auto-number same-role terminations so multiple placements stay
-      // distinguishable ("EPS 1", "EPS 2"…) before the user gets around
-      // to renaming them.
-      const defaultLabel = nextTerminationLabel(role)
-      const id = diagramState.addEmptyNode(defaultLabel)
-      const scene = scenesStore.find(sceneId)
-      const node = diagram.nodes.get(id)
-      if (node) {
-        diagram.nodes.set(id, {
-          ...node,
-          termination: { role },
-          parent: scene?.scopeSubgraphId ?? node.parent,
-        })
-        invalidateSheetCache()
-      }
-      diagramState.placeNodeInScene(sceneId, id, position)
+    // Sceneless internally — terminations live in the global registry
+    // now, not as scene-placed Nodes. The first argument is kept for
+    // callsite compatibility.
+    return diagramState.addTermination(role, position)
+  },
+  /**
+   * Add a physical cabling termination (EPS / Outlet / Panel) to the
+   * diagram's shared registry. Position is stored on the termination
+   * itself; the scene canvas reads it when synthesizing draggable
+   * handles. Auto-numbers the label so multiple placements stay
+   * distinguishable until the user renames them.
+   */
+  addTermination(role: 'outlet' | 'eps' | 'panel', position: { x: number; y: number }): string {
+    return commit('Add termination', () => {
+      const id = newId('node')
+      const label = nextTerminationLabel(role)
+      diagram.terminations = [
+        ...diagram.terminations,
+        { id, role, label, position: { x: position.x, y: position.y } },
+      ]
       return id
+    })
+  },
+  /**
+   * Edit any field on an existing termination (typically label or
+   * position). Returns silently if the id is unknown so callers can
+   * route node-or-termination updates through a single funnel.
+   */
+  updateTermination(
+    id: string,
+    updates: Partial<{ label: string; position: { x: number; y: number } }>,
+  ): void {
+    commit('Update termination', () => {
+      const idx = diagram.terminations.findIndex((t) => t.id === id)
+      if (idx < 0) return
+      const t = diagram.terminations[idx]
+      if (!t) return
+      diagram.terminations = diagram.terminations.map((entry, i) =>
+        i === idx ? { ...entry, ...updates } : entry,
+      )
+    })
+  },
+  /**
+   * Remove a termination from the registry and strip its id from
+   * every link's `via` chain — keeps the data layer consistent in
+   * the same way `removeNode` does for real Nodes.
+   */
+  removeTermination(id: string): void {
+    commit('Remove termination', () => {
+      const before = diagram.terminations.length
+      diagram.terminations = diagram.terminations.filter((t) => t.id !== id)
+      if (diagram.terminations.length === before) return
+      diagram.links = diagram.links.map((l) => {
+        if (!l.via?.length) return l
+        const nextVia = l.via.filter((v) => v !== id)
+        if (nextVia.length === l.via.length) return l
+        return { ...l, via: nextVia.length > 0 ? nextVia : undefined }
+      })
     })
   },
   /**

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -388,6 +388,7 @@ function getProjectSnapshot(): ProjectSnapshot {
     nodes: [...diagram.nodes.entries()],
     subgraphs: [...diagram.subgraphs.entries()],
     links: diagram.links,
+    terminations: diagram.terminations,
     products: productsStore.list,
     scenes: scenesStore.list,
   }) as ProjectSnapshot
@@ -398,6 +399,7 @@ function applyProjectSnapshot(snap: ProjectSnapshot): void {
   replaceMap(diagram.nodes, cloned.nodes)
   replaceMap(diagram.subgraphs, cloned.subgraphs)
   diagram.links = cloned.links
+  diagram.terminations = cloned.terminations ?? []
   productsStore.set(cloned.products)
   scenesStore.set(cloned.scenes)
   if (scenesStore.currentId && !scenesStore.find(scenesStore.currentId)) {
@@ -1950,6 +1952,7 @@ const EMPTY_SNAP: ProjectSnapshot = {
   nodes: [],
   subgraphs: [],
   links: [],
+  terminations: [],
   products: [],
   scenes: [],
 }
@@ -1960,6 +1963,7 @@ function projectToSnapshot(data: NetedProject): ProjectSnapshot {
     nodes: graph.nodes.map((n) => [n.id, n] as [string, Node]),
     subgraphs: (graph.subgraphs ?? []).map((sg) => [sg.id, sg] as [string, Subgraph]),
     links: graph.links,
+    terminations: graph.terminations ?? [],
     products: data.products ?? [],
     scenes: data.scenes ?? [],
   }
@@ -1979,6 +1983,7 @@ function snapshotToProject(
       nodes: snap.nodes.map(([_id, n]) => n),
       links: snap.links,
       subgraphs: snap.subgraphs.map(([_id, sg]) => sg),
+      terminations: snap.terminations.length > 0 ? snap.terminations : undefined,
     },
     scenes: snap.scenes,
   }

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -125,6 +125,7 @@ function buildAssignmentRows(): AssignmentRow[] {
     nodes: diagram.nodes,
     links: diagram.links,
     scenes: scenesStore.list,
+    terminations: diagram.terminations,
   })
 }
 
@@ -559,6 +560,9 @@ export const diagramState = {
   set links(v: Link[]) {
     diagram.links = v
   },
+  get terminations() {
+    return diagram.terminations
+  },
 
   // ----- Diagram mutations (commit-wrapped) ---------------------------
   addLink(link: Link) {
@@ -962,7 +966,7 @@ export const diagramState = {
   cableLengthMeters(linkId: string): { meters: number; source: 'scene' | 'stored' } | null {
     const link = diagram.links.find((l) => l.id === linkId)
     if (!link) return null
-    return cableLengthMeters(link, scenesStore.list, diagram.nodes)
+    return cableLengthMeters(link, scenesStore.list, diagram.nodes, diagram.terminations)
   },
   /**
    * Per-visible-segment cable lengths for a link. EPS-routed wires
@@ -972,7 +976,7 @@ export const diagramState = {
   cableSegmentLengths(linkId: string): Array<{ fromId: string; toId: string; meters: number }> {
     const link = diagram.links.find((l) => l.id === linkId)
     if (!link) return []
-    return cableSegmentLengths(link, scenesStore.list, diagram.nodes)
+    return cableSegmentLengths(link, scenesStore.list, diagram.nodes, diagram.terminations)
   },
   placedCount(productId: string): number {
     let n = 0
@@ -1272,7 +1276,11 @@ export const diagramState = {
    */
   updateTermination(
     id: string,
-    updates: Partial<{ label: string; position: { x: number; y: number } }>,
+    updates: Partial<{
+      label: string
+      position: { x: number; y: number }
+      metadata: Record<string, unknown>
+    }>,
   ): void {
     commit('Update termination', () => {
       const idx = diagram.terminations.findIndex((t) => t.id === id)

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -46,6 +46,7 @@ import {
   inheritProductIconFromCatalog,
   migrateBendNodesToLinkBends,
   migrateLegacyWireRoutes,
+  migrateTerminationNodesToGraphTerminations,
 } from './migrations'
 import { projectsDb } from './persistence/projects-store'
 import { readProjectZip } from './persistence/reader'
@@ -1611,6 +1612,11 @@ export const diagramState = {
       nodes: [...diagram.nodes.values()],
       links: [...diagram.links],
       subgraphs: [...diagram.subgraphs.values()],
+      // Cabling waypoints live separately from logical nodes — see
+      // the `Termination` type doc. Only emit the field when there's
+      // actually something to round-trip, so the JSON stays clean for
+      // projects without scenes.
+      terminations: diagram.terminations.length > 0 ? [...diagram.terminations] : undefined,
     }
   },
   /**
@@ -2024,12 +2030,28 @@ async function applyProject(data: Partial<NetedProject>) {
     // and strip the now-orphan placements.
     scenes: scenesStore.list,
   })
+  // EPS / Outlet / Panel were also `Node`s for the same reuse-of-
+  // infrastructure reason. They're routing waypoints with shared
+  // identity (multiple wires can pass through one EPS), not network
+  // equipment — so they move to their own `NetworkGraph.terminations`
+  // registry. `Link.via` keeps referencing them by id. Same scene-
+  // placement recovery trick as the bend migration above.
+  migrateTerminationNodesToGraphTerminations({
+    nodes: diagram.nodes,
+    terminations: diagram.terminations,
+    scenes: scenesStore.list,
+  })
 }
 
 async function applyGraph(graph: NetworkGraph) {
   invalidateSheetCache()
   const { nodes, subgraphs, links } = sanitizeGraph(graph)
   const direction = graph.settings?.direction ?? 'TB'
+  // Load the cabling waypoints first — they're consumed by the
+  // scene canvas, not by Sugiyama, and we want the store to be
+  // populated before the post-load migration runs (which can also
+  // append to this array when it sees legacy bend Nodes).
+  diagram.terminations = [...(graph.terminations ?? [])]
   const hasAnyNode = nodes.size > 0
   const allPositioned = hasAnyNode && [...nodes.values()].every((n) => n.position)
 

--- a/apps/editor/src/lib/migrations/index.ts
+++ b/apps/editor/src/lib/migrations/index.ts
@@ -9,3 +9,7 @@ export {
 } from './bend-nodes-to-link-bends'
 export { type LegacyScene, migrateLegacyWireRoutes } from './legacy-wire-routes'
 export { inheritProductIconFromCatalog } from './product-icon-inheritance'
+export {
+  migrateTerminationNodesToGraphTerminations,
+  type TerminationMigrationStats,
+} from './termination-nodes-to-graph-terminations'

--- a/apps/editor/src/lib/migrations/termination-nodes-to-graph-terminations.test.ts
+++ b/apps/editor/src/lib/migrations/termination-nodes-to-graph-terminations.test.ts
@@ -1,0 +1,103 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { Node, Termination } from '@shumoku/core'
+import { describe, expect, test } from 'vitest'
+import type { Scene } from '../types'
+import { migrateTerminationNodesToGraphTerminations } from './termination-nodes-to-graph-terminations'
+
+function termNode(id: string, role: 'eps' | 'outlet' | 'panel', label?: string): Node {
+  return { id, label: label ?? role, termination: { role } } as Node
+}
+
+function deviceNode(id: string): Node {
+  return { id, label: id } as Node
+}
+
+function nodesMap(...ns: Node[]): Map<string, Node> {
+  return new Map(ns.map((n) => [n.id, n]))
+}
+
+function scene(id: string, placements: Array<{ nodeId: string; x: number; y: number }>): Scene {
+  return {
+    id,
+    name: id,
+    nodePlacements: placements.map((p) => ({ nodeId: p.nodeId, position: { x: p.x, y: p.y } })),
+  }
+}
+
+describe('migrateTerminationNodesToGraphTerminations', () => {
+  test('no-op when there are no termination Nodes', () => {
+    const nodes = nodesMap(deviceNode('a'), deviceNode('b'))
+    const terminations: Termination[] = []
+    const stats = migrateTerminationNodesToGraphTerminations({ nodes, terminations })
+    expect(stats).toEqual({ nodesRemoved: 0, terminationsAdded: 0 })
+    expect(terminations).toEqual([])
+    expect(nodes.size).toBe(2)
+  })
+
+  test('lifts EPS / Outlet / Panel Nodes into the terminations array', () => {
+    const nodes = nodesMap(
+      deviceNode('a'),
+      termNode('eps-1', 'eps', '2F MDF'),
+      termNode('out-1', 'outlet'),
+      termNode('panel-1', 'panel'),
+    )
+    const terminations: Termination[] = []
+    const scenes = [
+      scene('s1', [
+        { nodeId: 'eps-1', x: 10, y: 20 },
+        { nodeId: 'out-1', x: 30, y: 40 },
+        { nodeId: 'panel-1', x: 50, y: 60 },
+      ]),
+    ]
+
+    const stats = migrateTerminationNodesToGraphTerminations({ nodes, terminations, scenes })
+    expect(stats.nodesRemoved).toBe(3)
+    expect(stats.terminationsAdded).toBe(3)
+    expect(nodes.has('a')).toBe(true)
+    expect(nodes.has('eps-1')).toBe(false)
+    expect(terminations).toHaveLength(3)
+    const eps = terminations.find((t) => t.id === 'eps-1')
+    expect(eps).toMatchObject({ role: 'eps', label: '2F MDF', position: { x: 10, y: 20 } })
+  })
+
+  test('strips the now-orphan placements from scenes', () => {
+    const nodes = nodesMap(termNode('eps-1', 'eps'))
+    const terminations: Termination[] = []
+    const scenes = [scene('s1', [{ nodeId: 'eps-1', x: 10, y: 20 }])]
+    migrateTerminationNodesToGraphTerminations({ nodes, terminations, scenes })
+    expect(scenes[0]?.nodePlacements.find((p) => p.nodeId === 'eps-1')).toBeUndefined()
+  })
+
+  test('preserves array-shaped labels by taking the first entry', () => {
+    const node: Node = {
+      id: 'eps-1',
+      label: ['2F MDF', 'secondary'],
+      termination: { role: 'eps' },
+    } as Node
+    const nodes = nodesMap(node)
+    const terminations: Termination[] = []
+    migrateTerminationNodesToGraphTerminations({ nodes, terminations })
+    expect(terminations[0]?.label).toBe('2F MDF')
+  })
+
+  test('idempotent — second pass is a no-op', () => {
+    const nodes = nodesMap(termNode('eps-1', 'eps'))
+    const terminations: Termination[] = []
+    migrateTerminationNodesToGraphTerminations({ nodes, terminations })
+    const stats2 = migrateTerminationNodesToGraphTerminations({ nodes, terminations })
+    expect(stats2).toEqual({ nodesRemoved: 0, terminationsAdded: 0 })
+    expect(terminations).toHaveLength(1)
+  })
+
+  test('skips bends (already handled by the bend migration)', () => {
+    const bend: Node = { id: 'bend-1', termination: { role: 'bend' } } as Node
+    const nodes = nodesMap(bend, termNode('eps-1', 'eps'))
+    const terminations: Termination[] = []
+    migrateTerminationNodesToGraphTerminations({ nodes, terminations })
+    expect(nodes.has('bend-1')).toBe(true) // bend left alone here
+    expect(nodes.has('eps-1')).toBe(false)
+    expect(terminations).toHaveLength(1)
+  })
+})

--- a/apps/editor/src/lib/migrations/termination-nodes-to-graph-terminations.ts
+++ b/apps/editor/src/lib/migrations/termination-nodes-to-graph-terminations.ts
@@ -1,0 +1,103 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Lift EPS / Outlet / Panel waypoints out of `NetworkGraph.nodes`
+ * into `NetworkGraph.terminations`.
+ *
+ * Historical context: physical cabling terminations were modelled
+ * as `Node`s with `termination.role` so they could ride Svelte
+ * Flow's drag/select machinery alongside real devices. The cost
+ * was that every consumer of `nodes` had to either filter them
+ * out (BOM "Equipment", JSON export, diagram view) or pretend they
+ * were devices.
+ *
+ * They're not devices — they're passive routing waypoints with
+ * identity. Mirroring the bend refactor, this migration moves them
+ * to their own collection. `Link.via` keeps referencing them by id.
+ * The scene canvas synthesizes draggable sf nodes from the
+ * `terminations` array so the user-facing UX is unchanged.
+ *
+ * Idempotent — calling it on an already-migrated graph is a no-op.
+ */
+
+import type { Node, Termination } from '@shumoku/core'
+import type { Scene } from '../types'
+
+export interface TerminationMigrationStats {
+  /** Termination Nodes removed from `nodes`. */
+  nodesRemoved: number
+  /** New `Termination` entries pushed into `terminations`. */
+  terminationsAdded: number
+}
+
+const TERMINATION_ROLES = new Set(['eps', 'outlet', 'panel'])
+
+export function migrateTerminationNodesToGraphTerminations(args: {
+  nodes: Map<string, Node>
+  terminations: Termination[]
+  /**
+   * Scenes are consulted to recover the termination's coordinates —
+   * `placeNodeInScene` only ever wrote to `scene.nodePlacements`,
+   * never to `node.position`, so without this hint every legacy
+   * termination would land at (0, 0).
+   */
+  scenes?: Scene[]
+}): TerminationMigrationStats {
+  const { nodes, terminations, scenes } = args
+  const stats: TerminationMigrationStats = { nodesRemoved: 0, terminationsAdded: 0 }
+
+  const termNodeIds: string[] = []
+  for (const [id, node] of nodes) {
+    if (node.termination?.role && TERMINATION_ROLES.has(node.termination.role)) {
+      termNodeIds.push(id)
+    }
+  }
+  if (termNodeIds.length === 0) return stats
+
+  // First-seen scene placement per node id — terminations placed
+  // in multiple scenes collapse to whichever scene appears first.
+  const placementById = new Map<string, { x: number; y: number }>()
+  for (const scene of scenes ?? []) {
+    for (const p of scene.nodePlacements ?? []) {
+      if (placementById.has(p.nodeId)) continue
+      placementById.set(p.nodeId, p.position)
+    }
+  }
+
+  const existingIds = new Set(terminations.map((t) => t.id))
+
+  for (const id of termNodeIds) {
+    const node = nodes.get(id)
+    if (!node) continue
+    nodes.delete(id)
+    stats.nodesRemoved++
+    if (existingIds.has(id)) continue // already migrated
+    const role = node.termination?.role
+    if (role !== 'eps' && role !== 'outlet' && role !== 'panel') continue
+    const label = Array.isArray(node.label)
+      ? (node.label[0] ?? id)
+      : typeof node.label === 'string'
+        ? node.label
+        : id
+    const pos = placementById.get(id) ?? node.position
+    terminations.push({
+      id,
+      role,
+      label,
+      position: pos ? { x: pos.x, y: pos.y } : undefined,
+    })
+    stats.terminationsAdded++
+  }
+
+  // Strip the now-orphan scene placements so the next save is clean.
+  if (scenes) {
+    const ids = new Set(termNodeIds)
+    for (const scene of scenes) {
+      if (!scene.nodePlacements?.length) continue
+      scene.nodePlacements = scene.nodePlacements.filter((p) => !ids.has(p.nodeId))
+    }
+  }
+
+  return stats
+}

--- a/apps/editor/src/lib/persistence/idb.ts
+++ b/apps/editor/src/lib/persistence/idb.ts
@@ -25,7 +25,7 @@
 // No in-place migration: v1 rows are abandoned on upgrade.
 
 const DB_NAME = 'shumoku'
-const DB_VERSION = 2
+const DB_VERSION = 3
 
 export const STORES = {
   projects: 'projects',
@@ -34,12 +34,20 @@ export const STORES = {
   links: 'links',
   products: 'products',
   scenes: 'scenes',
+  terminations: 'terminations',
   assets: 'assets',
 } as const
 
 export type EntityStore = Exclude<keyof typeof STORES, 'projects' | 'assets'>
 
-export const ENTITY_STORES: EntityStore[] = ['nodes', 'subgraphs', 'links', 'products', 'scenes']
+export const ENTITY_STORES: EntityStore[] = [
+  'nodes',
+  'subgraphs',
+  'links',
+  'products',
+  'scenes',
+  'terminations',
+]
 
 let dbPromise: Promise<IDBDatabase> | null = null
 
@@ -65,13 +73,22 @@ export function openDb(): Promise<IDBDatabase> {
       if (oldVersion < 2) {
         for (const name of Array.from(db.objectStoreNames)) db.deleteObjectStore(name)
       }
-      db.createObjectStore(STORES.projects, { keyPath: 'id' })
+      // From v2 → v3 we just need to add the `terminations` store —
+      // existing data stays. The bootstrap below uses `if not exists`
+      // semantics by skipping creation when the store already lives
+      // on the upgraded DB.
+      if (!db.objectStoreNames.contains(STORES.projects)) {
+        db.createObjectStore(STORES.projects, { keyPath: 'id' })
+      }
       for (const kind of ENTITY_STORES) {
+        if (db.objectStoreNames.contains(STORES[kind])) continue
         const store = db.createObjectStore(STORES[kind], { keyPath: ['projectId', 'id'] })
         store.createIndex('projectId', 'projectId')
       }
-      const assets = db.createObjectStore(STORES.assets, { keyPath: ['projectId', 'hash'] })
-      assets.createIndex('projectId', 'projectId')
+      if (!db.objectStoreNames.contains(STORES.assets)) {
+        const assets = db.createObjectStore(STORES.assets, { keyPath: ['projectId', 'hash'] })
+        assets.createIndex('projectId', 'projectId')
+      }
     }
     req.onsuccess = () => resolve(req.result)
     req.onerror = () => reject(req.error)

--- a/apps/editor/src/lib/persistence/projects-store.ts
+++ b/apps/editor/src/lib/persistence/projects-store.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2026-present Akitoshi Saeki
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { Link, Node, Subgraph } from '@shumoku/core'
+import type { Link, Node, Subgraph, Termination } from '@shumoku/core'
 import { rehydrateEntity, serializeEntity } from '../state/assets.svelte'
 import type { Product, Scene } from '../types'
 import type { ProjectSnapshot } from '../undo.svelte'
@@ -51,6 +51,11 @@ interface SceneRow {
   projectId: string
   id: string
   data: Scene
+}
+interface TerminationRow {
+  projectId: string
+  id: string
+  data: Termination
 }
 export interface AssetRow {
   projectId: string
@@ -142,12 +147,13 @@ export const projectsDb = {
           | ProjectMeta
           | undefined
         if (!meta) return null
-        const [nodes, subgraphs, links, products, scenes] = await Promise.all([
+        const [nodes, subgraphs, links, products, scenes, terminations] = await Promise.all([
           getAllByProject<NodeRow>(txn.objectStore(STORES.nodes), projectId),
           getAllByProject<SubgraphRow>(txn.objectStore(STORES.subgraphs), projectId),
           getAllByProject<LinkRow>(txn.objectStore(STORES.links), projectId),
           getAllByProject<ProductRow>(txn.objectStore(STORES.products), projectId),
           getAllByProject<SceneRow>(txn.objectStore(STORES.scenes), projectId),
+          getAllByProject<TerminationRow>(txn.objectStore(STORES.terminations), projectId),
         ])
         // Rehydrate `asset:` refs back to live blob URLs (caller
         // must have populated AssetStore from per-project asset
@@ -160,6 +166,7 @@ export const projectsDb = {
             links: links.map((r) => rehydrateEntity(r.data)),
             products: products.map((r) => rehydrateEntity(r.data)),
             scenes: scenes.map((r) => rehydrateEntity(r.data)),
+            terminations: terminations.map((r) => rehydrateEntity(r.data)),
           },
         }
       },
@@ -206,6 +213,10 @@ export const projectsDb = {
           txn
             .objectStore(STORES.scenes)
             .put({ projectId: meta.id, id: scene.id, data: serializeEntity(scene) })
+        for (const term of snapshot.terminations)
+          txn
+            .objectStore(STORES.terminations)
+            .put({ projectId: meta.id, id: term.id, data: serializeEntity(term) })
       },
     )
   },

--- a/apps/editor/src/lib/persistence/sync.test.ts
+++ b/apps/editor/src/lib/persistence/sync.test.ts
@@ -15,6 +15,7 @@ function snap(parts: Partial<ProjectSnapshot> = {}): ProjectSnapshot {
     links: parts.links ?? [],
     products: parts.products ?? [],
     scenes: parts.scenes ?? [],
+    terminations: parts.terminations ?? [],
   }
 }
 

--- a/apps/editor/src/lib/persistence/sync.ts
+++ b/apps/editor/src/lib/persistence/sync.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2026-present Akitoshi Saeki
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { Link, Node, Subgraph } from '@shumoku/core'
+import type { Link, Node, Subgraph, Termination } from '@shumoku/core'
 import { serializeEntity } from '../state/assets.svelte'
 import type { Product, Scene } from '../types'
 import type { ProjectSnapshot } from '../undo.svelte'
@@ -23,6 +23,7 @@ type EntityCollections = {
   links: Map<string, Link>
   products: Map<string, Product>
   scenes: Map<string, Scene>
+  terminations: Map<string, Termination>
 }
 
 function indexBySnapshot(snap: ProjectSnapshot): EntityCollections {
@@ -39,6 +40,7 @@ function indexBySnapshot(snap: ProjectSnapshot): EntityCollections {
     ),
     products: new Map(snap.products.map((p) => [p.id, p] as const)),
     scenes: new Map(snap.scenes.map((s) => [s.id, s] as const)),
+    terminations: new Map(snap.terminations.map((t) => [t.id, t] as const)),
   }
 }
 
@@ -65,6 +67,7 @@ interface SnapshotDiff {
   links: KindDiff<Link>
   products: KindDiff<Product>
   scenes: KindDiff<Scene>
+  terminations: KindDiff<Termination>
 }
 
 export function diffSnapshots(before: ProjectSnapshot, after: ProjectSnapshot): SnapshotDiff {
@@ -76,6 +79,7 @@ export function diffSnapshots(before: ProjectSnapshot, after: ProjectSnapshot): 
     links: diffKind(b.links, a.links),
     products: diffKind(b.products, a.products),
     scenes: diffKind(b.scenes, a.scenes),
+    terminations: diffKind(b.terminations, a.terminations),
   }
 }
 
@@ -119,6 +123,7 @@ export async function applySync(projectId: string, diff: SnapshotDiff): Promise<
         links: txn.objectStore(STORES.links),
         products: txn.objectStore(STORES.products),
         scenes: txn.objectStore(STORES.scenes),
+        terminations: txn.objectStore(STORES.terminations),
       }
       for (const kind of ENTITY_STORES) {
         const store = writers[kind]

--- a/apps/editor/src/lib/scene/auto-outlets.ts
+++ b/apps/editor/src/lib/scene/auto-outlets.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2026-present Akitoshi Saeki
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { Link, Node } from '@shumoku/core'
+import type { Link, Termination } from '@shumoku/core'
 
 /**
  * Auto-created outlets carry a stable metadata tag pointing at the
@@ -15,14 +15,14 @@ export function autoOutletTag(linkId: string, epsId: string): string {
 }
 
 export function findAutoOutlet(
-  nodes: Map<string, Node>,
+  terminations: readonly Termination[],
   linkId: string,
   epsId: string,
 ): string | null {
   const tag = autoOutletTag(linkId, epsId)
-  for (const n of nodes.values()) {
-    if (n.termination?.role !== 'outlet') continue
-    if (n.metadata?.autoFor === tag) return n.id
+  for (const t of terminations) {
+    if (t.role !== 'outlet') continue
+    if (t.metadata?.autoFor === tag) return t.id
   }
   return null
 }

--- a/apps/editor/src/lib/scene/cable-length.ts
+++ b/apps/editor/src/lib/scene/cable-length.ts
@@ -1,9 +1,10 @@
 // Copyright (C) 2026-present Akitoshi Saeki
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { Link, Node } from '@shumoku/core'
+import type { Link, Node, Termination } from '@shumoku/core'
 import type { Scene } from '../types'
 import { nodeCenterFromTopLeft } from './node-geometry'
+import { viaLookup } from './via-lookup'
 
 /**
  * Single source of truth for cable length number formatting:
@@ -69,12 +70,17 @@ function endpointPos(
  *   from=A, via=[outlet1, eps, outlet2], to=B
  *   → segments: [[A, outlet1, eps], [outlet2, B]]
  */
-export function visibleCableSegments(link: Link, nodes: Map<string, Node>): string[][] {
+export function visibleCableSegments(
+  link: Link,
+  nodes: Map<string, Node>,
+  terminations: readonly Termination[] = [],
+): string[][] {
+  const lookup = terminations.length > 0 ? viaLookup(nodes, terminations) : nodes
   const sequence = [link.from.node, ...(link.via ?? []), link.to.node]
   const segments: string[][] = []
   let current: string[] = []
   for (const id of sequence) {
-    const n = nodes.get(id)
+    const n = lookup.get(id)
     if (n?.termination?.role === 'eps') {
       current.push(id)
       segments.push(current)
@@ -129,6 +135,7 @@ export function cableSegmentLengths(
   link: Link,
   scenes: Scene[],
   nodes: Map<string, Node>,
+  terminations: readonly Termination[] = [],
 ): Array<{ fromId: string; toId: string; meters: number }> {
   // Walk the full polyline (nodes interleaved with bends), splitting
   // into visible cable segments at every EPS waypoint — the cable
@@ -136,6 +143,7 @@ export function cableSegmentLengths(
   // side. Bends inside a segment contribute straight-line distance
   // between adjacent waypoints, matching the curved polyline the
   // canvas draws.
+  const lookup = terminations.length > 0 ? viaLookup(nodes, terminations) : nodes
   const polyline = linkPolylineWaypoints(link)
   if (polyline.length < 2) return []
 
@@ -147,7 +155,7 @@ export function cableSegmentLengths(
   let run: Waypoint[] = []
   for (const w of polyline) {
     run.push(w)
-    if (w.kind === 'node' && nodes.get(w.nodeId)?.termination?.role === 'eps') {
+    if (w.kind === 'node' && lookup.get(w.nodeId)?.termination?.role === 'eps') {
       segmentRuns.push(run)
       run = []
     }
@@ -156,7 +164,7 @@ export function cableSegmentLengths(
 
   function resolve(w: Waypoint, scene: Scene): { x: number; y: number } | null {
     if (w.kind === 'bend') return { x: w.x, y: w.y }
-    return endpointPos(scene, w.nodeId, nodes)
+    return endpointPos(scene, w.nodeId, lookup)
   }
 
   function pixelLengthAcrossScenes(seg: Waypoint[], sceneList: Scene[]): number | null {
@@ -210,10 +218,11 @@ export function cableLengthMeters(
   link: Link,
   scenes: Scene[],
   nodes: Map<string, Node>,
+  terminations: readonly Termination[] = [],
 ): { meters: number; source: 'scene' | 'stored' } | null {
   // Length follows what's drawn: sum the visible segments. EPS internal
   // (chase-internal) length isn't modeled here.
-  const parts = cableSegmentLengths(link, scenes, nodes)
+  const parts = cableSegmentLengths(link, scenes, nodes, terminations)
   if (parts.length > 0) {
     const total = parts.reduce((s, p) => s + p.meters, 0)
     return { meters: total, source: 'scene' }

--- a/apps/editor/src/lib/scene/via-lookup.ts
+++ b/apps/editor/src/lib/scene/via-lookup.ts
@@ -1,0 +1,41 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Unified lookup for ids that appear in `Link.via`. A via id used to
+ * be guaranteed to be a `Node.id` (when terminations lived in
+ * `diagram.nodes`), so consumers walked `Map<string, Node>` directly.
+ * Now EPS / Outlet / Panel terminations live in a separate registry,
+ * so we wrap the two stores behind one lookup helper.
+ *
+ * The shadow Map this builds carries fake `Node`-shaped entries for
+ * terminations so existing call sites that look at `node.termination?.role`
+ * and `node.position` keep working without per-consumer plumbing.
+ * That's a compromise — the type lies a bit — but it concentrates
+ * the cost to this single helper. Callers that want the *real*
+ * termination shape can iterate the registry directly.
+ */
+
+import type { Node, Termination } from '@shumoku/core'
+
+/**
+ * Merge a Node map and a Termination array into a single lookup keyed
+ * by id. Termination entries are surfaced as Node-shaped shadows so
+ * `entry.termination?.role` and `entry.position` resolve uniformly
+ * across both real nodes and registry entries.
+ */
+export function viaLookup(
+  nodes: Map<string, Node>,
+  terminations: readonly Termination[],
+): Map<string, Node> {
+  const merged = new Map<string, Node>(nodes)
+  for (const t of terminations) {
+    merged.set(t.id, {
+      id: t.id,
+      label: t.label,
+      termination: { role: t.role },
+      position: t.position,
+    } as Node)
+  }
+  return merged
+}

--- a/apps/editor/src/lib/state/bom.ts
+++ b/apps/editor/src/lib/state/bom.ts
@@ -10,7 +10,7 @@
 // what an installer actually orders.
 // =========================================================================
 
-import type { Link, Node } from '@shumoku/core'
+import type { Link, Node, Termination } from '@shumoku/core'
 import { cableLengthMeters, cableSegmentLengths, formatMeters } from '../scene/cable-length'
 import type { AssignmentRow, Scene } from '../types'
 import { nodeDisplayLabel } from '../utils/labels'
@@ -38,9 +38,10 @@ export function cableRequirementKeys(
   link: Link,
   scenes: Scene[],
   nodes: Map<string, Node>,
+  terminations: readonly Termination[] = [],
 ): Array<{ key: string; lengthM: number | null }> {
   const cable = link.cable
-  const segs = cableSegmentLengths(link, scenes, nodes)
+  const segs = cableSegmentLengths(link, scenes, nodes, terminations)
   const baseParts = [cable?.category, cable?.medium].filter(Boolean) as string[]
 
   if (segs.length > 1) {
@@ -50,7 +51,7 @@ export function cableRequirementKeys(
     }))
   }
 
-  const eff = cableLengthMeters(link, scenes, nodes)
+  const eff = cableLengthMeters(link, scenes, nodes, terminations)
   if (!cable && !eff) return []
   const lengthLabel = eff
     ? formatLength(eff.meters)
@@ -66,8 +67,9 @@ export function buildAssignmentRows(args: {
   nodes: Map<string, Node>
   links: Link[]
   scenes: Scene[]
+  terminations?: readonly Termination[]
 }): AssignmentRow[] {
-  const { nodes, links, scenes } = args
+  const { nodes, links, scenes, terminations = [] } = args
   const rows: AssignmentRow[] = []
 
   for (const [nodeId, node] of nodes) {
@@ -104,7 +106,7 @@ export function buildAssignmentRows(args: {
         status: endpoint.plug?.module?.productId ? 'resolved' : 'generic',
       })
     }
-    const cableReqs = cableRequirementKeys(link, scenes, nodes)
+    const cableReqs = cableRequirementKeys(link, scenes, nodes, terminations)
     for (const [i, req] of cableReqs.entries()) {
       // Multi-segment wires get a "1/2" / "2/2" suffix on the row id
       // and label so the BOM can show which side of the chase each

--- a/apps/editor/src/lib/state/diagram.svelte.ts
+++ b/apps/editor/src/lib/state/diagram.svelte.ts
@@ -11,6 +11,7 @@ import {
   type ResolvedPort,
   routeEdges,
   type Subgraph,
+  type Termination,
 } from '@shumoku/core'
 import { SvelteMap } from 'svelte/reactivity'
 
@@ -25,6 +26,11 @@ export const diagram = $state({
   subgraphs: new SvelteMap<string, Subgraph>(),
   bounds: { x: 0, y: 0, width: 0, height: 0 },
   links: [] as Link[],
+  // Physical cabling waypoints with shared identity (EPS / Outlet /
+  // Panel). Referenced by `Link.via` ids — same lookup pattern as
+  // before, but the entries no longer live in `nodes` so the logical
+  // diagram view / JSON export / BOM Equipment section don't see them.
+  terminations: [] as Termination[],
 })
 
 /**

--- a/apps/editor/src/lib/undo.svelte.ts
+++ b/apps/editor/src/lib/undo.svelte.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2026-present Akitoshi Saeki
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { Link, Node, Subgraph } from '@shumoku/core'
+import type { Link, Node, Subgraph, Termination } from '@shumoku/core'
 import type { Product, Scene } from './types'
 
 /**
@@ -14,6 +14,10 @@ export interface ProjectSnapshot {
   nodes: [string, Node][]
   subgraphs: [string, Subgraph][]
   links: Link[]
+  /** Physical cabling registry (EPS / Outlet / Panel). Captured here
+   *  so undo / redo / persistence round-trip preserves them — they're
+   *  not under `nodes` after the registry refactor. */
+  terminations: Termination[]
   products: Product[]
   scenes: Scene[]
 }

--- a/apps/editor/src/routes/project/[id]/(content)/bom/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/bom/+page.svelte
@@ -89,7 +89,12 @@
   // so the tech can scan the label quickly.
 
   function nodeLabelOf(nodeId: string): string {
-    return nodeDisplayLabel(diagramState.nodes.get(nodeId), nodeId)
+    const real = diagramState.nodes.get(nodeId)
+    if (real) return nodeDisplayLabel(real, nodeId)
+    // Terminations live in their own registry now; fall back so via
+    // chain prefixes still read as "EPS 1 / Outlet 2: switch-B" etc.
+    const term = diagramState.terminations.find((t) => t.id === nodeId)
+    return term?.label ?? nodeId
   }
 
   function portLabelOf(nodeId: string, portId: string | undefined): string | null {

--- a/apps/editor/src/routes/project/[id]/(content)/connections/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/(content)/connections/+page.svelte
@@ -76,7 +76,10 @@
   })
 
   function nodeLabelOf(id: string): string {
-    return nodeDisplayLabel(diagramState.nodes.get(id), id)
+    const real = diagramState.nodes.get(id)
+    if (real) return nodeDisplayLabel(real, id)
+    const term = diagramState.terminations.find((t) => t.id === id)
+    return term?.label ?? id
   }
 
   function getPortLabel(p: PortOption) {

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -926,13 +926,46 @@ export interface GraphSettings {
   legend?: boolean | LegendSettings
 }
 
+/**
+ * Physical cabling termination — a passive transit point on a wire
+ * path. Includes wall outlets, EPS (electrical pipe shaft) risers,
+ * and patch panels. Unlike `Node`, terminations carry no logical
+ * configuration, no ports, and no data role — they're cabling-plan
+ * waypoints with stable identity (multiple wires can transit the
+ * same EPS, and the user labels them).
+ *
+ * Lives in its own `NetworkGraph.terminations` array (separate from
+ * `nodes`) so consumers of the logical topology — JSON export,
+ * Sugiyama layout, BOM "Equipment" — don't see them as devices.
+ * `Link.via` still references terminations by id; the scene canvas
+ * synthesizes draggable handles from this array so the UX of
+ * placing / labelling / moving them on a floor plan is unchanged.
+ */
+export interface Termination {
+  id: string
+  /** Display label. User can edit. */
+  label: string
+  /** Termination kind — drives the rendered glyph. */
+  role: 'eps' | 'outlet' | 'panel'
+  /**
+   * Position on the scene canvas. Like bends, terminations carry
+   * their own coordinates rather than relying on per-scene
+   * `nodePlacements`. Multiple scenes referencing the same
+   * termination share one position.
+   */
+  position?: { x: number; y: number }
+}
+
 export interface NetworkGraph {
   version: string
   name?: string
   description?: string
 
   /**
-   * All nodes (flat list)
+   * All nodes (flat list). Only logical entities — devices, compute,
+   * services. Physical cabling waypoints live separately:
+   * - bends → `Link.bends`
+   * - EPS / Outlet / Panel → `NetworkGraph.terminations`
    */
   nodes: Node[]
 
@@ -945,6 +978,13 @@ export interface NetworkGraph {
    * Subgraph definitions
    */
   subgraphs?: Subgraph[]
+
+  /**
+   * Physical cabling terminations referenced by `Link.via`. Each
+   * entry has stable identity so multiple wires can pass through
+   * the same EPS / patch panel.
+   */
+  terminations?: Termination[]
 
   /**
    * Global settings

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -954,6 +954,13 @@ export interface Termination {
    * termination share one position.
    */
   position?: { x: number; y: number }
+  /**
+   * Free-form metadata. The auto-outlet flow (EpsRoutingModal,
+   * NodeRoutingModal) stores `{ autoFor: "<linkId>:<epsId>" }` here
+   * so the inverse op (uncheck → cleanup) can find and remove the
+   * matching outlet without a separate registry.
+   */
+  metadata?: Record<string, unknown>
 }
 
 export interface NetworkGraph {


### PR DESCRIPTION
## Summary

After the bend refactor (#249), the diagram still rendered EPS / Outlet / Panel as floating Nodes — they were Nodes with \`termination.role\` set to one of those three, which made them appear in:

- the logical Diagram canvas (as disconnected boxes)
- \`exportGraph()\` JSON
- BOM \"Equipment\" rows
- every other \`diagram.nodes\` consumer

But these aren't network equipment — they're passive cabling waypoints with shared identity (multiple wires can transit one EPS, and users label them). Mirroring the bend split, this PR moves them to their own \`NetworkGraph.terminations\` registry.

**Stacked on #249** — the bend refactor and this share the same \"don't mix drawing artifacts with logical entities\" thesis.

## Phase 1 — schema + load migration

- \`core/types\`: new \`Termination\` type + \`NetworkGraph.terminations\` array
- \`diagram\` store: \`diagram.terminations: Termination[]\` mirrors the array
- \`migrations/termination-nodes-to-graph-terminations.ts\`: idempotent migration that lifts EPS/Outlet/Panel Nodes into the new registry. Position recovery prefers \`scene.nodePlacements\` (same trick as the bend migration). Orphan placements stripped.
- 6 unit tests

## Phase 2 — creation/edit primitives

- \`addTermination\` / \`updateTermination\` / \`removeTermination\` on diagramState
- \`addTerminationInScene\` becomes a thin wrapper for callsite compat
- \`nextTerminationLabel\` walks the registry now
- \`removeTermination\` strips the id from every link's via chain

## Phase 3 — rendering

- SceneCanvas synthesizes virtual sf nodes from \`diagram.terminations\`; drag / delete / rename intercepts route synthetic ids to the registry methods
- \`centerOf(id)\` falls back to the registry when a via id isn't in \`diagram.nodes\`
- \`cableSegmentLengths\` / \`visibleCableSegments\` / \`cableLengthMeters\` accept an optional \`terminations\` arg and merge via a unified \`viaLookup\` shadow Map
- \`NodeRoutingModal\` lists terminations from the registry directly (the prior parent-subgraph scope filter is moot — registry is global)
- Auto-outlet flow rewritten to write to / read from the registry via the new methods. \`Termination.metadata\` added so the \`{ autoFor }\` tag has a home.

## What's now true

- \`diagram.nodes\` contains only logical entities (devices)
- \`exportGraph\` JSON is clean — no scene-only artifacts
- Diagram view has nothing to filter — terminations literally aren't there
- BOM Equipment doesn't list EPS/Outlet rows
- All scene UX (place / drag / rename / route through EPS / auto-outlets) keeps working through the new primitives

## Test plan

- [x] Migration: 6/6 unit tests pass — lifts EPS/Outlet/Panel, recovers scene positions, strips orphan placements, leaves bends alone, idempotent
- [x] biome clean, svelte-check 0 errors
- [ ] Load existing project with EPS / Outlet Nodes → migration converts them, scene rendering identical
- [ ] Place a new EPS on a scene → appears with auto-numbered label, draggable
- [ ] Rename an EPS via the toolbar → label saved in registry, visible across scenes
- [ ] Route a wire through an EPS (NodeRoutingModal) → auto-outlet created, link.via updated
- [ ] Uncheck routing → auto-outlet removed, link.via cleaned
- [ ] Delete an EPS (Backspace) → registry entry removed, link.via entries stripped
- [ ] Save → reload: round-trip stable, second migration pass is a no-op
- [ ] JSON export, BOM Equipment section no longer contain EPS / Outlet / Panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)