### PR TITLE
fix(server-web): show node labels in diagram tooltips and modals

### DIFF
--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -10,12 +10,19 @@
     }
   }
 
+  export interface ConnectedLinkEndpoint {
+    /** Node id (used to match against metrics / mapping data). */
+    id: string
+    /** Human-readable node label (falls back to id when no label is set). */
+    label: string
+  }
+
   export interface NodeSelectEvent {
     node: NodeInfo
     connectedLinks: Array<{
       id: string
-      from: string
-      to: string
+      from: ConnectedLinkEndpoint
+      to: ConnectedLinkEndpoint
       standard?: string
     }>
   }
@@ -73,6 +80,7 @@
   } from '$lib/stores'
   import { resolvedTheme } from '$lib/stores/theme'
   import { formatTraffic } from '$lib/utils/format'
+  import { nodeLabel, nodeLabelById } from '$lib/utils/node-label'
   import { getUtilizationColor } from '$lib/weathermap'
 
   // --- Props (Svelte 5 runes) ---
@@ -188,6 +196,7 @@
     if (!graph || !onNodeSelect) return
     const node = graph.nodes.find((n) => n.id === nodeId)
     if (!node) return
+    const nodes = graph.nodes
     const connectedLinks = graph.links
       .filter((l) => {
         const from = typeof l.from === 'string' ? l.from : l.from.node
@@ -195,20 +204,19 @@
         return from === nodeId || to === nodeId
       })
       .map((l) => {
-        const from = l.from.node
-        const to = l.to.node
+        const fromId = l.from.node
+        const toId = l.to.node
         return {
-          id: l.id ?? `${from}->${to}`,
-          from,
-          to,
+          id: l.id ?? `${fromId}->${toId}`,
+          from: { id: fromId, label: nodeLabelById(nodes, fromId) },
+          to: { id: toId, label: nodeLabelById(nodes, toId) },
           standard: l.from.plug?.module?.standard ?? l.to.plug?.module?.standard,
         }
       })
-    const nodeLabel = Array.isArray(node.label) ? node.label.join(' ') : (node.label ?? node.id)
     onNodeSelect({
       node: {
         id: node.id,
-        label: nodeLabel,
+        label: nodeLabel(node),
         spec: node.spec
           ? {
               type: 'type' in node.spec ? node.spec.type : undefined,
@@ -251,9 +259,7 @@
 
   function buildTooltip(hovered: HoveredElement, g: NetworkGraph): string {
     if (hovered.kind === 'node') {
-      const n = g.nodes.find((x) => x.id === hovered.id)
-      const label = Array.isArray(n?.label) ? n?.label.join(' / ') : n?.label
-      return `<strong>${escapeHtml(label ?? hovered.id)}</strong>`
+      return `<strong>${escapeHtml(nodeLabelById(g.nodes, hovered.id))}</strong>`
     }
     if (hovered.kind === 'subgraph') {
       const sg = g.subgraphs?.find((x) => x.id === hovered.id)
@@ -262,8 +268,8 @@
     // Link: show endpoints + live metrics if available
     const link = g.links.find((x) => x.id === hovered.id)
     if (!link) return `<strong>${escapeHtml(hovered.id)}</strong>`
-    const from = link.from.node
-    const to = link.to.node
+    const from = nodeLabelById(g.nodes, link.from.node)
+    const to = nodeLabelById(g.nodes, link.to.node)
     let out = `<strong>${escapeHtml(from)} → ${escapeHtml(to)}</strong>`
     const std = link.from.plug?.module?.standard ?? link.to.plug?.module?.standard
     if (std) out += `<br><span class="muted">Standard: ${escapeHtml(String(std))}</span>`

--- a/apps/server/web/src/lib/components/NodeMappingModal.svelte
+++ b/apps/server/web/src/lib/components/NodeMappingModal.svelte
@@ -340,7 +340,7 @@
               </div>
               <div class="border rounded-lg divide-y max-h-48 overflow-y-auto">
                 {#each nodeData.connectedLinks as link}
-                  {@const isFrom = link.from === nodeData.node.id}
+                  {@const isFrom = link.from.id === nodeData.node.id}
                   {@const otherNode = isFrom ? link.to : link.from}
                   {@const metrics = linkMetricsMap[link.id]}
                   <div class="p-3 space-y-1">
@@ -350,7 +350,7 @@
                           class="w-2 h-2 rounded-full {getStatusBgColor(metrics?.status)}"
                         ></span>
                         {isFrom ? '→' : '←'}
-                        {otherNode}
+                        {otherNode.label}
                       </span>
                       {#if link.standard}
                         <span class="text-xs text-muted-foreground">{link.standard}</span>

--- a/apps/server/web/src/lib/utils/node-label.ts
+++ b/apps/server/web/src/lib/utils/node-label.ts
@@ -1,0 +1,27 @@
+/**
+ * Resolve a topology node to a human-readable label.
+ *
+ * Node labels can be a string, a string array (multi-line label), or
+ * missing entirely. Callers that want a single-line summary should use
+ * this helper instead of reading `node.label` directly — keeps the
+ * "fall back to id" rule in one place.
+ */
+
+interface NodeLike {
+  id: string
+  label?: string | string[]
+}
+
+/** One-line display name for a node. Empty/missing labels fall back to id. */
+export function nodeLabel(node: NodeLike | undefined | null): string {
+  if (!node) return ''
+  const raw = Array.isArray(node.label) ? node.label.join(' ') : node.label
+  return raw && raw.length > 0 ? raw : node.id
+}
+
+/** Look up a node by id and return its label. Returns the id if not found. */
+export function nodeLabelById(nodes: ReadonlyArray<NodeLike> | undefined, nodeId: string): string {
+  if (!nodes) return nodeId
+  const found = nodes.find((n) => n.id === nodeId)
+  return found ? nodeLabel(found) : nodeId
+}

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -42,6 +42,7 @@
     TopologyDataSource,
     TopologyDataSourceInput,
   } from '$lib/types'
+  import { nodeLabelById, nodeLabel as resolveNodeLabel } from '$lib/utils/node-label'
 
   // ============================================
   // State
@@ -594,20 +595,12 @@
   // Mapping Tab Functions
   // ============================================
 
-  function getNodeLabel(node: { label?: string | string[] }): string {
-    let label: string
-    if (Array.isArray(node.label)) {
-      label = node.label[0] || 'Unnamed'
-    } else {
-      label = node.label || 'Unnamed'
-    }
-    return label.replace(/<[^>]*>/g, '')
+  function getNodeLabel(node: { id: string; label?: string | string[] }): string {
+    return resolveNodeLabel(node)
   }
 
   function getNodeLabelById(nodeId: string): string {
-    const node = parsedTopology?.graph.nodes.find((n) => n.id === nodeId)
-    if (!node) return nodeId
-    return getNodeLabel(node)
+    return nodeLabelById(parsedTopology?.graph.nodes, nodeId)
   }
 
   function loadInterfacesForMappedNodes() {


### PR DESCRIPTION
## Summary

トポロジ詳細画面で、ノード参照が**生のID** (\`node-fvs4FRw02Z\` 等) のまま表示されてた箇所を label に統一する修正。

| 場所 | 修正前 | 修正後 |
|---|---|---|
| リンクホバー tooltip | \`node-XXX → node-YYY\` | \`foyer-sw02 → core-sw01\` |
| ノードクリックモーダルの connectedLinks | \`→ node-YYY\` | \`→ core-sw01\` |
| settings ページの edge 表示 | (動いてた) | 同じ util に統一 |

## 変更

- 新規 \`apps/server/web/src/lib/utils/node-label.ts\` に \`nodeLabel(node)\` / \`nodeLabelById(nodes, id)\` を切り出し
- ノード/ID解決ロジックが散らばってた3箇所 (InteractiveSvgDiagram の tooltip / event、settings) を全部この util に集約
- \`NodeSelectEvent.connectedLinks[].from/to\` を \`string\` → \`{ id, label }\` に変更 (consumer 側でルックアップ不要に)
- label 未設定の fallback は \`'Unnamed'\` ではなく id に変更 (壊れたグラフを目視で気づけるように)。元の HTML strip は他に例がなく過剰防御なので drop

## Test plan

- [ ] トポロジ画面でリンクにホバー → tooltip がノード**名前**で表示される
- [ ] ノードクリック → 接続モーダル \"Traffic\" 一覧の \`→ XXX\` 部分がノード名
- [ ] settings ページの mapping タブの edge 一覧表示が従来通り

🤖 Generated with [Claude Code](https://claude.com/claude-code)