### PR TITLE
fix(dashboard): restore alert→topology highlight + pan (host resolution, hover peek, click commit)

### DIFF
--- a/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
+++ b/apps/server/web/src/lib/components/topology/TopologyViewer.svelte
@@ -341,6 +341,18 @@
     return svgElement
   }
 
+  /** Snapshot the current camera transform so it can be restored later. */
+  export function getCameraTransform(): { x: number; y: number; k: number } | null {
+    return camera?.getTransform() ?? null
+  }
+
+  /** Restore a previously snapshotted transform (pan + zoom level). */
+  export function setCameraTransform(t: { x: number; y: number; k: number }): void {
+    if (!camera) return
+    camera.panTo(t.x, t.y)
+    camera.zoomTo(t.k)
+  }
+
   // Only constructed when the template branch below has already
   // checked that `graph` is defined, so the `graph!` non-null cast is
   // safe. This keeps ViewerContext's `graph` non-nullable for
@@ -400,16 +412,16 @@
   }
 
   /* Interaction gating via pointer-events on specific element types.
-                       Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
-                       propagation on the canvas background. d3-zoom's filter already
-                       handles wheel requiring ctrl/meta, but we also kill the background
-                       grid's clickability when selection is off. */
+                           Pan/zoom is wheel/drag-on-bg: we disable wheel by stopping
+                           propagation on the canvas background. d3-zoom's filter already
+                           handles wheel requiring ctrl/meta, but we also kill the background
+                           grid's clickability when selection is off. */
   .topology-viewer.no-panzoom :global(.canvas-bg) {
     pointer-events: none;
   }
 
   /* LOD: toggleable ornament classes. Rules match @shumoku/renderer's
-                       output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
+                           output structure (see SvgPort.svelte, SvgEdge.svelte, etc.). */
   .topology-viewer.hide-port-labels :global(.port-label),
   .topology-viewer.hide-port-labels :global(.port-label-bg) {
     display: none;

--- a/apps/server/web/src/lib/stores/widgetEvents.ts
+++ b/apps/server/web/src/lib/stores/widgetEvents.ts
@@ -15,6 +15,7 @@ export type WidgetEventType =
   | 'clear-highlight'
   | 'highlight-nodes'
   | 'highlight-by-attribute'
+  | 'restore-camera'
 
 /**
  * Widget event payload
@@ -26,6 +27,11 @@ export interface WidgetEvent {
     topologyId: string
     /** Target node ID (for single-node events) */
     nodeId?: string
+    /**
+     * Target monitoring host name (single-node events). Resolved to a node id
+     * via the topology's mapping. Use this when the emitter only knows hosts.
+     */
+    host?: string
     /** Target node IDs (for multi-node events) */
     nodeIds?: string[]
     /**
@@ -43,6 +49,11 @@ export interface WidgetEvent {
     duration?: number
     /** Custom highlight color (CSS color string) */
     highlightColor?: string
+    /**
+     * Transient zoom: receiver snapshots the camera before panning so a later
+     * `restore-camera` event can roll back. Use for hover-style previews.
+     */
+    transient?: boolean
     /** Source widget ID that triggered the event */
     sourceWidgetId?: string
   }
@@ -118,6 +129,37 @@ export function emitZoomToNode(topologyId: string, nodeId: string, sourceWidgetI
   widgetEvents.emit({
     type: 'zoom-to-node',
     payload: { topologyId, nodeId, sourceWidgetId },
+  })
+}
+
+/**
+ * Zoom to the node mapped to a monitoring host. The receiving widget resolves
+ * the host via its mapping (mapping.nodes[].hostName).
+ *
+ * Pass `transient: true` (hover-style previews) so the receiver snapshots the
+ * camera before panning and a later `restore-camera` event rolls it back.
+ */
+export function emitZoomToHost(
+  topologyId: string,
+  host: string,
+  options?: { transient?: boolean; sourceWidgetId?: string },
+): void {
+  widgetEvents.emit({
+    type: 'zoom-to-node',
+    payload: {
+      topologyId,
+      host,
+      transient: options?.transient,
+      sourceWidgetId: options?.sourceWidgetId,
+    },
+  })
+}
+
+/** Roll back the camera to the last snapshot taken by a transient zoom. */
+export function emitRestoreCamera(topologyId: string, sourceWidgetId?: string): void {
+  widgetEvents.emit({
+    type: 'restore-camera',
+    payload: { topologyId, sourceWidgetId },
   })
 }
 

--- a/apps/server/web/src/lib/stores/widgetEvents.ts
+++ b/apps/server/web/src/lib/stores/widgetEvents.ts
@@ -28,6 +28,13 @@ export interface WidgetEvent {
     nodeId?: string
     /** Target node IDs (for multi-node events) */
     nodeIds?: string[]
+    /**
+     * Target monitoring host names. The receiving topology resolves these to
+     * node ids via its own mapping (mapping.nodes[].hostName). Use this when
+     * the emitter only knows about hosts (e.g. AlertWidget) and isn't aware
+     * of per-topology node ids.
+     */
+    hosts?: string[]
     /** Attribute filter (for attribute-based highlight) */
     attribute?: { key: string; value: string }
     /** Enable spotlight (dim non-highlighted nodes) */
@@ -157,6 +164,34 @@ export function emitHighlightNodes(
     payload: {
       topologyId,
       nodeIds,
+      spotlight: options?.spotlight,
+      duration: options?.duration,
+      highlightColor: options?.highlightColor,
+      sourceWidgetId: options?.sourceWidgetId,
+    },
+  })
+}
+
+/**
+ * Highlight nodes by their mapped monitoring host name. The receiving widget
+ * resolves hosts to node ids via its topology's mapping. Use this from
+ * widgets that only know hosts (e.g. AlertWidget).
+ */
+export function emitHighlightHosts(
+  topologyId: string,
+  hosts: string[],
+  options?: {
+    spotlight?: boolean
+    duration?: number
+    highlightColor?: string
+    sourceWidgetId?: string
+  },
+): void {
+  widgetEvents.emit({
+    type: 'highlight-nodes',
+    payload: {
+      topologyId,
+      hosts,
       spotlight: options?.spotlight,
       duration: options?.duration,
       highlightColor: options?.highlightColor,

--- a/apps/server/web/src/lib/widgets/AlertWidget.svelte
+++ b/apps/server/web/src/lib/widgets/AlertWidget.svelte
@@ -13,7 +13,7 @@
   import { api } from '$lib/api'
   import * as Dialog from '$lib/components/ui/dialog'
   import { currentLayout, dashboardStore } from '$lib/stores/dashboards'
-  import { emitClearHighlight, emitHighlightNodes } from '$lib/stores/widgetEvents'
+  import { emitClearHighlight, emitHighlightHosts } from '$lib/stores/widgetEvents'
   import type { Alert, AlertSeverity, DataSource } from '$lib/types'
   import WidgetWrapper from './WidgetWrapper.svelte'
 
@@ -183,7 +183,7 @@
           if (newHosts.length > 0) {
             forEachTopology((tid) => emitClearHighlight(tid, id))
             forEachTopology((tid) =>
-              emitHighlightNodes(tid, newHosts, {
+              emitHighlightHosts(tid, newHosts, {
                 duration: 15000,
                 highlightColor: SEVERITY_HIGHLIGHT_COLORS[highestSeverity],
                 sourceWidgetId: id,
@@ -224,7 +224,7 @@
 
     forEachTopology((tid) => emitClearHighlight(tid, id))
     forEachTopology((tid) =>
-      emitHighlightNodes(tid, [host], {
+      emitHighlightHosts(tid, [host], {
         highlightColor: SEVERITY_HIGHLIGHT_COLORS[severity],
         sourceWidgetId: id,
       }),
@@ -235,7 +235,7 @@
     if (!alert.host) return
     const host = alert.host
     forEachTopology((tid) =>
-      emitHighlightNodes(tid, [host], {
+      emitHighlightHosts(tid, [host], {
         highlightColor: SEVERITY_HIGHLIGHT_COLORS[alert.severity],
         sourceWidgetId: id,
       }),

--- a/apps/server/web/src/lib/widgets/AlertWidget.svelte
+++ b/apps/server/web/src/lib/widgets/AlertWidget.svelte
@@ -13,7 +13,12 @@
   import { api } from '$lib/api'
   import * as Dialog from '$lib/components/ui/dialog'
   import { currentLayout, dashboardStore } from '$lib/stores/dashboards'
-  import { emitClearHighlight, emitHighlightHosts } from '$lib/stores/widgetEvents'
+  import {
+    emitClearHighlight,
+    emitHighlightHosts,
+    emitRestoreCamera,
+    emitZoomToHost,
+  } from '$lib/stores/widgetEvents'
   import type { Alert, AlertSeverity, DataSource } from '$lib/types'
   import WidgetWrapper from './WidgetWrapper.svelte'
 
@@ -234,22 +239,38 @@
   function handleAlertHover(alert: Alert) {
     if (!alert.host) return
     const host = alert.host
-    forEachTopology((tid) =>
+    forEachTopology((tid) => {
       emitHighlightHosts(tid, [host], {
         highlightColor: SEVERITY_HIGHLIGHT_COLORS[alert.severity],
         sourceWidgetId: id,
-      }),
-    )
+      })
+      // Peek the node — TopologyWidget snapshots the camera so leaving the
+      // alert row rolls it back.
+      emitZoomToHost(tid, host, { transient: true, sourceWidgetId: id })
+    })
   }
 
   function handleAlertLeave() {
     if (showDetailModal) return
+    // Roll back the transient peek-zoom from handleAlertHover regardless of
+    // pin mode (camera is independent of which highlight is active).
+    forEachTopology((tid) => emitRestoreCamera(tid, id))
     if (config.persistHighlight) {
       // Restore pinned alert highlight
       emitPinnedHighlight()
       return
     }
     forEachTopology((tid) => emitClearHighlight(tid, id))
+  }
+
+  function handleAlertClick(alert: Alert) {
+    selectedAlert = alert
+    showDetailModal = true
+    if (!alert.host) return
+    const host = alert.host
+    // Non-transient (committed) zoom — TopologyWidget drops the prior hover
+    // snapshot so the view stays put after the modal is dismissed.
+    forEachTopology((tid) => emitZoomToHost(tid, host, { sourceWidgetId: id }))
   }
 
   function handleRefresh() {
@@ -408,7 +429,7 @@
               class="w-full text-left p-2 rounded transition-colors cursor-pointer hover:brightness-90 {getAlertBgColor(
                 alert
               )}"
-              onclick={() => { selectedAlert = alert; showDetailModal = true }}
+              onclick={() => handleAlertClick(alert)}
               onmouseenter={() => handleAlertHover(alert)}
               onmouseleave={handleAlertLeave}
             >

--- a/apps/server/web/src/lib/widgets/TopologyWidget.svelte
+++ b/apps/server/web/src/lib/widgets/TopologyWidget.svelte
@@ -56,6 +56,9 @@
   let spotlight = $state(false)
   let highlightTimeout: ReturnType<typeof setTimeout> | null = null
   let unsubscribeEvents: (() => void) | null = null
+  let viewer = $state<TopologyViewer | null>(null)
+  /** Camera transform snapshot for transient zooms (hover previews). */
+  let savedTransform: { x: number; y: number; k: number } | null = null
 
   const currentTheme = $derived($resolvedTheme === 'dark' ? darkTheme : lightTheme)
   const editMode = $derived($dashboardEditMode)
@@ -137,9 +140,34 @@
       case 'highlight-node':
       case 'select-node':
       case 'zoom-to-node': {
-        const nodeId = event.payload.nodeId
+        // Resolve nodeId from either explicit nodeId or a host via mapping.
+        const nodeId =
+          event.payload.nodeId ??
+          (event.payload.host ? hostToNodeId.get(event.payload.host) : undefined)
         if (!nodeId) break
         applyHighlight(new Set([nodeId]), event.payload.duration ?? 3000)
+        if (event.type === 'zoom-to-node') {
+          if (event.payload.transient) {
+            // Snapshot only the first transient pan in a sequence so a chain
+            // of hovers restores to the pre-hover view, not the previous
+            // hover's target.
+            if (savedTransform === null) {
+              savedTransform = viewer?.getCameraTransform() ?? null
+            }
+          } else {
+            // Non-transient (committed) zoom — discard the snapshot so a
+            // later restore-camera doesn't unwind past this point.
+            savedTransform = null
+          }
+          viewer?.panToNode(nodeId)
+        }
+        break
+      }
+      case 'restore-camera': {
+        if (savedTransform) {
+          viewer?.setCameraTransform(savedTransform)
+          savedTransform = null
+        }
         break
       }
       case 'highlight-nodes': {
@@ -292,6 +320,7 @@
     {:else if rootGraph}
       <div class="h-full w-full relative group">
         <TopologyViewer
+          bind:this={viewer}
           graph={rootGraph}
           sheetId={config.sheetId || 'root'}
           theme={currentTheme}

--- a/apps/server/web/src/lib/widgets/TopologyWidget.svelte
+++ b/apps/server/web/src/lib/widgets/TopologyWidget.svelte
@@ -60,6 +60,28 @@
   const currentTheme = $derived($resolvedTheme === 'dark' ? darkTheme : lightTheme)
   const editMode = $derived($dashboardEditMode)
 
+  /**
+   * Reverse lookup: monitoring host name → topology node id. Built from the
+   * topology's saved mapping. Used to resolve cross-widget highlight events
+   * that arrive with hostnames (e.g. from AlertWidget) into node ids that
+   * HighlightOverlay can match against `data-id` in the SVG.
+   */
+  const hostToNodeId = $derived.by(() => {
+    const map = new Map<string, string>()
+    if (!topology?.mappingJson) return map
+    try {
+      const m = JSON.parse(topology.mappingJson) as {
+        nodes?: Record<string, { hostName?: string }>
+      }
+      for (const [nodeId, info] of Object.entries(m.nodes ?? {})) {
+        if (info?.hostName) map.set(info.hostName, nodeId)
+      }
+    } catch {
+      // ignore malformed mappingJson
+    }
+    return map
+  })
+
   async function loadTopologies() {
     try {
       topologies = await api.topologies.list()
@@ -121,11 +143,15 @@
         break
       }
       case 'highlight-nodes': {
-        const ids = event.payload.nodeIds
-        if (!ids?.length) break
+        const resolved = new Set<string>(event.payload.nodeIds ?? [])
+        for (const host of event.payload.hosts ?? []) {
+          const nodeId = hostToNodeId.get(host)
+          if (nodeId) resolved.add(nodeId)
+        }
+        if (resolved.size === 0) break
         highlightColor = event.payload.highlightColor
         spotlight = event.payload.spotlight ?? false
-        applyHighlight(new Set(ids), event.payload.duration)
+        applyHighlight(resolved, event.payload.duration)
         break
       }
       case 'clear-highlight':


### PR DESCRIPTION
## Summary

ダッシュボードの AlertWidget → TopologyWidget の連携が壊れていた問題の修正。

| 操作 | 修正前 | 修正後 |
|---|---|---|
| 新規アラート発生 | ノードが**光らない** | マッピング解決されてハイライト発火 |
| アラート行 hover | 何も起きない | ノードへパン+ハイライト |
| hover 解除 | — | カメラが元の位置・ズーム率に**自動復帰** |
| アラート行 click | モーダルだけ開く | パン+ハイライト + モーダル (元には戻らない) |

## 原因と背景

- **ハイライト**: AlertWidget が \`alert.host\` (Zabbix のホスト名) をそのまま node id として渡し、HighlightOverlay は \`g.node[data-id="...$"]\` で SVG ノードを検索。両者一致しないため silent fail。エディタが random node id を生成するようになって表面化。
- **ズーム**: 元々 \`0c8fd6c\` (2026-01) で実装されていた zoom-to-node 機能が、後のリファクタで \`applyHighlight\` 呼び出しのみに縮退してた (\`viewer.panToNode\` を呼ぶコードがそもそも残ってなかった)。

## 変更

### イベント payload
- \`hosts?: string[]\` / \`host?: string\` を payload に追加 → 受信側 (TopologyWidget) が \`topology.mappingJson\` でnodeIdに解決
- \`transient?: boolean\` フラグ → \`true\` ならカメラスナップショット保存 (hover preview向け)
- 新イベント \`restore-camera\` + ヘルパ \`emitHighlightHosts\` / \`emitZoomToHost\` / \`emitRestoreCamera\`

### TopologyViewer
- \`getCameraTransform()\` / \`setCameraTransform(t)\` 公開 (camera.getTransform + panTo+zoomTo のラッパ)

### TopologyWidget
- \`<TopologyViewer bind:this={viewer}>\` で参照保持
- \`hostToNodeId\` Map を \`\$derived\` で構築 (mappingJsonから)
- \`zoom-to-node\` ハンドラが本当にカメラを動かす + transient ⇒ snapshot、commit ⇒ snapshot破棄
- \`restore-camera\` ハンドラ追加

### AlertWidget
- hover: highlight + transient zoom
- leave: restore-camera + (pin/flash モードに応じた)highlight処理
- click: 名前付き \`handleAlertClick\` に整理、commit zoom + モーダル

## Test plan

事前: トポロジで該当ホストをノードにマッピング済みであること。

- [ ] 新規アラート発生 → ノードがパルスハイライト
- [ ] アラート行 hover → ノードへパン+ハイライト
- [ ] hover 解除 → 元のカメラ位置に戻る
- [ ] アラート行 click → パン + モーダル、閉じてもズーム維持
- [ ] persistHighlight ON でも上記が動く
- [ ] マッピング無いホストのアラート → 何も起きない (エラー無し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)