### PR TITLE
feat(node-status): split device state from monitoring health

### DIFF
--- a/apps/server/docs/topology-rendering.md
+++ b/apps/server/docs/topology-rendering.md
@@ -389,9 +389,10 @@ flowchart TD
   WMI["path.wm-overlay direction=in<br/>(WeathermapLinkOverlay)"]
   WMO["path.wm-overlay direction=out<br/>(WeathermapLinkOverlay)"]
   LH["path.link-hit"]
-  N["g.node<br/>+ .status-up/down/...<br/>+ .node-highlighted/dimmed"]
+  N["g.node<br/>+ .status-up/down/...<br/>+ .monitoring-healthy/failing/...<br/>+ .node-highlighted/dimmed"]
   NB["g.node-bg rect"]
   NF["g.node-fg<br/>(icon, label)"]
+  MB["g.shumoku-monitoring-badge<br/>(injected by NodeStatusOverlay)"]
   P["g.port<br/>(port box + label)"]
 
   SVG --> VP
@@ -405,6 +406,7 @@ flowchart TD
   VP --> N
   N --> NB
   N --> NF
+  N --> MB
   VP --> P
 ```
 
@@ -489,11 +491,18 @@ $effect(() => {
   if (!svgElement || !enabled) return
   const svg = svgElement
   for (const [id, meta] of Object.entries(status ?? {})) {
-    svg.querySelector(`g.node[data-id="${CSS.escape(id)}"]`)
-      ?.classList.add(`status-${meta.status}`)
+    const node = svg.querySelector(`g.node[data-id="${CSS.escape(id)}"]`)
+    if (!node) continue
+    // Device 状態 = 枠 (stroke)
+    node.classList.add(`status-${meta.status}`)
+    // Monitoring 健全性 = 角バッジ (separate SVG element)
+    if (meta.monitoring) {
+      node.classList.add(`monitoring-${meta.monitoring}`)
+      ensureBadge(node)  // <g class="shumoku-monitoring-badge"><circle/></g>
+    }
   }
   return () => {
-    /* clear classes on cleanup */
+    /* clear classes + remove badges on cleanup */
   }
 })
 ```
@@ -671,19 +680,35 @@ out lane:  offset = -laneOffset  (stroke 下半分)
 
 ### 6.2 Node Status(サイドカー、`<svelte:head>` で CSS 注入)
 
-**用途**: ノードに up/down/warning/degraded/unknown の状態色を反映。
+**用途**: ノードの状態を **3 軸独立** で可視化する。
+
+| 軸 | 意味 | どこに出る |
+|---|---|---|
+| **Mapping** | このノードがモニタリング側のホストに割り当て済みか | metrics 入力に entry が無ければ装飾なし |
+| **Device 状態** | 機材自体が up/down か (= ICMP 等の直接信号) | `g.node` に `status-*` クラス → 枠(stroke) |
+| **Monitoring 健全性** | 監視路自体が機能してるか (= データ収集できてるか) | `g.node` に `monitoring-*` クラス + 右下に小バッジ inject |
+
+3 軸が独立してるので、`status-up + monitoring-paused`(動いてるけど
+メンテ中で値は捨ててる)や `status-unknown + monitoring-failing`
+(監視到達不能、機材状態は不明)のような状態が**互いに上書きせず**
+共存する。
 
 **入力**:
 - `svgElement: SVGSVGElement`
-- `status: Record<nodeId, { status: string }>`
+- `status: Record<nodeId, { status: string; monitoring?: string }>`
 - `allowedStatuses?` (default: `['up', 'down', 'unknown', 'warning', 'degraded']`)
 
-**DOM 操作**: 各 `g.node[data-id]` に `status-up` / `status-down` 等の
-クラスを付与。要素自体は作らない、classList 操作だけ。
+**DOM 操作**:
+- 各 `g.node[data-id]` に `status-*` と `monitoring-*` のクラスを付与
+- `monitoring-*` が付くノードには `<g class="shumoku-monitoring-badge">`
+  を append。中身は `<circle r=5>` 一枚で、右下角に `transform` で
+  位置決め。塗り色は CSS が `monitoring-*` クラスから決める
+- バッジは冪等に再利用(re-render で要素が増えない)、cleanup で削除
 
 **CSS**(`<svelte:head>` で `<style id="shumoku-node-status-css">` を注入):
 
 ```css
+/* === Device 状態 (枠) === */
 g.node.status-up    .node-bg rect { stroke: #22c55e; stroke-width: 2px; }
 g.node.status-down  .node-bg rect {
   stroke: #ef4444; stroke-width: 2.5px;
@@ -693,13 +718,45 @@ g.node.status-down  .node-bg rect {
 g.node.status-warning  .node-bg rect { stroke: #f97316; ... }
 g.node.status-degraded .node-bg rect { stroke: #eab308; ... }
 g.node.status-unknown  .node-bg rect { stroke: #6b7280; stroke-dasharray: 4 3; }
+
+/* === Monitoring 健全性 (角バッジ) === */
+g.node g.shumoku-monitoring-badge { pointer-events: none; }
+g.node g.shumoku-monitoring-badge circle { stroke: #fff; stroke-width: 1.5; }
+g.node.monitoring-healthy g.shumoku-monitoring-badge circle { fill: #22c55e; }
+g.node.monitoring-failing g.shumoku-monitoring-badge circle { fill: #ef4444; }
+g.node.monitoring-pending g.shumoku-monitoring-badge circle { fill: #9ca3af; }
+g.node.monitoring-paused  g.shumoku-monitoring-badge circle { fill: #3b82f6; }
 ```
+
+CSS セレクタが `.node-bg rect`(枠側)と `g.shumoku-monitoring-badge circle`
+(バッジ側)で完全に分離してるので、片方の rule が片方を上書きしない。
 
 `<svelte:head>` 注入を使う理由は、複数の Svelte コンポーネントが
 同じ rule 集合を共有するため(scoped style だと各コンポーネントで
 重複定義になる)。
 
-`@media print` と `prefers-reduced-motion` も同じ block で扱う。
+`@media print` と `prefers-reduced-motion` も同じ block で扱う
+(バッジは print 時に `display: none`)。
+
+#### プラグイン契約
+
+プラグインが返す `NodeMetrics`(`@shumoku/core` の `plugin-types.ts`):
+
+```ts
+{
+  status: 'up' | 'down' | 'unknown' | 'warning' | 'degraded'
+  monitoring?: 'healthy' | 'failing' | 'pending' | 'paused'
+  monitoringError?: string  // failing 時に "なぜ失敗したか" を残す
+  lastSeen?: number
+}
+```
+
+`monitoring` は optional。プラグインが対応してない場合 undefined を
+返してOK(その場合はバッジが出ず、枠だけで表現される)。
+
+`unmapped` は entry を**そもそも作らない**ことで表現する
+(オーバーレイは entry の無いノードに対しては何もしない)。「mapped
+だけど不明」と「mapped されてない」を視覚的に区別できる。
 
 ### 6.3 Highlight(サイドカー、reactive + imperative)
 

--- a/apps/server/web/src/lib/components/NodeMappingModal.svelte
+++ b/apps/server/web/src/lib/components/NodeMappingModal.svelte
@@ -243,6 +243,62 @@
     }
   }
 
+  function getDeviceLabel(status: string | undefined): string {
+    switch (status) {
+      case 'up':
+        return 'Up'
+      case 'down':
+        return 'Down'
+      default:
+        return 'Unknown'
+    }
+  }
+
+  // ----- Monitoring health (orthogonal to device status) ------------------
+
+  function getMonitoringBgColor(monitoring: string | undefined): string {
+    switch (monitoring) {
+      case 'healthy':
+        return 'bg-success'
+      case 'failing':
+        return 'bg-destructive'
+      case 'paused':
+        return 'bg-info'
+      case 'pending':
+        return 'bg-muted-foreground'
+      default:
+        return 'bg-muted-foreground'
+    }
+  }
+
+  function getMonitoringTextColor(monitoring: string | undefined): string {
+    switch (monitoring) {
+      case 'healthy':
+        return 'text-success'
+      case 'failing':
+        return 'text-destructive'
+      case 'paused':
+        return 'text-info'
+      default:
+        return 'text-muted-foreground'
+    }
+  }
+
+  function getMonitoringLabel(monitoring: string | undefined): string {
+    switch (monitoring) {
+      case 'healthy':
+        return 'Healthy'
+      case 'failing':
+        return 'Failing'
+      case 'pending':
+        return 'Pending'
+      case 'paused':
+        return 'Paused'
+      default:
+        return '—'
+    }
+  }
+
   function stripHtmlTags(text: string | undefined): string {
     if (!text) return ''
     return text.replace(/<[^>]*>/g, '')
@@ -272,25 +328,12 @@
         <div class="space-y-4">
           <!-- Node Info & Status -->
           <div class="bg-muted/50 rounded-lg p-4 space-y-3">
-            <!-- Status Row -->
+            <!-- Mapping row -->
             <div class="flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                <span
-                  class="w-2.5 h-2.5 rounded-full {getStatusBgColor(nodeMetrics?.status)}"
-                ></span>
-                <span class="font-medium {getStatusColor(nodeMetrics?.status)}">
-                  {#if nodeMetrics?.status === 'up'}
-                    Up
-                  {:else if nodeMetrics?.status === 'down'}
-                    Down
-                  {:else}
-                    Unknown
-                  {/if}
-                </span>
-              </div>
+              <span class="text-xs uppercase tracking-wide text-muted-foreground">Mapping</span>
               {#if currentNodeMapping?.hostId}
-                <span class="text-xs text-muted-foreground">
-                  Mapped to: {currentNodeMapping.hostName || currentNodeMapping.hostId}
+                <span class="text-xs text-foreground">
+                  {currentNodeMapping.hostName || currentNodeMapping.hostId}
                 </span>
               {:else}
                 <span class="inline-flex items-center gap-1 text-xs text-warning">
@@ -299,6 +342,50 @@
                 </span>
               {/if}
             </div>
+
+            <!-- Device status row -->
+            <div class="flex items-center justify-between">
+              <span class="text-xs uppercase tracking-wide text-muted-foreground">Device</span>
+              <div class="flex items-center gap-2">
+                <span
+                  class="w-2.5 h-2.5 rounded-full {getStatusBgColor(nodeMetrics?.status)}"
+                ></span>
+                <span class="text-sm font-medium {getStatusColor(nodeMetrics?.status)}">
+                  {getDeviceLabel(nodeMetrics?.status)}
+                </span>
+              </div>
+            </div>
+
+            <!-- Monitoring health row (orthogonal to device) -->
+            {#if currentNodeMapping?.hostId}
+              <div class="flex items-center justify-between">
+                <span class="text-xs uppercase tracking-wide text-muted-foreground">
+                  Monitoring
+                </span>
+                <div class="flex flex-col items-end gap-0.5">
+                  <div class="flex items-center gap-2">
+                    <span
+                      class="w-2.5 h-2.5 rounded-full {getMonitoringBgColor(
+                        nodeMetrics?.monitoring,
+                      )}"
+                    ></span>
+                    <span
+                      class="text-sm font-medium {getMonitoringTextColor(nodeMetrics?.monitoring)}"
+                    >
+                      {getMonitoringLabel(nodeMetrics?.monitoring)}
+                    </span>
+                  </div>
+                  {#if nodeMetrics?.monitoringError}
+                    <span
+                      class="text-xs text-muted-foreground max-w-[16rem] truncate"
+                      title={nodeMetrics.monitoringError}
+                    >
+                      {nodeMetrics.monitoringError}
+                    </span>
+                  {/if}
+                </div>
+              </div>
+            {/if}
 
             <!-- Device Info -->
             <div class="flex flex-wrap gap-2 text-xs text-muted-foreground">

--- a/apps/server/web/src/lib/components/topology/NodeStatusOverlay.svelte
+++ b/apps/server/web/src/lib/components/topology/NodeStatusOverlay.svelte
@@ -1,15 +1,21 @@
 <script lang="ts">
   /**
-   * NodeStatusOverlay — paints up/down/unknown status classes onto
-   * node <g> elements based on live metrics. Pairs with styling in
-   * the host container (e.g. `g.node.status-down .node-bg rect { ... }`).
+   * NodeStatusOverlay — visualises two orthogonal signals per node:
    *
-   * No rendering of its own — this overlay is essentially a reactive
-   * classList manager.
+   *   1. Device status   → `status-{up,down,warning,degraded,unknown}` class
+   *                        on `g.node`. Styled via the node-bg rect border.
+   *   2. Monitoring path → `monitoring-{healthy,failing,pending,paused}`
+   *                        class + an injected corner badge so it doesn't
+   *                        compete with the device status for visual real
+   *                        estate.
+   *
+   * The two are independent — a node can be `status-up` (data flowing) and
+   * `monitoring-paused` (operator put it in maintenance), for instance.
    */
 
   interface NodeMetricsLike {
     status: string
+    monitoring?: string
   }
 
   interface Props {
@@ -21,13 +27,45 @@
   }
 
   const DEFAULT_STATUSES: readonly string[] = ['up', 'down', 'unknown', 'warning', 'degraded']
+  const MONITORING_STATES: readonly string[] = ['healthy', 'failing', 'pending', 'paused']
+  const BADGE_CLASS = 'shumoku-monitoring-badge'
+  const SVG_NS = 'http://www.w3.org/2000/svg'
 
   let { svgElement, status, enabled = true, allowedStatuses = DEFAULT_STATUSES }: Props = $props()
 
+  function clearNode(node: Element) {
+    for (const s of allowedStatuses) node.classList.remove(`status-${s}`)
+    for (const m of MONITORING_STATES) node.classList.remove(`monitoring-${m}`)
+    node.querySelector(`g.${BADGE_CLASS}`)?.remove()
+  }
+
   function clearAll(svg: SVGSVGElement) {
-    for (const node of svg.querySelectorAll('g.node')) {
-      for (const s of allowedStatuses) node.classList.remove(`status-${s}`)
+    for (const node of svg.querySelectorAll('g.node')) clearNode(node)
+  }
+
+  /**
+   * Place a small status dot at the top-right of the node's bounding rect.
+   * Idempotent: re-uses an existing badge so we don't accumulate elements
+   * across re-renders. Hidden by default; CSS shows it when the parent has
+   * a non-healthy `monitoring-*` class.
+   */
+  function ensureBadge(node: Element): void {
+    const rect = node.querySelector<SVGRectElement>('.node-bg rect')
+    if (!rect) return
+    const x = Number.parseFloat(rect.getAttribute('x') ?? '0')
+    const y = Number.parseFloat(rect.getAttribute('y') ?? '0')
+    const w = Number.parseFloat(rect.getAttribute('width') ?? '0')
+
+    let badge = node.querySelector<SVGGElement>(`g.${BADGE_CLASS}`)
+    if (!badge) {
+      badge = document.createElementNS(SVG_NS, 'g')
+      badge.setAttribute('class', BADGE_CLASS)
+      const circle = document.createElementNS(SVG_NS, 'circle')
+      circle.setAttribute('r', '5')
+      badge.appendChild(circle)
+      node.appendChild(badge)
     }
+    badge.setAttribute('transform', `translate(${x + w - 4}, ${y + 4})`)
   }
 
   $effect(() => {
@@ -39,8 +77,6 @@
       return
     }
 
-    // Apply current status. Skip over stale classes on nodes that
-    // have newly moved into an unknown category.
     clearAll(svg)
     for (const [id, meta] of Object.entries(status)) {
       const el = svg.querySelector(`g.node[data-id="${CSS.escape(id)}"]`)
@@ -48,20 +84,23 @@
       if (allowedStatuses.includes(meta.status)) {
         el.classList.add(`status-${meta.status}`)
       }
+      if (meta.monitoring && MONITORING_STATES.includes(meta.monitoring)) {
+        el.classList.add(`monitoring-${meta.monitoring}`)
+        // Always draw the badge — visual structure stays consistent across
+        // nodes, so the operator's eye is trained on the same spot.
+        ensureBadge(el)
+      }
     }
 
-    // Cleanup on unmount / status change: only strip what we painted.
     return () => clearAll(svg)
   })
 </script>
 
-<!-- Status-class styling is co-located here so any consumer that mounts
-     this overlay gets the visuals automatically. The selectors target
-     the renderer's `g.node > g.node-bg > rect` structure; CSS beats the
-     bare `stroke`/`stroke-width` SVG attributes the renderer writes,
-     so no inline-style mutation or !important is required here. -->
+<!-- Status-class + monitoring-badge styling co-located so any consumer that
+     mounts this overlay gets the visuals automatically. -->
 <svelte:head>
   {@html `<style id="shumoku-node-status-css">
+    /* === Device status (border on the node-bg rect) === */
     g.node.status-up .node-bg rect {
       stroke: #22c55e;
       stroke-width: 2px;
@@ -85,6 +124,18 @@
       stroke-width: 2px;
       stroke-dasharray: 4 3;
     }
+    /* === Monitoring path (small corner badge) ===
+       Separate from device status so a node can be e.g. status-up +
+       monitoring-paused without one signal overwriting the other. */
+    g.node g.shumoku-monitoring-badge { pointer-events: none; }
+    g.node g.shumoku-monitoring-badge circle {
+      stroke: #ffffff;
+      stroke-width: 1.5;
+    }
+    g.node.monitoring-healthy g.shumoku-monitoring-badge circle { fill: #22c55e; }
+    g.node.monitoring-failing g.shumoku-monitoring-badge circle { fill: #ef4444; }
+    g.node.monitoring-pending g.shumoku-monitoring-badge circle { fill: #9ca3af; }
+    g.node.monitoring-paused g.shumoku-monitoring-badge circle { fill: #3b82f6; }
     @keyframes shumoku-status-down-pulse {
       from { opacity: 1; }
       to   { opacity: 0.55; }
@@ -99,6 +150,7 @@
         filter: none !important;
         animation: none !important;
       }
+      g.node g.shumoku-monitoring-badge { display: none; }
     }
   </style>`}
 </svelte:head>

--- a/apps/server/web/src/lib/stores/metrics.ts
+++ b/apps/server/web/src/lib/stores/metrics.ts
@@ -9,8 +9,17 @@ import { derived, get, writable } from 'svelte/store'
 export type NodeStatus = 'up' | 'down' | 'unknown' | 'warning'
 export type EdgeStatus = 'up' | 'down' | 'unknown' | 'degraded'
 
+/** State of the monitoring path itself — see core plugin-types for details. */
+export type MonitoringHealth = 'healthy' | 'failing' | 'pending' | 'paused'
+
 export interface NodeMetrics {
   status: NodeStatus
+  /** Last time the host was confirmed reachable (epoch ms). */
+  lastSeen?: number
+  /** Whether monitoring is succeeding (orthogonal to device status). */
+  monitoring?: MonitoringHealth
+  /** Short reason when monitoring !== 'healthy' (e.g. SNMP timeout text). */
+  monitoringError?: string
 }
 
 export interface EdgeMetrics {

--- a/libs/@shumoku/core/src/plugin-types.ts
+++ b/libs/@shumoku/core/src/plugin-types.ts
@@ -111,8 +111,27 @@ export interface DataSourcePlugin {
  */
 export type MetricsStatus = 'up' | 'down' | 'unknown' | 'warning' | 'degraded'
 
+/**
+ * Health of the monitoring path itself — orthogonal to `status` (which is the
+ * device's operational state). Lets the UI distinguish "device is down" from
+ * "we can't reach the device to find out".
+ *
+ * - `healthy`: monitoring is collecting data
+ * - `failing`: monitoring has tried and explicitly failed (e.g. SNMP timeout,
+ *   agent unreachable). The reported `status` is best-effort.
+ * - `pending`: monitoring hasn't reached a verdict yet (e.g. host just added,
+ *   first poll not run, or backoff)
+ * - `paused`: monitoring intentionally muted by the operator (maintenance
+ *   window, host disabled). Not an error condition.
+ */
+export type MonitoringHealth = 'healthy' | 'failing' | 'pending' | 'paused'
+
 export interface NodeMetrics {
   status: MetricsStatus
+  /** State of the monitoring path (not the device). Omit if irrelevant. */
+  monitoring?: MonitoringHealth
+  /** Short human-readable reason when `monitoring !== 'healthy'`. */
+  monitoringError?: string
   cpu?: number
   memory?: number
   lastSeen?: number

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -20,6 +20,9 @@ import type {
   MetricsCapable,
   MetricsData,
   MetricsMapping,
+  MetricsStatus,
+  MonitoringHealth,
+  NodeMetrics,
 } from '@shumoku/core'
 import { addHttpWarning } from '@shumoku/core'
 import type { ZabbixHost, ZabbixItem, ZabbixPluginConfig } from './types.js'
@@ -28,6 +31,21 @@ import type { ZabbixHost, ZabbixItem, ZabbixPluginConfig } from './types.js'
 interface ZabbixLinkMapping extends LinkMetricsMapping {
   in?: string
   out?: string
+}
+
+/** Subset of item fields used by the health classifier. */
+interface HealthItem {
+  itemid: string
+  key_: string
+  lastclock: string
+  lastvalue: string
+}
+
+/** Subset of host fields used by the health classifier. */
+interface HostMeta {
+  hostid: string
+  maintenance_status?: string
+  interfaces?: Array<{ available: string; error?: string }>
 }
 
 export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapable, AlertsCapable {
@@ -81,20 +99,13 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
       timestamp: Date.now(),
     }
 
-    // Poll node metrics
+    // Poll node metrics. Unmapped nodes get no entry — "no data" = unmapped.
     for (const [nodeId, nodeMapping] of Object.entries(mapping.nodes || {})) {
-      if (nodeMapping.hostId) {
-        try {
-          const isAvailable = await this.getHostAvailability(nodeMapping.hostId)
-          metrics.nodes[nodeId] = {
-            status: isAvailable ? 'up' : 'down',
-            lastSeen: isAvailable ? Date.now() : undefined,
-          }
-        } catch {
-          metrics.nodes[nodeId] = { status: 'unknown' }
-        }
-      } else {
-        metrics.nodes[nodeId] = { status: 'unknown' }
+      if (!nodeMapping.hostId) continue
+      try {
+        metrics.nodes[nodeId] = await this.evaluateHostHealth(nodeMapping.hostId)
+      } catch {
+        metrics.nodes[nodeId] = { status: 'unknown', monitoring: 'pending' }
       }
     }
 
@@ -439,21 +450,123 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
     return result.result as T
   }
 
-  private async getHostAvailability(hostId: string): Promise<boolean> {
-    const items = await this.apiRequest<ZabbixItem[]>('item.get', {
-      output: ['itemid', 'key_', 'lastvalue'],
-      hostids: [hostId],
-      search: { key_: ['agent.ping', 'icmpping'] },
-      searchByAny: true,
-    })
+  /** Maximum staleness (seconds) for an item value to count as "fresh". */
+  private static readonly LIVE_DATA_WINDOW_SEC = 300
 
-    for (const item of items) {
-      if (item.lastvalue === '1') {
-        return true
-      }
+  /**
+   * Decide whether a Zabbix host is reachable.
+   *
+   * We treat the host as up when **any enabled item has fresh data** within
+   * the last few minutes. This is monitoring-style agnostic: Agent, SNMP,
+   * IPMI, and external scripts all stamp `lastclock` when they store a
+   * value, so we don't need separate logic per protocol.
+   *
+   * Earlier approaches were too narrow:
+   * - `agent.ping`/`icmpping` lookup: missed SNMP-only network gear which
+   *   has neither item, marking healthy switches as down.
+   * - Per-interface `available` flag: not reliably updated on SNMP-only
+   *   interfaces in some Zabbix configurations — interfaces stay at
+   *   "unknown" even while items poll successfully.
+   */
+  /**
+   * Compute a node's device-state + monitoring-path health by combining two
+   * independent signals from Zabbix.
+   *
+   *  - **Device state** is whether the equipment itself is responding. The
+   *    cleanest direct evidence is an ICMP-ping item value — non-zero =
+   *    reachable, zero = unreachable. Otherwise we infer `up` from any fresh
+   *    item data, and fall back to `unknown` when we have no evidence.
+   *  - **Monitoring path** is whether Zabbix can collect data at all. The
+   *    host's maintenance flag wins (operator-driven mute); otherwise we
+   *    read per-interface `available` (the same value Zabbix paints in its
+   *    own UI as the green/red/grey dot).
+   *
+   * Issued as two parallel API calls so a 50-host topology doesn't pay a
+   * sequential round-trip cost per node.
+   */
+  private async evaluateHostHealth(hostId: string): Promise<NodeMetrics> {
+    const [items, host] = await Promise.all([
+      this.fetchHealthItems(hostId),
+      this.fetchHostMeta(hostId),
+    ])
+    const nowSec = Math.floor(Date.now() / 1000)
+    const device = ZabbixPlugin.classifyDevice(items, nowSec)
+    const monitoring = ZabbixPlugin.classifyMonitoring(host, items, nowSec)
+    return {
+      status: device.status,
+      ...(device.lastSeen !== undefined && { lastSeen: device.lastSeen }),
+      monitoring: monitoring.health,
+      ...(monitoring.error !== undefined && { monitoringError: monitoring.error }),
     }
+  }
 
-    return false
+  // ---- Signal collection ------------------------------------------------
+
+  private async fetchHealthItems(hostId: string): Promise<HealthItem[]> {
+    return this.apiRequest<HealthItem[]>('item.get', {
+      output: ['itemid', 'key_', 'lastclock', 'lastvalue'],
+      hostids: [hostId],
+      filter: { status: '0', state: '0' },
+    })
+  }
+
+  private async fetchHostMeta(hostId: string): Promise<HostMeta | undefined> {
+    const hosts = await this.apiRequest<HostMeta[]>('host.get', {
+      output: ['hostid', 'maintenance_status'],
+      hostids: [hostId],
+      selectInterfaces: ['available', 'error'],
+    })
+    return hosts[0]
+  }
+
+  // ---- Pure classifiers -------------------------------------------------
+
+  /**
+   * Map raw items into a device-state verdict. ICMP ping is the strongest
+   * "device is alive / dead" signal we have — favour it when present.
+   */
+  private static classifyDevice(
+    items: HealthItem[],
+    nowSec: number,
+  ): { status: MetricsStatus; lastSeen?: number } {
+    const fresh = (t: string) => {
+      const n = Number(t)
+      return n > 0 && nowSec - n < ZabbixPlugin.LIVE_DATA_WINDOW_SEC
+    }
+    // 1. icmpping value of 0 from a recent poll = device unreachable.
+    const icmp = items.find((i) => i.key_ === 'icmpping' || i.key_.startsWith('icmpping['))
+    if (icmp && fresh(icmp.lastclock)) {
+      if (icmp.lastvalue === '0') return { status: 'down' }
+      if (icmp.lastvalue === '1') return { status: 'up', lastSeen: Date.now() }
+    }
+    // 2. Any other fresh data implies the device responded to monitoring,
+    //    so it must be alive even if we don't have a direct ICMP signal.
+    if (items.some((i) => fresh(i.lastclock))) {
+      return { status: 'up', lastSeen: Date.now() }
+    }
+    // 3. No evidence either way.
+    return { status: 'unknown' }
+  }
+
+  /**
+   * Map raw host info → monitoring-path health. Mirrors what Zabbix shows
+   * the operator in its host list (green/red/grey + "in maintenance").
+   */
+  private static classifyMonitoring(
+    host: HostMeta | undefined,
+    items: HealthItem[],
+    nowSec: number,
+  ): { health: MonitoringHealth; error?: string } {
+    if (host?.maintenance_status === '1') return { health: 'paused' }
+    const failingIface = host?.interfaces?.find((i) => i.available === '2')
+    if (failingIface) {
+      return { health: 'failing', error: failingIface.error || undefined }
+    }
+    const hasFreshData = items.some((i) => {
+      const t = Number(i.lastclock)
+      return t > 0 && nowSec - t < ZabbixPlugin.LIVE_DATA_WINDOW_SEC
+    })
+    return { health: hasFreshData ? 'healthy' : 'pending' }
   }
 
   private async getItemsByIds(itemIds: string[]): Promise<ZabbixItem[]> {


### PR DESCRIPTION
## Summary

ノードのステータス表示を **3軸独立** に分解。今までは1つの \`status\` 値に「機材状態」と「監視路状態」を詰め込んでいたため、Zabbixが到達できない（SNMPタイムアウト・メンテ中・未ポーリング）ホストを「機材自体が落ちてる」と同じ赤で塗っていて操作者にとって紛らわしかった。

| 軸 | 質問 | 表現 |
|---|---|---|
| **Mapping** | このノードはホストにマップ済み？ | metrics.nodes に entry があるか (entry無し=装飾なし) |
| **Device 状態** | 機材自体は up/down？ | \`status-*\` クラス → 枠 (stroke) |
| **Monitoring 健全性** | 監視路は機能してる？ | \`monitoring-*\` クラス → 角バッジ (右下に \`<circle>\` を inject) |

両軸は CSS セレクタで完全に分離されてるので互いに上書きしない (\`status-up + monitoring-paused\` のような状態が表現可能)。

## 変更内容

### \`@shumoku/core\` — 型拡張
- \`NodeMetrics\` に \`monitoring?: 'healthy' | 'failing' | 'pending' | 'paused'\` と \`monitoringError?: string\` を追加
- \`MonitoringHealth\` 型を新規エクスポート

### Zabbix プラグイン — 並列+classifier に refactor
- \`evaluateHostHealth()\`: \`item.get\` と \`host.get\` を **並列に発火**してから2つの純粋関数 (\`classifyDevice\` / \`classifyMonitoring\`) に流す
- **icmpping 検出を追加**: \`icmpping\` / \`icmpping[...]\` キーの値が \`'0'\` で新鮮なら \`status: 'down'\` を返す (これまで一度も \`down\` を出してなかった)
- \`host.maintenance_status === '1'\` → \`monitoring: 'paused'\`
- \`interface.available === '2'\` → \`monitoring: 'failing'\` + Zabbixのエラー文を \`monitoringError\` に転送
- unmapped なノードに entry を作らない (\`metrics.nodes\` から省略)

### \`NodeStatusOverlay.svelte\` — バッジ inject 機能
- 各 \`g.node\` の右上角に \`<g class=\"shumoku-monitoring-badge\"><circle/></g>\` を冪等に inject
- CSS で \`status-*\` (\`.node-bg rect\` stroke) と \`monitoring-*\` (\`g.shumoku-monitoring-badge circle\` fill) を分離スタイリング

### \`NodeMappingModal.svelte\` — UI 表記を3軸に分解
- 旧: 「Up」「Down」「Unknown」をピル1個で表示
- 新: \`Mapping / Device / Monitoring\` 3行ラベル、各々独立した色付きインジケータ + Monitoring に \`monitoringError\` 説明 (failingのときSNMPエラー文等)

### ドキュメント (\`apps/server/docs/topology-rendering.md §6.2\`)
- 3軸の説明、プラグイン契約、DOM 図、CSS サンプルを更新

## Test plan

- [ ] dev server 再起動 → トポロジ画面でモーダル開く → Mapping / Device / Monitoring 3行表示
- [ ] 正常ホスト → 緑枠 + 緑バッジ
- [ ] SNMPタイムアウト中ホスト → グレー破線枠 + 赤バッジ、モーダルで \"failing\" + SNMP error 文
- [ ] Zabbix側でホストを maintenance に → 青バッジ、モーダルで \"paused\"
- [ ] 未マッピングノード → 装飾なし
- [ ] icmpping=0 のホストがあれば → 赤枠+パルス (status=down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)