### PR TITLE
fix(node-status): trust ICMP, drop stale link metrics, preserve selection feedback

### DIFF
--- a/apps/server/web/src/lib/components/topology/NodeStatusOverlay.svelte
+++ b/apps/server/web/src/lib/components/topology/NodeStatusOverlay.svelte
@@ -100,26 +100,29 @@
      mounts this overlay gets the visuals automatically. -->
 <svelte:head>
   {@html `<style id="shumoku-node-status-css">
-    /* === Device status (border on the node-bg rect) === */
-    g.node.status-up .node-bg rect {
+    /* === Device status (border on the node-bg rect) ===
+       Suppressed when the node is selected so the renderer's selection
+       stroke (passed via the SVG attribute) stays visible — without this,
+       a colored node clicked by the operator gives no visual feedback. */
+    g.node.status-up:not(.selected) .node-bg rect {
       stroke: #22c55e;
       stroke-width: 2px;
     }
-    g.node.status-down .node-bg rect {
+    g.node.status-down:not(.selected) .node-bg rect {
       stroke: #ef4444;
       stroke-width: 2.5px;
       filter: drop-shadow(0 0 6px color-mix(in srgb, #ef4444 60%, transparent));
       animation: shumoku-status-down-pulse 1.6s ease-in-out infinite alternate;
     }
-    g.node.status-warning .node-bg rect {
+    g.node.status-warning:not(.selected) .node-bg rect {
       stroke: #f97316;
       stroke-width: 2px;
     }
-    g.node.status-degraded .node-bg rect {
+    g.node.status-degraded:not(.selected) .node-bg rect {
       stroke: #eab308;
       stroke-width: 2px;
     }
-    g.node.status-unknown .node-bg rect {
+    g.node.status-unknown:not(.selected) .node-bg rect {
       stroke: #6b7280;
       stroke-width: 2px;
       stroke-dasharray: 4 3;

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -148,7 +148,8 @@
 </script>
 
 <g
-  class={selected ? 'node selected' : 'node'}
+  class="node"
+  class:selected
   data-id={node.id}
   data-device-type={specDeviceType(node.spec) ?? ''}
   filter="url(#{shadowFilterId})"

--- a/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
@@ -74,7 +74,7 @@
   })
 </script>
 
-<g class={selected ? 'subgraph selected' : 'subgraph'} data-id={subgraph.id}>
+<g class="subgraph" class:selected data-id={subgraph.id}>
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
   <rect
     class="subgraph-bg"

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -130,16 +130,25 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
           const itemIds = [inItemId, outItemId].filter(Boolean) as string[]
           const items = await this.getItemsByIds(itemIds)
 
+          // Drop stale items — when a host goes unreachable Zabbix keeps the
+          // last polled value indefinitely. Without this check we'd paint
+          // utilization bars for a dead link from values minutes/hours old.
+          const nowSec = Math.floor(Date.now() / 1000)
           let inBps = 0
           let outBps = 0
-
+          let anyFresh = false
           for (const item of items) {
+            const lastclock = (item as ZabbixItem & { lastclock?: string }).lastclock ?? '0'
+            if (!ZabbixPlugin.isFreshClock(lastclock, nowSec)) continue
+            anyFresh = true
             const value = Number.parseFloat(item.lastvalue) || 0
-            if (item.itemid === inItemId) {
-              inBps = value
-            } else if (item.itemid === outItemId) {
-              outBps = value
-            }
+            if (item.itemid === inItemId) inBps = value
+            else if (item.itemid === outItemId) outBps = value
+          }
+
+          if (!anyFresh) {
+            metrics.links[linkId] = { status: 'unknown' }
+            continue
           }
 
           const capacity = linkMapping.bandwidth || 1_000_000_000
@@ -453,6 +462,25 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
   /** Maximum staleness (seconds) for an item value to count as "fresh". */
   private static readonly LIVE_DATA_WINDOW_SEC = 300
 
+  /** True iff a Zabbix `lastclock` timestamp falls within the freshness window. */
+  private static isFreshClock(lastclock: string, nowSec: number): boolean {
+    const t = Number(lastclock)
+    return t > 0 && nowSec - t < ZabbixPlugin.LIVE_DATA_WINDOW_SEC
+  }
+
+  /** Item keys produced by Zabbix's ICMP poller. */
+  private static isIcmpKey(key: string): boolean {
+    return key === 'icmpping' || key.startsWith('icmpping[')
+  }
+
+  /**
+   * Item keys whose `lastclock` reflects Zabbix server activity rather than
+   * the device responding. Excluded from "device is alive" inference.
+   */
+  private static isZabbixInternalKey(key: string): boolean {
+    return key.startsWith('zabbix[')
+  }
+
   /**
    * Decide whether a Zabbix host is reachable.
    *
@@ -522,26 +550,45 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
   // ---- Pure classifiers -------------------------------------------------
 
   /**
-   * Map raw items into a device-state verdict. ICMP ping is the strongest
-   * "device is alive / dead" signal we have — favour it when present.
+   * Map raw items into a device-state verdict.
+   *
+   * Rules in priority order:
+   *
+   * 1. **Fresh ICMP wins.** `icmpping=1` → up, `icmpping=0` → down.
+   *    Zabbix's own ICMP poller is the cleanest direct "the device is on
+   *    the network" signal — when it has a recent verdict, trust it over
+   *    anything else, including SNMP polls that may be returning cached or
+   *    Zabbix-internal data after the device disappeared.
+   * 2. **No ICMP, but real device data is fresh → up.** SNMP / agent items
+   *    polled *from* the device count, but we exclude `zabbix[...]` keys
+   *    (Zabbix server's internal metrics about the host, e.g. the
+   *    `zabbix[host,snmp,available]` flag) — those stay fresh even after
+   *    the device goes offline because they reflect the *poller's* state,
+   *    not the device's.
+   * 3. **No fresh signals at all → `unknown`.**
+   *
+   * Note: ICMP false-positive cases (ping filtered by ACL while SNMP works
+   * fine) are not handled here — the operator should disable / remove the
+   * misleading icmpping item if the device's ICMP is intentionally blocked.
    */
   private static classifyDevice(
     items: HealthItem[],
     nowSec: number,
   ): { status: MetricsStatus; lastSeen?: number } {
-    const fresh = (t: string) => {
-      const n = Number(t)
-      return n > 0 && nowSec - n < ZabbixPlugin.LIVE_DATA_WINDOW_SEC
+    const fresh = (i: HealthItem) => ZabbixPlugin.isFreshClock(i.lastclock, nowSec)
+    // 1. Fresh ICMP — authoritative.
+    const icmp = items.find((i) => ZabbixPlugin.isIcmpKey(i.key_) && fresh(i))
+    if (icmp) {
+      return icmp.lastvalue === '0' ? { status: 'down' } : { status: 'up', lastSeen: Date.now() }
     }
-    // 1. icmpping value of 0 from a recent poll = device unreachable.
-    const icmp = items.find((i) => i.key_ === 'icmpping' || i.key_.startsWith('icmpping['))
-    if (icmp && fresh(icmp.lastclock)) {
-      if (icmp.lastvalue === '0') return { status: 'down' }
-      if (icmp.lastvalue === '1') return { status: 'up', lastSeen: Date.now() }
-    }
-    // 2. Any other fresh data implies the device responded to monitoring,
-    //    so it must be alive even if we don't have a direct ICMP signal.
-    if (items.some((i) => fresh(i.lastclock))) {
+    // 2. No ICMP signal — fall back to any real device data, skipping Zabbix
+    //    server-internal items that don't actually prove the device is up.
+    if (
+      items.some(
+        (i) =>
+          !ZabbixPlugin.isIcmpKey(i.key_) && !ZabbixPlugin.isZabbixInternalKey(i.key_) && fresh(i),
+      )
+    ) {
       return { status: 'up', lastSeen: Date.now() }
     }
     // 3. No evidence either way.
@@ -562,10 +609,7 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
     if (failingIface) {
       return { health: 'failing', error: failingIface.error || undefined }
     }
-    const hasFreshData = items.some((i) => {
-      const t = Number(i.lastclock)
-      return t > 0 && nowSec - t < ZabbixPlugin.LIVE_DATA_WINDOW_SEC
-    })
+    const hasFreshData = items.some((i) => ZabbixPlugin.isFreshClock(i.lastclock, nowSec))
     return { health: hasFreshData ? 'healthy' : 'pending' }
   }
 


### PR DESCRIPTION
## Summary

直前の3軸split (#258) を実環境のZabbixで動かして見つかった3つの問題をまとめて修正。

### 1. ICMP が止まってる dead host が \"up\" に見えてた

\`classifyDevice\` が「ICMP以外の新鮮なitemがあれば up」と判定してた。が、Zabbix サーバ自身の内部 item (\`zabbix[host,snmp,available]\` 等) や、機器が死ぬ直前まで取れてた template item は **機器が落ちた後も** 数十秒〜数分 lastclock が新鮮なまま残る。結果、\`icmpping=0\` で明らかに死んでる host も緑になってた。

→ **ICMP が新鮮ならそれが authoritative** (1 → up、0 → down)。ICMP が無いとき初めて非ICMP itemにフォールバックし、その際 \`zabbix[...]\` 系内部 item は除外する。

### 2. dead link に古い traffic が出続けてた

リンクメトリクスのループが \`lastvalue\` だけ読んで \`lastclock\` を見てなかった。Zabbix は host 不通後も最後のサンプルを永続的に保持するので、死んだスイッチに繋がるリンクに \"31 Kbps in / 191 Kbps out\" が**何時間も**出続けてた。

→ \`LIVE_DATA_WINDOW_SEC\` (300s) で stale item を弾く。fresh なものが無ければ \`status: 'unknown'\` を返す。

### 3. 色付きノードをクリックすると色が消えて選択フィードバックも見えない

\`<g class={selected ? 'node selected' : 'node'}>\` がclass属性を**全置換**するため、\`NodeStatusOverlay\` が付けた \`status-*\` / \`monitoring-*\` / \`node-highlighted\` 等のクラスが全消えしてた。さらに status の CSS stroke が選択色を覆い隠してて、色付きノードのクリックフィードバック自体が見えなかった。

→ \`class:selected\` directive で他 class を保持。\`status-*\` セレクタは \`:not(.selected)\` でガードし、選択時は renderer の選択 stroke に明け渡す。

## 共通化 (refactor)

\`isFreshClock\` / \`isIcmpKey\` / \`isZabbixInternalKey\` を \`ZabbixPlugin\` の private static helpers に抽出。\`classifyDevice\`, \`classifyMonitoring\`, link polling の3箇所で重複してたチェックを1箇所に集約。

## Test plan

- [x] 実環境 Zabbix で \`icmpping=0\` の host が **down** 判定される (赤パルス枠)
- [x] dead link の traffic が **unknown** になる (0 Kbps 表示しない)
- [x] 色付きノードクリック → 選択色がちゃんと出る、デセレクトで status色に戻る (色が一瞬消えない)
- [ ] 色なしノードの選択挙動も従来通り
- [ ] 旧来の up/down セマンティクスが保たれる (icmpping無し host も SNMP item で up 判定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)