### PR TITLE
fix(editor): right-click no longer wipes the diagram selection

### DIFF
--- a/apps/editor/src/lib/state/diagram.replace-map.test.ts
+++ b/apps/editor/src/lib/state/diagram.replace-map.test.ts
@@ -1,0 +1,112 @@
+// Behavioural lock on `replaceMap`: it must reach the target shape
+// WITHOUT passing through a transient empty state. A clear-then-set
+// impl regresses the unmount-on-empty class of bugs (see PR #261 +
+// the follow-on root fix) — anyone reactive on map size would tear
+// down their state during the empty window.
+
+import { expect, test } from 'vitest'
+import { replaceMap } from './replace-map'
+
+test('does not pass through size === 0 when growing or replacing non-empty', () => {
+  const target = new Map<string, number>([
+    ['a', 1],
+    ['b', 2],
+  ])
+  const sizes: number[] = []
+  // Patch set/delete to record size after each mutation. (Map doesn't
+  // emit events; this is the closest we can observe without a
+  // SvelteMap dep.)
+  const origSet = target.set.bind(target)
+  const origDelete = target.delete.bind(target)
+  target.set = (k, v) => {
+    const r = origSet(k, v)
+    sizes.push(target.size)
+    return r
+  }
+  target.delete = (k) => {
+    const r = origDelete(k)
+    sizes.push(target.size)
+    return r
+  }
+
+  replaceMap(
+    target,
+    new Map([
+      ['a', 10], // existing → update in place
+      ['b', 20], // existing → update in place
+      ['c', 30], // new
+    ]),
+  )
+
+  expect([...target.entries()]).toEqual([
+    ['a', 10],
+    ['b', 20],
+    ['c', 30],
+  ])
+  // No observation should have seen size 0.
+  expect(sizes).not.toContain(0)
+  expect(Math.min(...sizes)).toBeGreaterThanOrEqual(2)
+})
+
+test('removes entries no longer in source', () => {
+  const target = new Map([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+  ])
+  replaceMap(target, new Map([['b', 22]]))
+  expect([...target.entries()]).toEqual([['b', 22]])
+})
+
+test('preserves insertion order for surviving keys', () => {
+  // Map.set on an existing key keeps the original position. We rely
+  // on this so keyed `{#each}` blocks don't churn when the diff is
+  // just an in-place update.
+  const target = new Map([
+    ['a', 1],
+    ['b', 2],
+    ['c', 3],
+  ])
+  replaceMap(
+    target,
+    new Map([
+      ['c', 33], // source-order changes, but...
+      ['a', 11],
+      ['b', 22],
+    ]),
+  )
+  expect([...target.keys()]).toEqual(['a', 'b', 'c'])
+})
+
+test('appends genuinely new keys at the tail in source order', () => {
+  const target = new Map([['a', 1]])
+  replaceMap(
+    target,
+    new Map([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ]),
+  )
+  expect([...target.keys()]).toEqual(['a', 'b', 'c'])
+})
+
+test('handles a truly empty source by emptying the target', () => {
+  // The intentional "empty everything" case still works — only the
+  // *transient* empty state is what we wanted to avoid.
+  const target = new Map([['a', 1]])
+  replaceMap(target, new Map())
+  expect(target.size).toBe(0)
+})
+
+test('accepts iterables that are not Maps', () => {
+  const target = new Map<string, number>()
+  replaceMap(target, [
+    ['a', 1],
+    ['b', 2],
+  ])
+  expect([...target.entries()]).toEqual([
+    ['a', 1],
+    ['b', 2],
+  ])
+})

--- a/apps/editor/src/lib/state/diagram.svelte.ts
+++ b/apps/editor/src/lib/state/diagram.svelte.ts
@@ -14,6 +14,7 @@ import {
   type Termination,
 } from '@shumoku/core'
 import { SvelteMap } from 'svelte/reactivity'
+import { replaceMap } from './replace-map'
 
 // Root diagram + sub-sheet mirror state. Pure store — primitives
 // only, no commit wrapping. Composer (`context.svelte.ts`) layers
@@ -81,14 +82,10 @@ export function currentSheetCacheGeneration() {
   return sheetCacheGeneration
 }
 
-/**
- * Replace the contents of a SvelteMap in place, preserving its
- * identity so bindings and downstream reactivity stay attached.
- */
-export function replaceMap<K, V>(target: Map<K, V>, source: Iterable<[K, V]>) {
-  target.clear()
-  for (const [k, v] of source) target.set(k, v)
-}
+// `replaceMap` lives in a plain `.ts` neighbour so vitest can import
+// it without booting the Svelte runes runtime. Re-exported here for
+// the existing call sites that consume it from this module.
+export { replaceMap }
 
 /**
  * Assign a `ResolvedLayout` into the given mirror state, preserving

--- a/apps/editor/src/lib/state/replace-map.ts
+++ b/apps/editor/src/lib/state/replace-map.ts
@@ -1,0 +1,33 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Replace the contents of a Map in place, preserving its identity
+ * so bindings and downstream reactivity stay attached.
+ *
+ * Diff-apply, NOT clear-then-set: the naive impl flashes the map
+ * to `size === 0` between clear() and the first set(), which trips
+ * any reactive consumer gated on `size > 0` (e.g. the diagram
+ * page's `{#if nodes.size > 0}` mount, action enabled predicates,
+ * derived counts). Those observers see the empty state and tear
+ * down — instance state on whatever just unmounted (the
+ * renderer's selection set is the canonical victim) goes with it.
+ *
+ * Diffing keeps `size` monotonic relative to the real change set,
+ * and Map.set on an existing key preserves insertion order, so
+ * keyed `{#each}` blocks stay aligned without DOM churn beyond
+ * the entries that actually moved.
+ *
+ * Pure module on purpose: separated from `diagram.svelte.ts` so
+ * it can be imported from vitest tests without dragging the Svelte
+ * runes runtime in.
+ */
+export function replaceMap<K, V>(target: Map<K, V>, source: Iterable<[K, V]>) {
+  const next = source instanceof Map ? source : new Map(source)
+  // Delete first, then upsert. Order matters: deleting `next`
+  // members before re-setting them would still cause a flash.
+  for (const k of [...target.keys()]) {
+    if (!next.has(k)) target.delete(k)
+  }
+  for (const [k, v] of next) target.set(k, v)
+}

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -41,10 +41,20 @@
   /**
    * Replace the contents of a Map in place (used when core helpers return
    * fresh Maps but we want to keep our reactive SvelteMap identity).
+   *
+   * Diff-apply, NOT clear-then-set: clear() makes the map flash
+   * to `size === 0`, and any host gated on `size > 0` (e.g. an
+   * `{#if nodes.size > 0}` mount around <ShumokuRenderer>) sees
+   * the empty state and tears the renderer down — taking the
+   * local selection / drag state with it. Diffing keeps `size`
+   * monotonic w.r.t. the real change set.
    */
   function replaceMap<K, V>(target: Map<K, V>, source: Iterable<[K, V]>) {
-    target.clear()
-    for (const [k, v] of source) target.set(k, v)
+    const next = source instanceof Map ? source : new Map(source)
+    for (const k of [...target.keys()]) {
+      if (!next.has(k)) target.delete(k)
+    }
+    for (const [k, v] of next) target.set(k, v)
   }
 
   interface RendererProps extends RendererOverlaySnippets {

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -128,7 +128,12 @@
   }
 
   function onEdgeDown(e: PointerEvent) {
-    if (!droplet) return
+    // Left-click only. Right / middle clicks need to bubble so the
+    // host's context menu (and pan / etc.) sees them — otherwise a
+    // two-finger trackpad right-click that lands in the 10px
+    // edge-zone halo would add a stray port and tear down the
+    // multi-selection via the addPort → replaceMap path.
+    if (e.button !== 0 || !droplet) return
     e.stopPropagation()
     e.preventDefault()
     onaddport?.(node.id, droplet.side)


### PR DESCRIPTION
## Symptom

Multi-select nodes in the diagram, two-finger right-click on one of them to open the context menu (intending 'Move to group') → the selection — and visually the nodes themselves — vanish before the menu is usable.

## Root cause

`replaceMap`, the update primitive for the live SvelteMaps backing the diagram view (`nodes`, `ports`, `edges`, `subgraphs`), ran `target.clear()` and then re-set each entry from the source. Every reactive consumer with a \`size > 0\` predicate saw an empty-everything state during the gap. The diagram page's mount gate (`{#if diagramState.nodes.size > 0 || status !== 'Loading...'}`) was the load-bearing one: it unmounted \`<ShumokuRenderer>\` mid-update and took the renderer-instance selection / drag state with it.

Many update paths bounced through `replaceMap` — `addPort`, `moveNodeToGroup`, `autoArrange`, sheet switching, full re-layout. The right-click report was just the most visible case: the 10px hover halo around each node was listening for `pointerdown` to spawn a custom port and had no `e.button === 0` guard, so a trackpad two-finger click that landed in the halo called `addPort` → `replaceMap` and flashed the map empty.

## Fix

Two changes, root + defence in depth:

1. **Root**: `replaceMap` now diffs in place. Drop keys not in the new source, then upsert each new entry. `Map.set` on an existing key preserves insertion order, so keyed `{#each}` blocks stay aligned without DOM churn beyond entries that actually moved. `size` only descends if entries are genuinely removed, so reactive gates see the real change set rather than a transient zero. Same fix applied to both copies (editor's `state/diagram.svelte.ts` and the renderer's internal helper). The function is pulled into a plain `.ts` neighbour so vitest can import it without booting the Svelte runes runtime; a behavioural test pins the no-flash invariant.

2. **Defence**: `onEdgeDown` in `SvgNode.svelte` gains the missing `e.button === 0` guard. Right / middle clicks now bubble straight through to context-menu and pan handlers as the other interaction sites already did.

## Test plan

- [ ] Multi-select two nodes (shift-click / marquee), right-click on one with a trackpad two-finger gesture, confirm context menu opens and selection is preserved
- [ ] Right-click hovering ~5px outside a node edge, confirm no stray port is added
- [ ] Left-click drag near a node edge still adds a port at the cursor
- [ ] Switch sheets via drill-in / drill-out, confirm selection state survives where it used to
- [ ] Auto-arrange a busy diagram, confirm no flash and the renderer doesn't remount
- [ ] \`bun test src/lib/state/diagram.replace-map.test.ts\` passes (no transient size === 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)