### PR TITLE
refactor(editor): drop size-based mount gate around the renderer

### DIFF
--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -186,7 +186,17 @@
         if (selected) openDetail(selected.id, selected.type)
       }}
     >
-      {#if diagramState.nodes.size > 0 || diagramState.status !== 'Loading...'}
+      <!-- Mount the renderer for any non-loading status, regardless of
+           node count. The legacy `nodes.size > 0 || status !== 'Loading...'`
+           gate also rendered an empty project once loaded, but the OR with
+           `size > 0` was a footgun: any update path that briefly flashed
+           the map empty (replaceMap, mid-flight reroutes) would tear the
+           renderer down and lose its instance state — selection, hover,
+           drag — between two reactive frames. `replaceMap` is now
+           diff-apply so it can no longer cause that, but the gate stays
+           gated only on status so a future regression in the update path
+           can't reintroduce the same class of bug. -->
+      {#if diagramState.status !== 'Loading...'}
         <ShumokuRenderer
           bind:this={renderer}
           bind:svgElement={rendererSvg}


### PR DESCRIPTION
## Why

The diagram page gated \`<ShumokuRenderer>\` on \`nodes.size > 0 || status !== 'Loading...'\`. The OR was a footgun: any update path that briefly flashed the SvelteMap empty (the canonical case was \`replaceMap\`'s clear-then-set — fixed in #261) tripped the gate and unmounted the renderer mid-update, taking its instance state (selection, hover, drag) with it.

#261 already neutralised the canonical offender by making \`replaceMap\` diff in place. This PR is the second half: make the gate itself unable to misfire so a future regression in the update layer can't bring the same class of bug back.

## Change

\`\`\`diff
- {#if diagramState.nodes.size > 0 || diagramState.status !== 'Loading...'}
+ {#if diagramState.status !== 'Loading...'}
\`\`\`

Same UX (Loading placeholder while loading, canvas otherwise), no \`size === 0\` surface.

## Stacked on

Depends on #261 — base branch is \`fix/edge-zone-button-guard\`.

## Test plan

- [ ] Open a fresh project (no nodes), confirm canvas mounts immediately instead of hanging on the loading placeholder
- [ ] Open a project mid-load (slow IDB), confirm the loading placeholder still shows until status flips
- [ ] Multi-select two nodes and run an action that mutates nodes/edges (e.g. duplicate via \`Cmd+D\`); selection survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)