### PR TITLE
refactor(renderer,editor): lift selection state out of the renderer instance

### DIFF
--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -68,12 +68,24 @@
       diagramState.setCurrentScene(null)
     }
   })
-  // Multi-selection state. The renderer drives this via
-  // `onselectionchange`; the page just mirrors it so the action
-  // registry / status bar / detail panel can react. `selected`
-  // (singular) is a derived convenience for surfaces that only care
-  // about the focused single item (StatusBadge, double-click detail).
+  // Multi-selection state.
+  //
+  // `selectionIds` is the page-owned source of truth, two-way bound
+  // into the renderer (which used to own it internally — see
+  // ShumokuRenderer's `selection` prop). Keeping it on the page
+  // means the set survives any remount of <ShumokuRenderer> (sheet
+  // switches, mount-gate flips, dev-server HMR) so the user doesn't
+  // lose their working selection across an invisible reactive blip.
+  //
+  // `selection` is the typed mirror the rest of the page consumes
+  // (ActionContext, StatusBadge, detail panel). The renderer still
+  // emits `onselectionchange` so we don't have to re-derive the
+  // type per id here — it has the same lookup data and emits once
+  // synchronously per mutation. `selected` (singular) is the
+  // convenience read for surfaces that care only about the focused
+  // single item.
   type SelType = ActionContext['selection']['types'][number]
+  let selectionIds = $state<Set<string>>(new Set())
   let selection = $state<{ ids: string[]; types: SelType[] }>({ ids: [], types: [] })
   const selected = $derived<{ id: string; type: string } | null>(
     selection.ids[0] && selection.types[0]
@@ -207,6 +219,7 @@
           bind:subgraphs={diagramState.activeView.subgraphs}
           bind:bounds={diagramState.activeView.bounds}
           bind:links={diagramState.activeView.links}
+          bind:selection={selectionIds}
           theme={editorState.theme}
           mode={diagramState.currentSheetId === null ? editorState.mode : 'view'}
           hideNode={(n) => !!n.termination}

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -134,6 +134,21 @@
      * suppression themselves.
      */
     preventContextMenuDefault?: boolean
+    /**
+     * Selected element ids. Bindable so the host can own the
+     * selection lifecycle independently of this renderer instance:
+     * when the renderer unmounts and remounts (e.g. its `{#if}`
+     * mount gate flips, or it's swapped between sheets), the
+     * selection survives. When the host doesn't bind, a fresh Set
+     * is created at instantiation and the renderer behaves as the
+     * sole owner — same UX as before this prop existed.
+     *
+     * Mutations from inside the renderer always assign a NEW Set
+     * reference (never `clear()` / `add()` on the existing one) so
+     * reactivity downstream sees a single atomic change instead of
+     * a transient empty state.
+     */
+    selection?: Set<string>
   }
 
   let {
@@ -164,6 +179,7 @@
     nodeOverlay,
     portOverlay,
     preventContextMenuDefault = true,
+    selection = $bindable(new Set<string>()),
   }: RendererProps = $props()
 
   const colors = $derived(themeToColors(theme))
@@ -187,7 +203,10 @@
   // Edit state
   // =========================================================================
 
-  let selection = $state(new Set<string>())
+  // `selection` lives on the host via $bindable (declared in $props
+  // above) so it survives renderer unmount / remount cycles. Other
+  // instance state (linkDrag, hover) is intentionally local — those
+  // are transient gestures that mean nothing across a remount.
   let linkDrag = $state<{
     fromPortId: string
     fromX: number


### PR DESCRIPTION
## Why

Third PR in the disappearing-selection root-cause series, after #261 (replaceMap diffs in place) and #263 (drop the size-based mount gate). The renderer's multi-selection Set was a local \`\$state\` on the component, so any host that unmounted the renderer — historical bug (now fixed in #263), sheet switches, dev-server HMR — silently wiped the user's working selection.

This PR closes the underlying coupling: selection now lives in the host, the renderer just borrows it.

## Change

\`<ShumokuRenderer>\` gains an optional \`selection\` \`\$bindable\` prop, defaulting to a fresh \`Set<string>\`. Consumers that don't bind it (the WebComponent, server/web's TopologyViewer) get exactly the old behaviour: renderer creates and owns a local Set per instance.

The editor's diagram page binds it to a page-scoped \`\$state\` (\`selectionIds\`). The set now lives in the page component's lifecycle, not the renderer's, so it survives any future remount.

The existing \`onselectionchange\` callback path stays in place: the page still uses it to populate its typed \`{ ids, types }\` mirror that \`ActionContext\` / \`StatusBadge\` / \`DetailPanel\` consume. Re-deriving types in the page would duplicate logic the renderer already has — the callback runs once synchronously per mutation, which is cheap.

Other instance state (linkDrag, hover) stays local — they're transient gestures that mean nothing across a remount.

## Stacked on

Depends on #263 (which depends on #261). Base branch is \`refactor/mount-gate-status-only\`.

## Test plan

- [ ] Multi-select two nodes, switch sheets and back; selection survives
- [ ] Multi-select two nodes, hit the dev-server HMR boundary (touch a Svelte file in the renderer); selection survives
- [ ] WebComponent embed in /docs editor preview still works without binding \`selection\` (no console errors, click-to-select behaves)
- [ ] Server's TopologyViewer (read-only) still highlights on hover / click as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)