### PR TITLE
refactor(renderer,editor): SvelteSet for selection + derive typed mirror

### DIFF
--- a/apps/editor/src/routes/project/[id]/diagram/+page.svelte
+++ b/apps/editor/src/routes/project/[id]/diagram/+page.svelte
@@ -3,6 +3,7 @@
   import { attachCamera } from '@shumoku/renderer'
   import ShumokuRenderer from '@shumoku/renderer/components/ShumokuRenderer.svelte'
   import { renderGraphToSvg } from '@shumoku/renderer-svg'
+  import { SvelteSet } from 'svelte/reactivity'
   import { page } from '$app/stores'
   import { clearActionContext, provideActionContext } from '$lib/actions/context-provider.svelte'
   import type { ActionContext, CameraHandle, RendererHandle } from '$lib/actions/types'
@@ -71,22 +72,30 @@
   // Multi-selection state.
   //
   // `selectionIds` is the page-owned source of truth, two-way bound
-  // into the renderer (which used to own it internally — see
-  // ShumokuRenderer's `selection` prop). Keeping it on the page
-  // means the set survives any remount of <ShumokuRenderer> (sheet
-  // switches, mount-gate flips, dev-server HMR) so the user doesn't
-  // lose their working selection across an invisible reactive blip.
+  // into the renderer (which used to own it internally). Keeping it
+  // on the page means the set survives any remount of
+  // <ShumokuRenderer> — sheet switches, mount-gate flips, dev-server
+  // HMR — so the user doesn't lose their working selection across
+  // an invisible reactive blip. SvelteSet so in-place mutations
+  // from any future caller stay reactive; today the renderer always
+  // reassigns with a fresh SvelteSet.
   //
-  // `selection` is the typed mirror the rest of the page consumes
-  // (ActionContext, StatusBadge, detail panel). The renderer still
-  // emits `onselectionchange` so we don't have to re-derive the
-  // type per id here — it has the same lookup data and emits once
-  // synchronously per mutation. `selected` (singular) is the
-  // convenience read for surfaces that care only about the focused
-  // single item.
+  // `selection` (typed) is `$derived` from `selectionIds` plus the
+  // diagramState lookup maps — single source of truth, no callback
+  // mirror to drift out of sync. The classifier mirrors the
+  // renderer's: edges > ports > subgraphs > nodes (default).
   type SelType = ActionContext['selection']['types'][number]
-  let selectionIds = $state<Set<string>>(new Set())
-  let selection = $state<{ ids: string[]; types: SelType[] }>({ ids: [], types: [] })
+  let selectionIds = $state<SvelteSet<string>>(new SvelteSet())
+  function classifyId(id: string): SelType {
+    if (diagramState.edges.has(id)) return 'edge'
+    if (diagramState.ports.has(id)) return 'port'
+    if (diagramState.subgraphs.has(id)) return 'subgraph'
+    return 'node'
+  }
+  const selection = $derived.by<{ ids: string[]; types: SelType[] }>(() => {
+    const ids = [...selectionIds]
+    return { ids, types: ids.map(classifyId) }
+  })
   const selected = $derived<{ id: string; type: string } | null>(
     selection.ids[0] && selection.types[0]
       ? { id: selection.ids[0], type: selection.types[0] }
@@ -225,14 +234,6 @@
           hideNode={(n) => !!n.termination}
           ondragstart={() => diagramState.beginTx('Move node')}
           ondragend={() => diagramState.endTx()}
-          onselectionchange={(ids: string[], types: string[]) => {
-            // Mirror the renderer's selection set so the action
-            // registry / status bar see the live state. Fires
-            // synchronously inside the renderer's click /
-            // right-click handler, so the ContextMenu wrapper
-            // sees the right selection when it opens.
-            selection = { ids, types: types as SelType[] }
-          }}
           onchange={() => {}}
           onlabeledit={(portId: string, label: string, screenX: number, screenY: number) => { labelEdit = { portId, label, x: screenX, y: screenY } }}
           onnodeadd={(_id: string) => {

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -26,7 +26,7 @@
     routeEdges,
     specDeviceType,
   } from '@shumoku/core'
-  import { SvelteMap } from 'svelte/reactivity'
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity'
   import type { RendererOverlaySnippets } from '../lib/overlays'
   import { themeToColors } from '../lib/render-colors'
   import { screenToWorld as screenToWorldUtil } from '../lib/svg-coords'
@@ -139,14 +139,19 @@
      * selection lifecycle independently of this renderer instance:
      * when the renderer unmounts and remounts (e.g. its `{#if}`
      * mount gate flips, or it's swapped between sheets), the
-     * selection survives. When the host doesn't bind, a fresh Set
-     * is created at instantiation and the renderer behaves as the
-     * sole owner — same UX as before this prop existed.
+     * selection survives. When the host doesn't bind, a fresh
+     * SvelteSet is created at instantiation and the renderer
+     * behaves as the sole owner — same UX as before this prop
+     * existed.
      *
-     * Mutations from inside the renderer always assign a NEW Set
-     * reference (never `clear()` / `add()` on the existing one) so
-     * reactivity downstream sees a single atomic change instead of
-     * a transient empty state.
+     * Typed as `Set<string>` so non-Svelte consumers can pass a
+     * plain Set, but the renderer's internal reassignments use
+     * `SvelteSet` so in-place ops (`.add` / `.delete` from a host
+     * that mutates rather than replaces) stay reactive. The
+     * renderer itself never mutates in place — every change
+     * produces a fresh SvelteSet and reassigns — so the bound
+     * value seen by `$derived` downstream is a single atomic
+     * snapshot per mutation.
      */
     selection?: Set<string>
   }
@@ -179,7 +184,7 @@
     nodeOverlay,
     portOverlay,
     preventContextMenuDefault = true,
-    selection = $bindable(new Set<string>()),
+    selection = $bindable<Set<string>>(new SvelteSet()),
   }: RendererProps = $props()
 
   const colors = $derived(themeToColors(theme))
@@ -274,7 +279,7 @@
   // keep showing a stale "N selected" until the user clicks elsewhere.
   $effect(() => {
     let changed = false
-    const next = new Set<string>()
+    const next = new SvelteSet<string>()
     for (const id of selection) {
       if (nodes.has(id) || edges.has(id) || subgraphs.has(id) || ports.has(id)) {
         next.add(id)
@@ -293,17 +298,17 @@
     // Plain click → replace.
     const additive = !!ev && (ev.shiftKey || ev.metaKey || ev.ctrlKey)
     if (additive) {
-      const next = new Set(selection)
+      const next = new SvelteSet(selection)
       if (next.has(id)) next.delete(id)
       else next.add(id)
       selection = next
     } else {
-      selection = new Set([id])
+      selection = new SvelteSet([id])
     }
     emitSelection()
   }
   function handleBackgroundClick() {
-    selection = new Set()
+    selection = new SvelteSet()
     emitSelection()
   }
   function handleContextMenu(id: string, type: string, e: MouseEvent) {
@@ -311,7 +316,7 @@
     // single item; right-click on something already selected keeps the
     // existing multi-selection so the menu applies to the whole set.
     if (!selection.has(id)) {
-      selection = new Set([id])
+      selection = new SvelteSet([id])
       emitSelection()
     }
     onctx?.(id, type, e.clientX, e.clientY)
@@ -319,7 +324,7 @@
 
   function handleKeyDown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
-      selection = new Set()
+      selection = new SvelteSet()
       emitSelection()
       linkDrag = null
     } else if ((e.metaKey || e.ctrlKey) && (e.key === 'a' || e.key === 'A')) {
@@ -327,7 +332,7 @@
       // intentionally excluded; they're rarely the target of bulk
       // operations and including them clutters Delete behavior.
       e.preventDefault()
-      const next = new Set<string>()
+      const next = new SvelteSet<string>()
       for (const id of nodes.keys()) next.add(id)
       for (const id of subgraphs.keys()) next.add(id)
       selection = next
@@ -431,7 +436,7 @@
       if (!b) continue
       if (intersects(b.x, b.y, b.x + b.width, b.y + b.height)) hits.add(id)
     }
-    selection = additive ? new Set([...selection, ...hits]) : hits
+    selection = additive ? new SvelteSet([...selection, ...hits]) : new SvelteSet(hits)
     emitSelection()
   }
 
@@ -496,7 +501,7 @@
     // rebalanceSubgraphs mutates the subgraphs map's entries in place; since
     // we now use a SvelteMap the mutations are picked up without any reassign.
     rebalanceSubgraphs(nodes, subgraphs, ports)
-    selection = new Set([id])
+    selection = new SvelteSet([id])
     emitSelection()
   }
 


### PR DESCRIPTION
Follow-up polish to #261 / #263 / #264 that left two Svelte-5-idiom smells behind:

## Change 1 — Bound \`selection\` is now SvelteSet

Svelte 5's \`\$state\` proxies plain objects / arrays but **not** built-in Set / Map. The lift in #264 used plain \`Set<string>\` for the bindable \`selection\` prop, which worked because the renderer always reassigned (\`selection = new Set([...])\`) — a reactivity-safe pattern. But a future caller mutating in place (\`selection.add(id)\`) would have hit a silent reactivity bug.

Switch the renderer's default and every internal reassignment to \`SvelteSet\` from \`svelte/reactivity\`. The public prop type stays \`Set<string>\` (SvelteSet extends Set), so non-Svelte consumers passing a plain Set still work; consumers that bind get full reactivity for either pattern.

## Change 2 — Typed \`selection\` is now derived

The diagram page held two sources of truth:

- \`selectionIds\` — the bound Set (page-scoped \`\$state\`)
- \`selection\` — the typed \`{ ids, types }\` mirror updated via the renderer's \`onselectionchange\` callback

They were synced because the callback fired synchronously, but structurally they could drift. Replace with a single \`\$derived\` that classifies ids on the page (mirroring the renderer's logic: edge > port > subgraph > node default). Drops the editor-side \`onselectionchange\` listener; the callback stays on the renderer's public API for viewer-only consumers (server/web TopologyViewer) that don't bind selection.

## Test plan

- [ ] Multi-select, switch sheets, return — selection survives (as in #264)
- [ ] StatusBadge / DetailPanel / ActionContext still see correct counts and types
- [ ] WebComponent (\`/docs\` editor preview) still works without binding selection
- [ ] \`typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)