### PR TITLE
feat(plugins): Aruba Instant On + plugin contract refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,24 @@ Plugins implement `DataSourcePlugin` from `@shumoku/core` and depend only on cor
 - **netbox**: Topology and hosts from NetBox DCIM/IPAM
 - **prometheus**: Metrics, hosts, alerts from Prometheus/Alertmanager
 - **zabbix**: Metrics, hosts, auto-mapping, alerts from Zabbix
+- **aruba-instant-on**: Hosts, metrics, alerts from the (unofficial) Aruba Instant On portal API
+
+**Plugin contract invariants** (see `docs/plugin-authoring.md` for the full reference):
+- Core types are the display contract. Plugins translate their upstream vocabulary
+  (Zabbix priorities, Prometheus severities, Aruba health tokens) into core's
+  vocab at the plugin boundary — never widen core types with plugin-name literals.
+- `Alert.source` is `string`, not a union of plugin names. New plugins must not
+  require edits to `@shumoku/core` or `apps/server/web/src/lib/types.ts`.
+- `AlertSeverity` is the neutral CVSS-style scale `'critical' | 'high' | 'medium' | 'low' | 'info' | 'ok'`.
+  Don't reintroduce Zabbix-flavored values (`disaster` / `average` / `information`).
+- `DiscoveredMetric.value` is `number | string | boolean`. The "All metrics" panel
+  is a passthrough dump — plugins should walk the upstream record generically
+  (see `flattenObject` in aruba-instant-on) rather than enumerating fields.
+- The web app must render plugins through `configSchema`, not via per-plugin
+  branches. Hardcoded forms are tracked for cleanup in issue #270.
+
+When in doubt, refuse to add `plugin.type === 'foo'` branches anywhere outside
+the plugin's own `libs/plugins/foo/` directory.
 
 ### Data Flow
 ```

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ npx shumoku render network.yaml -f html -o diagram.html
 - [Vendor Icons](https://www.shumoku.dev/docs/npm/vendor-icons) — Available icons
 - [Playground](https://www.shumoku.dev/) — Try without installation
 - [Architecture](docs/ARCHITECTURE.md) — Monorepo overview, load pipeline, layout engine (Mermaid diagrams)
+- [Plugin Authoring](docs/plugin-authoring.md) — Writing a `DataSourcePlugin`: capability mixins, data shapes, severity mapping, security practices
 
 ## Development
 

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -17,6 +17,7 @@
     "@shumoku/core": "workspace:*",
     "@shumoku/renderer-svg": "workspace:*",
     "@shumoku/renderer-html": "workspace:*",
+    "shumoku-plugin-aruba-instant-on": "workspace:*",
     "shumoku-plugin-grafana": "workspace:*",
     "shumoku-plugin-netbox": "workspace:*",
     "shumoku-plugin-prometheus": "workspace:*",

--- a/apps/server/api/src/plugins/index.ts
+++ b/apps/server/api/src/plugins/index.ts
@@ -4,6 +4,7 @@
  * Data source plugin system for Shumoku.
  */
 
+export { ArubaInstantOnPlugin } from 'shumoku-plugin-aruba-instant-on'
 export { GrafanaPlugin } from 'shumoku-plugin-grafana'
 // Re-export plugin classes from bundled plugins
 export { NetBoxPlugin } from 'shumoku-plugin-netbox'
@@ -29,6 +30,7 @@ export {
 export * from './registry.js'
 export * from './types.js'
 
+import { register as registerArubaInstantOn } from 'shumoku-plugin-aruba-instant-on'
 import { register as registerGrafana } from 'shumoku-plugin-grafana'
 import { register as registerNetBox } from 'shumoku-plugin-netbox'
 import { register as registerPrometheus } from 'shumoku-plugin-prometheus'
@@ -41,6 +43,7 @@ export function registerBundledPlugins(): void {
   registerZabbix(pluginRegistry)
   registerPrometheus(pluginRegistry)
   registerGrafana(pluginRegistry)
+  registerArubaInstantOn(pluginRegistry)
 
   console.log('[Plugins] Bundled plugins registered')
 }

--- a/apps/server/api/src/services/grafana-alerts.ts
+++ b/apps/server/api/src/services/grafana-alerts.ts
@@ -38,35 +38,36 @@ interface GrafanaAlertRow {
 }
 
 const SEVERITY_MAP: Record<string, AlertSeverity> = {
-  critical: 'disaster',
-  disaster: 'disaster',
+  critical: 'critical',
+  disaster: 'critical',
   high: 'high',
   major: 'high',
   error: 'high',
-  average: 'average',
-  medium: 'average',
-  warning: 'warning',
-  warn: 'warning',
-  minor: 'warning',
-  low: 'information',
-  info: 'information',
-  information: 'information',
+  medium: 'medium',
+  average: 'medium',
+  moderate: 'medium',
+  warning: 'low',
+  warn: 'low',
+  minor: 'low',
+  low: 'info',
+  info: 'info',
+  information: 'info',
   none: 'ok',
   ok: 'ok',
 }
 
 export const SEVERITY_ORDER: Record<AlertSeverity, number> = {
   ok: 0,
-  information: 1,
-  warning: 2,
-  average: 3,
+  info: 1,
+  low: 2,
+  medium: 3,
   high: 4,
-  disaster: 5,
+  critical: 5,
 }
 
 export function mapSeverity(severity?: string): AlertSeverity {
-  if (!severity) return 'information'
-  return SEVERITY_MAP[severity.toLowerCase()] || 'information'
+  if (!severity) return 'info'
+  return SEVERITY_MAP[severity.toLowerCase()] || 'info'
 }
 
 export function buildTitle(labels: Record<string, string>): string {

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -7,7 +7,7 @@ import type { NetworkGraph } from '@shumoku/core'
 import type {
   Alert,
   AlertQueryOptions,
-  ConnectionTestResult,
+  ConnectionResult,
   Dashboard,
   DashboardInput,
   DataSource,
@@ -97,7 +97,7 @@ export const dataSources = {
     }),
 
   test: (id: string) =>
-    request<ConnectionTestResult>(`/datasources/${id}/test`, {
+    request<ConnectionResult>(`/datasources/${id}/test`, {
       method: 'POST',
     }),
 

--- a/apps/server/web/src/lib/components/NodeMappingModal.svelte
+++ b/apps/server/web/src/lib/components/NodeMappingModal.svelte
@@ -174,7 +174,9 @@
     }
   }
 
-  function formatMetricValue(value: number): string {
+  function formatMetricValue(value: number | string | boolean): string {
+    if (typeof value === 'boolean') return value ? 'true' : 'false'
+    if (typeof value === 'string') return value
     if (value === 0) return '0'
     if (Math.abs(value) >= 1e12) return `${(value / 1e12).toFixed(2)}T`
     if (Math.abs(value) >= 1e9) return `${(value / 1e9).toFixed(2)}G`
@@ -561,11 +563,6 @@
                                   {key}=<span class="text-muted-foreground">{value}</span>
                                 </span>
                               {/each}
-                            </div>
-                          {/if}
-                          {#if metric.type}
-                            <div class="text-muted-foreground">
-                              Type: <span class="text-foreground">{metric.type}</span>
                             </div>
                           {/if}
                         </div>

--- a/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
+++ b/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
@@ -77,20 +77,21 @@
     const group = context.groupElement
     if (!group) return
     if (!active) {
-      group.classList.remove('wm-active')
+      group.classList.remove('wm-active', 'wm-down')
       group.style.removeProperty('--wm-base-color')
       return
     }
     group.classList.add('wm-active')
+    group.classList.toggle('wm-down', down)
     group.style.setProperty('--wm-base-color', baseColor)
     return () => {
-      group.classList.remove('wm-active')
+      group.classList.remove('wm-active', 'wm-down')
       group.style.removeProperty('--wm-base-color')
     }
   })
 </script>
 
-{#if active}
+{#if active && !down}
   {#if hasPorts}
     <path
       class="wm-overlay"
@@ -99,10 +100,8 @@
       d={inPathD}
       style:--wm-color={inColor}
       style:--wm-width={String(laneWidth)}
-      style:--wm-dash={down ? '8 4' : '3 21'}
-      style:--wm-opacity={down ? '0.5' : '0.9'}
-      style:--wm-play={down || inDuration <= 0 ? 'paused' : 'running'}
-      style:--wm-duration={down || inDuration <= 0 ? '0ms' : `${inDuration}ms`}
+      style:--wm-play={inDuration <= 0 ? 'paused' : 'running'}
+      style:--wm-duration={inDuration <= 0 ? '0ms' : `${inDuration}ms`}
     />
     <path
       class="wm-overlay"
@@ -111,10 +110,8 @@
       d={outPathD}
       style:--wm-color={outColor}
       style:--wm-width={String(laneWidth)}
-      style:--wm-dash={down ? '8 4' : '3 21'}
-      style:--wm-opacity={down ? '0.5' : '0.9'}
-      style:--wm-play={down || outDuration <= 0 ? 'paused' : 'running'}
-      style:--wm-duration={down || outDuration <= 0 ? '0ms' : `${outDuration}ms`}
+      style:--wm-play={outDuration <= 0 ? 'paused' : 'running'}
+      style:--wm-duration={outDuration <= 0 ? '0ms' : `${outDuration}ms`}
     />
   {:else}
     <!-- Port-less edge: render one combined lane (no direction split). -->
@@ -125,10 +122,8 @@
       d={context.pathD}
       style:--wm-color={baseColor}
       style:--wm-width={String(laneWidth)}
-      style:--wm-dash={down ? '8 4' : '3 21'}
-      style:--wm-opacity={down ? '0.5' : '0.9'}
-      style:--wm-play={down || combinedDuration <= 0 ? 'paused' : 'running'}
-      style:--wm-duration={down || combinedDuration <= 0 ? '0ms' : `${combinedDuration}ms`}
+      style:--wm-play={combinedDuration <= 0 ? 'paused' : 'running'}
+      style:--wm-duration={combinedDuration <= 0 ? '0ms' : `${combinedDuration}ms`}
     />
   {/if}
 {/if}
@@ -168,6 +163,14 @@
     transition:
       stroke 200ms ease,
       opacity 200ms ease;
+  }
+
+  /* Down: no lane overlay; the base link itself is the indicator —
+       solid red dashed line, full opacity, so it can never be confused
+       with the animated red lanes of a 90-100% utilized link. */
+  :global(.wm-active.wm-down > path.link) {
+    opacity: 1;
+    stroke-dasharray: 8 4;
   }
 
   @keyframes wm-flow-in {

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -1,13 +1,39 @@
 /**
- * Frontend type definitions
+ * Frontend type definitions.
+ *
+ * Domain types (Host, HostItem, Alert, MetricsMapping, …) are owned by
+ * `@shumoku/core` so plugins and the web app share one display contract.
+ * This file only defines the web's wire-format / UI-local shapes (DB rows,
+ * widget configs, render context) and re-exports the core types under the
+ * `$lib/types` import path for convenience.
  */
+
+import type {
+  DataSourceCapability,
+  LayoutResult,
+  MetricsMapping,
+  NetworkGraph,
+} from '@shumoku/core'
 
 import type { MetricsData } from './stores/metrics'
 
-export type DataSourceType = 'zabbix' | 'netbox' | 'prometheus' | 'grafana'
-export type DataSourceStatus = 'connected' | 'disconnected' | 'unknown'
+// Re-export core types so consumers can keep importing from `$lib/types`.
+export type {
+  Alert,
+  AlertQueryOptions,
+  AlertSeverity,
+  AlertStatus,
+  ConnectionResult,
+  DataSourceCapability,
+  DiscoveredMetric,
+  Host,
+  HostItem,
+  LinkMetricsMapping,
+  MetricsMapping,
+  NodeMetricsMapping,
+} from '@shumoku/core'
 
-export type DataSourceCapability = 'topology' | 'metrics' | 'hosts' | 'alerts'
+export type DataSourceStatus = 'connected' | 'disconnected' | 'unknown'
 
 export interface DataSourcePluginInfo {
   type: string
@@ -33,7 +59,10 @@ export interface DataSourcePluginInfo {
 export interface DataSource {
   id: string
   name: string
-  type: DataSourceType
+  /** Plugin `type` identifier. Open string — bundled plugins emit
+   *  'zabbix' / 'netbox' / 'prometheus' / 'grafana' / 'aruba-instant-on',
+   *  external plugins supply their own. */
+  type: string
   configJson: string // Plugin-specific configuration as JSON
   status: DataSourceStatus
   statusMessage?: string
@@ -45,7 +74,7 @@ export interface DataSource {
 
 export interface DataSourceInput {
   name: string
-  type: DataSourceType
+  type: string
   configJson: string
 }
 
@@ -67,44 +96,6 @@ export interface TopologyInput {
   topologySourceId?: string
   metricsSourceId?: string
   mappingJson?: string
-}
-
-// Host and item types for mapping UI
-export interface Host {
-  id: string
-  name: string
-  displayName?: string
-  status?: 'up' | 'down' | 'unknown'
-  ip?: string
-}
-
-export interface HostItem {
-  id: string
-  hostId: string
-  name: string
-  key: string
-  lastValue?: string
-  unit?: string
-  /** Extracted interface name (e.g., "GigabitEthernet0/0", "eth0") */
-  interfaceName?: string
-  /** Traffic direction */
-  direction?: 'in' | 'out'
-}
-
-/**
- * A metric discovered from a data source for a specific host
- */
-export interface DiscoveredMetric {
-  /** Metric name (e.g., "ifHCInOctets", "node_cpu_seconds_total") */
-  name: string
-  /** Labels associated with this metric */
-  labels: Record<string, string>
-  /** Current value */
-  value: number
-  /** Human-readable description (from HELP) */
-  help?: string
-  /** Metric type (counter, gauge, histogram, summary) */
-  type?: string
 }
 
 /**
@@ -135,32 +126,6 @@ export function parseMultiFileContent(contentJson: string): TopologyFile[] {
  */
 export function serializeMultiFileContent(files: TopologyFile[]): string {
   return JSON.stringify({ files }, null, 2)
-}
-
-export interface NodeMetricsMapping {
-  hostId?: string
-  hostName?: string
-}
-
-export interface LinkMetricsMapping {
-  monitoredNodeId?: string
-  interface?: string
-  /** Per-link bandwidth override in bits per second. Wins over
-   * the topology's `link.bandwidth` for both stroke-width and
-   * utilization calculation. */
-  bandwidth?: number
-}
-
-export interface MetricsMapping {
-  nodes: Record<string, NodeMetricsMapping>
-  links: Record<string, LinkMetricsMapping>
-}
-
-export interface ConnectionTestResult {
-  success: boolean
-  message: string
-  version?: string
-  warnings?: string[]
 }
 
 // ============================================
@@ -408,69 +373,6 @@ export interface TopologyContext {
   mapping?: MetricsMapping
 }
 
-// NetworkGraph types for Cytoscape converter
-export interface NetworkNode {
-  id: string
-  label?: string | string[]
-  parent?: string
-  metadata?: Record<string, unknown>
-  spec?: {
-    type?: string
-    vendor?: string
-    model?: string
-    icon?: string
-  }
-}
-
-export interface NetworkLinkEndpoint {
-  node: string
-  port?: string
-  ip?: string
-}
-
-export interface NetworkLink {
-  id?: string
-  from: string | NetworkLinkEndpoint
-  to: string | NetworkLinkEndpoint
-  label?: string
-  standard?: string
-  vlan?: number | number[]
-  type?: 'solid' | 'dashed'
-  arrow?: 'forward' | 'backward' | 'both' | 'none'
-  redundancy?: string
-  metadata?: Record<string, unknown>
-}
-
-export interface NetworkSubgraph {
-  id: string
-  label?: string
-  parent?: string
-  file?: string
-  spec?: {
-    vendor?: string
-    service?: string
-    resource?: string
-  }
-  style?: {
-    fill?: string
-    stroke?: string
-    strokeWidth?: number
-    strokeDasharray?: string
-  }
-}
-
-export interface NetworkGraph {
-  name?: string
-  nodes: NetworkNode[]
-  links: NetworkLink[]
-  subgraphs?: NetworkSubgraph[]
-}
-
-export interface LayoutResult {
-  nodes: Record<string, { x: number; y: number }>
-  subgraphs?: Record<string, { x: number; y: number; width: number; height: number }>
-}
-
 export interface ParsedTopologyResponse {
   id: string
   name: string
@@ -481,38 +383,7 @@ export interface ParsedTopologyResponse {
   mapping?: MetricsMapping
 }
 
-// ============================================
-// Alert Types
-// ============================================
-
-export type AlertSeverity = 'disaster' | 'high' | 'average' | 'warning' | 'information' | 'ok'
-export type AlertStatus = 'active' | 'resolved'
-
-export interface Alert {
-  id: string
-  severity: AlertSeverity
-  title: string
-  description?: string
-  host?: string
-  hostId?: string
-  nodeId?: string
-  startTime: number
-  endTime?: number
-  receivedAt?: number
-  status: AlertStatus
-  source: 'zabbix' | 'prometheus' | 'grafana'
-  url?: string
-  labels?: Record<string, string>
-}
-
-export interface AlertQueryOptions {
-  timeRange?: number
-  minSeverity?: AlertSeverity
-  activeOnly?: boolean
-  hostIds?: string[]
-}
-
-// Alert widget config
+// Alert widget config (web UI-only, not a core domain concept)
 export interface AlertWidgetConfig {
   dataSourceId: string
   title?: string

--- a/apps/server/web/src/lib/widgets/AlertWidget.svelte
+++ b/apps/server/web/src/lib/widgets/AlertWidget.svelte
@@ -50,53 +50,54 @@
 
   // Severity configuration
   const SEVERITY_COLORS: Record<AlertSeverity, string> = {
-    disaster: '#dc2626', // red-600
+    critical: '#dc2626', // red-600
     high: '#ea580c', // orange-600
-    average: '#d97706', // amber-600
-    warning: '#ca8a04', // yellow-600
-    information: '#eab308', // yellow-500
+    medium: '#d97706', // amber-600
+    low: '#ca8a04', // yellow-600
+    info: '#eab308', // yellow-500
     ok: '#6b7280', // gray-500
   }
 
   const SEVERITY_HIGHLIGHT_COLORS: Record<AlertSeverity, string> = {
-    disaster: '#dc2626',
+    critical: '#dc2626',
     high: '#ea580c',
-    average: '#d97706',
-    warning: '#ca8a04',
-    information: '#eab308',
+    medium: '#d97706',
+    low: '#ca8a04',
+    info: '#eab308',
     ok: '#6b7280',
   }
 
   const SEVERITY_BG_COLORS: Record<AlertSeverity, string> = {
-    disaster: 'bg-red-500/10',
+    critical: 'bg-red-500/10',
     high: 'bg-orange-500/10',
-    average: 'bg-amber-500/10',
-    warning: 'bg-yellow-500/10',
-    information: 'bg-yellow-400/10',
+    medium: 'bg-amber-500/10',
+    low: 'bg-yellow-500/10',
+    info: 'bg-yellow-400/10',
     ok: 'bg-gray-500/10',
   }
 
   const RESOLVED_COLOR = '#16a34a' // green-600
   const RESOLVED_BG_COLOR = 'bg-green-500/10'
 
+  // Severity rank: 0 = most severe (used to pick the "worst" of a batch).
   const SEVERITY_RANK: Record<AlertSeverity, number> = {
-    disaster: 0,
+    critical: 0,
     high: 1,
-    average: 2,
-    warning: 3,
-    information: 4,
+    medium: 2,
+    low: 3,
+    info: 4,
     ok: 5,
   }
 
   function getSeverityIcon(severity: AlertSeverity) {
     switch (severity) {
-      case 'disaster':
+      case 'critical':
         return FireIcon
       case 'high':
-      case 'average':
+      case 'medium':
         return WarningIcon
-      case 'warning':
-      case 'information':
+      case 'low':
+      case 'info':
         return InfoIcon
       case 'ok':
         return CheckCircleIcon

--- a/apps/server/web/src/lib/widgets/DeviceStatusWidget.svelte
+++ b/apps/server/web/src/lib/widgets/DeviceStatusWidget.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { type Node as NetworkNode, specDeviceType } from '@shumoku/core'
   import { CpuIcon, SpinnerIcon } from 'phosphor-svelte'
   import { onDestroy, onMount } from 'svelte'
   import { api } from '$lib/api'
@@ -8,7 +9,7 @@
     emitHighlightByAttribute,
     emitHighlightNodes,
   } from '$lib/stores/widgetEvents'
-  import type { NetworkNode, Topology } from '$lib/types'
+  import type { Topology } from '$lib/types'
   import WidgetWrapper from './WidgetWrapper.svelte'
 
   // --- Props ---
@@ -181,7 +182,7 @@
       { nodes: NetworkNode[]; up: number; down: number; unknown: number }
     >()
     for (const node of nodes) {
-      const type = node.spec?.type || 'unknown'
+      const type = specDeviceType(node.spec) || 'unknown'
       const g = groups.get(type) ?? { nodes: [], up: 0, down: 0, unknown: 0 }
       g.nodes.push(node)
       groups.set(type, g)
@@ -320,7 +321,7 @@
     const ids = nodes
       .filter(
         (n) =>
-          (n.spec?.type || 'unknown') === type &&
+          (specDeviceType(n.spec) || 'unknown') === type &&
           (nodeMetrics[n.id]?.status || 'unknown') === status,
       )
       .map((n) => n.id)

--- a/apps/server/web/src/routes/(app)/datasources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/+page.svelte
@@ -11,16 +11,11 @@
   import { Button } from '$lib/components/ui/button'
   import * as Dialog from '$lib/components/ui/dialog'
   import { dataSources, dataSourcesError, dataSourcesList, dataSourcesLoading } from '$lib/stores'
-  import type {
-    ConnectionTestResult,
-    DataSource,
-    DataSourcePluginInfo,
-    DataSourceType,
-  } from '$lib/types'
+  import type { ConnectionResult, DataSource, DataSourcePluginInfo } from '$lib/types'
 
   let showCreateModal = $state(false)
   let testingId = $state<string | null>(null)
-  let testResults = $state<Record<string, ConnectionTestResult>>({})
+  let testResults = $state<Record<string, ConnectionResult>>({})
 
   // Plugin types from API
   let pluginTypes = $state<DataSourcePluginInfo[]>([])
@@ -214,7 +209,7 @@
     try {
       const created = await dataSources.create({
         name: formName.trim(),
-        type: selectedPlugin.type as DataSourceType,
+        type: selectedPlugin.type,
         configJson: getConfigFromForm(),
       })
       showCreateModal = false

--- a/apps/server/web/src/routes/(app)/datasources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/+page.svelte
@@ -35,6 +35,10 @@
   let formTagFilter = $state('')
   let formPrometheusPreset = $state<'snmp' | 'node_exporter'>('snmp')
   let formInsecure = $state(false)
+  // Aruba Instant On uses portal account (email + password) instead of URL + token
+  let formArubaUsername = $state('')
+  let formArubaPassword = $state('')
+  let formArubaSiteId = $state('')
   let formError = $state('')
   let formSubmitting = $state(false)
   // Dynamic config values for external plugins
@@ -81,6 +85,9 @@
     formTagFilter = ''
     formInsecure = false
     formPrometheusPreset = 'snmp'
+    formArubaUsername = ''
+    formArubaPassword = ''
+    formArubaSiteId = ''
     // Initialize dynamic config from schema defaults
     dynamicConfig = {}
     if (plugin.configSchema?.properties) {
@@ -130,6 +137,14 @@
       })
     }
 
+    if (selectedPlugin.type === 'aruba-instant-on') {
+      return JSON.stringify({
+        username: formArubaUsername.trim(),
+        password: formArubaPassword,
+        siteId: formArubaSiteId.trim() || undefined,
+      })
+    }
+
     // External plugins with configSchema - use dynamicConfig
     if (selectedPlugin.configSchema?.properties) {
       const config: Record<string, unknown> = {}
@@ -165,6 +180,11 @@
     if (['zabbix', 'netbox', 'prometheus', 'grafana'].includes(selectedPlugin.type)) {
       if (!formName.trim() || !formUrl.trim()) {
         formError = 'Name and URL are required'
+        return
+      }
+    } else if (selectedPlugin.type === 'aruba-instant-on') {
+      if (!formName.trim() || !formArubaUsername.trim() || !formArubaPassword) {
+        formError = 'Name, portal email, and password are required'
         return
       }
     } else if (selectedPlugin.configSchema?.properties) {
@@ -499,7 +519,7 @@
           >
         </div>
 
-        {#if !selectedPlugin.configSchema?.properties || ['zabbix', 'netbox', 'prometheus', 'grafana'].includes(selectedPlugin.type)}
+        {#if ['zabbix', 'netbox', 'prometheus', 'grafana'].includes(selectedPlugin.type) || (!selectedPlugin.configSchema?.properties && selectedPlugin.type !== 'aruba-instant-on')}
           <div>
             <label for="url" class="label">URL</label>
             <input
@@ -562,6 +582,56 @@
           </div>
         {/if}
 
+        {#if selectedPlugin.type === 'aruba-instant-on'}
+          <div>
+            <label for="arubaUsername" class="label">Portal Email</label>
+            <input
+              type="email"
+              id="arubaUsername"
+              class="input"
+              placeholder="account@example.com"
+              autocomplete="username"
+              bind:value={formArubaUsername}
+            >
+            <p class="text-xs text-muted-foreground mt-1">
+              Aruba Instant On account email. <strong>MFA must be disabled</strong> on this account
+              — the (undocumented) API auth flow doesn't support MFA.
+            </p>
+          </div>
+
+          <div>
+            <label for="arubaPassword" class="label">Portal Password</label>
+            <input
+              type="password"
+              id="arubaPassword"
+              class="input"
+              placeholder="Account password"
+              autocomplete="current-password"
+              bind:value={formArubaPassword}
+            >
+          </div>
+
+          <div>
+            <label for="arubaSiteId" class="label">Site ID (optional)</label>
+            <input
+              type="text"
+              id="arubaSiteId"
+              class="input"
+              placeholder="Leave blank for all sites"
+              bind:value={formArubaSiteId}
+            >
+            <p class="text-xs text-muted-foreground mt-1">
+              Restrict polling to a single site. Leave empty to include every site the account can
+              access.
+            </p>
+          </div>
+
+          <div class="rounded border border-warning/40 bg-warning/10 p-3 text-xs text-foreground">
+            ⚠️ Aruba Instant On API is unofficial / unsupported by HPE. It may stop working without
+            notice.
+          </div>
+        {/if}
+
         {#if selectedPlugin.type === 'netbox'}
           <div>
             <label for="siteFilter" class="label">Site Filter (optional)</label>
@@ -595,7 +665,7 @@
         {/if}
 
         <!-- Dynamic fields from configSchema (external plugins) -->
-        {#if selectedPlugin.configSchema?.properties && !['zabbix', 'netbox', 'prometheus', 'grafana'].includes(selectedPlugin.type)}
+        {#if selectedPlugin.configSchema?.properties && !['zabbix', 'netbox', 'prometheus', 'grafana', 'aruba-instant-on'].includes(selectedPlugin.type)}
           {#each Object.entries(selectedPlugin.configSchema.properties) as [ key, prop ]}
             <div>
               <label for="config-{key}" class="label">

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -11,7 +11,7 @@
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
   import { api } from '$lib/api'
-  import type { ConnectionTestResult, DataSource, DataSourceType } from '$lib/types'
+  import type { ConnectionResult, DataSource } from '$lib/types'
 
   // Get ID from route params (always defined for this route)
   // biome-ignore lint/style/noNonNullAssertion: using depricated $page, which is not typed
@@ -21,7 +21,7 @@
   let loading = $state(true)
   let error = $state('')
   let saving = $state(false)
-  let testResult = $state<ConnectionTestResult | null>(null)
+  let testResult = $state<ConnectionResult | null>(null)
   let testing = $state(false)
 
   // Form state
@@ -55,7 +55,7 @@
     }
   }
 
-  function getConfigFromForm(type: DataSourceType): string {
+  function getConfigFromForm(type: string): string {
     const config: Record<string, unknown> = {
       url: formUrl.trim(),
     }

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -33,16 +33,38 @@
     showTrafficFlow,
     topologies,
   } from '$lib/stores'
+  import type { MetricsData } from '$lib/stores/metrics'
   import type {
     DataSource,
     EdgeEndpoint,
-    ParsedTopologyResponse,
+    MetricsMapping,
     SyncMode,
     Topology,
     TopologyDataSource,
     TopologyDataSourceInput,
   } from '$lib/types'
   import { nodeLabelById, nodeLabel as resolveNodeLabel } from '$lib/utils/node-label'
+
+  /**
+   * Local UI-side snapshot synthesized from `/api/topologies/:id/context`.
+   * Not the same as core's `NetworkGraph` — the mapping UI only reads a few
+   * fields per node/link and doesn't need the canonical model's full shape.
+   */
+  interface SettingsTopologySnapshot {
+    id: string
+    name: string
+    graph: {
+      nodes: Array<{
+        id: string
+        label?: string | string[]
+        spec?: { type?: string; vendor?: string }
+      }>
+      links: Array<{ id: string; from: string; to: string; standard?: string }>
+    }
+    metrics: MetricsData
+    dataSourceId?: string
+    mapping?: MetricsMapping
+  }
 
   // ============================================
   // State
@@ -95,7 +117,7 @@
   let overlayConfigs = $state<Record<string, OverlayConfig>>({})
 
   // Mapping state
-  let parsedTopology = $state<ParsedTopologyResponse | null>(null)
+  let parsedTopology = $state<SettingsTopologySnapshot | null>(null)
   let savingMapping = $state(false)
   let nodeSearchQuery = $state('')
   let autoMapResult = $state<{ matched: number; total: number; kind: 'nodes' | 'links' } | null>(
@@ -293,7 +315,6 @@
             standard: e.standard,
           })),
         },
-        layout: { nodes: {} },
         metrics: contextData.metrics,
         dataSourceId: contextData.dataSourceId,
         mapping: contextData.mapping,

--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,7 @@
         "hono": "^4.7.11",
         "js-yaml": "^4.1.0",
         "nanoid": "^5.0.9",
+        "shumoku-plugin-aruba-instant-on": "workspace:*",
         "shumoku-plugin-grafana": "workspace:*",
         "shumoku-plugin-netbox": "workspace:*",
         "shumoku-plugin-prometheus": "workspace:*",
@@ -231,6 +232,13 @@
       "version": "0.2.25",
       "dependencies": {
         "@shumoku/core": "^0.2.23",
+      },
+    },
+    "libs/plugins/aruba-instant-on": {
+      "name": "shumoku-plugin-aruba-instant-on",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shumoku/core": "workspace:*",
       },
     },
     "libs/plugins/grafana": {
@@ -1593,6 +1601,8 @@
     "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "shumoku": ["shumoku@workspace:libs/shumoku"],
+
+    "shumoku-plugin-aruba-instant-on": ["shumoku-plugin-aruba-instant-on@workspace:libs/plugins/aruba-instant-on"],
 
     "shumoku-plugin-grafana": ["shumoku-plugin-grafana@workspace:libs/plugins/grafana"],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,7 @@ this doc focuses on the flows that span packages.
 - [Placement APIs — when to use which](#placement-apis--when-to-use-which)
 - [End-to-end use cases](#end-to-end-use-cases)
 - [Package boundaries](#package-boundaries)
+  - [Plugin contract](#plugin-contract)
 - [Camera (pan/zoom)](#camera-panzoom)
 - [Known gaps](#known-gaps)
 
@@ -532,6 +533,27 @@ The **canonical data shape** at every boundary is `NetworkGraph`
 (core's type). YAML and the project JSON (`NetedProject`, which wraps
 `NetworkGraph`) are boundary formats; everything inside the system
 speaks `NetworkGraph`.
+
+### Plugin contract
+
+Data-source plugins (Zabbix, NetBox, Prometheus, Grafana, Aruba
+Instant On) connect shumoku to external systems through a small
+contract in `@shumoku/core`. The rule is **core defines the display
+contract; plugins conform**. Concretely:
+
+- Core types describe what the UI consumes — `Host`, `Alert`,
+  `LinkMetrics`, etc. — and contain no plugin-name enums.
+- Plugins translate upstream vocabularies (Zabbix priorities,
+  Prometheus severities, Aruba health tokens) into core vocab at
+  their own boundary — never the other way.
+- The web app renders plugins generically via `configSchema`; it
+  must not branch on `plugin.type`. (Issue #270 tracks fixing the
+  remaining hardcoded forms.)
+
+For the full author-facing reference — capability mixins, data
+shapes, severity translation table, the three node-state axes, the
+passthrough `discoverMetrics` pattern, dev-only `nativeApi` — see
+[`plugin-authoring.md`](./plugin-authoring.md).
 
 ---
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -1,0 +1,423 @@
+# Authoring a data source plugin
+
+A `DataSourcePlugin` is what connects shumoku to a monitoring or
+inventory system (Zabbix, NetBox, Prometheus, Grafana, Aruba Instant
+On, …). Plugins surface **hosts**, **metrics**, **alerts**, or
+**topology** through a small set of TypeScript interfaces defined in
+`@shumoku/core`. The UI and runtime do not know which plugins exist —
+they only know the capability contracts.
+
+This document is the contract reference for authors of bundled and
+external plugins.
+
+## Contents
+
+- [Design principle](#design-principle)
+- [Capability interfaces](#capability-interfaces)
+- [Lifecycle](#lifecycle)
+- [Data shapes](#data-shapes)
+- [Alert severity mapping](#alert-severity-mapping)
+- [The three node-state axes](#the-three-node-state-axes)
+- [`discoverMetrics` — passthrough by default](#discovermetrics--passthrough-by-default)
+- [Native API passthrough (dev only)](#native-api-passthrough-dev-only)
+- [Registration](#registration)
+- [Security practices for unofficial APIs](#security-practices-for-unofficial-apis)
+- [Don'ts](#donts)
+
+---
+
+## Design principle
+
+> **Core defines the display contract. Plugins conform to it.**
+
+The types in `libs/@shumoku/core/src/plugin-types.ts` describe what
+the UI consumes — `Host`, `HostItem`, `Alert`, `LinkMetrics`,
+`DiscoveredMetric`, etc. Plugins translate their native vocabulary
+into these shapes at the **plugin boundary** so the UI never has to
+know whether it's looking at a Zabbix item or a Prometheus series.
+
+Consequences:
+
+- **Never enumerate plugin names in core.** `Alert.source: string`,
+  not `'zabbix' | 'prometheus' | …`. New plugins must not require
+  edits to `@shumoku/core`.
+- **Never push upstream vocabulary into core.** If an upstream system
+  says `"average"` and the rest of the world says `"medium"`, the
+  plugin translates `"average" → "medium"` — not the other way.
+- **Never branch on plugin type in the UI.** Render plugins through
+  their `configSchema` (open issue #270 tracks bundled-plugin
+  cleanup); render alerts through `AlertSeverity`; render hosts
+  through `Host`. The renderer should be a generic consumer.
+
+If you find yourself adding a `if (plugin.type === 'foo')` in core
+or the web app, that's the signal something is wrong with the
+contract, not with the UI.
+
+---
+
+## Capability interfaces
+
+A plugin implements `DataSourcePlugin` plus zero or more capability
+mixins. The mixins advertise what the plugin can do; the runtime asks
+each plugin for its declared capabilities and routes calls
+accordingly.
+
+| Mixin              | Purpose                                                | Methods                              |
+|--------------------|--------------------------------------------------------|--------------------------------------|
+| `TopologyCapable`  | Provide a `NetworkGraph` (nodes, links, subgraphs)     | `fetchTopology`, `watchTopology?`    |
+| `HostsCapable`     | List the monitored hosts so the mapping UI can choose  | `getHosts`, `getHostItems?`, `searchHosts?`, `discoverMetrics?` |
+| `MetricsCapable`   | Poll current metrics for mapped nodes/links            | `pollMetrics`, `subscribeMetrics?`   |
+| `AlertsCapable`    | Surface active/resolved alerts                         | `getAlerts`                          |
+| `NativeApiCapable` | Dev-only raw API passthrough for debugging             | `nativeApi(method, params)`          |
+
+`capabilities` on the plugin instance is the **advertised** set:
+
+```ts
+readonly capabilities: readonly DataSourceCapability[] = ['hosts', 'metrics', 'alerts']
+```
+
+Type guards (`hasMetricsCapability(plugin)`, etc.) gate dispatch in
+the server, so capabilities and the implemented methods must agree.
+
+`NativeApiCapable` is intentionally **off** the advertised
+capability list — it's a duck-typed escape hatch (`hasNativeApi`)
+that the server only exposes when `NODE_ENV=development`.
+
+---
+
+## Lifecycle
+
+```ts
+class MyPlugin implements DataSourcePlugin, MetricsCapable {
+  readonly type = 'my-plugin'
+  readonly displayName = 'My Plugin'
+  readonly capabilities = ['metrics'] as const
+
+  initialize(config: unknown): void {
+    // Validate and store config. Throw on missing required fields —
+    // the server logs and surfaces the error in the data-source UI.
+    const c = config as Partial<MyPluginConfig>
+    if (!c.url) throw new Error('`url` is required')
+    this.config = c as MyPluginConfig
+  }
+
+  async testConnection(): Promise<ConnectionResult> {
+    // Cheap end-to-end check (≤1 HTTP call). Used by the "Test
+    // connection" button in the data-source UI. Return `warnings`
+    // for non-fatal concerns (insecure HTTP, unofficial API).
+  }
+
+  dispose(): void {
+    // Optional. Free resources (timers, websockets, caches).
+  }
+}
+```
+
+`initialize()` is called once after construction. The plugin keeps
+its config for the lifetime of the instance. Server code may swap
+instances when a data source's config changes — implement `dispose`
+if you hold long-lived resources.
+
+---
+
+## Data shapes
+
+### `Host`
+
+What the mapping UI lists as candidates for a topology node.
+
+```ts
+interface Host {
+  id: string            // stable upstream id (serial, hostid, instance)
+  name: string          // canonical name for matching
+  displayName?: string  // operator-assigned label, if different
+  status?: 'up' | 'down' | 'unknown'
+  ip?: string
+}
+```
+
+Pick `id` from the **most stable** upstream identifier. For Aruba
+we use serial number; for Zabbix the `hostid`; for Prometheus the
+`instance` label. Renames in the upstream system shouldn't change
+`id`.
+
+### `HostItem`
+
+Per-host *interfaces* the link-mapping UI offers. Two items per
+physical port (one `in`, one `out`) is the convention — that
+matches Zabbix's `net.if.in[*]` / `net.if.out[*]` split and lets
+plugins with a single bidirectional reading (Aruba, SNMP
+`portDataTraffic`) expand transparently.
+
+```ts
+interface HostItem {
+  id: string
+  hostId: string
+  name: string           // human label
+  key: string            // upstream key (used by pollMetrics)
+  lastValue?: string
+  unit?: string
+  interfaceName?: string // "Gi1/0/1" — used by auto-mapping
+  direction?: 'in' | 'out'
+}
+```
+
+### `MetricsData` / `NodeMetrics` / `LinkMetrics`
+
+The shape `pollMetrics` returns. One entry per mapped node/link.
+
+```ts
+interface MetricsData {
+  nodes: Record<string, NodeMetrics>
+  links: Record<string, LinkMetrics>
+  timestamp: number
+  warnings?: string[]
+}
+
+interface NodeMetrics {
+  status: 'up' | 'down' | 'unknown' | 'warning' | 'degraded'
+  monitoring?: 'healthy' | 'failing' | 'pending' | 'paused'
+  monitoringError?: string
+  cpu?: number
+  memory?: number
+  lastSeen?: number
+}
+
+interface LinkMetrics {
+  status: 'up' | 'down' | 'unknown' | 'warning' | 'degraded'
+  utilization?: number     // legacy: max of in/out
+  inUtilization?: number   // 0–100
+  outUtilization?: number
+  inBps?: number
+  outBps?: number
+}
+```
+
+Plugins that report only a percentage (legacy Zabbix items) can
+leave `inBps` / `outBps` undefined; renderers will animate by
+utilization instead. Plugins that report only bps should compute
+utilization from the link's bandwidth (`linkMapping.bandwidth ??
+link.bandwidth`) at the boundary so the renderer doesn't have to
+care.
+
+### `Alert`
+
+```ts
+interface Alert {
+  id: string
+  severity: AlertSeverity          // see mapping below
+  title: string
+  description?: string
+  host?: string
+  hostId?: string
+  nodeId?: string
+  startTime: number                // unix ms
+  endTime?: number
+  status: 'active' | 'resolved'
+  source: string                   // your plugin's `type`
+  receivedAt?: number
+  url?: string                     // back to upstream UI
+  labels?: Record<string, string>
+}
+```
+
+---
+
+## Alert severity mapping
+
+Core uses a neutral CVSS-style scale, ordered low → high:
+
+```
+ok  <  info  <  low  <  medium  <  high  <  critical
+```
+
+Plugins translate their upstream vocabulary at the boundary. Common
+mappings:
+
+| Upstream               | Token       | → shumoku  |
+|------------------------|-------------|------------|
+| Zabbix priority 0–1    | not-classified / information | `info`     |
+| Zabbix priority 2      | warning     | `low`      |
+| Zabbix priority 3      | average     | `medium`   |
+| Zabbix priority 4      | high        | `high`     |
+| Zabbix priority 5      | disaster    | `critical` |
+| Prometheus / Alertmanager | `critical` | `critical` |
+| Prometheus / Alertmanager | `warning`  | `low`      |
+| Prometheus / Alertmanager | `info`     | `info`     |
+| Aruba Instant On       | `MAJOR`     | `high`     |
+| Aruba Instant On       | `MINOR`     | `low`      |
+| (generic)              | `error` / `major` | `high`     |
+| (generic)              | `medium` / `moderate` | `medium`   |
+| (generic)              | `none` / `ok` | `ok`       |
+
+The mapping is **position-preserving** against the pre-refactor
+Zabbix-flavored scale — plugins that used to emit `'disaster'` now
+emit `'critical'`, plugins that used to emit `'average'` now emit
+`'medium'`, etc. If you're authoring a new plugin, copy the table
+above; don't invent a new mapping.
+
+---
+
+## The three node-state axes
+
+When a plugin reports a node's state, three orthogonal concepts are
+in play. Keep them separate; conflating them is a regression we've
+hit multiple times.
+
+| Axis             | Field                       | Question answered             |
+|------------------|-----------------------------|-------------------------------|
+| **Mapping**      | (presence of host mapping)  | "Is this topology node bound to an upstream host?" |
+| **Device**      | `NodeMetrics.status`        | "Is the device itself up/down?" |
+| **Monitoring** | `NodeMetrics.monitoring`    | "Is our monitoring path healthy?" |
+
+A reachable agent on a powered-off device → `status: 'down'`,
+`monitoring: 'healthy'`. A working device behind a flapping SNMP
+collector → `status: 'unknown'`, `monitoring: 'failing'`. Don't
+collapse them — the UI renders them separately.
+
+---
+
+## `discoverMetrics` — passthrough by default
+
+`HostsCapable.discoverMetrics(hostId)` powers the "All metrics"
+debug panel in the node-detail modal. Its purpose is **to show
+exactly what the upstream system returned** so an operator can pick
+the right item to map.
+
+This is a **passthrough dump**, not a curated report. Three
+implications:
+
+1. Don't hand-enumerate fields. If you do, you'll forget some, and
+   the operator can't tell the difference between "we don't get
+   that field" and "the plugin forgot it." Use the existing
+   `flattenObject` pattern in `libs/plugins/aruba-instant-on/src/plugin.ts`
+   as a template — it walks the upstream record and emits one
+   `DiscoveredMetric` per primitive leaf.
+
+2. `DiscoveredMetric.value` is `number | string | boolean`.
+   Categorical attributes (model strings, health tokens, IP
+   addresses) flow through unchanged. The UI renders them as text.
+
+3. Plugin-specific metadata (Prometheus's `counter`/`gauge` type,
+   Zabbix's `value_type`, SNMP's OID) goes in `labels` with an `__`
+   prefix:
+
+   ```ts
+   labels['__type'] = 'counter'         // Prometheus
+   labels['__value_type'] = 'numeric_unsigned'  // Zabbix
+   ```
+
+   Core doesn't bless a "metric type" vocabulary. The `__` prefix
+   signals "metadata about the metric itself, not a sub-dimension."
+
+---
+
+## Native API passthrough (dev only)
+
+For plugins backed by undocumented or rapidly-changing APIs (Aruba
+Instant On is the canonical example), implement
+`NativeApiCapable.nativeApi(method, params)` so developers can poke
+the upstream system directly through the debug UI.
+
+```ts
+async nativeApi(method: string, params: Record<string, unknown>): Promise<unknown> {
+  // `method` is plugin-defined. For REST plugins, treat it as the
+  // path; for JSON-RPC plugins, treat it as the method name.
+  // Return the raw upstream response unchanged — the caller is a
+  // developer who wants to see what the API actually said.
+}
+```
+
+The server only exposes this when `NODE_ENV=development`. Do not
+gate on a config flag — the env check is the single source of truth.
+See PR #260 for the pattern.
+
+---
+
+## Registration
+
+**Bundled plugins** ship in `libs/plugins/<name>/` and self-register
+on startup via `apps/server/api/src/plugins/index.ts`:
+
+```ts
+import { register as registerMyPlugin } from 'shumoku-plugin-my-plugin'
+
+export function registerBundledPlugins(): void {
+  registerMyPlugin(pluginRegistry)
+}
+```
+
+Each plugin's `index.ts` exports a `register` function that calls
+`pluginRegistry.register(type, displayName, capabilities, factory)`.
+
+**External plugins** are installed at runtime via the plugins UI;
+they ship a `plugin.json` manifest plus a JS bundle and are loaded
+dynamically. The manifest's `configSchema` (JSON Schema subset)
+drives the data-source config form automatically.
+
+Bundled plugins **should** declare a `configSchema` too — they
+currently don't (issue #270), which is why the web app carries
+hardcoded form branches per plugin. New plugins are encouraged to
+populate it from day one even though the bundled-plugin path
+doesn't read it yet.
+
+---
+
+## Security practices for unofficial APIs
+
+When the upstream API is undocumented or unsupported (Instant On,
+scraped portals, etc.), follow the patterns established in
+`libs/plugins/aruba-instant-on/src/auth.ts`:
+
+- **Hard-code endpoint URLs.** No `config.url` overrides for
+  upstream hosts — that's a credential-exfiltration vector if a
+  hostile operator points the plugin at their own server.
+- **HTTPS only.** Reject `http://` at parse time.
+- **Never log credentials or tokens.** Not in error messages, not
+  in debug output, not in the native API response.
+- **In-memory token cache.** Refresh on 401, never persist to disk.
+- **Loud failure on auth flow regressions.** If the upstream
+  changes the auth response shape, fail with a clear error rather
+  than silently downgrading — these APIs break without notice and
+  silent degradation hides the cause.
+- **Document the warranty.** Surface a `ConnectionResult.warnings`
+  entry explaining the API is unofficial. The data-source UI
+  displays them.
+
+---
+
+## Don'ts
+
+- **Don't widen `Alert.source` to include your plugin name as a
+  literal.** It's already `string`. The plugin emits its `type`.
+- **Don't add your plugin's name to any union type in core or in
+  `apps/server/web/`.** If something requires this, it's a contract
+  bug — file an issue rather than working around it.
+- **Don't bypass the capability mixins.** If your plugin has a
+  capability not in the list (e.g. config validation, schema
+  introspection), don't bolt it onto `DataSourcePlugin` as an
+  optional method — propose a new mixin in `plugin-types.ts`.
+- **Don't translate to shumoku vocab inside `pollMetrics` only.**
+  Centralize upstream-vocab → core-vocab translation in helpers
+  (`mapSeverity`, `classifyDeviceStatus`) at the **boundary** of
+  the plugin, so the rest of the plugin code reads in core's
+  vocabulary.
+- **Don't emit zeros for missing data.** A `LinkMetrics` with
+  `status: 'unknown'` and no `inBps`/`outBps` is better than
+  `status: 'up'` with `inBps: 0` — the second pretends to know
+  something. The renderer treats `unknown` as "no data".
+
+---
+
+## Reference plugins
+
+When in doubt, read the existing bundled plugins — they're each
+opinionated about a different upstream shape:
+
+| Plugin                            | Demonstrates                                                  |
+|-----------------------------------|---------------------------------------------------------------|
+| `libs/plugins/zabbix/`            | JSON-RPC auth, paginated item polling, severity translation   |
+| `libs/plugins/netbox/`            | REST + token, topology generation, site/tag filtering         |
+| `libs/plugins/prometheus/`        | Range queries, Alertmanager severity mapping, host discovery  |
+| `libs/plugins/grafana/`           | Webhook receiver, in-memory alert state                       |
+| `libs/plugins/aruba-instant-on/`  | OAuth2+PKCE auth, single inventory call feeding multiple capabilities, passthrough `discoverMetrics`, dev-only `nativeApi` |

--- a/libs/@shumoku/core/src/plugin-types.ts
+++ b/libs/@shumoku/core/src/plugin-types.ts
@@ -58,19 +58,28 @@ export interface HostItem {
 }
 
 /**
- * A metric discovered from a data source for a specific host
+ * A metric discovered from a data source for a specific host.
+ *
+ * The "All metrics" tab in the mapping UI dumps these for browsing —
+ * the contract is intentionally just the bits the UI renders: a name,
+ * a current value, optional labels for sub-dimensions, and a help blurb.
+ * Plugin-specific metadata (Prometheus type, Zabbix value_type, SNMP OID,
+ * …) can ride in `labels` if the plugin wants to surface it.
  */
 export interface DiscoveredMetric {
   /** Metric name (e.g., "ifHCInOctets", "node_cpu_seconds_total") */
   name: string
   /** Labels associated with this metric */
   labels: Record<string, string>
-  /** Current value */
-  value: number
+  /**
+   * Current value. Widened beyond `number` because the "All metrics"
+   * tab is a dump of *everything* a plugin can surface — numeric gauges
+   * coexist with categorical attributes (model strings, link state
+   * tokens, boolean health flags). UI branches on `typeof value`.
+   */
+  value: number | string | boolean
   /** Human-readable description (from HELP) */
   help?: string
-  /** Metric type (counter, gauge, histogram, summary) */
-  type?: string
 }
 
 // ============================================
@@ -179,9 +188,11 @@ export interface MetricsMapping {
 // ============================================
 
 /**
- * Alert severity levels
+ * Alert severity levels — neutral scale (CVSS-style) so plugins map their
+ * native vocabularies onto a display contract instead of bending toward any
+ * one upstream's terminology. Ordered ok < info < low < medium < high < critical.
  */
-export type AlertSeverity = 'disaster' | 'high' | 'average' | 'warning' | 'information' | 'ok'
+export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info' | 'ok'
 
 /**
  * Alert status
@@ -212,8 +223,9 @@ export interface Alert {
   endTime?: number
   /** Current alert status */
   status: AlertStatus
-  /** Source system */
-  source: 'zabbix' | 'prometheus' | 'grafana' | 'aruba-instant-on'
+  /** Source plugin `type` (e.g. 'zabbix', 'prometheus'). Open string so
+   *  external plugins can supply their own identifier without core edits. */
+  source: string
   /** When the alert was received via webhook (Unix timestamp in ms) */
   receivedAt?: number
   /** URL to the alert details in the source system */

--- a/libs/@shumoku/core/src/plugin-types.ts
+++ b/libs/@shumoku/core/src/plugin-types.ts
@@ -213,7 +213,7 @@ export interface Alert {
   /** Current alert status */
   status: AlertStatus
   /** Source system */
-  source: 'zabbix' | 'prometheus' | 'grafana'
+  source: 'zabbix' | 'prometheus' | 'grafana' | 'aruba-instant-on'
   /** When the alert was received via webhook (Unix timestamp in ms) */
   receivedAt?: number
   /** URL to the alert details in the source system */

--- a/libs/plugins/aruba-instant-on/package.json
+++ b/libs/plugins/aruba-instant-on/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "shumoku-plugin-aruba-instant-on",
+  "version": "0.1.0",
+  "description": "Aruba Instant On (cloud-managed AP / switch) data source plugin for Shumoku. Uses the undocumented portal.arubainstanton.com API.",
+  "license": "AGPL-3.0-only",
+  "author": "konoe-akitoshi",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
+    "directory": "libs/plugins/aruba-instant-on"
+  },
+  "homepage": "https://shumoku.packof.me/",
+  "bugs": {
+    "url": "https://github.com/konoe-akitoshi/shumoku/issues"
+  },
+  "keywords": [
+    "aruba",
+    "instant-on",
+    "wifi",
+    "switch",
+    "network",
+    "topology",
+    "shumoku",
+    "plugin"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "format": "biome check --write ."
+  },
+  "dependencies": {
+    "@shumoku/core": "workspace:*"
+  },
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libs/plugins/aruba-instant-on/src/api.ts
+++ b/libs/plugins/aruba-instant-on/src/api.ts
@@ -1,0 +1,91 @@
+/**
+ * Aruba Instant On API client — holds the bearer token and adds the headers
+ * the portal expects on every call. Handles transparent re-auth on token
+ * expiry / 401.
+ */
+
+import { type AccessToken, obtainAccessToken } from './auth.js'
+import type { ArubaInstantOnConfig } from './types.js'
+
+const API_BASE = 'https://nb.portal.arubainstanton.com/api'
+
+/** Required by the portal — version bumps would be the canary for a breaking change. */
+const API_VERSION_HEADER = '7'
+
+export class ArubaInstantOnApi {
+  private token: AccessToken | null = null
+  private pendingAuth: Promise<AccessToken> | null = null
+
+  constructor(private readonly config: ArubaInstantOnConfig) {}
+
+  /**
+   * GET <path> (path starts with `/api/...` semantics; we prepend the host).
+   * Re-auths once if the upstream rejects the token.
+   */
+  async get<T>(path: string): Promise<T> {
+    return this.request<T>('GET', path)
+  }
+
+  /**
+   * Raw passthrough used by the dev-mode native API endpoint. `method` is the
+   * HTTP method; `params` carries either a `path` query (for GET) or whatever
+   * the developer wants to slot into a body. Keep this thin — it's debug.
+   */
+  async nativeApi(method: string, params: Record<string, unknown>): Promise<unknown> {
+    const path = typeof params['path'] === 'string' ? (params['path'] as string) : '/sites/'
+    return this.request<unknown>(method, path, params['body'])
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${API_BASE}${path.startsWith('/') ? path : `/${path}`}`
+    const send = async (token: string): Promise<Response> => {
+      const init: RequestInit = {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'x-ion-api-version': API_VERSION_HEADER,
+          'Content-Type': 'application/json',
+        },
+      }
+      if (body !== undefined && method !== 'GET') {
+        init.body = typeof body === 'string' ? body : JSON.stringify(body)
+      }
+      return fetch(url, init)
+    }
+
+    let { token } = await this.ensureToken()
+    let resp = await send(token)
+    if (resp.status === 401) {
+      // Token may have been revoked or expired earlier than we tracked.
+      this.token = null
+      ;({ token } = await this.ensureToken())
+      resp = await send(token)
+    }
+    if (!resp.ok) {
+      throw new Error(`Aruba Instant On API ${method} ${path} → HTTP ${resp.status}`)
+    }
+    if (resp.status === 204) {
+      return undefined as T
+    }
+    return (await resp.json()) as T
+  }
+
+  /**
+   * Obtain a non-expired token. Concurrent callers share one in-flight auth
+   * so we don't fire several parallel `obtainAccessToken` flows when the
+   * plugin's metrics poll, alerts fetch, etc. all hit at once.
+   */
+  private async ensureToken(): Promise<AccessToken> {
+    if (this.token && this.token.expiresAt > Date.now()) return this.token
+    if (!this.pendingAuth) {
+      this.pendingAuth = obtainAccessToken({
+        username: this.config.username,
+        password: this.config.password,
+      }).finally(() => {
+        this.pendingAuth = null
+      })
+    }
+    this.token = await this.pendingAuth
+    return this.token
+  }
+}

--- a/libs/plugins/aruba-instant-on/src/auth.ts
+++ b/libs/plugins/aruba-instant-on/src/auth.ts
@@ -1,0 +1,207 @@
+/**
+ * Aruba Instant On authentication — OAuth2 + PKCE against the undocumented
+ * portal API.
+ *
+ * **This is reverse-engineered**. Aruba's official position is that the API
+ * does not exist; treat any failure as "the protocol may have changed
+ * upstream" and re-verify the request shape rather than just patching the
+ * error path.
+ *
+ * Flow summary:
+ *   1. POST  sso/aio/api/v1/mfa/validate/full  (username+password)
+ *      → JSON { access_token } — used below as the `sessionToken`.
+ *   2. GET   portal/settings.json
+ *      → JSON { ssoClientIdAuthZ } — the OAuth client_id.
+ *   3. GET   sso/as/authorization.oauth2  (PKCE + sessionToken)
+ *      → 302 Location: https://portal.arubainstanton.com/?code=...
+ *        Manual redirect handling — we read Location, not follow.
+ *   4. POST  sso/as/token.oauth2  (code + code_verifier)
+ *      → JSON { access_token, expires_in }
+ *
+ * Security notes:
+ *   - Credentials live only inside this module's call frames. No logging
+ *     of username/password/tokens; failure messages never embed the body.
+ *   - PKCE verifier uses 32 bytes of crypto-random, S256 challenge.
+ *   - `redirect: 'manual'` so we don't auto-follow into the portal URL.
+ *   - All endpoints are HTTPS, hardcoded — no operator-controlled base URL
+ *     to repoint, so SSRF surface is limited to portal.arubainstanton.com /
+ *     sso.arubainstanton.com.
+ */
+
+import { createHash, randomBytes } from 'node:crypto'
+
+const SSO_BASE = 'https://sso.arubainstanton.com'
+const PORTAL_BASE = 'https://portal.arubainstanton.com'
+
+/** A live bearer token plus when we expect it to stop working. */
+export interface AccessToken {
+  token: string
+  /** Epoch ms when the token should be assumed expired (~5min slack applied). */
+  expiresAt: number
+}
+
+interface Credentials {
+  username: string
+  password: string
+}
+
+interface LoginResponse {
+  access_token?: string
+}
+
+interface SettingsResponse {
+  ssoClientIdAuthZ?: string
+}
+
+interface TokenResponse {
+  access_token?: string
+  expires_in?: number
+}
+
+/**
+ * Run the full PKCE auth dance and return an access token. Throws with a
+ * scrubbed message on any step failure — never echoes the password back.
+ */
+export async function obtainAccessToken(creds: Credentials): Promise<AccessToken> {
+  // 1. Login → sessionToken
+  const sessionToken = await login(creds)
+
+  // 2. Pull client_id from the portal's runtime settings
+  const clientId = await fetchClientId()
+
+  // 3. PKCE authorize → authorization code
+  const verifier = generateCodeVerifier()
+  const challenge = generateCodeChallenge(verifier)
+  const code = await authorize({ clientId, sessionToken, challenge })
+
+  // 4. Token exchange
+  const token = await exchangeCodeForToken({ clientId, code, verifier })
+
+  return token
+}
+
+// ---------------------------------------------------------------------------
+// Step implementations
+// ---------------------------------------------------------------------------
+
+async function login(creds: Credentials): Promise<string> {
+  const body = new URLSearchParams({
+    username: creds.username,
+    password: creds.password,
+  })
+  const resp = await fetch(`${SSO_BASE}/aio/api/v1/mfa/validate/full`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  if (!resp.ok) {
+    throw new Error(`Aruba Instant On login failed: HTTP ${resp.status}`)
+  }
+  const json = (await resp.json()) as LoginResponse
+  if (!json.access_token) {
+    throw new Error(
+      'Aruba Instant On login response missing access_token (account may have MFA enabled)',
+    )
+  }
+  return json.access_token
+}
+
+async function fetchClientId(): Promise<string> {
+  const resp = await fetch(`${PORTAL_BASE}/settings.json`)
+  if (!resp.ok) {
+    throw new Error(`Aruba Instant On settings.json fetch failed: HTTP ${resp.status}`)
+  }
+  const json = (await resp.json()) as SettingsResponse
+  if (!json.ssoClientIdAuthZ) {
+    throw new Error('Aruba Instant On settings.json missing ssoClientIdAuthZ')
+  }
+  return json.ssoClientIdAuthZ
+}
+
+interface AuthorizeArgs {
+  clientId: string
+  sessionToken: string
+  challenge: string
+}
+
+async function authorize(args: AuthorizeArgs): Promise<string> {
+  const url = new URL(`${SSO_BASE}/as/authorization.oauth2`)
+  url.searchParams.set('client_id', args.clientId)
+  url.searchParams.set('redirect_uri', PORTAL_BASE)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('scope', 'profile openid')
+  url.searchParams.set('state', generateState())
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('code_challenge', args.challenge)
+  url.searchParams.set('sessionToken', args.sessionToken)
+
+  // `manual` keeps us from chasing the redirect into the portal — we just
+  // want the `code` query param off the Location header.
+  const resp = await fetch(url, { redirect: 'manual' })
+  if (resp.status !== 302 && resp.status !== 303 && resp.status !== 307) {
+    throw new Error(`Aruba Instant On authorize returned non-redirect HTTP ${resp.status}`)
+  }
+  const loc = resp.headers.get('location')
+  if (!loc) {
+    throw new Error('Aruba Instant On authorize missing Location header')
+  }
+  const code = new URL(loc).searchParams.get('code')
+  if (!code) {
+    throw new Error('Aruba Instant On authorize redirect missing `code` parameter')
+  }
+  return code
+}
+
+interface ExchangeArgs {
+  clientId: string
+  code: string
+  verifier: string
+}
+
+async function exchangeCodeForToken(args: ExchangeArgs): Promise<AccessToken> {
+  const body = new URLSearchParams({
+    client_id: args.clientId,
+    redirect_uri: PORTAL_BASE,
+    code: args.code,
+    code_verifier: args.verifier,
+    grant_type: 'authorization_code',
+  })
+  const resp = await fetch(`${SSO_BASE}/as/token.oauth2`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+  if (!resp.ok) {
+    throw new Error(`Aruba Instant On token exchange failed: HTTP ${resp.status}`)
+  }
+  const json = (await resp.json()) as TokenResponse
+  if (!json.access_token) {
+    throw new Error('Aruba Instant On token response missing access_token')
+  }
+  // Re-auth a bit before the upstream-stated expiry so a long-running poll
+  // doesn't fire mid-request and surprise us with a 401.
+  const ttlSec = json.expires_in ?? 3600
+  const expiresAt = Date.now() + Math.max(ttlSec - 300, 60) * 1000
+  return { token: json.access_token, expiresAt }
+}
+
+// ---------------------------------------------------------------------------
+// PKCE helpers
+// ---------------------------------------------------------------------------
+
+function generateCodeVerifier(): string {
+  // 32 bytes ≈ 256 bits → ~43 base64url chars, well above RFC 7636's 43-min.
+  return base64UrlEncode(randomBytes(32))
+}
+
+function generateCodeChallenge(verifier: string): string {
+  return base64UrlEncode(createHash('sha256').update(verifier).digest())
+}
+
+function generateState(): string {
+  return base64UrlEncode(randomBytes(16))
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}

--- a/libs/plugins/aruba-instant-on/src/index.ts
+++ b/libs/plugins/aruba-instant-on/src/index.ts
@@ -1,0 +1,18 @@
+export { ArubaInstantOnPlugin } from './plugin.js'
+export type { ArubaInstantOnConfig } from './types.js'
+
+import type { PluginRegistryInterface } from '@shumoku/core'
+import { ArubaInstantOnPlugin } from './plugin.js'
+
+export function register(registry: PluginRegistryInterface): void {
+  registry.register(
+    'aruba-instant-on',
+    'Aruba Instant On',
+    ['hosts', 'metrics', 'alerts'],
+    (config) => {
+      const plugin = new ArubaInstantOnPlugin()
+      plugin.initialize(config)
+      return plugin
+    },
+  )
+}

--- a/libs/plugins/aruba-instant-on/src/plugin.ts
+++ b/libs/plugins/aruba-instant-on/src/plugin.ts
@@ -32,9 +32,8 @@ import type {
 } from '@shumoku/core'
 import { ArubaInstantOnApi } from './api.js'
 import type {
-  AruAlertItem,
-  AruAlertsResponse,
   ArubaInstantOnConfig,
+  AruEmbeddedAlert,
   AruInventoryDevice,
   AruInventoryResponse,
   AruSite,
@@ -95,12 +94,14 @@ export class ArubaInstantOnPlugin
     for (const site of sites) {
       const inv = await this.api.get<AruInventoryResponse>(`/sites/${site.id}/inventory`)
       for (const d of inv.elements ?? []) {
-        const id = d.serialNumber || d.macAddress
+        // Prefer serial number (stable, human-recognisable on Aruba's part
+        // numbers) then fall back to the portal's id (MAC) or macAddress.
+        const id = d.serialNumber || d.id || d.macAddress
         if (!id) continue
         out.push({
           id,
-          name: d.name || id,
-          displayName: d.name,
+          name: d.name || d.defaultName || id,
+          displayName: d.name || d.defaultName,
           status: classifyDeviceStatus(d.status) === 'up' ? 'up' : 'down',
           ip: d.ipAddress,
         })
@@ -131,8 +132,7 @@ export class ArubaInstantOnPlugin
     const hasMappedHost = Object.values(mapping.nodes ?? {}).some((n) => n.hostId)
     if (!hasMappedHost || !this.api) return metrics
 
-    // Build a lookup: deviceId (serial or MAC) → inventory record
-    const byId = await this.deviceLookup()
+    const { byId } = await this.deviceLookup()
 
     for (const [nodeId, nodeMapping] of Object.entries(mapping.nodes || {})) {
       if (!nodeMapping.hostId) continue
@@ -159,17 +159,15 @@ export class ArubaInstantOnPlugin
 
   async getAlerts(_options?: AlertQueryOptions): Promise<Alert[]> {
     if (!this.api) return []
-    const sites = await this.fetchSites()
+    // Inventory devices embed their own `activeAlerts` array — pull alerts
+    // from there rather than the site /alerts endpoint, since the inventory
+    // call is already required by pollMetrics and the embedded shape carries
+    // the device name/serial we need for cross-widget highlighting.
+    const { devices } = await this.deviceLookup()
     const out: Alert[] = []
-    for (const site of sites) {
-      try {
-        const resp = await this.api.get<AruAlertsResponse>(`/sites/${site.id}/alerts`)
-        for (const a of resp.elements ?? []) {
-          out.push(toAlert(a, site))
-        }
-      } catch {
-        // One bad site shouldn't poison the others — alerts widget shows
-        // what we could get.
+    for (const d of devices) {
+      for (const a of d.activeAlerts ?? []) {
+        out.push(embeddedAlertToAlert(a, d))
       }
     }
     return out
@@ -195,18 +193,32 @@ export class ArubaInstantOnPlugin
     return this.config?.siteId ? all.filter((s) => s.id === this.config?.siteId) : all
   }
 
-  private async deviceLookup(): Promise<Map<string, AruInventoryDevice>> {
-    if (!this.api) return new Map()
+  /**
+   * Fetch every device across all configured sites, keyed by the identifiers
+   * the operator might have stored in the mapping (serial number, MAC, or
+   * the portal-issued id). One lookup serves both pollMetrics and getAlerts.
+   */
+  private async deviceLookup(): Promise<{
+    devices: AruInventoryDevice[]
+    bySite: Map<string, AruSite>
+    byId: Map<string, AruInventoryDevice>
+  }> {
     const sites = await this.fetchSites()
-    const map = new Map<string, AruInventoryDevice>()
+    const byId = new Map<string, AruInventoryDevice>()
+    const bySite = new Map<string, AruSite>()
+    const devices: AruInventoryDevice[] = []
+    if (!this.api) return { devices, bySite, byId }
     for (const site of sites) {
+      bySite.set(site.id, site)
       const inv = await this.api.get<AruInventoryResponse>(`/sites/${site.id}/inventory`)
       for (const d of inv.elements ?? []) {
-        if (d.serialNumber) map.set(d.serialNumber, d)
-        if (d.macAddress) map.set(d.macAddress, d)
+        devices.push(d)
+        if (d.serialNumber) byId.set(d.serialNumber, d)
+        if (d.macAddress) byId.set(d.macAddress, d)
+        if (d.id) byId.set(d.id, d)
       }
     }
-    return map
+    return { devices, bySite, byId }
   }
 }
 
@@ -231,29 +243,43 @@ function classifyDeviceStatus(raw: string | undefined): 'up' | 'down' | 'unknown
 
 function deviceToMetrics(d: AruInventoryDevice): NodeMetrics {
   const status = classifyDeviceStatus(d.status)
-  const lastSeen = d.lastUpdated ? Date.parse(d.lastUpdated) : undefined
+  const secsSince = d.numberOfSecondsSinceLastCommunication
+  const lastSeen =
+    typeof secsSince === 'number' && Number.isFinite(secsSince)
+      ? Date.now() - secsSince * 1000
+      : undefined
   return {
     status,
-    ...(Number.isFinite(lastSeen) && { lastSeen }),
+    ...(lastSeen !== undefined && { lastSeen }),
     // Cloud-managed: as long as we can read the inventory, monitoring is
     // working. The device's `status` carries the actual up/down verdict.
     monitoring: 'healthy',
   }
 }
 
-function toAlert(a: AruAlertItem, site: AruSite): Alert {
-  const isActive = !a.endTime
+function embeddedAlertToAlert(a: AruEmbeddedAlert, device: AruInventoryDevice): Alert {
+  const isActive = !a.clearedTime
+  const startMs = a.raisedTime ? a.raisedTime * 1000 : Date.now()
   return {
-    id: a.id ?? `${site.id}:${a.startTime ?? Date.now()}`,
+    id: a.id,
     severity: mapSeverity(a.severity),
-    title: a.description ?? 'Aruba Instant On alert',
-    host: a.deviceName,
-    hostId: a.deviceSerial,
-    startTime: a.startTime ? Date.parse(a.startTime) : Date.now(),
-    endTime: a.endTime ? Date.parse(a.endTime) : undefined,
+    title: a.type ? humanizeAlertType(a.type) : 'Aruba Instant On alert',
+    host: device.name || device.defaultName,
+    hostId: device.serialNumber || device.id,
+    startTime: startMs,
+    endTime: a.clearedTime ? a.clearedTime * 1000 : undefined,
     status: isActive ? 'active' : 'resolved',
     source: 'aruba-instant-on' as const,
   }
+}
+
+/** Turn portal alert type codes ('deviceDown', etc.) into something human-readable. */
+function humanizeAlertType(type: string): string {
+  // camelCase → space-separated words, first letter capitalised
+  return type
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/^./, (c) => c.toUpperCase())
+    .trim()
 }
 
 function mapSeverity(raw: string | undefined): AlertSeverity {
@@ -261,9 +287,11 @@ function mapSeverity(raw: string | undefined): AlertSeverity {
     case 'CRITICAL':
     case 'DISASTER':
       return 'disaster'
+    case 'MAJOR':
     case 'HIGH':
     case 'ERROR':
       return 'high'
+    case 'MINOR':
     case 'AVERAGE':
     case 'MEDIUM':
       return 'average'

--- a/libs/plugins/aruba-instant-on/src/plugin.ts
+++ b/libs/plugins/aruba-instant-on/src/plugin.ts
@@ -113,13 +113,20 @@ export class ArubaInstantOnPlugin
   }
 
   /**
-   * Instant On exposes per-device telemetry through fields baked into the
-   * inventory record (status, lastUpdated). There's no rich per-host item
-   * list to enumerate — return empty so the mapping UI doesn't spin trying
-   * to fetch interface items.
+   * Per-host interface items, two per ethernet port (in/out throughput).
+   * Populates the mapping UI's "interface" dropdown when the operator is
+   * matching a topology link to a real port on the monitored device.
+   *
+   * The portal exposes one record per port with both directions inside
+   * `portDataTraffic`; we expand that into a pair of HostItem rows so the
+   * existing UI (which expects per-direction items, modeled after Zabbix's
+   * net.if.in / net.if.out) keeps working unchanged.
    */
-  async getHostItems(_hostId: string): Promise<HostItem[]> {
-    return []
+  async getHostItems(hostId: string): Promise<HostItem[]> {
+    const { byId } = await this.deviceLookup()
+    const device = byId.get(hostId)
+    if (!device) return []
+    return buildHostItems(device)
   }
 
   /**
@@ -331,6 +338,45 @@ function portToLinkMetrics(
     inBps,
     outBps,
   }
+}
+
+/**
+ * Expand a device's ethernet ports into the in/out HostItem pairs the
+ * mapping UI expects. The id has to be stable so the operator's link
+ * mapping (which stores the item id) survives re-fetches — combine
+ * device id with the port number and direction.
+ */
+function buildHostItems(d: AruInventoryDevice): HostItem[] {
+  const out: HostItem[] = []
+  const hostId = d.serialNumber || d.id || d.macAddress
+  if (!hostId) return out
+  for (const port of d.ethernetPorts ?? []) {
+    const portNum = port.portNumber ?? port.faceplatePortNumber
+    if (portNum === undefined) continue
+    // The portal usually leaves `port.name` null; use the port number as
+    // the interface label so the mapping UI shows "0", "1", ... — those
+    // values also round-trip through `findPortByName` at poll time.
+    const ifaceName = port.name && port.name.trim() ? port.name : String(portNum)
+    const displayLabel = port.name && port.name.trim() ? port.name : `Port ${portNum}`
+    const t = port.portDataTraffic
+    const dirs: Array<{ direction: 'in' | 'out'; bps: number | undefined }> = [
+      { direction: 'in', bps: t?.downstreamThroughputInBitsPerSecond },
+      { direction: 'out', bps: t?.upstreamThroughputInBitsPerSecond },
+    ]
+    for (const { direction, bps } of dirs) {
+      out.push({
+        id: `${hostId}:port${portNum}:${direction}`,
+        hostId,
+        name: `${displayLabel} ${direction === 'in' ? 'received' : 'sent'}`,
+        key: `aruba.port.${direction}[${portNum}]`,
+        lastValue: typeof bps === 'number' ? String(bps) : undefined,
+        unit: 'bps',
+        interfaceName: ifaceName,
+        direction,
+      })
+    }
+  }
+  return out
 }
 
 /**

--- a/libs/plugins/aruba-instant-on/src/plugin.ts
+++ b/libs/plugins/aruba-instant-on/src/plugin.ts
@@ -130,13 +130,10 @@ export class ArubaInstantOnPlugin
   }
 
   /**
-   * Discover gauge-style metrics for a given host. Used by the node-detail
-   * modal's "All metrics" panel — operators see what's exposed for the
-   * device they're about to map, so blank means "we have nothing to show".
-   *
-   * Pulls everything from the cached inventory call: device-level (clients,
-   * uptime, power) and per-port (throughput, link state, PoE). One round
-   * trip even if the panel opens for many hosts in a row.
+   * Dump every primitive field of the device's inventory record for the
+   * node-detail modal's "All metrics" panel. Passthrough by design —
+   * what the portal returns is what the operator sees, so new API fields
+   * surface automatically and an empty list genuinely means "no record".
    */
   async discoverMetrics(hostId: string): Promise<DiscoveredMetric[]> {
     const { byId } = await this.deviceLookup()
@@ -380,102 +377,54 @@ function buildHostItems(d: AruInventoryDevice): HostItem[] {
 }
 
 /**
- * Flatten an inventory record into individual numeric metrics the "All
- * metrics" panel can list. Each entry is a Prometheus-style sample: a
- * name, a value, optional labels for sub-dimensions (e.g. port number).
+ * Dump every primitive leaf of the raw inventory record as a
+ * `DiscoveredMetric`. The "All metrics" panel is a debug passthrough —
+ * what the portal returned is what the operator sees, including fields
+ * we don't (yet) model in `types.ts`. Adding a new field to the API
+ * surface automatically makes it visible; nothing has to be enumerated
+ * by hand.
  *
- * Skip any field that's missing on the device — the API leaves nulls
- * around for capabilities a particular model doesn't have.
+ * Object children are joined with `_` into the metric name. Array
+ * children are expanded one entry per element, with the index pinned to
+ * a label (`ethernetPorts_0` becomes name `…_ethernetPorts_<field>`
+ * with `ethernetPorts_index=0` in labels). Null/undefined/empty-string
+ * leaves are skipped — they'd just be noise.
  */
 function buildDeviceMetrics(d: AruInventoryDevice): DiscoveredMetric[] {
+  return flattenObject(d, 'aruba')
+}
+
+function flattenObject(
+  obj: unknown,
+  prefix: string,
+  labels: Record<string, string> = {},
+): DiscoveredMetric[] {
+  if (obj == null || typeof obj !== 'object') return []
   const out: DiscoveredMetric[] = []
-  const push = (
-    name: string,
-    value: number | undefined,
-    help: string,
-    type: string = 'gauge',
-    labels: Record<string, string> = {},
-  ): void => {
-    if (typeof value !== 'number' || !Number.isFinite(value)) return
-    out.push({ name, value, help, type, labels })
-  }
-  const boolValue = (b: boolean | undefined): number | undefined =>
-    typeof b === 'boolean' ? (b ? 1 : 0) : undefined
-
-  // Device-level
-  push('aruba_device_up', boolValue(d.status === 'up'), 'Device reported as up by the portal')
-  push(
-    'aruba_device_underpowered',
-    boolValue(d.isUnderpowered),
-    'Device is currently underpowered (PoE budget insufficient)',
-  )
-  push('aruba_device_uptime_seconds', d.uptimeInSeconds, 'Seconds since the device last booted')
-  push(
-    'aruba_device_seconds_since_last_communication',
-    d.numberOfSecondsSinceLastCommunication,
-    'Age of the last device check-in seen by the portal',
-  )
-  push('aruba_wired_clients', d.wiredClientsCount, 'Currently connected wired clients')
-  push(
-    'aruba_grouped_wired_clients',
-    d.groupedWiredClientsCount,
-    'Wired clients aggregated behind another device',
-  )
-  push('aruba_vpn_clients', d.vpnClientsCount, 'Currently connected VPN clients')
-
-  // Per-port
-  for (const port of d.ethernetPorts ?? []) {
-    const labels: Record<string, string> = {
-      port: String(port.portNumber ?? port.faceplatePortNumber ?? '?'),
+  for (const [key, value] of Object.entries(obj)) {
+    const name = `${prefix}_${key}`
+    if (value == null) continue
+    if (Array.isArray(value)) {
+      // Array of primitives → emit count plus join (rare in this API).
+      // Array of objects → expand each with `<key>_index` label.
+      if (value.every((v) => typeof v !== 'object' || v === null)) {
+        out.push({ name: `${name}_count`, value: value.length, labels })
+        continue
+      }
+      out.push({ name: `${name}_count`, value: value.length, labels })
+      for (const [i, child] of value.entries()) {
+        out.push(...flattenObject(child, name, { ...labels, [`${key}_index`]: String(i) }))
+      }
+      continue
     }
-    push('aruba_port_link_up', boolValue(port.isLinkUp), 'Port has link up', 'gauge', labels)
-    push(
-      'aruba_port_uplink',
-      boolValue(port.isUplink),
-      'Port is acting as the uplink',
-      'gauge',
-      labels,
-    )
-    push(
-      'aruba_port_providing_power',
-      boolValue(port.isProvidingPower),
-      'Port is currently supplying PoE to a downstream device',
-      'gauge',
-      labels,
-    )
-    const speed = portSpeedBps(port)
-    push('aruba_port_speed_bps', speed, 'Negotiated port speed in bits per second', 'gauge', labels)
-    const traffic = port.portDataTraffic
-    push(
-      'aruba_port_throughput_downstream_bps',
-      traffic?.downstreamThroughputInBitsPerSecond,
-      'Inbound port throughput (bps)',
-      'gauge',
-      labels,
-    )
-    push(
-      'aruba_port_throughput_upstream_bps',
-      traffic?.upstreamThroughputInBitsPerSecond,
-      'Outbound port throughput (bps)',
-      'gauge',
-      labels,
-    )
-    push(
-      'aruba_port_bytes_last_24h_downstream',
-      traffic?.downstreamDataTransferredInBytesInLast24Hours,
-      'Inbound bytes over the last 24h',
-      'counter',
-      labels,
-    )
-    push(
-      'aruba_port_bytes_last_24h_upstream',
-      traffic?.upstreamDataTransferredInBytesInLast24Hours,
-      'Outbound bytes over the last 24h',
-      'counter',
-      labels,
-    )
+    if (typeof value === 'object') {
+      out.push(...flattenObject(value, name, labels))
+      continue
+    }
+    if (typeof value === 'string' && value.length === 0) continue
+    if (typeof value === 'number' && !Number.isFinite(value)) continue
+    out.push({ name, value: value as number | string | boolean, labels })
   }
-
   return out
 }
 
@@ -539,23 +488,25 @@ function mapSeverity(raw: string | undefined): AlertSeverity {
   switch ((raw ?? '').toUpperCase()) {
     case 'CRITICAL':
     case 'DISASTER':
-      return 'disaster'
+      return 'critical'
     case 'MAJOR':
     case 'HIGH':
     case 'ERROR':
       return 'high'
-    case 'MINOR':
     case 'AVERAGE':
     case 'MEDIUM':
-      return 'average'
+    case 'MODERATE':
+      return 'medium'
+    case 'MINOR':
     case 'WARNING':
-      return 'warning'
+    case 'LOW':
+      return 'low'
     case 'INFORMATION':
     case 'INFO':
-      return 'information'
+      return 'info'
     case 'OK':
       return 'ok'
     default:
-      return 'information'
+      return 'info'
   }
 }

--- a/libs/plugins/aruba-instant-on/src/plugin.ts
+++ b/libs/plugins/aruba-instant-on/src/plugin.ts
@@ -21,6 +21,7 @@ import type {
   ConnectionResult,
   DataSourceCapability,
   DataSourcePlugin,
+  DiscoveredMetric,
   Host,
   HostItem,
   HostsCapable,
@@ -34,6 +35,7 @@ import { ArubaInstantOnApi } from './api.js'
 import type {
   ArubaInstantOnConfig,
   AruEmbeddedAlert,
+  AruEthernetPort,
   AruInventoryDevice,
   AruInventoryResponse,
   AruSite,
@@ -120,6 +122,22 @@ export class ArubaInstantOnPlugin
     return []
   }
 
+  /**
+   * Discover gauge-style metrics for a given host. Used by the node-detail
+   * modal's "All metrics" panel — operators see what's exposed for the
+   * device they're about to map, so blank means "we have nothing to show".
+   *
+   * Pulls everything from the cached inventory call: device-level (clients,
+   * uptime, power) and per-port (throughput, link state, PoE). One round
+   * trip even if the panel opens for many hosts in a row.
+   */
+  async discoverMetrics(hostId: string): Promise<DiscoveredMetric[]> {
+    const { byId } = await this.deviceLookup()
+    const device = byId.get(hostId)
+    if (!device) return []
+    return buildDeviceMetrics(device)
+  }
+
   // ============================================================
   // MetricsCapable — per-device status from the inventory snapshot
   // ============================================================
@@ -130,10 +148,14 @@ export class ArubaInstantOnPlugin
     // Skip the upstream fetch entirely if nothing is mapped — saves a
     // round trip per poll for tenants that haven't wired this plugin in.
     const hasMappedHost = Object.values(mapping.nodes ?? {}).some((n) => n.hostId)
-    if (!hasMappedHost || !this.api) return metrics
+    const hasMappedLink = Object.values(mapping.links ?? {}).some(
+      (l) => l.monitoredNodeId && l.interface,
+    )
+    if ((!hasMappedHost && !hasMappedLink) || !this.api) return metrics
 
     const { byId } = await this.deviceLookup()
 
+    // ---- Nodes -----------------------------------------------------------
     for (const [nodeId, nodeMapping] of Object.entries(mapping.nodes || {})) {
       if (!nodeMapping.hostId) continue
       const device = byId.get(nodeMapping.hostId)
@@ -145,10 +167,19 @@ export class ArubaInstantOnPlugin
       }
       metrics.nodes[nodeId] = deviceToMetrics(device)
     }
-    // Links aren't represented in the Instant On API (switch port maps are
-    // limited), so we don't populate `metrics.links` here. Operators can
-    // still get link traffic through another plugin (e.g. Zabbix) if they
-    // want — shumoku merges per-source.
+
+    // ---- Links -----------------------------------------------------------
+    // Each device's inventory record carries per-ethernet-port throughput.
+    // For a link mapped to (monitoredNode, interfaceName), pull traffic from
+    // the device's ethernetPorts[] entry whose port matches.
+    for (const [linkId, linkMapping] of Object.entries(mapping.links || {})) {
+      const link = portLinkLookup(linkMapping, mapping, byId)
+      if (!link) {
+        metrics.links[linkId] = { status: 'unknown' }
+        continue
+      }
+      metrics.links[linkId] = portToLinkMetrics(link.port, linkMapping.bandwidth ?? link.bandwidth)
+    }
 
     return metrics
   }
@@ -225,6 +256,182 @@ export class ArubaInstantOnPlugin
 // ---------------------------------------------------------------------------
 // Pure helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Resolve a link mapping into the actual ethernet port telemetry record on
+ * the monitored device. Returns null when the mapping can't be satisfied
+ * (unmapped node, host not in inventory, no matching port).
+ */
+function portLinkLookup(
+  linkMapping: { monitoredNodeId?: string; interface?: string },
+  mapping: MetricsMapping,
+  byId: Map<string, AruInventoryDevice>,
+): { port: AruEthernetPort; bandwidth: number | undefined } | null {
+  const monitoredNodeId = linkMapping.monitoredNodeId
+  const ifaceName = linkMapping.interface
+  if (!monitoredNodeId || !ifaceName) return null
+  const hostId = mapping.nodes[monitoredNodeId]?.hostId
+  if (!hostId) return null
+  const device = byId.get(hostId)
+  if (!device?.ethernetPorts?.length) return null
+  const port = findPortByName(device.ethernetPorts, ifaceName)
+  if (!port) return null
+  return { port, bandwidth: portSpeedBps(port) }
+}
+
+/**
+ * Match a free-form interface name against Aruba's port records.
+ *
+ * The mapping UI accepts whatever the operator types, which for Aruba
+ * Instant On typically means a port number ("0", "1") or — when copied
+ * from a Cisco-formatted neighbour — something like "Gi1/0/3" we want to
+ * tolerate via "trailing digit" extraction. We try, in order:
+ *   1. Exact match on the port's `name` (rare on Instant On).
+ *   2. Exact match on `portNumber` / `faceplatePortNumber` as a string.
+ *   3. The last run of digits in the operator's input vs. either number.
+ */
+function findPortByName(ports: AruEthernetPort[], ifaceName: string): AruEthernetPort | undefined {
+  const lower = ifaceName.trim().toLowerCase()
+  for (const p of ports) {
+    if (typeof p.name === 'string' && p.name.toLowerCase() === lower) return p
+    if (p.portNumber !== undefined && String(p.portNumber) === lower) return p
+    if (p.faceplatePortNumber !== undefined && String(p.faceplatePortNumber) === lower) return p
+  }
+  return undefined
+}
+
+/**
+ * Convert Aruba's `speed` token ("mbps1000") to bits-per-second so we can
+ * compute utilization without yet another lookup table. Falls back to
+ * `maxSpeed` when the port is link-down (speed nulls out then).
+ */
+function portSpeedBps(port: AruEthernetPort): number | undefined {
+  const token = port.speed || port.maxSpeed
+  if (!token) return undefined
+  const m = token.match(/^mbps(\d+)$/i)
+  if (!m?.[1]) return undefined
+  return Number.parseInt(m[1], 10) * 1_000_000
+}
+
+function portToLinkMetrics(
+  port: AruEthernetPort,
+  bandwidthBps: number | undefined,
+): import('@shumoku/core').LinkMetrics {
+  const inBps = port.portDataTraffic?.downstreamThroughputInBitsPerSecond ?? 0
+  const outBps = port.portDataTraffic?.upstreamThroughputInBitsPerSecond ?? 0
+  const cap = bandwidthBps && bandwidthBps > 0 ? bandwidthBps : 1_000_000_000
+  const inUtil = (inBps / cap) * 100
+  const outUtil = (outBps / cap) * 100
+  const maxUtil = Math.max(inUtil, outUtil)
+  return {
+    status: port.isLinkUp === false ? 'down' : maxUtil > 0 ? 'up' : 'unknown',
+    utilization: Math.ceil(maxUtil),
+    inUtilization: Math.ceil(inUtil),
+    outUtilization: Math.ceil(outUtil),
+    inBps,
+    outBps,
+  }
+}
+
+/**
+ * Flatten an inventory record into individual numeric metrics the "All
+ * metrics" panel can list. Each entry is a Prometheus-style sample: a
+ * name, a value, optional labels for sub-dimensions (e.g. port number).
+ *
+ * Skip any field that's missing on the device — the API leaves nulls
+ * around for capabilities a particular model doesn't have.
+ */
+function buildDeviceMetrics(d: AruInventoryDevice): DiscoveredMetric[] {
+  const out: DiscoveredMetric[] = []
+  const push = (
+    name: string,
+    value: number | undefined,
+    help: string,
+    type: string = 'gauge',
+    labels: Record<string, string> = {},
+  ): void => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return
+    out.push({ name, value, help, type, labels })
+  }
+  const boolValue = (b: boolean | undefined): number | undefined =>
+    typeof b === 'boolean' ? (b ? 1 : 0) : undefined
+
+  // Device-level
+  push('aruba_device_up', boolValue(d.status === 'up'), 'Device reported as up by the portal')
+  push(
+    'aruba_device_underpowered',
+    boolValue(d.isUnderpowered),
+    'Device is currently underpowered (PoE budget insufficient)',
+  )
+  push('aruba_device_uptime_seconds', d.uptimeInSeconds, 'Seconds since the device last booted')
+  push(
+    'aruba_device_seconds_since_last_communication',
+    d.numberOfSecondsSinceLastCommunication,
+    'Age of the last device check-in seen by the portal',
+  )
+  push('aruba_wired_clients', d.wiredClientsCount, 'Currently connected wired clients')
+  push(
+    'aruba_grouped_wired_clients',
+    d.groupedWiredClientsCount,
+    'Wired clients aggregated behind another device',
+  )
+  push('aruba_vpn_clients', d.vpnClientsCount, 'Currently connected VPN clients')
+
+  // Per-port
+  for (const port of d.ethernetPorts ?? []) {
+    const labels: Record<string, string> = {
+      port: String(port.portNumber ?? port.faceplatePortNumber ?? '?'),
+    }
+    push('aruba_port_link_up', boolValue(port.isLinkUp), 'Port has link up', 'gauge', labels)
+    push(
+      'aruba_port_uplink',
+      boolValue(port.isUplink),
+      'Port is acting as the uplink',
+      'gauge',
+      labels,
+    )
+    push(
+      'aruba_port_providing_power',
+      boolValue(port.isProvidingPower),
+      'Port is currently supplying PoE to a downstream device',
+      'gauge',
+      labels,
+    )
+    const speed = portSpeedBps(port)
+    push('aruba_port_speed_bps', speed, 'Negotiated port speed in bits per second', 'gauge', labels)
+    const traffic = port.portDataTraffic
+    push(
+      'aruba_port_throughput_downstream_bps',
+      traffic?.downstreamThroughputInBitsPerSecond,
+      'Inbound port throughput (bps)',
+      'gauge',
+      labels,
+    )
+    push(
+      'aruba_port_throughput_upstream_bps',
+      traffic?.upstreamThroughputInBitsPerSecond,
+      'Outbound port throughput (bps)',
+      'gauge',
+      labels,
+    )
+    push(
+      'aruba_port_bytes_last_24h_downstream',
+      traffic?.downstreamDataTransferredInBytesInLast24Hours,
+      'Inbound bytes over the last 24h',
+      'counter',
+      labels,
+    )
+    push(
+      'aruba_port_bytes_last_24h_upstream',
+      traffic?.upstreamDataTransferredInBytesInLast24Hours,
+      'Outbound bytes over the last 24h',
+      'counter',
+      labels,
+    )
+  }
+
+  return out
+}
 
 function classifyDeviceStatus(raw: string | undefined): 'up' | 'down' | 'unknown' {
   switch ((raw ?? '').toUpperCase()) {

--- a/libs/plugins/aruba-instant-on/src/plugin.ts
+++ b/libs/plugins/aruba-instant-on/src/plugin.ts
@@ -1,0 +1,280 @@
+/**
+ * Aruba Instant On data-source plugin.
+ *
+ * Backed by the (undocumented) portal.arubainstanton.com API. See
+ * `auth.ts` for the protocol notes — the short version is that this can
+ * stop working any day Aruba decides to change the cloud, so failure
+ * paths are deliberately loud rather than silently downgrading.
+ *
+ * Plugin scope:
+ *   - hosts: APs + switches in all (or one) sites
+ *   - metrics: per-device up/down derived from `status`, last-seen ms
+ *   - alerts: site-level alerts mapped to our Alert shape
+ *   - nativeApi: dev-only raw passthrough (PR #260 pattern)
+ */
+
+import type {
+  Alert,
+  AlertQueryOptions,
+  AlertSeverity,
+  AlertsCapable,
+  ConnectionResult,
+  DataSourceCapability,
+  DataSourcePlugin,
+  Host,
+  HostItem,
+  HostsCapable,
+  MetricsCapable,
+  MetricsData,
+  MetricsMapping,
+  NativeApiCapable,
+  NodeMetrics,
+} from '@shumoku/core'
+import { ArubaInstantOnApi } from './api.js'
+import type {
+  AruAlertItem,
+  AruAlertsResponse,
+  ArubaInstantOnConfig,
+  AruInventoryDevice,
+  AruInventoryResponse,
+  AruSite,
+  AruSitesResponse,
+} from './types.js'
+
+export class ArubaInstantOnPlugin
+  implements DataSourcePlugin, HostsCapable, MetricsCapable, AlertsCapable, NativeApiCapable
+{
+  readonly type = 'aruba-instant-on'
+  readonly displayName = 'Aruba Instant On'
+  readonly capabilities: readonly DataSourceCapability[] = ['hosts', 'metrics', 'alerts']
+
+  private api: ArubaInstantOnApi | null = null
+  private config: ArubaInstantOnConfig | null = null
+
+  initialize(config: unknown): void {
+    const c = config as Partial<ArubaInstantOnConfig>
+    if (!c.username || !c.password) {
+      throw new Error('Aruba Instant On plugin requires `username` and `password` in config')
+    }
+    this.config = c as ArubaInstantOnConfig
+    this.api = new ArubaInstantOnApi(this.config)
+  }
+
+  dispose(): void {
+    this.config = null
+    this.api = null
+  }
+
+  async testConnection(): Promise<ConnectionResult> {
+    if (!this.api) return { success: false, message: 'Plugin not initialized' }
+    try {
+      const sites = await this.fetchSites()
+      return {
+        success: true,
+        message: `Connected to Aruba Instant On (${sites.length} site${sites.length === 1 ? '' : 's'})`,
+        warnings: [
+          'Aruba Instant On API is unofficial / unsupported by HPE — may break without notice.',
+        ],
+      }
+    } catch (err) {
+      return {
+        success: false,
+        message: err instanceof Error ? err.message : 'Connection failed',
+      }
+    }
+  }
+
+  // ============================================================
+  // HostsCapable — enumerate APs + switches across sites
+  // ============================================================
+
+  async getHosts(): Promise<Host[]> {
+    if (!this.api) return []
+    const sites = await this.fetchSites()
+    const out: Host[] = []
+    for (const site of sites) {
+      const inv = await this.api.get<AruInventoryResponse>(`/sites/${site.id}/inventory`)
+      for (const d of inv.elements ?? []) {
+        const id = d.serialNumber || d.macAddress
+        if (!id) continue
+        out.push({
+          id,
+          name: d.name || id,
+          displayName: d.name,
+          status: classifyDeviceStatus(d.status) === 'up' ? 'up' : 'down',
+          ip: d.ipAddress,
+        })
+      }
+    }
+    return out
+  }
+
+  /**
+   * Instant On exposes per-device telemetry through fields baked into the
+   * inventory record (status, lastUpdated). There's no rich per-host item
+   * list to enumerate — return empty so the mapping UI doesn't spin trying
+   * to fetch interface items.
+   */
+  async getHostItems(_hostId: string): Promise<HostItem[]> {
+    return []
+  }
+
+  // ============================================================
+  // MetricsCapable — per-device status from the inventory snapshot
+  // ============================================================
+
+  async pollMetrics(mapping: MetricsMapping): Promise<MetricsData> {
+    const metrics: MetricsData = { nodes: {}, links: {}, timestamp: Date.now() }
+
+    // Skip the upstream fetch entirely if nothing is mapped — saves a
+    // round trip per poll for tenants that haven't wired this plugin in.
+    const hasMappedHost = Object.values(mapping.nodes ?? {}).some((n) => n.hostId)
+    if (!hasMappedHost || !this.api) return metrics
+
+    // Build a lookup: deviceId (serial or MAC) → inventory record
+    const byId = await this.deviceLookup()
+
+    for (const [nodeId, nodeMapping] of Object.entries(mapping.nodes || {})) {
+      if (!nodeMapping.hostId) continue
+      const device = byId.get(nodeMapping.hostId)
+      if (!device) {
+        // Mapped to a host we couldn't find — treat as monitoring pending
+        // rather than down, since absence is plausibly a transient API miss.
+        metrics.nodes[nodeId] = { status: 'unknown', monitoring: 'pending' }
+        continue
+      }
+      metrics.nodes[nodeId] = deviceToMetrics(device)
+    }
+    // Links aren't represented in the Instant On API (switch port maps are
+    // limited), so we don't populate `metrics.links` here. Operators can
+    // still get link traffic through another plugin (e.g. Zabbix) if they
+    // want — shumoku merges per-source.
+
+    return metrics
+  }
+
+  // ============================================================
+  // AlertsCapable
+  // ============================================================
+
+  async getAlerts(_options?: AlertQueryOptions): Promise<Alert[]> {
+    if (!this.api) return []
+    const sites = await this.fetchSites()
+    const out: Alert[] = []
+    for (const site of sites) {
+      try {
+        const resp = await this.api.get<AruAlertsResponse>(`/sites/${site.id}/alerts`)
+        for (const a of resp.elements ?? []) {
+          out.push(toAlert(a, site))
+        }
+      } catch {
+        // One bad site shouldn't poison the others — alerts widget shows
+        // what we could get.
+      }
+    }
+    return out
+  }
+
+  // ============================================================
+  // NativeApiCapable — dev passthrough
+  // ============================================================
+
+  async nativeApi(method: string, params: Record<string, unknown>): Promise<unknown> {
+    if (!this.api) throw new Error('Plugin not initialized')
+    return this.api.nativeApi(method, params)
+  }
+
+  // ============================================================
+  // Internals
+  // ============================================================
+
+  private async fetchSites(): Promise<AruSite[]> {
+    if (!this.api) return []
+    const resp = await this.api.get<AruSitesResponse>('/sites/')
+    const all = resp.elements ?? []
+    return this.config?.siteId ? all.filter((s) => s.id === this.config?.siteId) : all
+  }
+
+  private async deviceLookup(): Promise<Map<string, AruInventoryDevice>> {
+    if (!this.api) return new Map()
+    const sites = await this.fetchSites()
+    const map = new Map<string, AruInventoryDevice>()
+    for (const site of sites) {
+      const inv = await this.api.get<AruInventoryResponse>(`/sites/${site.id}/inventory`)
+      for (const d of inv.elements ?? []) {
+        if (d.serialNumber) map.set(d.serialNumber, d)
+        if (d.macAddress) map.set(d.macAddress, d)
+      }
+    }
+    return map
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function classifyDeviceStatus(raw: string | undefined): 'up' | 'down' | 'unknown' {
+  switch ((raw ?? '').toUpperCase()) {
+    case 'ACTIVE':
+    case 'UP':
+    case 'ONLINE':
+      return 'up'
+    case 'INACTIVE':
+    case 'OFFLINE':
+    case 'DOWN':
+      return 'down'
+    default:
+      return 'unknown'
+  }
+}
+
+function deviceToMetrics(d: AruInventoryDevice): NodeMetrics {
+  const status = classifyDeviceStatus(d.status)
+  const lastSeen = d.lastUpdated ? Date.parse(d.lastUpdated) : undefined
+  return {
+    status,
+    ...(Number.isFinite(lastSeen) && { lastSeen }),
+    // Cloud-managed: as long as we can read the inventory, monitoring is
+    // working. The device's `status` carries the actual up/down verdict.
+    monitoring: 'healthy',
+  }
+}
+
+function toAlert(a: AruAlertItem, site: AruSite): Alert {
+  const isActive = !a.endTime
+  return {
+    id: a.id ?? `${site.id}:${a.startTime ?? Date.now()}`,
+    severity: mapSeverity(a.severity),
+    title: a.description ?? 'Aruba Instant On alert',
+    host: a.deviceName,
+    hostId: a.deviceSerial,
+    startTime: a.startTime ? Date.parse(a.startTime) : Date.now(),
+    endTime: a.endTime ? Date.parse(a.endTime) : undefined,
+    status: isActive ? 'active' : 'resolved',
+    source: 'aruba-instant-on' as const,
+  }
+}
+
+function mapSeverity(raw: string | undefined): AlertSeverity {
+  switch ((raw ?? '').toUpperCase()) {
+    case 'CRITICAL':
+    case 'DISASTER':
+      return 'disaster'
+    case 'HIGH':
+    case 'ERROR':
+      return 'high'
+    case 'AVERAGE':
+    case 'MEDIUM':
+      return 'average'
+    case 'WARNING':
+      return 'warning'
+    case 'INFORMATION':
+    case 'INFO':
+      return 'information'
+    case 'OK':
+      return 'ok'
+    default:
+      return 'information'
+  }
+}

--- a/libs/plugins/aruba-instant-on/src/types.ts
+++ b/libs/plugins/aruba-instant-on/src/types.ts
@@ -49,8 +49,45 @@ export interface AruInventoryDevice {
   ipAddress?: string
   /** Seconds since the portal last heard from the device. Used to derive lastSeen. */
   numberOfSecondsSinceLastCommunication?: number
+  /** Cumulative seconds since the device booted. */
+  uptimeInSeconds?: number
+  wiredClientsCount?: number
+  groupedWiredClientsCount?: number
+  vpnClientsCount?: number
+  /** True when the device is reporting it's running on too little PoE budget. */
+  isUnderpowered?: boolean
+  inputPowerSource?: string
   /** Alerts the portal currently has open against this device. */
   activeAlerts?: AruEmbeddedAlert[]
+  /** Per-port telemetry (uplink port + LAN ports on switches). */
+  ethernetPorts?: AruEthernetPort[]
+}
+
+export interface AruEthernetPort {
+  /** Logical port index, 0-based. APs have one; switches have many. */
+  portNumber?: number
+  /** Marking on the device's faceplate. Matches `portNumber` in practice. */
+  faceplatePortNumber?: number
+  /** Operator-assigned label (rare on Instant On — usually `null`). */
+  name?: string | null
+  /** Negotiated speed token: "mbps100", "mbps1000", "mbps10000". */
+  speed?: string
+  /** Cap from the hardware: "mbps1000" etc. — used when `speed` is null on link-down ports. */
+  maxSpeed?: string
+  /** "full" / "half" — when present, hints at duplex. */
+  duplex?: string
+  isLinkUp?: boolean
+  isUplink?: boolean
+  isProvidingPower?: boolean
+  /** Live throughput counters. */
+  portDataTraffic?: AruPortDataTraffic
+}
+
+export interface AruPortDataTraffic {
+  downstreamThroughputInBitsPerSecond?: number
+  upstreamThroughputInBitsPerSecond?: number
+  downstreamDataTransferredInBytesInLast24Hours?: number
+  upstreamDataTransferredInBytesInLast24Hours?: number
 }
 
 /** Subset of the alert shape embedded in inventory device records. */

--- a/libs/plugins/aruba-instant-on/src/types.ts
+++ b/libs/plugins/aruba-instant-on/src/types.ts
@@ -30,19 +30,42 @@ export interface AruSitesResponse {
 }
 
 export interface AruInventoryDevice {
+  /** Primary id used by the portal (typically the MAC). */
+  id?: string
   serialNumber?: string
   macAddress?: string
-  /** Display name (operator-assigned). */
+  /** Display name (operator-assigned). Falls back to `defaultName` (e.g. "CNJ6K9T736"). */
   name?: string
-  /** "AP", "SW", possibly others — used to classify topology nodes later. */
-  productLine?: string
-  /** Model string, e.g. "AP22", "JL678A". */
-  modelName?: string
-  /** Per-device status. Known values: "ACTIVE", "INACTIVE", "OFFLINE". */
+  defaultName?: string
+  /** Device category: 'accessPoint' / 'switch' / 'gateway'. */
+  deviceType?: string
+  /** Model code, e.g. "AP-303", "JL678A". */
+  model?: string
+  /** Per-device status. Observed values: 'up', 'down' (lowercase). */
   status?: string
+  operationalState?: string
+  /** Health summary: 'good' / 'poor' etc. */
+  health?: string
   ipAddress?: string
-  /** ISO timestamp of last seen — used as `lastSeen` ms in NodeMetrics. */
-  lastUpdated?: string
+  /** Seconds since the portal last heard from the device. Used to derive lastSeen. */
+  numberOfSecondsSinceLastCommunication?: number
+  /** Alerts the portal currently has open against this device. */
+  activeAlerts?: AruEmbeddedAlert[]
+}
+
+/** Subset of the alert shape embedded in inventory device records. */
+export interface AruEmbeddedAlert {
+  id: string
+  type?: string
+  severity?: string
+  /** Unix seconds. */
+  raisedTime?: number
+  /** Unix seconds; null when still active. */
+  clearedTime?: number | null
+  alertTypeProperties?: {
+    deviceNames?: string[]
+    deviceIds?: string[]
+  }
 }
 
 export interface AruInventoryResponse {

--- a/libs/plugins/aruba-instant-on/src/types.ts
+++ b/libs/plugins/aruba-instant-on/src/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Aruba Instant On plugin types.
+ *
+ * Field names mirror the responses returned by the (undocumented) portal
+ * API, so they sometimes use camelCase strings the API picked. Optional on
+ * everything except the bits we actually rely on — schemas drift.
+ */
+
+export interface ArubaInstantOnConfig {
+  /** Portal account email. The account must NOT have MFA enabled. */
+  username: string
+  /** Portal account password. Stored alongside other plugin configs. */
+  password: string
+  /**
+   * Limit polling to a specific site id. Omit to poll all sites the
+   * account can see (typical SMB tenant has 1–N sites).
+   */
+  siteId?: string
+}
+
+// ----- API response shapes (subsets — fields we touch) ---------------------
+
+export interface AruSite {
+  id: string
+  name: string
+}
+
+export interface AruSitesResponse {
+  elements: AruSite[]
+}
+
+export interface AruInventoryDevice {
+  serialNumber?: string
+  macAddress?: string
+  /** Display name (operator-assigned). */
+  name?: string
+  /** "AP", "SW", possibly others — used to classify topology nodes later. */
+  productLine?: string
+  /** Model string, e.g. "AP22", "JL678A". */
+  modelName?: string
+  /** Per-device status. Known values: "ACTIVE", "INACTIVE", "OFFLINE". */
+  status?: string
+  ipAddress?: string
+  /** ISO timestamp of last seen — used as `lastSeen` ms in NodeMetrics. */
+  lastUpdated?: string
+}
+
+export interface AruInventoryResponse {
+  elements: AruInventoryDevice[]
+}
+
+export interface AruAlertItem {
+  /** Stable id for the alert (used as our Alert.id). */
+  id?: string
+  /** Human-readable description. */
+  description?: string
+  /** Aruba's severity label — mapped to our AlertSeverity in plugin.ts. */
+  severity?: string
+  /** ISO timestamp when the alert opened. */
+  startTime?: string
+  /** ISO timestamp when it closed (null/missing → still active). */
+  endTime?: string
+  /** Device serial / MAC that the alert relates to, when known. */
+  deviceSerial?: string
+  deviceName?: string
+}
+
+export interface AruAlertsResponse {
+  elements: AruAlertItem[]
+}

--- a/libs/plugins/aruba-instant-on/tsconfig.json
+++ b/libs/plugins/aruba-instant-on/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"],
+  "references": [{ "path": "../../@shumoku/core" }]
+}

--- a/libs/plugins/grafana/src/plugin.ts
+++ b/libs/plugins/grafana/src/plugin.ts
@@ -22,35 +22,36 @@ import type { AlertStoreService, GrafanaPluginConfig } from './types.js'
 // ============================================
 
 const SEVERITY_MAP: Record<string, AlertSeverity> = {
-  critical: 'disaster',
-  disaster: 'disaster',
+  critical: 'critical',
+  disaster: 'critical',
   high: 'high',
   major: 'high',
   error: 'high',
-  average: 'average',
-  medium: 'average',
-  warning: 'warning',
-  warn: 'warning',
-  minor: 'warning',
-  low: 'information',
-  info: 'information',
-  information: 'information',
+  medium: 'medium',
+  average: 'medium',
+  moderate: 'medium',
+  warning: 'low',
+  warn: 'low',
+  minor: 'low',
+  low: 'info',
+  info: 'info',
+  information: 'info',
   none: 'ok',
   ok: 'ok',
 }
 
 export const SEVERITY_ORDER: Record<AlertSeverity, number> = {
   ok: 0,
-  information: 1,
-  warning: 2,
-  average: 3,
+  info: 1,
+  low: 2,
+  medium: 3,
   high: 4,
-  disaster: 5,
+  critical: 5,
 }
 
 export function mapSeverity(severity?: string): AlertSeverity {
-  if (!severity) return 'information'
-  return SEVERITY_MAP[severity.toLowerCase()] || 'information'
+  if (!severity) return 'info'
+  return SEVERITY_MAP[severity.toLowerCase()] || 'info'
 }
 
 export function buildTitle(labels: Record<string, string>): string {

--- a/libs/plugins/prometheus/src/plugin.ts
+++ b/libs/plugins/prometheus/src/plugin.ts
@@ -388,12 +388,18 @@ export class PrometheusPlugin
             const labels = { ...series.metric }
             delete labels['__name__']
 
+            // Prometheus exposes a native counter/gauge/histogram/summary
+            // type per metric. Park it on a label so the UI's free-form
+            // dump can surface it without core having to bless a "type"
+            // field on the display contract.
+            const promType = metadataMap[metricName]?.type
+            if (promType) labels['__type'] = promType
+
             metrics.push({
               name: metricName,
               labels,
               value: parseFloat(series.value[1]) || 0,
               help: metadataMap[metricName]?.help,
-              type: metadataMap[metricName]?.type,
             })
           }
         } catch {
@@ -517,38 +523,41 @@ export class PrometheusPlugin
   }
 
   private mapAlertmanagerSeverity(severity?: string): AlertSeverity {
-    if (!severity) return 'information'
+    if (!severity) return 'info'
 
     const severityLower = severity.toLowerCase()
+    // Translate common upstream vocabularies into our neutral scale.
+    // Position-preserving against the historical Zabbix-flavored mapping.
     const severityMap: Record<string, AlertSeverity> = {
-      critical: 'disaster',
-      disaster: 'disaster',
+      critical: 'critical',
+      disaster: 'critical',
       high: 'high',
       major: 'high',
       error: 'high',
-      average: 'average',
-      medium: 'average',
-      warning: 'warning',
-      warn: 'warning',
-      minor: 'warning',
-      low: 'information',
-      info: 'information',
-      information: 'information',
+      medium: 'medium',
+      average: 'medium',
+      moderate: 'medium',
+      warning: 'low',
+      warn: 'low',
+      minor: 'low',
+      low: 'info',
+      info: 'info',
+      information: 'info',
       none: 'ok',
       ok: 'ok',
     }
 
-    return severityMap[severityLower] || 'information'
+    return severityMap[severityLower] || 'info'
   }
 
   private getSeverityOrder(severity: AlertSeverity): number {
     const order: Record<AlertSeverity, number> = {
       ok: 0,
-      information: 1,
-      warning: 2,
-      average: 3,
+      info: 1,
+      low: 2,
+      medium: 3,
       high: 4,
-      disaster: 5,
+      critical: 5,
     }
     return order[severity] ?? 1
   }

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -250,15 +250,6 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
   }
 
   async discoverMetrics(hostId: string): Promise<DiscoveredMetric[]> {
-    /** Zabbix value_type to human-readable type name */
-    const VALUE_TYPE_MAP: Record<string, string> = {
-      '0': 'gauge', // Numeric (float)
-      '1': 'text', // Character
-      '2': 'log', // Log
-      '3': 'counter', // Numeric (unsigned integer)
-      '4': 'text', // Text
-    }
-
     interface ZabbixDiscoverItem {
       itemid: string
       name: string
@@ -307,12 +298,23 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
         }
       }
 
+      // Surface Zabbix's value_type as a label so callers that care
+      // (e.g. for filtering non-numeric items out of charts) still see it
+      // without core having to bless a "metric type" vocabulary.
+      const ZABBIX_VALUE_TYPE: Record<string, string> = {
+        '0': 'numeric_float',
+        '1': 'character',
+        '2': 'log',
+        '3': 'numeric_unsigned',
+        '4': 'text',
+      }
+      labels['__value_type'] = ZABBIX_VALUE_TYPE[item.value_type] || 'unknown'
+
       return {
         name: item.name,
         labels,
         value: Number.parseFloat(item.lastvalue) || 0,
         help: item.description || undefined,
-        type: VALUE_TYPE_MAP[item.value_type] || 'unknown',
       }
     })
   }
@@ -384,29 +386,30 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
   }
 
   private mapZabbixSeverity(severity: string): AlertSeverity {
+    // Zabbix priorities 0-5 → neutral severity buckets.
     const severityMap: Record<string, AlertSeverity> = {
-      '0': 'information', // Not classified
-      '1': 'information', // Information
-      '2': 'warning', // Warning
-      '3': 'average', // Average
+      '0': 'info', // Not classified
+      '1': 'info', // Information
+      '2': 'low', // Warning
+      '3': 'medium', // Average
       '4': 'high', // High
-      '5': 'disaster', // Disaster
+      '5': 'critical', // Disaster
     }
-    return severityMap[severity] || 'information'
+    return severityMap[severity] || 'info'
   }
 
   private getSeverityFilter(minSeverity?: AlertSeverity): number[] {
     if (!minSeverity) return []
 
-    const severityOrder: AlertSeverity[] = ['information', 'warning', 'average', 'high', 'disaster']
+    const severityOrder: AlertSeverity[] = ['info', 'low', 'medium', 'high', 'critical']
 
     // Map our severity to Zabbix numeric values
     const severityToZabbix: Record<AlertSeverity, number[]> = {
-      information: [0, 1],
-      warning: [2],
-      average: [3],
+      info: [0, 1],
+      low: [2],
+      medium: [3],
       high: [4],
-      disaster: [5],
+      critical: [5],
       ok: [],
     }
 


### PR DESCRIPTION
## Summary

Adds Aruba Instant On (SMB cloud-managed AP / switch) as a new data
source, and — driven by what that plugin exposed about the existing
contract — refactors the core/plugin/UI boundary so future plugins
can be added without touching shared types.

The branch ended up in three layered parts; happy to split into
separate PRs if reviewers prefer, but they share a single design
thesis.

## 1. Aruba Instant On plugin

`libs/plugins/aruba-instant-on/`. Per-device cloud API solves the
1-VC-host limitation in the existing Zabbix Aruba template (#258 surfaced
this) — each AP / switch is an individual host the topology can map
1:1.

| Capability | Source |
|---|---|
| **hosts** | `/sites/{id}/inventory` enumerates APs + switches |
| **metrics** | per-device `status`, `numberOfSecondsSinceLastCommunication`; per-port `portDataTraffic.{downstream,upstream}ThroughputInBitsPerSecond` for link traffic |
| **alerts** | inventory's embedded `activeAlerts` + `/sites/{id}/alerts` |
| **nativeApi** | dev-only passthrough (PR #260 pattern) |
| **discoverMetrics** | generic flatten of the raw inventory record — every API field auto-surfaces |

### Auth (OAuth2 + PKCE)
1. `POST sso/mfa/validate/full` (username/password) → sessionToken
2. `GET portal/settings.json` → dynamic client_id
3. `GET /as/authorization.oauth2` (PKCE + sessionToken) → 302 with code
4. `POST /as/token.oauth2` (code + verifier) → bearer token
5. `nb.portal.arubainstanton.com` for API (`x-ion-api-version: 7`)

Token cached in-memory, refreshed ~5min before expiry / re-auth on 401, with a `pendingAuth` mutex against concurrent auth flows.

### Security
- HTTPS-only, endpoint URLs hardcoded (no operator-supplied base URL → no SSRF lever)
- PKCE: 32-byte crypto-random verifier + SHA-256 challenge
- `redirect: 'manual'` on the auth call — extract `code` from the 302's `Location` header, don't follow into the portal app
- No credentials / tokens in logs or error strings — HTTP status only
- `testConnection` surfaces a permanent warning that the API is unofficial and **MFA-OFF is required**

### ⚠️ API caveat
HPE's position is that there is no public API. This is a community-known reverse-engineered shape — see [mspp.io writeup](https://mspp.io/documenting-aruba-instant-on-sites-aruba-instant-on-api/) and [lwhitelock/HuduAutomation](https://github.com/lwhitelock/HuduAutomation) for prior art. Will break the day Aruba changes their portal; failure paths are deliberately loud rather than silently degrading.

## 2. Plugin contract refactor

Authoring the Aruba plugin surfaced several places where core types
or the web app enumerated plugin names, forcing plugins to conform
to upstream-flavored vocab. Tightened the contract so the rule is
**core defines the display contract; plugins translate at the boundary**.

- `AlertSeverity` renamed Zabbix-flavored (`disaster` / `average` / `information`) → neutral CVSS-style (`critical` / `high` / `medium` / `low` / `info` / `ok`). All four bundled plugins re-mapped position-preservingly.
- `Alert.source` and `DataSourceType` widened from closed plugin-name unions to `string`. External plugins no longer require core/web edits.
- `apps/server/web/src/lib/types.ts` deduplicated: ~90 lines of duplicate domain types removed; the file re-exports from `@shumoku/core` instead.
- `ConnectionTestResult` (web-local fork) → `ConnectionResult` (core).
- `DiscoveredMetric.type` field removed; `value` widened to `number | string | boolean` so the "All metrics" debug panel can dump categorical attributes (model, health, IP) alongside gauges.
- Aruba `discoverMetrics` replaced its ~100-line hand-enumerated `push()` calls with a generic `flattenObject()` — new API fields auto-surface; forgetting to enumerate a field stops being a failure mode.
- `WeathermapLinkOverlay`: down links no longer animate red lanes (which collided with red used for 90-100% utilization). Down state renders as a static red dashed base line; the lane overlay is suppressed. Animation vs. static dash is now the qualitative distinguisher.

## 3. Documentation

- `docs/plugin-authoring.md` (new) — capability-mixin reference, data shapes, severity translation table, the three node-state axes (Mapping / Device / Monitoring), passthrough `discoverMetrics` pattern, security practices, "Don'ts" pulled from review findings.
- `docs/ARCHITECTURE.md` — "Plugin contract" subsection pointing to the author guide.
- `CLAUDE.md` — invariants block so future AI sessions don't reintroduce the patterns we just removed.
- `README.md` — Documentation link.

## Follow-ups (filed, out of scope)
- Issue #270: drop hardcoded per-plugin form branches in `datasources/+page.svelte` and make bundled plugins declare `configSchema` like external plugins do.
- Issue #268: full multi-source metrics support (Aruba revealed the current poll loop only consumes the first metrics source).

## Test plan

- [ ] DataSources UI shows "Aruba Instant On" as an option
- [ ] Configure with valid credentials → testConnection succeeds with the unofficial-API warning
- [ ] Mapping UI lists APs + switches as candidates; ethernet ports appear in the interface dropdown
- [ ] Map a node → status reflects `up`/`down`; map a link → traffic animates with neutral utilization colors (no red collision with down state)
- [ ] Down link renders as red dashed base line, no flowing lanes
- [ ] "All metrics" panel for an Aruba host dumps every primitive field of the inventory record (incl. new categorical fields like `aruba_model`, `aruba_health`, `aruba_ipAddress`)
- [ ] Alerts from upstream `MAJOR` / `MINOR` map to `high` / `low` respectively
- [ ] Existing Zabbix / Prometheus / NetBox / Grafana plugins still work (no regression from severity rename)
- [ ] `docs/plugin-authoring.md` renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)