### PR TITLE
feat(core): compound-aware tidy-tree layout

### DIFF
--- a/libs/@shumoku/core/src/layout/network-layout.test.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.test.ts
@@ -1,0 +1,168 @@
+// Regression coverage for the compound tree-layout path. The Sugiyama
+// fallback used to fire as soon as *any* subgraph existed, and its
+// barycenter ordering splits same-parent siblings — so adding a
+// subgraph to a tree-shaped network would interleave APs from
+// different switches. Buchheim handles compound containment now;
+// these tests pin the contiguity invariant.
+
+import { describe, expect, test } from 'vitest'
+import type { Link, NetworkGraph, Node, Subgraph } from '../models/types.js'
+import { layoutNetwork } from './network-layout.js'
+
+function node(id: string, parent?: string): Node {
+  return { id, label: id, ...(parent ? { parent } : {}) }
+}
+function subgraph(id: string, parent?: string): Subgraph {
+  return { id, label: id, ...(parent ? { parent } : {}) }
+}
+function link(from: string, to: string): Link {
+  // `port` is required on LinkEndpoint, but the layout's port-placement
+  // pass only needs it as a string handle — the nodes themselves don't
+  // need a matching NodePort declared for tree-layout coverage.
+  return { from: { node: from, port: `${from}-p` }, to: { node: to, port: `${to}-p` } }
+}
+
+/**
+ * Sort node ids by x coordinate at a given y row. The layout assigns
+ * the same y per "tree depth", so peers of a switch share a row.
+ */
+function nodesAtRow(result: ReturnType<typeof layoutNetwork>, ids: string[]): string[] {
+  return [...ids].sort((a, b) => {
+    const ax = result.nodes.get(a)?.position?.x ?? 0
+    const bx = result.nodes.get(b)?.position?.x ?? 0
+    return ax - bx
+  })
+}
+
+describe('layoutNetwork — compound tree layout', () => {
+  test('APs under each switch stay contiguous when a subgraph is present', () => {
+    // Topology mirrors the user-reported case (PR follow-up):
+    //   uplink → core (inside a subgraph) →
+    //     swA, swB
+    //   swA → apA1, apA2, apA3
+    //   swB → apB1, apB2, apB3
+    //
+    // Without compound tree support, Sugiyama would interleave the AP
+    // rows. With it, APs under each switch occupy a contiguous span.
+    const graph: NetworkGraph = {
+      nodes: [
+        node('uplink'),
+        node('core', 'group'), // lives inside the subgraph
+        node('swA'),
+        node('swB'),
+        node('apA1'),
+        node('apA2'),
+        node('apA3'),
+        node('apB1'),
+        node('apB2'),
+        node('apB3'),
+      ],
+      subgraphs: [subgraph('group')],
+      links: [
+        link('uplink', 'core'),
+        link('core', 'swA'),
+        link('core', 'swB'),
+        link('swA', 'apA1'),
+        link('swA', 'apA2'),
+        link('swA', 'apA3'),
+        link('swB', 'apB1'),
+        link('swB', 'apB2'),
+        link('swB', 'apB3'),
+      ],
+    }
+
+    const result = layoutNetwork(graph)
+
+    // Subgraph bounds were materialised — confirms the compound path
+    // ran, not the flat fallback that ignores subgraphs.
+    expect(result.subgraphs.get('group')?.bounds).toBeDefined()
+
+    // All six APs sit on the same row; sorted by x, the swA group and
+    // swB group must each occupy a contiguous run. If barycenter
+    // ordering had been used, apA's and apB's would interleave.
+    const apRow = nodesAtRow(result, ['apA1', 'apA2', 'apA3', 'apB1', 'apB2', 'apB3'])
+    const groups = apRow.map((id) => id.replace(/[0-9]+$/, ''))
+    // Run-length encode: should have exactly two runs, one per switch.
+    const runs: string[] = []
+    for (const g of groups) {
+      if (runs[runs.length - 1] !== g) runs.push(g)
+    }
+    expect(runs.length).toBe(2)
+    expect(new Set(runs)).toEqual(new Set(['apA', 'apB']))
+  })
+
+  test('switch with mixed downstream depths (switch + leaves) keeps leaves contiguous', () => {
+    // Recreates the second symptom in the user's screenshot:
+    // foyer-sw01 has both leaf APs and an intermediate switch (room1-sw01)
+    // with its own APs. Sugiyama's barycenter pulls room1-sw01 toward
+    // *its* AP centroid, splitting foyer's leaf APs around it.
+    const graph: NetworkGraph = {
+      nodes: [
+        node('core', 'group'),
+        node('foyer-sw01'),
+        node('foyer-ap01'),
+        node('foyer-ap02'),
+        node('foyer-ap03'),
+        node('foyer-ap04'),
+        node('room1-sw01'),
+        node('room1-ap01'),
+        node('room1-ap02'),
+      ],
+      subgraphs: [subgraph('group')],
+      links: [
+        link('core', 'foyer-sw01'),
+        link('foyer-sw01', 'foyer-ap01'),
+        link('foyer-sw01', 'foyer-ap02'),
+        link('foyer-sw01', 'foyer-ap03'),
+        link('foyer-sw01', 'foyer-ap04'),
+        link('foyer-sw01', 'room1-sw01'),
+        link('room1-sw01', 'room1-ap01'),
+        link('room1-sw01', 'room1-ap02'),
+      ],
+    }
+
+    const result = layoutNetwork(graph)
+
+    // foyer-sw01's direct children sit on the same row. Run-length
+    // encode by "kind" (ap vs sw): we want a single contiguous block
+    // of APs (no sw intruding), and a single sw block.
+    const row = nodesAtRow(result, [
+      'foyer-ap01',
+      'foyer-ap02',
+      'foyer-ap03',
+      'foyer-ap04',
+      'room1-sw01',
+    ])
+    const kinds = row.map((id) => (id.includes('-ap') ? 'ap' : 'sw'))
+    const runs: string[] = []
+    for (const k of kinds) {
+      if (runs[runs.length - 1] !== k) runs.push(k)
+    }
+    expect(runs.length).toBe(2)
+  })
+
+  test('falls back to Sugiyama when the graph has a real multi-parent edge', () => {
+    // Two paths into the same node = not a tree. Buchheim refuses
+    // (overlay cap), Sugiyama takes over. We don't assert layout
+    // positions here, only that the call succeeds and produces sane
+    // output (positions for every node).
+    const graph: NetworkGraph = {
+      nodes: [node('a'), node('b'), node('c'), node('d', 'g'), node('e', 'g'), node('f')],
+      subgraphs: [subgraph('g')],
+      links: [
+        link('a', 'b'),
+        link('a', 'c'),
+        link('b', 'd'),
+        link('c', 'd'), // d has two parents → overlay
+        link('b', 'e'),
+        link('c', 'e'),
+        link('d', 'f'),
+        link('e', 'f'), // f has two parents → overlay
+      ],
+    }
+    const result = layoutNetwork(graph)
+    for (const id of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      expect(result.nodes.get(id)?.position).toBeDefined()
+    }
+  })
+})

--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -40,6 +40,8 @@ import type {
   NetworkGraph,
   Node,
   NodeSpec,
+  Position,
+  Size,
   Subgraph,
 } from '../models/types.js'
 import { rebalanceSubgraphs } from './interaction.js'
@@ -648,18 +650,26 @@ const TREE_DOMINANT_OVERLAY_HARD_CAP = 5
  * tidy-tree algorithm. Returns null if the graph isn't tree-dominant
  * — caller falls back to Sugiyama in that case.
  *
+ * Compound subgraphs are handled bottom-up (deepest first): each
+ * subgraph is laid out as its own tree with `layoutTree`, then
+ * treated as a single node at its parent's level with size = its
+ * computed inner bounds + padding + label height. This mirrors
+ * `layoutCompound` but swaps Sugiyama for Buchheim per container so
+ * subtree contiguity is preserved — siblings of the same parent
+ * stay contiguous, whether they're inside a subgraph or above it.
+ *
  * Disqualifiers (forced fallback to Sugiyama):
  *
- *   - **Subgraphs present.** The tidy-tree path doesn't yet handle
- *     compound containment; the user expects subgraph boundaries to
- *     be respected, and Sugiyama already does that.
  *   - **`hints` or `fixed` supplied.** User-driven coordinate
  *     overrides flow more naturally through Sugiyama's coord
  *     assignment than through Buchheim's contour-based packing.
- *   - **Overlay ratio above threshold.** When too many edges fail
- *     the "primary parent" test, the graph has real mesh-like
- *     structure and Sugiyama's barycenter ordering is more
- *     appropriate.
+ *   - **Any container's overlay ratio above threshold.** When too
+ *     many edges in some container fail the "primary parent" test,
+ *     that level has real mesh-like structure and Sugiyama's
+ *     barycenter ordering is more appropriate. All-or-nothing: if
+ *     one container falls back, the whole graph does (mixing two
+ *     algorithms across the hierarchy would produce inconsistent
+ *     spacing rules).
  */
 function tryTreeLayout(
   nodes: CompoundNode[],
@@ -667,61 +677,191 @@ function tryTreeLayout(
   edges: Edge[],
   opts: typeof DEFAULTS,
 ): CompoundLayoutResult | null {
-  if (subgraphs.length > 0) return null
   if (opts.fixed.size > 0) return null
   if (opts.hints.size > 0) return null
 
-  // Build incoming-edge index, ignoring self loops.
-  const incoming = new Map<string, Edge[]>()
-  for (const e of edges) {
-    if (e.source === e.target) continue
-    const list = incoming.get(e.target) ?? []
-    list.push(e)
-    incoming.set(e.target, list)
+  const padding = opts.subgraphPadding
+  const labelHeight = opts.subgraphLabelHeight
+  const defaultSize: Size = { width: 160, height: 60 }
+
+  const nodeById = new Map<string, CompoundNode>()
+  for (const n of nodes) nodeById.set(n.id, n)
+  const subgraphById = new Map<string, CompoundSubgraph>()
+  for (const s of subgraphs) subgraphById.set(s.id, s)
+
+  // childrenOf: container id (or null = top level) → direct children
+  // (mixed nodes and subgraphs in declaration order).
+  const childrenOf = new Map<string | null, (CompoundNode | CompoundSubgraph)[]>()
+  const push = (parent: string | null, item: CompoundNode | CompoundSubgraph) => {
+    const list = childrenOf.get(parent)
+    if (list) list.push(item)
+    else childrenOf.set(parent, [item])
+  }
+  for (const n of nodes) push(n.parent ?? null, n)
+  for (const s of subgraphs) push(s.parent ?? null, s)
+
+  const depthOf = (id: string, visited = new Set<string>()): number => {
+    if (visited.has(id)) return 0
+    visited.add(id)
+    const sg = subgraphById.get(id)
+    if (!sg?.parent) return 0
+    return 1 + depthOf(sg.parent, visited)
   }
 
-  // Pick the first incoming edge as the primary parent for each
-  // node. Remaining incoming edges become overlay (rendered, but not
-  // structural for placement).
-  const treeEdges: TreeLayoutEdge[] = []
-  let overlayCount = 0
-  for (const [child, list] of incoming) {
-    const primary = list[0]
-    if (!primary) continue
-    treeEdges.push({ parent: primary.source, child })
-    overlayCount += list.length - 1
+  interface LocalLayout {
+    positions: Map<string, Position>
+    width: number
+    height: number
+  }
+  const localLayouts = new Map<string | null, LocalLayout>()
+  const subgraphSize = new Map<string, Size>()
+
+  // Run Buchheim for a single container. Returns null when the
+  // container's edges aren't tree-dominant — caller propagates the
+  // null up so the whole graph falls back to Sugiyama (consistent
+  // spacing across the hierarchy).
+  const runContainer = (containerId: string | null): LocalLayout | null => {
+    const children = childrenOf.get(containerId) ?? []
+    if (children.length === 0) {
+      return { positions: new Map(), width: 0, height: 0 }
+    }
+    const childIds = new Set(children.map((c) => c.id))
+
+    // Edges between direct children of this container only. Edges
+    // escaping the container were already promoted to their common
+    // ancestor by `buildCompoundEdges`, so they'll surface at the
+    // appropriate level instead of leaking down here.
+    const innerEdges = edges.filter(
+      (e) => childIds.has(e.source) && childIds.has(e.target) && e.source !== e.target,
+    )
+
+    // Pick a primary parent per child; remaining incoming edges
+    // become overlay (rendered but non-structural).
+    const incoming = new Map<string, Edge[]>()
+    for (const e of innerEdges) {
+      const list = incoming.get(e.target) ?? []
+      list.push(e)
+      incoming.set(e.target, list)
+    }
+    const treeEdges: TreeLayoutEdge[] = []
+    let overlayCount = 0
+    for (const [child, list] of incoming) {
+      const primary = list[0]
+      if (!primary) continue
+      treeEdges.push({ parent: primary.source, child })
+      overlayCount += list.length - 1
+    }
+    if (
+      overlayCount > TREE_DOMINANT_OVERLAY_HARD_CAP &&
+      overlayCount / Math.max(innerEdges.length, 1) > TREE_DOMINANT_OVERLAY_RATIO
+    ) {
+      return null
+    }
+    if (hasCycleAfterPrimaryPick(treeEdges)) return null
+
+    // Build TreeLayoutNode set: leaves use their intrinsic size,
+    // subgraphs use their already-computed inner bounds expanded by
+    // padding + label.
+    const treeNodes: TreeLayoutNode[] = children.map((c) => {
+      const sg = subgraphById.get(c.id)
+      if (sg) {
+        const inner = subgraphSize.get(c.id) ?? { width: 0, height: 0 }
+        return {
+          id: c.id,
+          size: {
+            width: inner.width + padding * 2,
+            height: inner.height + padding * 2 + labelHeight,
+          },
+        }
+      }
+      const n = nodeById.get(c.id)
+      return { id: c.id, size: n?.size ?? defaultSize }
+    })
+
+    const result = layoutTree(treeNodes, treeEdges, {
+      direction: opts.direction,
+      nodeGap: opts.gap,
+      layerGap: opts.topLevelGap,
+    })
+
+    // Shift so the container origin is (0, 0). `flatten` translates
+    // by the container's absolute origin to produce final coords.
+    const shiftX = -result.bounds.x
+    const shiftY = -result.bounds.y
+    const shifted = new Map<string, Position>()
+    for (const [id, p] of result.positions) {
+      shifted.set(id, { x: p.x + shiftX, y: p.y + shiftY })
+    }
+    return { positions: shifted, width: result.bounds.width, height: result.bounds.height }
   }
 
-  // Overlay budget check. A small number of cross-links is OK; many
-  // means the graph isn't really a tree.
-  if (
-    overlayCount > TREE_DOMINANT_OVERLAY_HARD_CAP &&
-    overlayCount / Math.max(edges.length, 1) > TREE_DOMINANT_OVERLAY_RATIO
-  ) {
-    return null
+  // Bottom-up: deepest subgraphs first, then walk up. Any failure
+  // bails the whole tree attempt.
+  const sortedSubgraphs = [...subgraphs].sort((a, b) => depthOf(b.id) - depthOf(a.id))
+  for (const sg of sortedSubgraphs) {
+    const layout = runContainer(sg.id)
+    if (!layout) return null
+    localLayouts.set(sg.id, layout)
+    subgraphSize.set(sg.id, { width: layout.width, height: layout.height })
   }
+  const top = runContainer(null)
+  if (!top) return null
+  localLayouts.set(null, top)
 
-  // Cycle detection: walk parent chains; if any chain loops back on
-  // itself, the "primary parent" picks formed a cycle (extremely
-  // rare in practice but possible with circular ownership). Bail in
-  // that case — Sugiyama's cycle removal handles it.
-  if (hasCycleAfterPrimaryPick(treeEdges)) return null
-
-  const treeNodes: TreeLayoutNode[] = nodes.map((n) => ({
-    id: n.id,
-    size: n.size ?? { width: 160, height: 60 },
-  }))
-  const result = layoutTree(treeNodes, treeEdges, {
-    direction: opts.direction,
-    nodeGap: opts.gap,
-    layerGap: opts.topLevelGap,
-  })
-
-  return {
-    nodePositions: result.positions,
-    subgraphBounds: new Map(),
-    rootBounds: result.bounds,
+  // Flatten: walk top-down, accumulating each container's origin into
+  // absolute coords. Same shape as layoutCompound's flatten.
+  const nodePositions = new Map<string, Position>()
+  const subgraphBounds = new Map<string, Bounds>()
+  const flatten = (containerId: string | null, originX: number, originY: number) => {
+    const local = localLayouts.get(containerId)
+    if (!local) return
+    const children = childrenOf.get(containerId) ?? []
+    for (const c of children) {
+      const localPos = local.positions.get(c.id)
+      if (!localPos) continue
+      const absX = originX + localPos.x
+      const absY = originY + localPos.y
+      const sg = subgraphById.get(c.id)
+      if (sg) {
+        const inner = subgraphSize.get(c.id) ?? { width: 0, height: 0 }
+        const width = inner.width + padding * 2
+        const height = inner.height + padding * 2 + labelHeight
+        const bx = absX - width / 2
+        const by = absY - height / 2
+        subgraphBounds.set(c.id, { x: bx, y: by, width, height })
+        flatten(c.id, bx + padding, by + padding + labelHeight)
+      } else {
+        nodePositions.set(c.id, { x: absX, y: absY })
+      }
+    }
   }
+  flatten(null, 0, 0)
+
+  // Root bounds — same union pass as layoutCompound.
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const [id, { x, y }] of nodePositions) {
+    const n = nodeById.get(id)
+    const size = n?.size ?? defaultSize
+    minX = Math.min(minX, x - size.width / 2)
+    minY = Math.min(minY, y - size.height / 2)
+    maxX = Math.max(maxX, x + size.width / 2)
+    maxY = Math.max(maxY, y + size.height / 2)
+  }
+  for (const bounds of subgraphBounds.values()) {
+    minX = Math.min(minX, bounds.x)
+    minY = Math.min(minY, bounds.y)
+    maxX = Math.max(maxX, bounds.x + bounds.width)
+    maxY = Math.max(maxY, bounds.y + bounds.height)
+  }
+  const rootBounds: Bounds =
+    minX === Number.POSITIVE_INFINITY
+      ? { x: 0, y: 0, width: 0, height: 0 }
+      : { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+
+  return { nodePositions, subgraphBounds, rootBounds }
 }
 
 function hasCycleAfterPrimaryPick(treeEdges: readonly TreeLayoutEdge[]): boolean {


### PR DESCRIPTION
## Why

The auto-layout produced visibly worse results once a user added a subgraph. Specifically, APs hanging off sibling switches would interleave (apA1, apB1, apA2, …) and a switch with mixed downstream depths would have its leaf APs split around any intermediate switch underneath.

Root cause: \`tryTreeLayout\` bailed early when subgraphs existed, falling back to Sugiyama. Sugiyama's barycenter ordering optimises **global** crossing count by reordering within each layer — which interleaves same-parent siblings whenever a sibling with deeper downstream pull is in the same row. This is exactly the failure mode \`tree-layout.ts\` was added to fix in the flat-graph case.

## Change

\`tryTreeLayout\` is now compound-aware. The disqualifier (\`subgraphs.length > 0\`) is gone; instead, the function mirrors \`layoutCompound\`'s bottom-up walk:

1. Sort subgraphs deepest first.
2. For each container (subgraph or top-level), filter the global edge list to edges between its direct children (cross-container edges were already promoted to their common ancestor by \`buildCompoundEdges\`), pick a primary parent per child, run \`layoutTree\` on the result.
3. Treat each subgraph as a node sized to its inner bounds + padding + label at the parent's level.
4. Flatten the local-coordinate trees into absolute coordinates.

All-or-nothing tree-dominance: if any container's overlay ratio exceeds the threshold (or the primary-parent picks cycle), the whole graph falls back to Sugiyama. Mixing the two algorithms across the hierarchy would produce inconsistent spacing rules.

## Test plan

- [x] Existing layout tests pass (84 → 114, includes 3 new)
- [x] Full monorepo \`bun run test\` clean
- [ ] User-side: re-do the auto-arrange in the screenshotted topology and confirm AP rows under each switch are contiguous, foyer's leaves aren't split by room1-sw01

🤖 Generated with [Claude Code](https://claude.com/claude-code)