### PR TITLE
fix(editor): guard context menu against stray right-click activation

### DIFF
--- a/apps/editor/src/lib/components/CanvasContextMenu.svelte
+++ b/apps/editor/src/lib/components/CanvasContextMenu.svelte
@@ -89,10 +89,7 @@
   }
 </script>
 
-<ContextMenu.Root
-  bind:open
-  onOpenChange={(o) => { if (o) openedAt = performance.now() }}
->
+<ContextMenu.Root bind:open onOpenChange={(o) => { if (o) openedAt = performance.now() }}>
   <ContextMenu.Trigger oncontextmenu={captureCursor} class="block h-full w-full">
     {@render children()}
   </ContextMenu.Trigger>

--- a/apps/editor/src/lib/components/CanvasContextMenu.svelte
+++ b/apps/editor/src/lib/components/CanvasContextMenu.svelte
@@ -55,9 +55,12 @@
   // under 150ms.
   const RIGHT_CLICK_GUARD_MS = 250
   let openedAt = 0
-  $effect(() => {
-    if (open) openedAt = performance.now()
-  })
+  // Use `onOpenChange` (synchronous, fires inside the contextmenu
+  // event handler) instead of `$effect` so the timestamp is in
+  // place before the menu finishes rendering. A `$effect` would
+  // also work in practice — microtasks drain before the next event
+  // — but the synchronous path leaves no scheduling assumption to
+  // regress on.
 
   function captureCursor(e: MouseEvent) {
     cursorPoint = { x: e.clientX, y: e.clientY }
@@ -86,7 +89,10 @@
   }
 </script>
 
-<ContextMenu.Root bind:open>
+<ContextMenu.Root
+  bind:open
+  onOpenChange={(o) => { if (o) openedAt = performance.now() }}
+>
   <ContextMenu.Trigger oncontextmenu={captureCursor} class="block h-full w-full">
     {@render children()}
   </ContextMenu.Trigger>

--- a/apps/editor/src/lib/components/CanvasContextMenu.svelte
+++ b/apps/editor/src/lib/components/CanvasContextMenu.svelte
@@ -38,6 +38,27 @@
     canvasPos: cursorPoint ?? ctx.canvasPos,
   })
 
+  // Trackpad two-finger right-clicks land both a `contextmenu`
+  // (opens the menu at the cursor) and a `pointerup` (~60-100ms
+  // later) in one fast gesture. If the pointerup happens to fall
+  // on a freshly rendered menu item, bits-ui's onSelect fires and
+  // the user activates an action they never meant to — typically
+  // the top item (Undo), which rolls back recent edits and looks
+  // like "nodes disappeared". Browser semantics for right-click
+  // would only fire `auxclick`, not `click`, but Radix/bits-ui's
+  // menu activates on pointerup regardless of button.
+  //
+  // Guard: ignore any pickAction/pickItem call that fires within
+  // a short window of menu open. Deliberate click activations
+  // come ≥250ms after open (humans don't move and click that
+  // fast); the trackpad gesture's trailing release is reliably
+  // under 150ms.
+  const RIGHT_CLICK_GUARD_MS = 250
+  let openedAt = 0
+  $effect(() => {
+    if (open) openedAt = performance.now()
+  })
+
   function captureCursor(e: MouseEvent) {
     cursorPoint = { x: e.clientX, y: e.clientY }
   }
@@ -48,13 +69,19 @@
     return a.enabled ? a.enabled(openCtx) : true
   }
 
+  function isStrayRightClickActivation(): boolean {
+    return performance.now() - openedAt < RIGHT_CLICK_GUARD_MS
+  }
+
   async function pickAction(a: Action) {
     if (a.submenu) return
+    if (isStrayRightClickActivation()) return
     await runAction(a.id, openCtx)
   }
 
   async function pickItem(item: SubmenuItem) {
     if (item.enabled === false) return
+    if (isStrayRightClickActivation()) return
     await item.pick(openCtx)
   }
 </script>

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -389,7 +389,7 @@
     replaceMap(edges, result.edges)
     if (result.subgraphs) replaceMap(subgraphs, result.subgraphs)
 
-    if (!multiDragOrigin || !multiDragOrigin.has(id)) return
+    if (!multiDragOrigin?.has(id)) return
     // Where the dragged element ended up after collision resolution.
     const draggedNow = nodes.get(id)?.position ?? subgraphs.get(id)?.bounds
     const origin = multiDragOrigin.get(id)


### PR DESCRIPTION
## Symptom

User-reported regression on the disappearing-selection class of bugs we thought was closed by #261 / #263 / #264. Different mechanic this time — trace from the failing environment shows the actual sequence:

\`\`\`
t=0    pointerdown button=2 on node    (right-click)
t=2    contextmenu fires               → menu opens at cursor
t=60   pointerup button=2 on item DIV  (60ms later, same gesture)
t=60   click  button=0 on item DIV     (synthesized by bits-ui)
→ onSelect fires → 'Undo' (top of menu) runs → recent edits roll back
  → looks like the selected nodes disappeared
\`\`\`

Browser semantics would dispatch \`auxclick\` (not \`click\`) for a right-button release, but bits-ui's Menu Item activates on \`pointerup\` regardless of button. The trackpad's two-finger tap is fast enough (~60-100ms between contextmenu and pointerup) that the menu has just rendered under the cursor by the time the release lands, and the trailing release of the *same* gesture activates whatever item is there.

Important detail from the event trace: \`nodes.delete\` / \`nodes.clear\` instrumentation never fires during the bug — nodes aren't actually deleted, they're rolled back by an accidental Undo activation. Same observable symptom, different root cause from the earlier fixes.

## Fix

Guard \`CanvasContextMenu\`'s \`pickAction\` / \`pickItem\` to ignore activations within 250ms of menu open. Deliberate clicks come well after that — humans don't move and click that fast — but every trackpad gesture's trailing release is reliably under the threshold.

Tracked via \`openedAt\` (set in a \`\$effect\` watching \`open\`) plus \`performance.now()\` at activation time. No event-level hooks needed; we don't have to know which event triggered the select.

## Test plan

- [ ] Multi-select two nodes, two-finger right-click on one — context menu opens, **no item activates**, selection preserved
- [ ] Right-click on a node, wait, then click 'Move to group' deliberately → action fires as before
- [ ] Right-click then immediately keyboard-arrow to an item and Enter → still works (keyboard nav happens >250ms after open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)