### PR TITLE
feat(server): poll metrics from all configured sources

### DIFF
--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -27,6 +27,29 @@ import { TopologySourcesService } from './services/topology-sources.js'
 import { TopologyManager } from './topology.js'
 import type { ClientMessage, ClientState, Config, MetricsData, MetricsMapping } from './types.js'
 
+/**
+ * Merge metrics from a later poll into an accumulator. Sources are
+ * polled in priority order, so the later result is **lower-priority**
+ * — earlier values win on conflicts. Plugin host-id namespaces are
+ * structurally disjoint in practice so the typical case is that
+ * `incoming` fills slots that `acc` doesn't have yet.
+ *
+ * `warnings` is concatenated (every source's warnings get surfaced);
+ * the timestamp tracks the latest poll so consumers see freshness.
+ */
+function mergeMetricsData(acc: MetricsData | null, incoming: MetricsData): MetricsData {
+  if (!acc) return incoming
+  const nodes = { ...incoming.nodes, ...acc.nodes }
+  const links = { ...incoming.links, ...acc.links }
+  const warnings = [...(acc.warnings ?? []), ...(incoming.warnings ?? [])]
+  return {
+    nodes,
+    links,
+    timestamp: Math.max(acc.timestamp, incoming.timestamp),
+    warnings: warnings.length > 0 ? warnings : undefined,
+  }
+}
+
 export class Server {
   private app: Hono
   private config: Config
@@ -338,52 +361,55 @@ export class Server {
 
       let metrics: MetricsData | null = null
 
-      // Try to get metrics from configured data source
+      // Poll every attached metrics source and merge their results.
+      // Plugin host-id namespaces are structurally disjoint in practice
+      // (Zabbix numeric ids vs Aruba serials vs NetBox integers), so
+      // each plugin naturally answers for the subset of mapped nodes
+      // it recognizes and ignores the rest. Sources iterate in
+      // priority order (low number = high precedence); when two
+      // sources happen to return metrics for the same nodeId/linkId,
+      // the higher-priority result wins.
       const metricsSources = this.topologySourcesService.listByPurpose(topology.id, 'metrics')
-      if (metricsSources[0]) {
-        const source = metricsSources[0] // Use first metrics source
-        const dataSource = this.dataSourceService.get(source.dataSourceId)
-
-        if (dataSource) {
+      if (metricsSources.length > 0) {
+        // Parse mapping once — every plugin sees the same view.
+        let mapping: MetricsMapping = { nodes: {}, links: {} }
+        if (topology.mappingJson) {
           try {
-            // Get or create plugin instance
+            mapping = JSON.parse(topology.mappingJson)
+          } catch {
+            // Invalid mapping JSON, use empty
+          }
+        }
+
+        // Backfill link bandwidth from the topology spec exactly once.
+        // The plugin sees a single authoritative bps per link.
+        if (parsed?.graph?.links) {
+          for (const [i, link] of parsed.graph.links.entries()) {
+            const linkId = link.id || `link-${i}`
+            const linkMapping = mapping.links?.[linkId]
+            if (linkMapping && linkMapping.bandwidth === undefined) {
+              const bps = linkSpeedBps(link)
+              if (bps !== undefined) linkMapping.bandwidth = bps
+            }
+          }
+        }
+
+        for (const source of metricsSources) {
+          const dataSource = this.dataSourceService.get(source.dataSourceId)
+          if (!dataSource) continue
+          try {
             const config = JSON.parse(dataSource.configJson)
             const plugin = pluginRegistry.getInstance(dataSource.id, dataSource.type, config)
+            if (!hasMetricsCapability(plugin)) continue
 
-            if (hasMetricsCapability(plugin)) {
-              // Parse mapping from topology
-              let mapping: MetricsMapping = { nodes: {}, links: {} }
-              if (topology.mappingJson) {
-                try {
-                  mapping = JSON.parse(topology.mappingJson)
-                } catch {
-                  // Invalid mapping JSON, use empty
-                }
-              }
-
-              // Backfill mapping.bandwidth from the topology's link spec
-              // (Ethernet standard) when the operator hasn't set an explicit
-              // override. The plugin sees a single authoritative bps per link.
-              if (parsed?.graph?.links) {
-                for (const [i, link] of parsed.graph.links.entries()) {
-                  const linkId = link.id || `link-${i}`
-                  const linkMapping = mapping.links?.[linkId]
-                  if (linkMapping && linkMapping.bandwidth === undefined) {
-                    const bps = linkSpeedBps(link)
-                    if (bps !== undefined) linkMapping.bandwidth = bps
-                  }
-                }
-              }
-
-              // Poll real metrics
-              metrics = await plugin.pollMetrics(mapping)
-              console.log(
-                `[Server] Polled real metrics for topology "${topology.name}" from ${dataSource.type}`,
-              )
-            }
+            const m = await plugin.pollMetrics(mapping)
+            metrics = mergeMetricsData(metrics, m)
+            console.log(
+              `[Server] Polled metrics for topology "${topology.name}" from ${dataSource.type}`,
+            )
           } catch (err) {
             console.error(
-              `[Server] Failed to poll metrics for topology "${topology.name}":`,
+              `[Server] Failed to poll metrics from ${dataSource.type} for topology "${topology.name}":`,
               err instanceof Error ? err.message : err,
             )
           }

--- a/apps/server/web/src/lib/components/NodeMappingModal.svelte
+++ b/apps/server/web/src/lib/components/NodeMappingModal.svelte
@@ -16,7 +16,7 @@
   import { api } from '$lib/api'
   import { Button } from '$lib/components/ui/button'
   import * as Dialog from '$lib/components/ui/dialog'
-  import { mappingHosts, mappingStore, metricsData } from '$lib/stores'
+  import { mappingHosts, mappingStore, metricsData, metricsSources } from '$lib/stores'
   import type { DiscoveredMetric, MetricsMapping } from '$lib/types'
   import { formatTraffic } from '$lib/utils/format'
   import type { NodeSelectEvent } from './InteractiveSvgDiagram.svelte'
@@ -24,7 +24,6 @@
   interface Props {
     open: boolean
     topologyId: string
-    metricsSourceId: string | undefined
     netboxBaseUrl: string | undefined
     nodeData: NodeSelectEvent | null
     currentMapping: MetricsMapping | null
@@ -34,7 +33,6 @@
   let {
     open = $bindable(false),
     topologyId,
-    metricsSourceId,
     netboxBaseUrl,
     nodeData = null,
     currentMapping = null,
@@ -72,8 +70,29 @@
       : hosts,
   )
 
+  // Group filtered hosts by source so the radio list can render a
+  // header per data source when 2+ are attached. With a single source
+  // the header is suppressed to keep the simpler look.
+  let groupedFilteredHosts = $derived.by(() => {
+    const groups = new Map<string, { sourceName: string; items: typeof filteredHosts }>()
+    for (const h of filteredHosts) {
+      const g = groups.get(h.sourceId)
+      if (g) g.items.push(h)
+      else groups.set(h.sourceId, { sourceName: h.sourceName, items: [h] })
+    }
+    return [...groups.values()]
+  })
+
   let currentNodeMapping = $derived(nodeData && currentMapping?.nodes?.[nodeData.node.id])
-  let hasMetricsSource = $derived(!!metricsSourceId)
+  let hasMetricsSource = $derived($metricsSources.length > 0)
+  // Resolve which source owns the mapped host so discoverMetrics can
+  // call the right plugin. Plugin host-id namespaces are disjoint, so
+  // the host's recorded source tag is unambiguous.
+  let mappedHostSourceId = $derived(
+    currentNodeMapping?.hostId
+      ? hosts.find((h) => h.id === currentNodeMapping.hostId)?.sourceId
+      : undefined,
+  )
 
   // Filter discovered metrics by search query
   let filteredMetrics = $derived(
@@ -151,13 +170,13 @@
   // Hosts are loaded via shared store
 
   async function loadDiscoveredMetrics() {
-    if (!metricsSourceId || !currentNodeMapping?.hostId) return
+    if (!mappedHostSourceId || !currentNodeMapping?.hostId) return
 
     loadingMetrics = true
     metricsError = ''
     try {
       discoveredMetrics = await api.dataSources.discoverMetrics(
-        metricsSourceId,
+        mappedHostSourceId,
         currentNodeMapping.hostId,
       )
     } catch (e) {
@@ -669,7 +688,7 @@
                 >
               </div>
 
-              <!-- Host List -->
+              <!-- Host List (grouped by source when 2+ sources are attached) -->
               <div class="max-h-48 overflow-y-auto border rounded-md">
                 {#if filteredHosts.length === 0}
                   <div class="p-3 text-sm text-muted-foreground text-center">
@@ -677,31 +696,40 @@
                   </div>
                 {:else}
                   <div class="divide-y">
-                    {#each filteredHosts as host}
-                      <label
-                        class="flex items-center gap-3 p-2 hover:bg-muted/50 cursor-pointer transition-colors"
-                      >
-                        <input
-                          type="radio"
-                          name="host"
-                          value={host.id}
-                          bind:group={selectedHostId}
-                          class="w-4 h-4"
+                    {#each groupedFilteredHosts as group}
+                      {#if groupedFilteredHosts.length > 1}
+                        <div
+                          class="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground bg-muted/30 sticky top-0"
                         >
-                        <div class="flex-1 min-w-0">
-                          <div class="text-sm font-medium truncate">
-                            {host.displayName || host.name}
-                          </div>
-                          {#if host.ip}
-                            <div class="text-xs text-muted-foreground">{host.ip}</div>
-                          {/if}
+                          {group.sourceName}
                         </div>
-                        {#if host.status === 'up'}
-                          <span class="w-2 h-2 bg-success rounded-full flex-shrink-0"></span>
-                        {:else if host.status === 'down'}
-                          <span class="w-2 h-2 bg-destructive rounded-full flex-shrink-0"></span>
-                        {/if}
-                      </label>
+                      {/if}
+                      {#each group.items as host}
+                        <label
+                          class="flex items-center gap-3 p-2 hover:bg-muted/50 cursor-pointer transition-colors"
+                        >
+                          <input
+                            type="radio"
+                            name="host"
+                            value={host.id}
+                            bind:group={selectedHostId}
+                            class="w-4 h-4"
+                          >
+                          <div class="flex-1 min-w-0">
+                            <div class="text-sm font-medium truncate">
+                              {host.displayName || host.name}
+                            </div>
+                            {#if host.ip}
+                              <div class="text-xs text-muted-foreground">{host.ip}</div>
+                            {/if}
+                          </div>
+                          {#if host.status === 'up'}
+                            <span class="w-2 h-2 bg-success rounded-full flex-shrink-0"></span>
+                          {:else if host.status === 'down'}
+                            <span class="w-2 h-2 bg-destructive rounded-full flex-shrink-0"></span>
+                          {/if}
+                        </label>
+                      {/each}
                     {/each}
                   </div>
                 {/if}

--- a/apps/server/web/src/lib/stores/index.ts
+++ b/apps/server/web/src/lib/stores/index.ts
@@ -20,10 +20,12 @@ export {
   hostInterfaces,
   hostInterfacesLoading,
   linkMapping,
+  type MappingHost,
   mappingError,
   mappingHosts,
   mappingLoading,
   mappingStore,
+  metricsSources,
   nodeMapping,
 } from './mapping'
 export {

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -1,6 +1,19 @@
 /**
  * Mapping Store
- * Shared state for topology node/link mapping across pages
+ * Shared state for topology node/link mapping across pages.
+ *
+ * A topology can have multiple `metrics`-purpose data sources attached.
+ * Each plugin uses its own host-id namespace (Zabbix host ids, Aruba
+ * serials, NetBox device ids, …) so they partition naturally — a host
+ * id is unambiguous about which source owns it. The store keeps each
+ * loaded host tagged with its `sourceId` so the mapping UI can:
+ *
+ * 1. group dropdowns by source for the operator,
+ * 2. resolve which source to ask for a given host's interfaces.
+ *
+ * The persisted mapping shape (`MetricsMapping` from `@shumoku/core`)
+ * is intentionally source-agnostic — see `docs/plugin-authoring.md`'s
+ * "core defines the display contract" principle.
  */
 
 import { derived, get, writable } from 'svelte/store'
@@ -8,29 +21,99 @@ import { api } from '$lib/api'
 import { NODE_MATCH_THRESHOLD, nodeNameMatchScore } from '$lib/auto-mapping'
 import type { Host, HostItem, MetricsMapping, Topology, TopologyDataSource } from '$lib/types'
 
+/**
+ * A `Host` annotated with its origin data source. Web-local — does not
+ * leak into the persisted mapping shape, which stays plugin-agnostic.
+ */
+export interface MappingHost extends Host {
+  /** Data source this host came from. */
+  sourceId: string
+  /** Human-readable source name for UI grouping (`<optgroup>` label). */
+  sourceName: string
+}
+
+interface MetricsSourceInfo {
+  id: string
+  name: string
+  /** Higher precedence wins on metrics merge conflicts. Lower number = higher precedence. */
+  priority: number
+}
+
 interface MappingState {
   topologyId: string | null
   mapping: MetricsMapping
-  hosts: Host[]
+  /** Flat list of hosts across all metrics sources, each tagged with its source. */
+  hosts: MappingHost[]
+  /** Metrics sources for this topology (id + display name). Empty when none configured. */
+  metricsSources: MetricsSourceInfo[]
   // Interfaces per host (hostId -> interfaces)
   hostInterfaces: Record<string, HostItem[]>
   hostInterfacesLoading: Record<string, boolean>
   loading: boolean
   hostsLoading: boolean
   error: string | null
-  metricsSourceId: string | null
 }
 
 const initialState: MappingState = {
   topologyId: null,
   mapping: { nodes: {}, links: {} },
   hosts: [],
+  metricsSources: [],
   hostInterfaces: {},
   hostInterfacesLoading: {},
   loading: false,
   hostsLoading: false,
   error: null,
-  metricsSourceId: null,
+}
+
+/**
+ * Look up which metrics source owns a host. Plugin host-id namespaces
+ * are structurally disjoint in practice (Zabbix numbers vs Aruba
+ * serials vs NetBox ids), so the first match wins. Returns undefined
+ * if the host isn't currently in the loaded set.
+ */
+function sourceIdForHost(hosts: MappingHost[], hostId: string): string | undefined {
+  return hosts.find((h) => h.id === hostId)?.sourceId
+}
+
+async function loadHostsForSources(
+  sources: MetricsSourceInfo[],
+  dataSourceLookup: Map<string, TopologyDataSource>,
+): Promise<MappingHost[]> {
+  // Fetch every source in parallel. A single source failing must not
+  // block the others — the UI shows whatever loaded successfully.
+  const results = await Promise.allSettled(
+    sources.map(async (src) => {
+      const hosts = await api.dataSources.getHosts(src.id)
+      const name = dataSourceLookup.get(src.id)?.dataSource?.name ?? src.name
+      return hosts.map<MappingHost>((h) => ({ ...h, sourceId: src.id, sourceName: name }))
+    }),
+  )
+  const out: MappingHost[] = []
+  for (const r of results) {
+    if (r.status === 'fulfilled') out.push(...r.value)
+  }
+  return out
+}
+
+function buildSourcesFromTopology(sources: TopologyDataSource[]): {
+  metricsSources: MetricsSourceInfo[]
+  lookup: Map<string, TopologyDataSource>
+} {
+  const lookup = new Map<string, TopologyDataSource>()
+  for (const s of sources) lookup.set(s.dataSourceId, s)
+
+  const metricsSources: MetricsSourceInfo[] = sources
+    .filter((s) => s.purpose === 'metrics')
+    .map((s) => ({
+      id: s.dataSourceId,
+      name: s.dataSource?.name ?? s.dataSourceId,
+      priority: s.priority,
+    }))
+    // Sort by priority ascending (lower number = higher precedence) so the
+    // UI presents sources in operator-defined order.
+    .sort((a, b) => a.priority - b.priority)
+  return { metricsSources, lookup }
 }
 
 function createMappingStore() {
@@ -54,22 +137,20 @@ function createMappingStore() {
         }
       }
 
-      const metricsSource = sources.find((s) => s.purpose === 'metrics')
-      const metricsSourceId = metricsSource?.dataSourceId || null
+      const { metricsSources, lookup } = buildSourcesFromTopology(sources)
 
       update((s) => ({
         ...s,
         topologyId,
         mapping,
-        metricsSourceId,
+        metricsSources,
         loading: false,
         error: null,
       }))
 
-      if (metricsSourceId) {
+      if (metricsSources.length > 0) {
         update((s) => ({ ...s, hostsLoading: true }))
-        api.dataSources
-          .getHosts(metricsSourceId)
+        loadHostsForSources(metricsSources, lookup)
           .then((hosts) => update((s) => ({ ...s, hosts, hostsLoading: false })))
           .catch(() => update((s) => ({ ...s, hostsLoading: false })))
       }
@@ -105,22 +186,19 @@ function createMappingStore() {
           }
         }
 
-        // Find metrics source
-        const metricsSource = sources.find((s) => s.purpose === 'metrics')
-        const metricsSourceId = metricsSource?.dataSourceId || null
+        const { metricsSources, lookup } = buildSourcesFromTopology(sources)
 
         update((s) => ({
           ...s,
           mapping,
-          metricsSourceId,
+          metricsSources,
           loading: false,
         }))
 
-        // Load hosts if metrics source is available
-        if (metricsSourceId) {
+        if (metricsSources.length > 0) {
           update((s) => ({ ...s, hostsLoading: true }))
           try {
-            const hosts = await api.dataSources.getHosts(metricsSourceId)
+            const hosts = await loadHostsForSources(metricsSources, lookup)
             update((s) => ({ ...s, hosts, hostsLoading: false }))
           } catch {
             update((s) => ({ ...s, hostsLoading: false }))
@@ -191,11 +269,14 @@ function createMappingStore() {
     },
 
     /**
-     * Load interfaces for a specific host
+     * Load interfaces for a specific host. Picks the source the host
+     * was loaded from (recorded in the `MappingHost` tag) — important
+     * because the host-id namespace is plugin-defined.
      */
     loadHostInterfaces: async (hostId: string) => {
       const current = get({ subscribe })
-      if (!current.metricsSourceId) return
+      const sourceId = sourceIdForHost(current.hosts, hostId)
+      if (!sourceId) return
 
       // Skip if already loaded or loading
       if (current.hostInterfaces[hostId] || current.hostInterfacesLoading[hostId]) {
@@ -208,7 +289,7 @@ function createMappingStore() {
       }))
 
       try {
-        const items = await api.dataSources.getHostItems(current.metricsSourceId, hostId)
+        const items = await api.dataSources.getHostItems(sourceId, hostId)
         // Filter to unique interface names (remove :in/:out suffix)
         const interfaceNames = new Set<string>()
         const interfaces: HostItem[] = []
@@ -280,8 +361,11 @@ function createMappingStore() {
         const nodeLabel = Array.isArray(node.label) ? node.label[0] : node.label
         if (!nodeLabel) continue
 
-        // Find best matching host by score
-        let bestHost: Host | null = null
+        // Find best matching host across all sources by score. Ties are
+        // broken by source priority via the order of `current.hosts`
+        // (hosts are loaded source-by-source in priority order, so a
+        // higher-priority source's host wins on equal scores).
+        let bestHost: MappingHost | null = null
         let bestScore = 0
         for (const host of current.hosts) {
           const score = nodeNameMatchScore(nodeLabel, host.name, host.displayName)
@@ -339,5 +423,6 @@ export const mappingError = derived(mappingStore, ($s) => $s.error)
 export const nodeMapping = derived(mappingStore, ($s) => $s.mapping.nodes)
 export const linkMapping = derived(mappingStore, ($s) => $s.mapping.links)
 export const mappingHosts = derived(mappingStore, ($s) => $s.hosts)
+export const metricsSources = derived(mappingStore, ($s) => $s.metricsSources)
 export const hostInterfaces = derived(mappingStore, ($s) => $s.hostInterfaces)
 export const hostInterfacesLoading = derived(mappingStore, ($s) => $s.hostInterfacesLoading)

--- a/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
@@ -45,7 +45,6 @@
   $: topologyId = $page.params.id!
 
   // Get mapping from store
-  $: metricsSourceId = $mappingStore.metricsSourceId ?? undefined
   $: currentMapping = $mappingStore.mapping
 
   onMount(async () => {
@@ -235,7 +234,6 @@
   <NodeMappingModal
     bind:open={mappingModalOpen}
     {topologyId}
-    {metricsSourceId}
     {netboxBaseUrl}
     nodeData={selectedNodeData}
     {currentMapping}

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -185,8 +185,7 @@
   // Derived
   // ============================================
 
-  let metricsSourceId = $derived($mappingStore.metricsSourceId)
-  let hasMetricsSource = $derived(!!metricsSourceId)
+  let hasMetricsSource = $derived($mappingStore.metricsSources.length > 0)
 
   let topologySources = $derived(editableSources.filter((s) => s.purpose === 'topology'))
   let metricsSources = $derived(editableSources.filter((s) => s.purpose === 'metrics'))
@@ -215,6 +214,19 @@
     }).length,
   )
   let totalLinks = $derived(edges.length)
+
+  /** Hosts grouped by their owning data source, in source priority
+   *  order. Drives `<optgroup>` rendering in the host dropdown so the
+   *  operator sees which source each candidate comes from. */
+  let hostsBySource = $derived.by(() => {
+    const groups = new Map<string, { sourceName: string; items: typeof $mappingHosts }>()
+    for (const h of $mappingHosts) {
+      const g = groups.get(h.sourceId)
+      if (g) g.items.push(h)
+      else groups.set(h.sourceId, { sourceName: h.sourceName, items: [h] })
+    }
+    return [...groups.values()]
+  })
 
   // ============================================
   // Lifecycle
@@ -1588,8 +1600,18 @@
                       onchange={(e) => handleNodeMappingChange(node.id, e.currentTarget.value)}
                     >
                       <option value="">Not mapped</option>
-                      {#each $mappingHosts as host}
-                        <option value={host.id}>{host.displayName || host.name}</option>
+                      {#each hostsBySource as group}
+                        {#if hostsBySource.length > 1}
+                          <optgroup label={group.sourceName}>
+                            {#each group.items as host}
+                              <option value={host.id}>{host.displayName || host.name}</option>
+                            {/each}
+                          </optgroup>
+                        {:else}
+                          {#each group.items as host}
+                            <option value={host.id}>{host.displayName || host.name}</option>
+                          {/each}
+                        {/if}
                       {/each}
                     </select>
                   </div>

--- a/libs/plugins/aruba-instant-on/src/plugin.ts
+++ b/libs/plugins/aruba-instant-on/src/plugin.ts
@@ -160,28 +160,29 @@ export class ArubaInstantOnPlugin
     const { byId } = await this.deviceLookup()
 
     // ---- Nodes -----------------------------------------------------------
+    //
+    // Stay silent on hosts whose `hostId` isn't in *our* inventory —
+    // either the mapping points at a different source's host (multi-
+    // source case), or the operator typed a bad id. Either way, another
+    // plugin in the poll loop may have the real answer, so emitting a
+    // fake `{ status: unknown, monitoring: pending }` here would
+    // clobber that real result during merge. The server uses absence
+    // (no metrics from any plugin) to render "unknown" / "pending".
     for (const [nodeId, nodeMapping] of Object.entries(mapping.nodes || {})) {
       if (!nodeMapping.hostId) continue
       const device = byId.get(nodeMapping.hostId)
-      if (!device) {
-        // Mapped to a host we couldn't find — treat as monitoring pending
-        // rather than down, since absence is plausibly a transient API miss.
-        metrics.nodes[nodeId] = { status: 'unknown', monitoring: 'pending' }
-        continue
-      }
+      if (!device) continue
       metrics.nodes[nodeId] = deviceToMetrics(device)
     }
 
     // ---- Links -----------------------------------------------------------
-    // Each device's inventory record carries per-ethernet-port throughput.
-    // For a link mapped to (monitoredNode, interfaceName), pull traffic from
-    // the device's ethernetPorts[] entry whose port matches.
+    // Same silence rule: only emit traffic for links whose monitored
+    // node sits in our inventory. Links pointing at another source's
+    // host (or unmapped) are left to other plugins / the default
+    // "unknown" rendering.
     for (const [linkId, linkMapping] of Object.entries(mapping.links || {})) {
       const link = portLinkLookup(linkMapping, mapping, byId)
-      if (!link) {
-        metrics.links[linkId] = { status: 'unknown' }
-        continue
-      }
+      if (!link) continue
       metrics.links[linkId] = portToLinkMetrics(link.port, linkMapping.bandwidth ?? link.bandwidth)
     }
 

--- a/libs/plugins/prometheus/src/plugin.ts
+++ b/libs/plugins/prometheus/src/plugin.ts
@@ -169,26 +169,27 @@ export class PrometheusPlugin
       }
     }
 
-    // Poll node metrics (up/down status)
+    // Poll node metrics (up/down status). Stay silent on host ids
+    // Prometheus has no data for — in a multi-source setup another
+    // plugin owns the node and a fake `{ status: unknown }` here would
+    // clobber its real result during merge.
     for (const [nodeId, nodeMapping] of Object.entries(mapping.nodes || {})) {
       const instance = nodeMapping.hostId
-
-      if (instance) {
-        try {
-          const isUp = await this.checkHostUp(instance)
-          metrics.nodes[nodeId] = {
-            status: isUp ? 'up' : 'down',
-            lastSeen: isUp ? Date.now() : undefined,
-          }
-        } catch {
-          metrics.nodes[nodeId] = { status: 'unknown' }
+      if (!instance) continue
+      try {
+        const isUp = await this.checkHostUp(instance)
+        if (isUp === undefined) continue // no data for this instance
+        metrics.nodes[nodeId] = {
+          status: isUp ? 'up' : 'down',
+          lastSeen: isUp ? Date.now() : undefined,
         }
-      } else {
-        metrics.nodes[nodeId] = { status: 'unknown' }
+      } catch {
+        // Transport failure — leave silent (future: emit failing once
+        // we can distinguish transport from "instance not in this Prom").
       }
     }
 
-    // Poll link metrics (interface traffic)
+    // Poll link metrics (interface traffic) — same silence rule.
     for (const [linkId, linkMapping] of Object.entries(mapping.links || {})) {
       // Get instance via monitoredNodeId -> node mapping
       let instance: string | undefined
@@ -196,34 +197,31 @@ export class PrometheusPlugin
       if (monitoredNodeId && mapping.nodes?.[monitoredNodeId]) {
         instance = mapping.nodes[monitoredNodeId].hostId
       }
-
       const interfaceName = linkMapping.interface
+      if (!instance || !interfaceName) continue
 
-      if (instance && interfaceName) {
-        try {
-          const traffic = await this.getInterfaceTraffic(instance, interfaceName)
-          const capacity = linkMapping.bandwidth || 1_000_000_000 // Default 1Gbps
+      try {
+        const traffic = await this.getInterfaceTraffic(instance, interfaceName)
+        // No samples for either direction → not a Prometheus link;
+        // leave silent so another source can fill the slot.
+        if (!traffic.hasData) continue
+        const capacity = linkMapping.bandwidth || 1_000_000_000 // Default 1Gbps
+        const inBps = traffic.inBytesPerSec * 8
+        const outBps = traffic.outBytesPerSec * 8
+        const inUtil = (inBps / capacity) * 100
+        const outUtil = (outBps / capacity) * 100
+        const maxUtil = Math.max(inUtil, outUtil)
 
-          // Calculate utilization (traffic is in bytes/sec, convert to bits)
-          const inBps = traffic.inBytesPerSec * 8
-          const outBps = traffic.outBytesPerSec * 8
-          const inUtil = (inBps / capacity) * 100
-          const outUtil = (outBps / capacity) * 100
-          const maxUtil = Math.max(inUtil, outUtil)
-
-          metrics.links[linkId] = {
-            status: 'up',
-            utilization: Math.ceil(maxUtil),
-            inUtilization: Math.ceil(inUtil),
-            outUtilization: Math.ceil(outUtil),
-            inBps,
-            outBps,
-          }
-        } catch {
-          metrics.links[linkId] = { status: 'unknown' }
+        metrics.links[linkId] = {
+          status: 'up',
+          utilization: Math.ceil(maxUtil),
+          inUtilization: Math.ceil(inUtil),
+          outUtilization: Math.ceil(outUtil),
+          inBps,
+          outBps,
         }
-      } else {
-        metrics.links[linkId] = { status: 'unknown' }
+      } catch {
+        // Transport failure — leave silent.
       }
     }
 
@@ -648,9 +646,9 @@ export class PrometheusPlugin
    * then falls back to standard "up" metric for non-SNMP devices (e.g. APs).
    * For others: up == 1 means the scrape target is reachable.
    */
-  private async checkHostUp(instance: string): Promise<boolean> {
+  private async checkHostUp(instance: string): Promise<boolean | undefined> {
     if (!this.config || !this.metrics) {
-      return false
+      return undefined
     }
 
     const hostLabel = this.config.hostLabel || 'instance'
@@ -663,6 +661,10 @@ export class PrometheusPlugin
       return `${metric}{${hostLabel}="${instance}"}`
     }
 
+    // Empty result = "Prometheus has no series matching this instance"
+    // which we surface as `undefined` so the caller can stay silent
+    // (multi-source merge correctness). `false` is reserved for "we
+    // have data and it says the host is down".
     try {
       const result = await this.instantQuery(buildQuery(upMetric))
 
@@ -673,12 +675,14 @@ export class PrometheusPlugin
         }
         // No SNMP metrics for this host — fall back to standard "up" metric
         const fallback = await this.instantQuery(buildQuery('up'))
+        if (fallback.result.length === 0) return undefined
         return fallback.result.some((r) => r.value[1] === '1')
       }
 
+      if (result.result.length === 0) return undefined
       return result.result.some((r) => r.value[1] === '1')
     } catch {
-      return false
+      return undefined
     }
   }
 
@@ -689,9 +693,9 @@ export class PrometheusPlugin
   private async getInterfaceTraffic(
     instance: string,
     interfaceName: string,
-  ): Promise<{ inBytesPerSec: number; outBytesPerSec: number }> {
+  ): Promise<{ inBytesPerSec: number; outBytesPerSec: number; hasData: boolean }> {
     if (!this.config || !this.metrics) {
-      return { inBytesPerSec: 0, outBytesPerSec: 0 }
+      return { inBytesPerSec: 0, outBytesPerSec: 0, hasData: false }
     }
 
     const hostLabel = this.config.hostLabel || 'instance'
@@ -709,11 +713,13 @@ export class PrometheusPlugin
 
     let inBytesPerSec = 0
     let outBytesPerSec = 0
+    let hasData = false
 
     try {
       const inResult = await this.instantQuery(inQuery)
       if (inResult.result[0]) {
         inBytesPerSec = parseFloat(inResult.result[0].value[1]) || 0
+        hasData = true
       }
     } catch {
       // Ignore errors for individual metrics
@@ -723,12 +729,13 @@ export class PrometheusPlugin
       const outResult = await this.instantQuery(outQuery)
       if (outResult.result[0]) {
         outBytesPerSec = parseFloat(outResult.result[0].value[1]) || 0
+        hasData = true
       }
     } catch {
       // Ignore errors for individual metrics
     }
 
-    return { inBytesPerSec, outBytesPerSec }
+    return { inBytesPerSec, outBytesPerSec, hasData }
   }
 
   /**

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -100,16 +100,26 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
     }
 
     // Poll node metrics. Unmapped nodes get no entry — "no data" = unmapped.
+    //
+    // We also stay silent on host ids Zabbix doesn't know — in a
+    // multi-source setup another plugin (Aruba, Prometheus, …) may be
+    // the actual owner, and emitting a fake `pending` here would
+    // clobber its real result during merge in the server.
     for (const [nodeId, nodeMapping] of Object.entries(mapping.nodes || {})) {
       if (!nodeMapping.hostId) continue
       try {
-        metrics.nodes[nodeId] = await this.evaluateHostHealth(nodeMapping.hostId)
+        const node = await this.evaluateHostHealth(nodeMapping.hostId)
+        if (node) metrics.nodes[nodeId] = node
       } catch {
-        metrics.nodes[nodeId] = { status: 'unknown', monitoring: 'pending' }
+        // Transport / auth failure — let the absence speak. Future
+        // work: emit `{ monitoring: 'failing' }` once we can tell
+        // a transport error apart from "host not in this Zabbix".
       }
     }
 
-    // Poll link metrics
+    // Poll link metrics. Same silence rule as nodes — emit nothing
+    // when the link doesn't resolve to a Zabbix-owned interface, so
+    // another metrics source can fill it.
     for (const [linkId, baseLinkMapping] of Object.entries(mapping.links || {})) {
       try {
         const linkMapping = baseLinkMapping as ZabbixLinkMapping
@@ -126,49 +136,44 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
           }
         }
 
-        if (inItemId || outItemId) {
-          const itemIds = [inItemId, outItemId].filter(Boolean) as string[]
-          const items = await this.getItemsByIds(itemIds)
+        if (!inItemId && !outItemId) continue // not a Zabbix-monitored link
 
-          // Drop stale items — when a host goes unreachable Zabbix keeps the
-          // last polled value indefinitely. Without this check we'd paint
-          // utilization bars for a dead link from values minutes/hours old.
-          const nowSec = Math.floor(Date.now() / 1000)
-          let inBps = 0
-          let outBps = 0
-          let anyFresh = false
-          for (const item of items) {
-            const lastclock = (item as ZabbixItem & { lastclock?: string }).lastclock ?? '0'
-            if (!ZabbixPlugin.isFreshClock(lastclock, nowSec)) continue
-            anyFresh = true
-            const value = Number.parseFloat(item.lastvalue) || 0
-            if (item.itemid === inItemId) inBps = value
-            else if (item.itemid === outItemId) outBps = value
-          }
+        const itemIds = [inItemId, outItemId].filter(Boolean) as string[]
+        const items = await this.getItemsByIds(itemIds)
 
-          if (!anyFresh) {
-            metrics.links[linkId] = { status: 'unknown' }
-            continue
-          }
+        // Drop stale items — when a host goes unreachable Zabbix keeps the
+        // last polled value indefinitely. Without this check we'd paint
+        // utilization bars for a dead link from values minutes/hours old.
+        const nowSec = Math.floor(Date.now() / 1000)
+        let inBps = 0
+        let outBps = 0
+        let anyFresh = false
+        for (const item of items) {
+          const lastclock = (item as ZabbixItem & { lastclock?: string }).lastclock ?? '0'
+          if (!ZabbixPlugin.isFreshClock(lastclock, nowSec)) continue
+          anyFresh = true
+          const value = Number.parseFloat(item.lastvalue) || 0
+          if (item.itemid === inItemId) inBps = value
+          else if (item.itemid === outItemId) outBps = value
+        }
 
-          const capacity = linkMapping.bandwidth || 1_000_000_000
-          const inUtil = (inBps / capacity) * 100
-          const outUtil = (outBps / capacity) * 100
-          const maxUtil = Math.max(inUtil, outUtil)
+        if (!anyFresh) continue // stale data on a Zabbix link → leave silent
 
-          metrics.links[linkId] = {
-            status: maxUtil > 0 ? 'up' : 'unknown',
-            utilization: Math.ceil(maxUtil),
-            inUtilization: Math.ceil(inUtil),
-            outUtilization: Math.ceil(outUtil),
-            inBps,
-            outBps,
-          }
-        } else {
-          metrics.links[linkId] = { status: 'unknown' }
+        const capacity = linkMapping.bandwidth || 1_000_000_000
+        const inUtil = (inBps / capacity) * 100
+        const outUtil = (outBps / capacity) * 100
+        const maxUtil = Math.max(inUtil, outUtil)
+
+        metrics.links[linkId] = {
+          status: maxUtil > 0 ? 'up' : 'unknown',
+          utilization: Math.ceil(maxUtil),
+          inUtilization: Math.ceil(inUtil),
+          outUtilization: Math.ceil(outUtil),
+          inBps,
+          outBps,
         }
       } catch {
-        metrics.links[linkId] = { status: 'unknown' }
+        // Transport / auth failure — let the absence speak.
       }
     }
 
@@ -530,11 +535,15 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
    * Issued as two parallel API calls so a 50-host topology doesn't pay a
    * sequential round-trip cost per node.
    */
-  private async evaluateHostHealth(hostId: string): Promise<NodeMetrics> {
+  private async evaluateHostHealth(hostId: string): Promise<NodeMetrics | undefined> {
     const [items, host] = await Promise.all([
       this.fetchHealthItems(hostId),
       this.fetchHostMeta(hostId),
     ])
+    // Zabbix returns no host record + no items → this hostId isn't in
+    // *this* Zabbix tenant. Stay silent so a different metrics source
+    // in the poll loop can own the node.
+    if (!host && items.length === 0) return undefined
     const nowSec = Math.floor(Date.now() / 1000)
     const device = ZabbixPlugin.classifyDevice(items, nowSec)
     const monitoring = ZabbixPlugin.classifyMonitoring(host, items, nowSec)


### PR DESCRIPTION
## Summary

Fix the single-metrics-source limitation surfaced by PR #266 — a
topology with both Aruba (APs) and Zabbix (switches) attached only
got data from whichever source was sorted first.

Resolves #268.

## Approach

Mapping data shape stays plugin-agnostic (`NodeMetricsMapping.hostId`
is an opaque string, no source tag). Each plugin's host-id namespace
is structurally disjoint in practice — Zabbix numeric ids, Aruba
serials, NetBox integers — so at poll time each plugin naturally
recognizes the mapped subset of nodes it owns and ignores the rest.
Multi-source becomes a runtime-resolution change, not a data-model
change.

### Server (`apps/server/api/src/server.ts`)
- Replace `metricsSources[0]` with full iteration in priority order.
- Each source's `pollMetrics(mapping)` receives the entire mapping;
  plugins return metrics for nodes whose `hostId` falls in their
  namespace.
- New `mergeMetricsData()` helper unions node/link results; on the
  rare conflict (two sources answer for the same nodeId), the
  higher-priority result wins (priority defined by the existing
  `tds.priority` column).
- Backfill of `linkMapping.bandwidth` from the topology spec now
  happens once before any plugin sees the mapping, instead of
  per-source.

### Web mapping store (`apps/server/web/src/lib/stores/mapping.ts`)
- Drop the `metricsSourceId: string | null` field; replace with
  `metricsSources: MetricsSourceInfo[]`.
- Load hosts from every metrics source in parallel and tag each
  `Host` with its origin (`MappingHost` extends `Host` with
  `sourceId` + `sourceName`). Web-local — does not leak into the
  persisted mapping shape.
- `loadHostInterfaces(hostId)` now looks up the owning source from
  the tagged host list (`sourceIdForHost`) instead of relying on a
  store-level source id.

### Mapping UI
- `NodeMappingModal`: drop the `metricsSourceId` prop; render the
  host radio list grouped by source name when 2+ sources are
  attached. Single-source case is visually unchanged.
- `topologies/[id]/settings`: host `<select>` dropdown uses
  `<optgroup>` per source for 2+ sources, flat list otherwise.

## Backwards compatibility

- `MetricsMapping` data shape is unchanged. No migration of stored
  mappings.
- Single-source topologies behave identically.
- `Topology.metricsSourceId` legacy column on the DB row stays in
  `lib/types.ts` (unused but harmless — separate cleanup if/when
  the DB schema gets a sweep).

## Test plan

- [ ] Topology with one metrics source: dropdown is a flat list, no
  source header; mapping/poll behavior matches main
- [ ] Topology with two metrics sources (Aruba + Zabbix): dropdown
  shows source headers in priority order; each host shows under its
  origin; selecting a host saves only `hostId` (verify mapping JSON
  has no `sourceId` field)
- [ ] Map a node to a host from each source → both nodes report
  status from their respective source
- [ ] Map a link to a node mapped to source A → traffic comes from
  source A's `pollMetrics` output
- [ ] Map two nodes to hosts whose ids collide across sources (rare,
  mostly impossible due to namespace disjointness — set up
  artificially if needed) → higher-priority source's value wins
- [ ] Remove a metrics source: hosts from that source disappear from
  the dropdown next load; nodes that were mapped to it show as
  "Not mapped" effectively (their hostId is still persisted but
  doesn't resolve)
- [ ] "All metrics" panel still works — uses the host's tagged
  source for the `discoverMetrics` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known design caveat (follow-up in #274)

This PR resolves the multi-source clobbering bug by making plugins
"stay silent" on hosts they don't own. The fix collapses two
distinct cases into the same silent branch:

- **B**: plugin owns the host but can't reach upstream (transport
  error)
- **C**: plugin genuinely doesn't own this host

Both currently emit nothing. The downside is that when *every*
source covering a node is unreachable, the operator sees "no data"
instead of "monitoring failing". For now this is judged an
acceptable trade for correctness — multi-source merge no longer
displays false data — but the proper split (host-membership cache,
emit `{ monitoring: 'failing' }` only when we know we own the
host) is captured as #274 for a follow-up.