### PR TITLE
fix(plugins): silence-rule corrections + multi-source cleanup

### DIFF
--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -365,10 +365,7 @@ export class Server {
       // Plugin host-id namespaces are structurally disjoint in practice
       // (Zabbix numeric ids vs Aruba serials vs NetBox integers), so
       // each plugin naturally answers for the subset of mapped nodes
-      // it recognizes and ignores the rest. Sources iterate in
-      // priority order (low number = high precedence); when two
-      // sources happen to return metrics for the same nodeId/linkId,
-      // the higher-priority result wins.
+      // it recognizes and ignores the rest.
       const metricsSources = this.topologySourcesService.listByPurpose(topology.id, 'metrics')
       if (metricsSources.length > 0) {
         // Parse mapping once — every plugin sees the same view.
@@ -394,24 +391,41 @@ export class Server {
           }
         }
 
-        const polledFrom: string[] = []
-        for (const source of metricsSources) {
-          const dataSource = this.dataSourceService.get(source.dataSourceId)
-          if (!dataSource) continue
-          try {
+        // Poll all sources concurrently — they're independent plugin
+        // instances hitting independent upstreams, so a poll cycle
+        // should cost max(source latency), not the sum. `allSettled`
+        // keeps one source's failure from sinking the others.
+        const polled = await Promise.allSettled(
+          metricsSources.map(async (source) => {
+            const dataSource = this.dataSourceService?.get(source.dataSourceId)
+            if (!dataSource) return null
             const config = JSON.parse(dataSource.configJson)
             const plugin = pluginRegistry.getInstance(dataSource.id, dataSource.type, config)
-            if (!hasMetricsCapability(plugin)) continue
+            if (!hasMetricsCapability(plugin)) return null
+            const data = await plugin.pollMetrics(mapping)
+            return { type: dataSource.type, data }
+          }),
+        )
 
-            const m = await plugin.pollMetrics(mapping)
-            metrics = mergeMetricsData(metrics, m)
-            polledFrom.push(dataSource.type)
-          } catch (err) {
+        // Merge in source order. `metricsSources` is priority-sorted
+        // (low number = high precedence) and `allSettled` preserves
+        // input order, so on the rare nodeId/linkId conflict the
+        // higher-priority source wins (see `mergeMetricsData`).
+        const polledFrom: string[] = []
+        for (const [i, result] of polled.entries()) {
+          if (result.status === 'rejected') {
+            const type = metricsSources[i]
+              ? (this.dataSourceService.get(metricsSources[i].dataSourceId)?.type ?? 'unknown')
+              : 'unknown'
             console.error(
-              `[Server] Failed to poll metrics from ${dataSource.type} for topology "${topology.name}":`,
-              err instanceof Error ? err.message : err,
+              `[Server] Failed to poll metrics from ${type} for topology "${topology.name}":`,
+              result.reason instanceof Error ? result.reason.message : result.reason,
             )
+            continue
           }
+          if (!result.value) continue
+          metrics = mergeMetricsData(metrics, result.value.data)
+          polledFrom.push(result.value.type)
         }
         // One line per topology per poll cycle, not one per source —
         // keeps the log readable when many topologies × sources poll.

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -394,6 +394,7 @@ export class Server {
           }
         }
 
+        const polledFrom: string[] = []
         for (const source of metricsSources) {
           const dataSource = this.dataSourceService.get(source.dataSourceId)
           if (!dataSource) continue
@@ -404,15 +405,20 @@ export class Server {
 
             const m = await plugin.pollMetrics(mapping)
             metrics = mergeMetricsData(metrics, m)
-            console.log(
-              `[Server] Polled metrics for topology "${topology.name}" from ${dataSource.type}`,
-            )
+            polledFrom.push(dataSource.type)
           } catch (err) {
             console.error(
               `[Server] Failed to poll metrics from ${dataSource.type} for topology "${topology.name}":`,
               err instanceof Error ? err.message : err,
             )
           }
+        }
+        // One line per topology per poll cycle, not one per source —
+        // keeps the log readable when many topologies × sources poll.
+        if (polledFrom.length > 0) {
+          console.log(
+            `[Server] Polled metrics for topology "${topology.name}" from ${polledFrom.join(', ')}`,
+          )
         }
       }
 

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -76,17 +76,17 @@ function sourceIdForHost(hosts: MappingHost[], hostId: string): string | undefin
   return hosts.find((h) => h.id === hostId)?.sourceId
 }
 
-async function loadHostsForSources(
-  sources: MetricsSourceInfo[],
-  dataSourceLookup: Map<string, TopologyDataSource>,
-): Promise<MappingHost[]> {
+async function loadHostsForSources(sources: MetricsSourceInfo[]): Promise<MappingHost[]> {
   // Fetch every source in parallel. A single source failing must not
   // block the others — the UI shows whatever loaded successfully.
   const results = await Promise.allSettled(
     sources.map(async (src) => {
       const hosts = await api.dataSources.getHosts(src.id)
-      const name = dataSourceLookup.get(src.id)?.dataSource?.name ?? src.name
-      return hosts.map<MappingHost>((h) => ({ ...h, sourceId: src.id, sourceName: name }))
+      return hosts.map<MappingHost>((h) => ({
+        ...h,
+        sourceId: src.id,
+        sourceName: src.name,
+      }))
     }),
   )
   const out: MappingHost[] = []
@@ -96,24 +96,20 @@ async function loadHostsForSources(
   return out
 }
 
-function buildSourcesFromTopology(sources: TopologyDataSource[]): {
-  metricsSources: MetricsSourceInfo[]
-  lookup: Map<string, TopologyDataSource>
-} {
-  const lookup = new Map<string, TopologyDataSource>()
-  for (const s of sources) lookup.set(s.dataSourceId, s)
-
-  const metricsSources: MetricsSourceInfo[] = sources
-    .filter((s) => s.purpose === 'metrics')
-    .map((s) => ({
-      id: s.dataSourceId,
-      name: s.dataSource?.name ?? s.dataSourceId,
-      priority: s.priority,
-    }))
-    // Sort by priority ascending (lower number = higher precedence) so the
-    // UI presents sources in operator-defined order.
-    .sort((a, b) => a.priority - b.priority)
-  return { metricsSources, lookup }
+/** Extract the `metrics`-purpose sources, resolved + priority-sorted. */
+function metricsSourcesOf(sources: TopologyDataSource[]): MetricsSourceInfo[] {
+  return (
+    sources
+      .filter((s) => s.purpose === 'metrics')
+      .map((s) => ({
+        id: s.dataSourceId,
+        name: s.dataSource?.name ?? s.dataSourceId,
+        priority: s.priority,
+      }))
+      // Sort by priority ascending (lower number = higher precedence) so the
+      // UI presents sources in operator-defined order.
+      .sort((a, b) => a.priority - b.priority)
+  )
 }
 
 function createMappingStore() {
@@ -137,7 +133,7 @@ function createMappingStore() {
         }
       }
 
-      const { metricsSources, lookup } = buildSourcesFromTopology(sources)
+      const metricsSources = metricsSourcesOf(sources)
 
       update((s) => ({
         ...s,
@@ -150,7 +146,7 @@ function createMappingStore() {
 
       if (metricsSources.length > 0) {
         update((s) => ({ ...s, hostsLoading: true }))
-        loadHostsForSources(metricsSources, lookup)
+        loadHostsForSources(metricsSources)
           .then((hosts) => update((s) => ({ ...s, hosts, hostsLoading: false })))
           .catch(() => update((s) => ({ ...s, hostsLoading: false })))
       }
@@ -186,7 +182,7 @@ function createMappingStore() {
           }
         }
 
-        const { metricsSources, lookup } = buildSourcesFromTopology(sources)
+        const metricsSources = metricsSourcesOf(sources)
 
         update((s) => ({
           ...s,
@@ -198,7 +194,7 @@ function createMappingStore() {
         if (metricsSources.length > 0) {
           update((s) => ({ ...s, hostsLoading: true }))
           try {
-            const hosts = await loadHostsForSources(metricsSources, lookup)
+            const hosts = await loadHostsForSources(metricsSources)
             update((s) => ({ ...s, hosts, hostsLoading: false }))
           } catch {
             update((s) => ({ ...s, hostsLoading: false }))

--- a/libs/plugins/aruba-instant-on/src/plugin.ts
+++ b/libs/plugins/aruba-instant-on/src/plugin.ts
@@ -176,13 +176,20 @@ export class ArubaInstantOnPlugin
     }
 
     // ---- Links -----------------------------------------------------------
-    // Same silence rule: only emit traffic for links whose monitored
-    // node sits in our inventory. Links pointing at another source's
-    // host (or unmapped) are left to other plugins / the default
-    // "unknown" rendering.
+    // A link's metrics come from the device its `monitoredNodeId` maps
+    // to. Two distinct outcomes, mirroring the node loop:
+    //   - monitored node isn't an Aruba device  → silent (another
+    //     source owns it; emitting here would clobber on merge).
+    //   - monitored node IS ours but the port can't be resolved →
+    //     emit `{ status: 'unknown' }`. A link is owned by exactly one
+    //     source, so this is a real signal, not a merge hazard.
     for (const [linkId, linkMapping] of Object.entries(mapping.links || {})) {
       const link = portLinkLookup(linkMapping, mapping, byId)
-      if (!link) continue
+      if (link === 'not-ours') continue
+      if (link === 'port-unresolved') {
+        metrics.links[linkId] = { status: 'unknown' }
+        continue
+      }
       metrics.links[linkId] = portToLinkMetrics(link.port, linkMapping.bandwidth ?? link.bandwidth)
     }
 
@@ -263,24 +270,35 @@ export class ArubaInstantOnPlugin
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve a link mapping into the actual ethernet port telemetry record on
- * the monitored device. Returns null when the mapping can't be satisfied
- * (unmapped node, host not in inventory, no matching port).
+ * Resolve a link mapping into the ethernet port telemetry record on the
+ * monitored device. Three outcomes:
+ *
+ * - `'not-ours'` — the monitored node isn't an Aruba device (or the link
+ *   isn't fully mapped). The caller stays silent so another metrics
+ *   source can answer.
+ * - `'port-unresolved'` — the monitored node *is* an Aruba device, but
+ *   the mapped interface name doesn't match any of its ports. The caller
+ *   emits an explicit `unknown` — a real signal, and safe because a link
+ *   is owned by exactly one source.
+ * - `{ port, bandwidth }` — resolved.
  */
 function portLinkLookup(
   linkMapping: { monitoredNodeId?: string; interface?: string },
   mapping: MetricsMapping,
   byId: Map<string, AruInventoryDevice>,
-): { port: AruEthernetPort; bandwidth: number | undefined } | null {
+): { port: AruEthernetPort; bandwidth: number | undefined } | 'not-ours' | 'port-unresolved' {
   const monitoredNodeId = linkMapping.monitoredNodeId
   const ifaceName = linkMapping.interface
-  if (!monitoredNodeId || !ifaceName) return null
+  if (!monitoredNodeId || !ifaceName) return 'not-ours'
   const hostId = mapping.nodes[monitoredNodeId]?.hostId
-  if (!hostId) return null
+  if (!hostId) return 'not-ours'
   const device = byId.get(hostId)
-  if (!device?.ethernetPorts?.length) return null
-  const port = findPortByName(device.ethernetPorts, ifaceName)
-  if (!port) return null
+  if (!device) return 'not-ours'
+  // The monitored device is in our inventory — the link is ours from here.
+  const port = device.ethernetPorts?.length
+    ? findPortByName(device.ethernetPorts, ifaceName)
+    : undefined
+  if (!port) return 'port-unresolved'
   return { port, bandwidth: portSpeedBps(port) }
 }
 

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -157,7 +157,15 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
           else if (item.itemid === outItemId) outBps = value
         }
 
-        if (!anyFresh) continue // stale data on a Zabbix link → leave silent
+        // Stale data on a link Zabbix *does* own (items resolved) — emit
+        // an explicit `unknown` so the renderer drops the weathermap flow
+        // rather than animating hours-old values. Not the silence rule:
+        // a link is owned by exactly one source (its monitoredNode maps
+        // to one hostId), so this can't clobber another source.
+        if (!anyFresh) {
+          metrics.links[linkId] = { status: 'unknown' }
+          continue
+        }
 
         const capacity = linkMapping.bandwidth || 1_000_000_000
         const inUtil = (inBps / capacity) * 100


### PR DESCRIPTION
## Summary

Follow-up to PR #273. That PR introduced a "silence rule" — a plugin
emits nothing for hosts outside its namespace, so a multi-source
merge doesn't let one plugin's `{ status: 'unknown' }` fallback
clobber another plugin's real data.

Reviewing the diff afterwards, the silence rule had over-reached: it
also silenced two **case-A sub-states**, where the plugin genuinely
*owns* the link and the original explicit `{ status: 'unknown' }`
was a deliberate signal. A link is owned by exactly one source (its
`monitoredNodeId` resolves to a single `hostId`), so emitting
`unknown` for an owned link can never clobber another source — the
silence rule simply didn't apply there.

## Changes

- **zabbix**: a link whose Zabbix items resolved but whose samples
  are all stale is a Zabbix-owned link with no fresh data. PR #273
  changed this from `{ status: 'unknown' }` to silent. Restored the
  explicit `unknown` so the renderer drops the weathermap flow
  instead of animating hours-old values — which is exactly what the
  surrounding "drop stale items" comment says the check is for.

- **aruba-instant-on**: `portLinkLookup` collapsed two distinct
  outcomes into a single `null`:
  - monitored node isn't an Aruba device → genuinely not ours
  - monitored node *is* an Aruba device but the mapped interface
    name didn't match any port → ours, undetermined

  Split into a discriminated result: `'not-ours'` stays silent,
  `'port-unresolved'` emits `{ status: 'unknown' }`.

- **prometheus**: reviewed, intentionally left as-is. An empty
  `rate(metric[5m])` result genuinely cannot distinguish "series
  never existed" from "series went stale" — conflating them into
  silence is forced by Prometheus's data model, not an unforced
  choice like the two above. The PR #273 behavior is also strictly
  better than what preceded it (stale links used to render as
  `{ status: 'up', 0 bps }`).

## Why this matters

Without this, a single-source Zabbix user whose monitored device
goes unreachable (Zabbix keeps serving the last value indefinitely)
would see the weathermap silently stop engaging instead of the link
flipping to a visible `unknown` state. PR #273's intent was purely
multi-source correctness; this restores the unrelated single-source
behavior it accidentally changed.

## Test plan

- [ ] Single Zabbix source, link mapped to a device that has gone
  unreachable (stale items) → link renders `unknown`, weathermap
  flow stops; not silently absent
- [ ] Multi-source: a Zabbix-owned stale link still renders
  `unknown` and does not clobber any Aruba link metrics
- [ ] Aruba link mapped with a valid port → traffic animates
- [ ] Aruba link whose monitored node is an Aruba device but with a
  bogus interface name → renders `unknown` (not silently absent)
- [ ] Aruba link whose monitored node belongs to another source →
  stays silent, that source fills it
- [ ] No regression in `discoverMetrics` / node status

🤖 Generated with [Claude Code](https://claude.com/claude-code)