### PR TITLE
feat(core/layout): quality harness for measuring algorithm changes

### DIFF
--- a/libs/@shumoku/core/package.json
+++ b/libs/@shumoku/core/package.json
@@ -58,6 +58,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest --passWithNoTests",
+    "quality": "vitest run src/layout/quality/harness.test.ts --reporter verbose",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "format": "biome check --write ."

--- a/libs/@shumoku/core/src/layout/quality/corpus.ts
+++ b/libs/@shumoku/core/src/layout/quality/corpus.ts
@@ -1,0 +1,210 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Layout quality corpus.
+ *
+ * Compact set of representative `NetworkGraph` fixtures. The
+ * harness runs the engine over each, collects quality metrics,
+ * and reports a per-fixture row + an aggregate summary. Adding
+ * a new shape is one entry in {@link CORPUS} — no other
+ * plumbing.
+ *
+ * Each fixture targets a different stress on the engine:
+ *
+ *   minimal           — two-node chain, smoke test
+ *   linear-chain      — five-node single line, edge-length sanity
+ *   star              — one hub + four leaves, sibling fan-out
+ *   wide-tree         — three layers, ~15 nodes, multi-row spread
+ *   deep-chain        — ten-node line, vertical extent
+ *   multi-component   — two disconnected stars, component packing
+ *   ha-pair           — switch + ha-redundancy peer, overlay edge
+ *   single-subgraph   — one subgraph wrapping a chain (single
+ *                       emitter, no spine alignment needed)
+ *   multi-emitter-sg  — subgraph with two emitters → splits into
+ *                       two blocks + spine alignment
+ *   nested-subgraph   — outer hull contains inner hull
+ *   noc-like          — NOC pattern: stacked emitter chain in a
+ *                       subgraph, each emitter dropping to a
+ *                       distinct downstream subgraph
+ */
+
+import type { Link, NetworkGraph, Node, Subgraph } from '../../models/types.js'
+
+function n(id: string, parent?: string): Node {
+  return {
+    id,
+    label: id,
+    shape: 'rect',
+    ...(parent ? { parent } : {}),
+    size: { width: 80, height: 60 },
+  }
+}
+
+function graph(
+  name: string,
+  nodes: Node[],
+  links: Link[],
+  subgraphs: Subgraph[] = [],
+): NetworkGraph {
+  return { version: '1', name, nodes, links, subgraphs }
+}
+
+function sg(id: string, parent?: string): Subgraph {
+  return { id, label: id, ...(parent ? { parent } : {}) }
+}
+
+function l(from: string, to: string, opts: Partial<Link> = {}): Link {
+  return {
+    from: { node: from, port: `${from}-${to}` },
+    to: { node: to, port: `${to}-${from}` },
+    ...opts,
+  }
+}
+
+export interface CorpusFixture {
+  name: string
+  description: string
+  graph: NetworkGraph
+}
+
+export const CORPUS: readonly CorpusFixture[] = [
+  {
+    name: 'minimal',
+    description: 'two-node chain',
+    graph: graph('minimal', [n('a'), n('b')], [l('a', 'b')]),
+  },
+  {
+    name: 'linear-chain',
+    description: 'five-node single line',
+    graph: graph(
+      'linear-chain',
+      ['a', 'b', 'c', 'd', 'e'].map((id) => n(id)),
+      [l('a', 'b'), l('b', 'c'), l('c', 'd'), l('d', 'e')],
+    ),
+  },
+  {
+    name: 'star',
+    description: 'one hub plus four leaves',
+    graph: graph(
+      'star',
+      ['hub', 'l1', 'l2', 'l3', 'l4'].map((id) => n(id)),
+      [l('hub', 'l1'), l('hub', 'l2'), l('hub', 'l3'), l('hub', 'l4')],
+    ),
+  },
+  {
+    name: 'wide-tree',
+    description: 'three-layer tree, ~15 nodes',
+    graph: (() => {
+      const nodes: Node[] = [n('root')]
+      const links: Link[] = []
+      for (let i = 0; i < 3; i++) {
+        const mid = `m${i}`
+        nodes.push(n(mid))
+        links.push(l('root', mid))
+        for (let j = 0; j < 4; j++) {
+          const leaf = `l${i}_${j}`
+          nodes.push(n(leaf))
+          links.push(l(mid, leaf))
+        }
+      }
+      return graph('wide-tree', nodes, links)
+    })(),
+  },
+  {
+    name: 'deep-chain',
+    description: 'ten-node line, vertical extent',
+    graph: (() => {
+      const ids = Array.from({ length: 10 }, (_, i) => `n${i}`)
+      const links: Link[] = []
+      for (let i = 0; i < ids.length - 1; i++) {
+        const from = ids[i]
+        const to = ids[i + 1]
+        if (from && to) links.push(l(from, to))
+      }
+      return graph(
+        'deep-chain',
+        ids.map((id) => n(id)),
+        links,
+      )
+    })(),
+  },
+  {
+    name: 'multi-component',
+    description: 'two disconnected stars',
+    graph: graph(
+      'multi-component',
+      ['h1', 'h1a', 'h1b', 'h2', 'h2a', 'h2b'].map((id) => n(id)),
+      [l('h1', 'h1a'), l('h1', 'h1b'), l('h2', 'h2a'), l('h2', 'h2b')],
+    ),
+  },
+  {
+    name: 'ha-pair',
+    description: 'two switches with one HA-redundancy link',
+    graph: graph(
+      'ha-pair',
+      ['sw1', 'sw2', 'host1', 'host2'].map((id) => n(id)),
+      [l('sw1', 'host1'), l('sw2', 'host2'), l('sw1', 'sw2', { redundancy: 'ha' })],
+    ),
+  },
+  {
+    name: 'single-subgraph',
+    description: 'one subgraph wrapping a three-node chain',
+    graph: graph(
+      'single-subgraph',
+      [n('a', 'g'), n('b', 'g'), n('c', 'g')],
+      [l('a', 'b'), l('b', 'c')],
+      [sg('g')],
+    ),
+  },
+  {
+    name: 'multi-emitter-sg',
+    description: 'subgraph with two internal members, each emitting to an external child',
+    graph: graph(
+      'multi-emitter-sg',
+      [n('e1', 'g'), n('e2', 'g'), n('extA'), n('extB')],
+      [l('e1', 'e2'), l('e1', 'extA'), l('e2', 'extB')],
+      [sg('g')],
+    ),
+  },
+  {
+    name: 'nested-subgraph',
+    description: 'inner subgraph nested inside outer; one node in inner',
+    graph: graph(
+      'nested-subgraph',
+      [n('a', 'inner'), n('b'), n('c')],
+      [l('b', 'a'), l('a', 'c')],
+      [sg('outer'), sg('inner', 'outer')],
+    ),
+  },
+  {
+    name: 'noc-like',
+    description:
+      'NOC pattern: stacked emitter chain in a subgraph, each emitter drops to a downstream subgraph',
+    graph: graph(
+      'noc-like',
+      [
+        n('eps-sw01', 'NOC'),
+        n('eps-sw02', 'NOC'),
+        n('lobby-sw', 'LOBBY'),
+        n('lobby-ap', 'LOBBY'),
+        n('hall-sw', 'HALL'),
+      ],
+      [
+        l('eps-sw01', 'eps-sw02'),
+        l('eps-sw01', 'hall-sw'),
+        l('eps-sw02', 'lobby-sw'),
+        l('lobby-sw', 'lobby-ap'),
+      ],
+      [sg('NOC'), sg('LOBBY'), sg('HALL')],
+    ),
+  },
+] as const
+
+/** Look up one fixture by name. Throws if not found. */
+export function fixture(name: string): CorpusFixture {
+  const f = CORPUS.find((c) => c.name === name)
+  if (!f) throw new Error(`No corpus fixture: ${name}`)
+  return f
+}

--- a/libs/@shumoku/core/src/layout/quality/harness.test.ts
+++ b/libs/@shumoku/core/src/layout/quality/harness.test.ts
@@ -1,0 +1,58 @@
+// Regression bounds for the engine over the corpus.
+//
+// The harness runs every corpus fixture and asserts:
+//   1. Hull-overlap invariant (sibling hulls must not overlap).
+//   2. Per-fixture upper bounds on edge-crossings (catches the
+//      "we accidentally regressed sort order" class of bug).
+//   3. Total runtime stays in the same order of magnitude.
+//
+// When this test fails after an algorithm change, look at the
+// printed table for which fixture moved.
+
+import { describe, expect, test } from 'vitest'
+import { formatReport, runHarness } from './harness.js'
+
+describe('layout quality harness', () => {
+  test('all fixtures lay out without sibling-hull overlap', () => {
+    const report = runHarness()
+    // Print so a developer running `bun x vitest run harness.test.ts`
+    // sees the numbers.
+    console.log(`\n${formatReport(report)}\n`)
+    for (const fx of report.fixtures) {
+      expect(fx.metrics.siblingHullOverlap, `${fx.name} has sibling-hull overlap`).toBe(0)
+    }
+  })
+
+  test('crossings stay within per-fixture upper bounds', () => {
+    // Tight upper bounds informed by the current engine output.
+    // A regression that increases crossings will trip the matching
+    // fixture; a real improvement (lower crossings) flips this
+    // safely — adjust the bound down in the same PR.
+    const upperBounds: Record<string, number> = {
+      minimal: 0,
+      'linear-chain': 0,
+      star: 0,
+      'wide-tree': 0,
+      'deep-chain': 0,
+      'multi-component': 0,
+      'ha-pair': 1, // overlay edge crosses primary chain in worst case
+      'single-subgraph': 0,
+      'multi-emitter-sg': 0,
+      'nested-subgraph': 0,
+      'noc-like': 2,
+    }
+    const report = runHarness()
+    for (const fx of report.fixtures) {
+      const bound = upperBounds[fx.name] ?? 0
+      expect(
+        fx.metrics.crossings.total,
+        `${fx.name} crossings ${fx.metrics.crossings.total} exceeded bound ${bound}`,
+      ).toBeLessThanOrEqual(bound)
+    }
+  })
+
+  test('total runtime stays under 200 ms for the whole corpus', () => {
+    const report = runHarness()
+    expect(report.totals.elapsedMs).toBeLessThan(200)
+  })
+})

--- a/libs/@shumoku/core/src/layout/quality/harness.ts
+++ b/libs/@shumoku/core/src/layout/quality/harness.ts
@@ -1,0 +1,147 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Layout quality harness.
+ *
+ * Runs the flat-tree engine over the corpus, collects metrics
+ * per fixture, and produces a single report. Use in tests
+ * (`harness.test.ts`) for regression bounds, and in interactive
+ * `bun run quality` runs to compare two algorithm versions.
+ */
+
+import { createFlatTreeEngine } from '../flat-tree/engine.js'
+import type { FlatTreeLayoutResult, Size } from '../flat-tree/types.js'
+import { CORPUS, type CorpusFixture } from './corpus.js'
+import { type QualityReport, summarize } from './metrics.js'
+
+export interface FixtureReport {
+  name: string
+  description: string
+  nodeCount: number
+  linkCount: number
+  result: FlatTreeLayoutResult
+  metrics: QualityReport
+  /** Wall-clock milliseconds spent in `engine.layout`. */
+  elapsedMs: number
+}
+
+export interface HarnessReport {
+  fixtures: FixtureReport[]
+  /** Aggregate sums across the corpus. */
+  totals: {
+    nodes: number
+    links: number
+    edgeLengthTotal: number
+    rootAreaTotal: number
+    crossingsTotal: number
+    crossingsOverlay: number
+    siblingHullOverlapTotal: number
+    elapsedMs: number
+  }
+}
+
+/**
+ * Run the engine over every corpus fixture and collect metrics.
+ *
+ * @param fixtures Override the fixture set (defaults to {@link CORPUS}).
+ */
+export function runHarness(fixtures: readonly CorpusFixture[] = CORPUS): HarnessReport {
+  const engine = createFlatTreeEngine()
+  const out: FixtureReport[] = []
+  for (const fx of fixtures) {
+    const sizeById = new Map<string, Size>(
+      fx.graph.nodes.map((node) => [node.id, node.size ?? { width: 80, height: 60 }]),
+    )
+    const t0 = performance.now()
+    const result = engine.layout(fx.graph, { sizeById })
+    const elapsedMs = performance.now() - t0
+    out.push({
+      name: fx.name,
+      description: fx.description,
+      nodeCount: fx.graph.nodes.length,
+      linkCount: fx.graph.links.length,
+      result,
+      metrics: summarize(fx.graph, result),
+      elapsedMs,
+    })
+  }
+  return {
+    fixtures: out,
+    totals: aggregate(out),
+  }
+}
+
+function aggregate(rows: FixtureReport[]): HarnessReport['totals'] {
+  let nodes = 0
+  let links = 0
+  let edgeLengthTotal = 0
+  let rootAreaTotal = 0
+  let crossingsTotal = 0
+  let crossingsOverlay = 0
+  let siblingHullOverlapTotal = 0
+  let elapsedMs = 0
+  for (const r of rows) {
+    nodes += r.nodeCount
+    links += r.linkCount
+    edgeLengthTotal += r.metrics.edgeLength.total
+    rootAreaTotal += r.metrics.rootArea
+    crossingsTotal += r.metrics.crossings.total
+    crossingsOverlay += r.metrics.crossings.overlay
+    siblingHullOverlapTotal += r.metrics.siblingHullOverlap
+    elapsedMs += r.elapsedMs
+  }
+  return {
+    nodes,
+    links,
+    edgeLengthTotal,
+    rootAreaTotal,
+    crossingsTotal,
+    crossingsOverlay,
+    siblingHullOverlapTotal,
+    elapsedMs,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Pretty-printing
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Format a harness report as a fixed-width text table. Used by
+ * the harness test (which logs it as the run completes) and by
+ * the `bun run quality` script.
+ */
+export function formatReport(report: HarnessReport): string {
+  const header = ['fixture', 'N', 'L', 'edge_tot', 'area', 'ar', 'xings', 'xov', 'hull_ov', 'ms']
+  const rows: string[][] = [header.map((h) => h)]
+  for (const fx of report.fixtures) {
+    rows.push([
+      fx.name,
+      String(fx.nodeCount),
+      String(fx.linkCount),
+      fx.metrics.edgeLength.total.toFixed(0),
+      fx.metrics.rootArea.toFixed(0),
+      fx.metrics.aspectRatio.toFixed(2),
+      String(fx.metrics.crossings.total),
+      String(fx.metrics.crossings.overlay),
+      fx.metrics.siblingHullOverlap.toFixed(0),
+      fx.elapsedMs.toFixed(2),
+    ])
+  }
+  rows.push([
+    'TOTAL',
+    String(report.totals.nodes),
+    String(report.totals.links),
+    report.totals.edgeLengthTotal.toFixed(0),
+    report.totals.rootAreaTotal.toFixed(0),
+    '—',
+    String(report.totals.crossingsTotal),
+    String(report.totals.crossingsOverlay),
+    report.totals.siblingHullOverlapTotal.toFixed(0),
+    report.totals.elapsedMs.toFixed(2),
+  ])
+  const widths = header.map((_, col) => Math.max(...rows.map((r) => (r[col] ?? '').length)))
+  return rows.map((r) => r.map((cell, col) => cell.padEnd(widths[col] ?? 0)).join('  ')).join('\n')
+}

--- a/libs/@shumoku/core/src/layout/quality/metrics.test.ts
+++ b/libs/@shumoku/core/src/layout/quality/metrics.test.ts
@@ -1,0 +1,182 @@
+// Quality metric primitives.
+
+import { describe, expect, test } from 'vitest'
+import type { Bounds, NetworkGraph } from '../../models/types.js'
+import {
+  aspectRatio,
+  edgeCrossings,
+  edgeCrossingsByKind,
+  edgeLength,
+  hullOverlap,
+  rootArea,
+  siblingHullOverlap,
+  stabilityScore,
+} from './metrics.js'
+
+function pos(...entries: Array<[string, number, number]>): Map<string, { x: number; y: number }> {
+  return new Map(entries.map(([id, x, y]) => [id, { x, y }]))
+}
+
+function bounds(x: number, y: number, w: number, h: number): Bounds {
+  return { x, y, width: w, height: h }
+}
+
+describe('edgeLength', () => {
+  test('zero edges → zero metrics', () => {
+    const graph: NetworkGraph = { name: 't', nodes: [], links: [], subgraphs: [] }
+    const m = edgeLength(graph, new Map())
+    expect(m).toEqual({ total: 0, mean: 0, max: 0, count: 0 })
+  })
+
+  test('three-four-five triangle gives length 5', () => {
+    const graph: NetworkGraph = {
+      name: 't',
+      nodes: [],
+      links: [
+        {
+          from: { node: 'a', port: 'p' },
+          to: { node: 'b', port: 'p' },
+        },
+      ],
+      subgraphs: [],
+    }
+    const m = edgeLength(graph, pos(['a', 0, 0], ['b', 3, 4]))
+    expect(m.total).toBeCloseTo(5, 5)
+    expect(m.max).toBeCloseTo(5, 5)
+    expect(m.count).toBe(1)
+  })
+
+  test('skips edges with missing endpoint positions', () => {
+    const graph: NetworkGraph = {
+      name: 't',
+      nodes: [],
+      links: [
+        { from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'p' } },
+        { from: { node: 'a', port: 'p' }, to: { node: 'ghost', port: 'p' } },
+      ],
+      subgraphs: [],
+    }
+    const m = edgeLength(graph, pos(['a', 0, 0], ['b', 3, 4]))
+    expect(m.count).toBe(1)
+  })
+})
+
+describe('rootArea / aspectRatio', () => {
+  test('area is width × height', () => {
+    expect(rootArea(bounds(0, 0, 100, 50))).toBe(5000)
+  })
+
+  test('aspectRatio = width / height', () => {
+    expect(aspectRatio(bounds(0, 0, 200, 100))).toBe(2)
+  })
+
+  test('aspectRatio handles zero-height bounds', () => {
+    expect(aspectRatio(bounds(0, 0, 100, 0))).toBe(0)
+  })
+})
+
+describe('edgeCrossings', () => {
+  function makeGraph(...edges: Array<[string, string]>): NetworkGraph {
+    return {
+      name: 't',
+      nodes: [],
+      links: edges.map(([from, to]) => ({
+        from: { node: from, port: 'p' },
+        to: { node: to, port: 'p' },
+      })),
+      subgraphs: [],
+    }
+  }
+
+  test('two parallel horizontal segments do not cross', () => {
+    const g = makeGraph(['a', 'b'], ['c', 'd'])
+    const p = pos(['a', 0, 0], ['b', 10, 0], ['c', 0, 5], ['d', 10, 5])
+    expect(edgeCrossings(g, p)).toBe(0)
+  })
+
+  test('X pattern: two segments cross once', () => {
+    const g = makeGraph(['a', 'b'], ['c', 'd'])
+    const p = pos(['a', 0, 0], ['b', 10, 10], ['c', 0, 10], ['d', 10, 0])
+    expect(edgeCrossings(g, p)).toBe(1)
+  })
+
+  test('segments sharing a node do not count as crossing', () => {
+    const g = makeGraph(['a', 'b'], ['a', 'c'])
+    const p = pos(['a', 0, 0], ['b', 10, 0], ['c', 5, 10])
+    expect(edgeCrossings(g, p)).toBe(0)
+  })
+
+  test('overlay vs primary split via edgeCrossingsByKind', () => {
+    const g: NetworkGraph = {
+      name: 't',
+      nodes: [],
+      links: [
+        { from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'p' } },
+        {
+          from: { node: 'c', port: 'p' },
+          to: { node: 'd', port: 'p' },
+          redundancy: 'ha',
+        },
+      ],
+      subgraphs: [],
+    }
+    const p = pos(['a', 0, 0], ['b', 10, 10], ['c', 0, 10], ['d', 10, 0])
+    const split = edgeCrossingsByKind(g, p)
+    expect(split.total).toBe(1)
+    // One overlay edge involved → overlay bucket.
+    expect(split.overlay).toBe(1)
+    expect(split.primary).toBe(0)
+  })
+})
+
+describe('hullOverlap', () => {
+  test('non-overlapping hulls → 0', () => {
+    const m = new Map([
+      ['a', bounds(0, 0, 10, 10)],
+      ['b', bounds(20, 0, 10, 10)],
+    ])
+    expect(hullOverlap(m)).toBe(0)
+  })
+
+  test('half-overlapping pair', () => {
+    const m = new Map([
+      ['a', bounds(0, 0, 10, 10)],
+      ['b', bounds(5, 0, 10, 10)],
+    ])
+    // overlap rect: x=[5,10], y=[0,10] → 5*10 = 50
+    expect(hullOverlap(m)).toBe(50)
+  })
+
+  test('siblingHullOverlap skips nested pairs', () => {
+    const m = new Map([
+      ['outer', bounds(0, 0, 20, 20)],
+      ['inner', bounds(2, 2, 5, 5)],
+    ])
+    const parents = new Map<string, string | undefined>([
+      ['outer', undefined],
+      ['inner', 'outer'],
+    ])
+    expect(siblingHullOverlap(m, parents)).toBe(0)
+  })
+})
+
+describe('stabilityScore', () => {
+  test('identical layouts → 0', () => {
+    const a = pos(['x', 0, 0], ['y', 10, 10])
+    const b = pos(['x', 0, 0], ['y', 10, 10])
+    expect(stabilityScore(a, b)).toBe(0)
+  })
+
+  test('RMS displacement of one node by 5 units → 5/√2 (averaged with one zero-shift)', () => {
+    const a = pos(['x', 0, 0], ['y', 10, 10])
+    const b = pos(['x', 3, 4], ['y', 10, 10])
+    // Displacements: x=5, y=0 → RMS = sqrt((25+0)/2) ≈ 3.535
+    expect(stabilityScore(a, b)).toBeCloseTo(Math.sqrt(25 / 2), 3)
+  })
+
+  test('nodes only in one map are ignored', () => {
+    const a = pos(['x', 0, 0])
+    const b = pos(['x', 0, 0], ['ghost', 100, 100])
+    expect(stabilityScore(a, b)).toBe(0)
+  })
+})

--- a/libs/@shumoku/core/src/layout/quality/metrics.ts
+++ b/libs/@shumoku/core/src/layout/quality/metrics.ts
@@ -1,0 +1,342 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Layout quality metrics.
+ *
+ * Pure functions that score one `FlatTreeLayoutResult` against the
+ * `NetworkGraph` it came from. Used by the layout harness
+ * (`./harness.ts`) to evaluate algorithm changes with numbers
+ * instead of visual anecdotes.
+ *
+ * The metrics are deliberately simple and composable:
+ *
+ *   edgeLength       — total / mean / max edge run, proxies for
+ *                      "are wires kept short?"
+ *   rootArea         — bbox area, proxies for "canvas density"
+ *   aspectRatio      — width / height, proxies for "does it fit a
+ *                      typical screen?"
+ *   edgeCrossings    — pairwise segment intersection count, proxy
+ *                      for "is it readable?"
+ *   hullOverlap      — sum of pairwise subgraph hull overlap areas;
+ *                      should always be zero for the engine's
+ *                      non-overlap invariant, useful as a guard
+ *   stabilityScore   — RMS node displacement between two layouts
+ *                      (same node-set), used to evaluate
+ *                      incremental-stability work
+ *
+ * All metrics consume the result + the graph; none of them touch
+ * the engine internals, so they double as a sanity check that
+ * the engine's output is well-formed.
+ */
+
+import type { Bounds, Link, NetworkGraph } from '../../models/types.js'
+import type { FlatTreeLayoutResult, Position } from '../flat-tree/types.js'
+
+// ─────────────────────────────────────────────────────────────────────
+// Edge length
+// ─────────────────────────────────────────────────────────────────────
+
+export interface EdgeLengthMetrics {
+  total: number
+  mean: number
+  max: number
+  count: number
+}
+
+/**
+ * Sum / mean / max of straight-line edge length in SVG units.
+ * Skips edges whose endpoints aren't in `nodePositions`.
+ */
+export function edgeLength(
+  graph: NetworkGraph,
+  nodePositions: Map<string, Position>,
+): EdgeLengthMetrics {
+  let total = 0
+  let max = 0
+  let count = 0
+  for (const link of graph.links) {
+    const a = nodePositions.get(link.from.node)
+    const b = nodePositions.get(link.to.node)
+    if (!a || !b) continue
+    const d = Math.hypot(b.x - a.x, b.y - a.y)
+    total += d
+    if (d > max) max = d
+    count++
+  }
+  return { total, mean: count > 0 ? total / count : 0, max, count }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Bounding box shape
+// ─────────────────────────────────────────────────────────────────────
+
+/** Area of the root bbox in square SVG units. */
+export function rootArea(bounds: Bounds): number {
+  return Math.max(0, bounds.width) * Math.max(0, bounds.height)
+}
+
+/**
+ * Width / height ratio. 1.0 = square; > 1 = landscape; < 1 =
+ * portrait. Returns 0 when height is 0 (degenerate).
+ */
+export function aspectRatio(bounds: Bounds): number {
+  return bounds.height > 0 ? bounds.width / bounds.height : 0
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Edge crossings
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Number of pairs of edges whose straight-line segments cross
+ * (proper intersection — shared endpoints don't count).
+ *
+ * Brute-force O(L²) — only suitable for diagnostic / regression
+ * use, not in the hot layout loop. Skips edges with missing
+ * endpoints and ignores self-loops.
+ *
+ * Treats overlay (redundancy) and primary edges as equal weight.
+ * Use {@link edgeCrossingsByKind} when you need to distinguish.
+ */
+export function edgeCrossings(graph: NetworkGraph, nodePositions: Map<string, Position>): number {
+  const segs = collectSegments(graph, nodePositions)
+  let n = 0
+  for (let i = 0; i < segs.length; i++) {
+    for (let j = i + 1; j < segs.length; j++) {
+      const a = segs[i]
+      const b = segs[j]
+      if (a && b && segmentsCross(a, b)) n++
+    }
+  }
+  return n
+}
+
+/**
+ * Crossings split by edge kind. Overlay = `link.redundancy` set;
+ * primary = everything else. The split matters because the
+ * engine's overlay-aware reorder (issue #X) targets overlay
+ * crossings without disturbing primary structure.
+ */
+export function edgeCrossingsByKind(
+  graph: NetworkGraph,
+  nodePositions: Map<string, Position>,
+): { primary: number; overlay: number; total: number } {
+  const primaryIdx: number[] = []
+  const overlayIdx: number[] = []
+  const segs = collectSegments(graph, nodePositions, (link, i) => {
+    if (link.redundancy) overlayIdx.push(i)
+    else primaryIdx.push(i)
+  })
+  let primary = 0
+  let overlay = 0
+  for (let i = 0; i < segs.length; i++) {
+    for (let j = i + 1; j < segs.length; j++) {
+      const a = segs[i]
+      const b = segs[j]
+      if (!a || !b || !segmentsCross(a, b)) continue
+      const aIsOverlay = overlayIdx.includes(i)
+      const bIsOverlay = overlayIdx.includes(j)
+      if (aIsOverlay || bIsOverlay) overlay++
+      else primary++
+    }
+  }
+  return { primary, overlay, total: primary + overlay }
+}
+
+interface Segment {
+  ax: number
+  ay: number
+  bx: number
+  by: number
+  /** Endpoint node ids — used to ignore "crossings" that just share an endpoint. */
+  endpoints: [string, string]
+}
+
+function collectSegments(
+  graph: NetworkGraph,
+  nodePositions: Map<string, Position>,
+  onLink?: (link: Link, segIndex: number) => void,
+): Segment[] {
+  const segs: Segment[] = []
+  for (const link of graph.links) {
+    if (link.from.node === link.to.node) continue
+    const a = nodePositions.get(link.from.node)
+    const b = nodePositions.get(link.to.node)
+    if (!a || !b) continue
+    onLink?.(link, segs.length)
+    segs.push({
+      ax: a.x,
+      ay: a.y,
+      bx: b.x,
+      by: b.y,
+      endpoints: [link.from.node, link.to.node],
+    })
+  }
+  return segs
+}
+
+/**
+ * Proper segment intersection: the two segments share a point
+ * strictly inside both. Shared endpoints (common node) don't
+ * count as a crossing — those are unavoidable in graph drawings.
+ */
+function segmentsCross(s1: Segment, s2: Segment): boolean {
+  // Shared endpoint → not a crossing.
+  for (const e of s1.endpoints) {
+    if (s2.endpoints.includes(e)) return false
+  }
+  const d1 = direction(s2.ax, s2.ay, s2.bx, s2.by, s1.ax, s1.ay)
+  const d2 = direction(s2.ax, s2.ay, s2.bx, s2.by, s1.bx, s1.by)
+  const d3 = direction(s1.ax, s1.ay, s1.bx, s1.by, s2.ax, s2.ay)
+  const d4 = direction(s1.ax, s1.ay, s1.bx, s1.by, s2.bx, s2.by)
+  if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) && ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))) {
+    return true
+  }
+  // Colinear cases: treat as non-crossing (segments overlap but
+  // don't "cross"). Network diagrams with truly colinear edges
+  // are extremely rare and the layout aims to avoid them
+  // upstream.
+  return false
+}
+
+function direction(ax: number, ay: number, bx: number, by: number, px: number, py: number): number {
+  return (px - ax) * (by - ay) - (py - ay) * (bx - ax)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Hull overlap
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Sum of pairwise axis-aligned-rect overlap areas across all
+ * subgraph hulls. The engine's invariant is non-overlap for
+ * sibling hulls (nested ones are expected to be contained); a
+ * non-zero value here flags a layout bug.
+ *
+ * Note: this includes nested hulls' "overlap" (an inner hull
+ * fully inside its outer). Use {@link siblingHullOverlap} when
+ * you only want to measure flat sibling overlap.
+ */
+export function hullOverlap(subgraphBounds: Map<string, Bounds>): number {
+  const bs = [...subgraphBounds.values()]
+  let total = 0
+  for (let i = 0; i < bs.length; i++) {
+    for (let j = i + 1; j < bs.length; j++) {
+      const a = bs[i]
+      const b = bs[j]
+      if (a && b) total += rectOverlapArea(a, b)
+    }
+  }
+  return total
+}
+
+/**
+ * Sum of pairwise overlap area across only *sibling* subgraphs
+ * (i.e. ignore parent/child nesting). Caller passes the subgraph
+ * parent map.
+ */
+export function siblingHullOverlap(
+  subgraphBounds: Map<string, Bounds>,
+  subgraphParents: ReadonlyMap<string, string | undefined>,
+): number {
+  const entries = [...subgraphBounds.entries()]
+  let total = 0
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      const ei = entries[i]
+      const ej = entries[j]
+      if (!ei || !ej) continue
+      const [ai, ab] = ei
+      const [bi, bb] = ej
+      if (areNested(ai, bi, subgraphParents)) continue
+      total += rectOverlapArea(ab, bb)
+    }
+  }
+  return total
+}
+
+function areNested(
+  a: string,
+  b: string,
+  parents: ReadonlyMap<string, string | undefined>,
+): boolean {
+  // Walk a's ancestry; if b is found, nested.
+  let cur: string | undefined = parents.get(a)
+  while (cur !== undefined) {
+    if (cur === b) return true
+    cur = parents.get(cur)
+  }
+  cur = parents.get(b)
+  while (cur !== undefined) {
+    if (cur === a) return true
+    cur = parents.get(cur)
+  }
+  return false
+}
+
+function rectOverlapArea(a: Bounds, b: Bounds): number {
+  const ox = Math.max(0, Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x))
+  const oy = Math.max(0, Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y))
+  return ox * oy
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Stability
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * RMS displacement of nodes between two layouts of the same
+ * node set. Used to score how much a small structural edit
+ * disturbs the rest of the diagram (the smaller, the more
+ * "incremental" the engine's behaviour).
+ *
+ * Nodes present in only one of the two layouts are ignored.
+ * Returns 0 when there are no nodes in common.
+ */
+export function stabilityScore(
+  before: Map<string, Position>,
+  after: Map<string, Position>,
+): number {
+  let sumSq = 0
+  let n = 0
+  for (const [id, a] of before) {
+    const b = after.get(id)
+    if (!b) continue
+    sumSq += (b.x - a.x) ** 2 + (b.y - a.y) ** 2
+    n++
+  }
+  return n > 0 ? Math.sqrt(sumSq / n) : 0
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// One-shot summary
+// ─────────────────────────────────────────────────────────────────────
+
+export interface QualityReport {
+  edgeLength: EdgeLengthMetrics
+  rootArea: number
+  aspectRatio: number
+  crossings: { primary: number; overlay: number; total: number }
+  hullOverlap: number
+  siblingHullOverlap: number
+}
+
+/**
+ * Convenience: compute every metric in one pass. The harness
+ * uses this; tests may prefer the individual functions when
+ * focusing on a specific signal.
+ */
+export function summarize(graph: NetworkGraph, result: FlatTreeLayoutResult): QualityReport {
+  const subgraphParents = new Map<string, string | undefined>()
+  for (const s of graph.subgraphs ?? []) subgraphParents.set(s.id, s.parent)
+  return {
+    edgeLength: edgeLength(graph, result.nodePositions),
+    rootArea: rootArea(result.rootBounds),
+    aspectRatio: aspectRatio(result.rootBounds),
+    crossings: edgeCrossingsByKind(graph, result.nodePositions),
+    hullOverlap: hullOverlap(result.subgraphBounds),
+    siblingHullOverlap: siblingHullOverlap(result.subgraphBounds, subgraphParents),
+  }
+}


### PR DESCRIPTION
## Summary

Stand-up of a layout quality harness so future algorithm changes can be evaluated with numbers instead of screenshots.

`libs/@shumoku/core/src/layout/quality/`:

- **`metrics.ts`** — pure functions over `(NetworkGraph, FlatTreeLayoutResult)`: edge length (total/mean/max), bbox area, aspect ratio, edge crossings (primary vs overlay), hull overlap (all-pair + sibling-only), and an RMS-displacement stability score for incremental work.
- **`corpus.ts`** — 11 representative fixtures stressing different engine paths (minimal, chains, star, wide tree, multi-component, HA pair, single/multi-emitter subgraph, nested, NOC-like).
- **`harness.ts`** — runs the engine over the corpus, returns a `HarnessReport`, formats as a fixed-width table.
- **`metrics.test.ts`** + **`harness.test.ts`** — 19 new tests. Regression bounds: zero sibling-hull overlap on every fixture, per-fixture crossing caps, whole-corpus runtime < 200 ms.

`bun run quality` in `@shumoku/core` runs the harness with the verbose reporter so the table prints.

## Baseline at HEAD

```
fixture           N   L   edge_tot  area     ar    xings  xov  hull_ov  ms
minimal           2   1   199       20720    0.31  0      0    0        1.55
linear-chain      5   4   796       68480    0.09  0      0    0        7.25
star              5   4   1044      142709   2.13  0      0    0        0.41
wide-tree         16  15  4650      827606   3.95  0      0    0        0.50
deep-chain        10  9   1791      148080   0.04  0      0    0        0.13
multi-component   6   4   856       142709   2.13  0      0    0        0.12
ha-pair           4   3   555       61383    0.92  0      0    0        0.05
single-subgraph   3   2   220       41760    0.34  0      0    0        0.41
multi-emitter-sg  4   3   651       130042   0.51  0      0    0        0.16
nested-subgraph   3   2   398       73280    0.35  0      0    0        0.06
noc-like          5   4   761       176172   0.44  0      0    0        0.13
TOTAL             63  51  11922     1832941  —     0      0    0        10.76
```

Every fixture lays out with 0 crossings, 0 sibling-hull overlap. Future PRs (adaptive sibling sort, overlay-aware block reorder) can show concrete deltas against these numbers.

## Test plan

- [x] `bun run build` clean
- [x] `bun x vitest run` — 190 / 190 (171 prior + 19 new)
- [x] `bun run quality` prints the table