### PR TITLE
feat(core/flat-tree): explainability diagnostics for engine decisions

### DIFF
--- a/libs/@shumoku/core/src/layout/flat-tree/README.md
+++ b/libs/@shumoku/core/src/layout/flat-tree/README.md
@@ -146,7 +146,9 @@ The engine computes everything in TB orientation internally and rotates the fina
 
 ### Diagnostics
 
-`result.diagnostics` reports input-validation warnings (duplicate node ids, dangling subgraph parents, links to missing nodes, missing node sizes) and engine info (self-loops, cycle breaks). Empty array means clean input.
+`result.diagnostics` reports input-validation warnings (duplicate node ids, dangling subgraph parents, links to missing nodes, missing node sizes) and engine info (self-loops). Empty array means clean input.
+
+Pass `{ explain: true }` to additionally surface per-decision *explainability* diagnostics — `block-join` (why each node ended up in its block), `sibling-order` (what key decided the order under each parent), `spine-aligned` (where the spine pass fired), `cycle-broken` (which edge was dropped to break a primary-parent cycle). These are info-level and verbose; off by default so production callers don't pay the cost. Useful when investigating a layout that looks wrong.
 
 ### Pinned positions
 

--- a/libs/@shumoku/core/src/layout/flat-tree/blocks.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/blocks.ts
@@ -39,6 +39,7 @@
  */
 
 import type { NetworkGraph } from '../../models/types.js'
+import { blockJoinDiagnostic, type Diagnostic } from './diagnostics.js'
 import type { BlockMembers, BlockOfNode } from './types.js'
 
 export interface BlockPartition {
@@ -56,7 +57,11 @@ export interface BlockPartition {
  *   - `parents` — primary-parent map from {@link
  *     ./parents.ts | buildPrimaryParents}.
  */
-export function buildBlocks(graph: NetworkGraph, parents: Map<string, string>): BlockPartition {
+export function buildBlocks(
+  graph: NetworkGraph,
+  parents: Map<string, string>,
+  diagnostics?: Diagnostic[],
+): BlockPartition {
   const subgraphMembers = groupBySubgraph(graph)
   const isEmitter = findEmitters(subgraphMembers, parents)
 
@@ -68,6 +73,7 @@ export function buildBlocks(graph: NetworkGraph, parents: Map<string, string>): 
     if (!n.parent) {
       blockOfNode.set(n.id, n.id)
       blockMembers.set(n.id, [n.id])
+      diagnostics?.push(blockJoinDiagnostic(n.id, n.id, 'top-level-singleton'))
     }
   }
 
@@ -76,13 +82,17 @@ export function buildBlocks(graph: NetworkGraph, parents: Map<string, string>): 
     if (emitters.length <= 1) {
       // Collapse: one block holds the whole subgraph.
       const blockId = sg
-      for (const m of members) blockOfNode.set(m, blockId)
+      for (const m of members) {
+        blockOfNode.set(m, blockId)
+        diagnostics?.push(blockJoinDiagnostic(m, blockId, 'single-emitter-subgraph'))
+      }
       blockMembers.set(blockId, [...members])
     } else {
       // Split: each emitter becomes its own block.
       for (const e of emitters) {
         blockOfNode.set(e, e)
         blockMembers.set(e, [e])
+        diagnostics?.push(blockJoinDiagnostic(e, e, 'emitter-of-multi-emitter-subgraph'))
       }
       // Non-emitter members join the block of their nearest
       // tree-parent emitter inside the same subgraph. If none
@@ -98,9 +108,11 @@ export function buildBlocks(graph: NetworkGraph, parents: Map<string, string>): 
         if (cur !== undefined && memberSet.has(cur) && isEmitter.has(cur)) {
           blockOfNode.set(m, cur)
           blockMembers.get(cur)?.push(m)
+          diagnostics?.push(blockJoinDiagnostic(m, cur, 'non-emitter-joined-nearest-emitter'))
         } else {
           blockOfNode.set(m, m)
           blockMembers.set(m, [m])
+          diagnostics?.push(blockJoinDiagnostic(m, m, 'top-level-singleton'))
         }
       }
     }

--- a/libs/@shumoku/core/src/layout/flat-tree/diagnostics.test.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/diagnostics.test.ts
@@ -128,3 +128,108 @@ describe('layoutFlatTree diagnostics integration', () => {
     expect(result.diagnostics).toEqual([])
   })
 })
+
+describe('explainability diagnostics (opt-in via { explain: true })', () => {
+  const baseSize = new Map<string, { width: number; height: number }>()
+
+  function setUp(nodes: Node[], links: Link[], subgraphs: Subgraph[] = []) {
+    const graph: NetworkGraph = { name: 't', nodes, links, subgraphs }
+    const nodesById = new Map(nodes.map((n) => [n.id, n]))
+    const subgraphsById = new Map(subgraphs.map((s) => [s.id, s]))
+    const sizeById = new Map<string, { width: number; height: number }>(
+      nodes.map((n) => [n.id, { width: 80, height: 60 }]),
+    )
+    return { graph, nodesById, subgraphsById, sizeById }
+  }
+
+  test('default (no explain) keeps info diagnostics empty for clean input', () => {
+    const env = setUp([node('a'), node('b')], [link('a', 'b')])
+    const result = layoutFlatTree(
+      env.graph,
+      env.nodesById,
+      env.subgraphsById,
+      env.sizeById,
+      () => false,
+    )
+    expect(result.diagnostics.filter((d) => d.severity === 'info')).toEqual([])
+  })
+
+  test('explain emits block-join diagnostic per node', () => {
+    const env = setUp([node('a'), node('b')], [link('a', 'b')])
+    const result = layoutFlatTree(
+      env.graph,
+      env.nodesById,
+      env.subgraphsById,
+      env.sizeById,
+      () => false,
+      { explain: true },
+    )
+    const joins = result.diagnostics.filter((d) => d.code === 'block-join')
+    expect(joins.length).toBe(2)
+    expect(joins.every((d) => d.severity === 'info')).toBe(true)
+  })
+
+  test('explain emits sibling-order with source-port-label reason when port labels differ', () => {
+    const env = setUp(
+      [node('p'), node('a'), node('b')],
+      [
+        // Distinct source ports — sort decided by port label.
+        {
+          from: { node: 'p', port: 'p1' },
+          to: { node: 'a', port: 'q' },
+        },
+        {
+          from: { node: 'p', port: 'p2' },
+          to: { node: 'b', port: 'q' },
+        },
+      ],
+    )
+    const result = layoutFlatTree(
+      env.graph,
+      env.nodesById,
+      env.subgraphsById,
+      env.sizeById,
+      () => false,
+      { explain: true },
+    )
+    const ord = result.diagnostics.find((d) => d.code === 'sibling-order')
+    expect(ord).toBeDefined()
+    expect(ord?.message.includes('source-port-label')).toBe(true)
+  })
+
+  test('explain emits spine-aligned when multi-emitter subgraph forces a shift', () => {
+    const env = setUp(
+      [node('e1', 'sg'), node('e2', 'sg'), node('extA'), node('extB')],
+      [link('e1', 'e2'), link('e1', 'extA'), link('e2', 'extB')],
+      [subgraph('sg')],
+    )
+    const result = layoutFlatTree(
+      env.graph,
+      env.nodesById,
+      env.subgraphsById,
+      env.sizeById,
+      () => false,
+      { explain: true },
+    )
+    expect(result.diagnostics.some((d) => d.code === 'spine-aligned')).toBe(true)
+  })
+
+  test('explain emits cycle-broken when a cycle is detected', () => {
+    const env = setUp(
+      [node('a'), node('b'), node('c')],
+      [link('a', 'b'), link('b', 'c'), link('c', 'a')],
+    )
+    const result = layoutFlatTree(
+      env.graph,
+      env.nodesById,
+      env.subgraphsById,
+      env.sizeById,
+      () => false,
+      { explain: true },
+    )
+    const broken = result.diagnostics.find((d) => d.code === 'cycle-broken')
+    expect(broken).toBeDefined()
+    // The cycle list should appear in the message.
+    expect(broken?.message.includes('→')).toBe(true)
+  })
+})

--- a/libs/@shumoku/core/src/layout/flat-tree/diagnostics.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/diagnostics.ts
@@ -125,11 +125,71 @@ export function missingSizeDiagnostic(nodeId: string): Diagnostic {
 }
 
 /** Diagnostic for cycle breaking. */
-export function cycleBreakDiagnostic(nodeId: string): Diagnostic {
+export function cycleBreakDiagnostic(nodeId: string, cycle: readonly string[]): Diagnostic {
   return {
     severity: 'info',
     code: 'cycle-broken',
-    message: `Primary-parent cycle through node '${nodeId}' was broken to keep the graph acyclic.`,
+    message: `Primary-parent cycle through [${cycle.join(' → ')}] was broken by dropping the parent edge of node '${nodeId}' (lexically-last member of the cycle).`,
     ref: { kind: 'node', id: nodeId },
+  }
+}
+
+/**
+ * Why a node ended up in a particular block. Most cases are
+ * structural (one block per single-emitter subgraph, etc.) but
+ * non-emitter joins to the nearest emitter ancestor are worth
+ * surfacing when debugging a multi-emitter subgraph's split.
+ */
+export function blockJoinDiagnostic(
+  nodeId: string,
+  blockId: string,
+  reason:
+    | 'top-level-singleton'
+    | 'single-emitter-subgraph'
+    | 'emitter-of-multi-emitter-subgraph'
+    | 'non-emitter-joined-nearest-emitter',
+): Diagnostic {
+  return {
+    severity: 'info',
+    code: 'block-join',
+    message: `Node '${nodeId}' joined block '${blockId}' (reason: ${reason}).`,
+    ref: { kind: 'node', id: nodeId },
+  }
+}
+
+/**
+ * Why a sibling-block sort ordering was chosen. Emitted at most
+ * once per parent block whose children were sorted.
+ */
+export function siblingOrderDiagnostic(
+  parentBlockId: string,
+  reason: 'source-port-label' | 'id-tiebreaker' | 'singleton',
+  order: readonly string[],
+): Diagnostic {
+  return {
+    severity: 'info',
+    code: 'sibling-order',
+    message: `Sibling blocks under '${parentBlockId}' ordered by ${reason}: [${order.join(', ')}].`,
+  }
+}
+
+/**
+ * Spine alignment shifted a child block onto its same-subgraph
+ * parent's x column. Useful when investigating "why is this
+ * subgraph rendering as a narrow strip?" — when present, it's
+ * working as designed; when absent for a vertical-strip case,
+ * the spine detection missed.
+ */
+export function spineAlignedDiagnostic(
+  parentBlockId: string,
+  childBlockId: string,
+  subgraphId: string,
+  shift: number,
+): Diagnostic {
+  return {
+    severity: 'info',
+    code: 'spine-aligned',
+    message: `Spine alignment pulled block '${childBlockId}' onto x of '${parentBlockId}' (subgraph '${subgraphId}', shift ${shift.toFixed(1)}px).`,
+    ref: { kind: 'subgraph', id: subgraphId },
   }
 }

--- a/libs/@shumoku/core/src/layout/flat-tree/index.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/index.ts
@@ -53,6 +53,18 @@ export interface FlatTreeLayoutOptions {
    * {@link ./spacing.ts | LayoutMetrics}.
    */
   metrics?: LayoutMetrics
+  /**
+   * When true, every pipeline phase appends explainability
+   * `Diagnostic`s describing why decisions were made (which
+   * cycle edge was broken, why a node joined its block, what
+   * sort key drove sibling order, when spine alignment fired,
+   * etc.). Default false — these are info-level and verbose,
+   * useful for debugging snapshots that look wrong but noise
+   * for production callers. Input-validation diagnostics
+   * (missing-node-size, link-endpoint-missing, …) are emitted
+   * regardless of this flag.
+   */
+  explain?: boolean
 }
 
 export type { Diagnostic, DiagnosticSeverity } from './diagnostics.js'
@@ -106,13 +118,17 @@ export function layoutFlatTree(
   for (const n of graph.nodes) {
     if (!sizeById.has(n.id)) diagnostics.push(missingSizeDiagnostic(n.id))
   }
+  // Explainability bucket — only populated when the caller
+  // opted in. Separate sink so the input-validation bucket
+  // stays clean for callers who don't want the verbosity.
+  const explain = options.explain ? diagnostics : undefined
 
   // 1. Parents.
   const parents = buildPrimaryParents(graph.links, nodesById, shouldFlip)
-  breakCycles(parents)
+  breakCycles(parents, explain)
 
   // 2. Blocks.
-  const { blockOfNode, blockMembers } = buildBlocks(graph, parents)
+  const { blockOfNode, blockMembers } = buildBlocks(graph, parents, explain)
   const blockEmitsExternal = findExternalEmitterBlocks(blockMembers, parents)
 
   // 3. Internal layout per block.
@@ -132,6 +148,7 @@ export function layoutFlatTree(
     graph.links,
     nodesById,
     shouldFlip,
+    explain,
   )
 
   // Block size for tidy-tree includes the hull padding + label
@@ -163,7 +180,7 @@ export function layoutFlatTree(
 
   // 5. Spine alignment.
   const blockPositions = new Map(tree.positions)
-  alignSameSubgraphSpine(blockPositions, blockChildren, blockMembers, nodesById)
+  alignSameSubgraphSpine(blockPositions, blockChildren, blockMembers, nodesById, explain)
 
   // 6. Expand to absolute node positions.
   const nodePositions = new Map<string, Position>()

--- a/libs/@shumoku/core/src/layout/flat-tree/outer.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/outer.ts
@@ -25,6 +25,7 @@
  */
 
 import type { Link, Node } from '../../models/types.js'
+import type { Diagnostic } from './diagnostics.js'
 import { sortBlocksBySourcePort } from './sort.js'
 import type { BlockChildren, BlockMembers, BlockOfNode, BlockParents } from './types.js'
 
@@ -64,6 +65,7 @@ export function buildBlockChildren(
   links: readonly Link[],
   nodesById: Map<string, Node>,
   shouldFlip: (link: Link) => boolean,
+  diagnostics?: Diagnostic[],
 ): BlockChildren {
   const out: BlockChildren = new Map()
   for (const [block, par] of blockParents) {
@@ -72,7 +74,10 @@ export function buildBlockChildren(
     out.set(par, list)
   }
   for (const [par, kids] of out) {
-    out.set(par, sortBlocksBySourcePort(kids, par, blockMembers, links, nodesById, shouldFlip))
+    out.set(
+      par,
+      sortBlocksBySourcePort(kids, par, blockMembers, links, nodesById, shouldFlip, diagnostics),
+    )
   }
   return out
 }

--- a/libs/@shumoku/core/src/layout/flat-tree/parents.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/parents.ts
@@ -24,6 +24,7 @@
  */
 
 import type { Link, Node } from '../../models/types.js'
+import { cycleBreakDiagnostic, type Diagnostic } from './diagnostics.js'
 
 /**
  * Build the primary tree-parent for each node. The map is
@@ -69,7 +70,7 @@ export function buildPrimaryParents(
  *   4. Skip nodes that became roots in earlier iterations so we
  *      don't over-remove edges in tangled graphs.
  */
-export function breakCycles(parents: Map<string, string>): void {
+export function breakCycles(parents: Map<string, string>, diagnostics?: Diagnostic[]): void {
   const startNodes = [...parents.keys()].sort((a, b) => a.localeCompare(b))
   for (const start of startNodes) {
     if (!parents.has(start)) continue
@@ -85,6 +86,7 @@ export function breakCycles(parents: Map<string, string>): void {
           if (c.localeCompare(victim) > 0) victim = c
         }
         parents.delete(victim)
+        diagnostics?.push(cycleBreakDiagnostic(victim, cycleNodes))
         break
       }
       seen.add(cur)

--- a/libs/@shumoku/core/src/layout/flat-tree/sort.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/sort.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Link, Node } from '../../models/types.js'
+import { type Diagnostic, siblingOrderDiagnostic } from './diagnostics.js'
 import type { BlockId, BlockMembers } from './types.js'
 
 /**
@@ -35,6 +36,7 @@ export function sortBlocksBySourcePort(
   links: readonly Link[],
   nodesById: Map<string, Node>,
   shouldFlip: (link: Link) => boolean,
+  diagnostics?: Diagnostic[],
 ): BlockId[] {
   const parentMembers = new Set(blockMembers.get(parentBlockId) ?? [])
   const portLabelOf = (nodeId: string, portId: string): string => {
@@ -61,7 +63,8 @@ export function sortBlocksBySourcePort(
     const primary = blockMembers.get(block)?.[0] ?? block
     return nodesById.get(primary)?.parent ?? ''
   }
-  return [...blockIds].sort((a, b) => {
+  let portLabelDecided = false
+  const ordered = [...blockIds].sort((a, b) => {
     const ka = keyOf(a)
     const kb = keyOf(b)
     // Blocks with no matching source link sort last.
@@ -73,10 +76,23 @@ export function sortBlocksBySourcePort(
       return -1
     } else {
       const portCmp = ka.localeCompare(kb, undefined, { numeric: true })
-      if (portCmp !== 0) return portCmp
+      if (portCmp !== 0) {
+        portLabelDecided = true
+        return portCmp
+      }
     }
     const sgCmp = subgraphOf(a).localeCompare(subgraphOf(b))
     if (sgCmp !== 0) return sgCmp
     return a.localeCompare(b)
   })
+  if (diagnostics && ordered.length > 1) {
+    diagnostics.push(
+      siblingOrderDiagnostic(
+        parentBlockId,
+        portLabelDecided ? 'source-port-label' : 'id-tiebreaker',
+        ordered,
+      ),
+    )
+  }
+  return ordered
 }

--- a/libs/@shumoku/core/src/layout/flat-tree/spine.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/spine.ts
@@ -26,6 +26,7 @@
  */
 
 import type { Node } from '../../models/types.js'
+import { type Diagnostic, spineAlignedDiagnostic } from './diagnostics.js'
 import type { BlockChildren, BlockId, BlockMembers, Position } from './types.js'
 
 /**
@@ -38,6 +39,7 @@ export function alignSameSubgraphSpine(
   blockChildren: BlockChildren,
   blockMembers: BlockMembers,
   nodesById: Map<string, Node>,
+  diagnostics?: Diagnostic[],
 ): void {
   const subgraphOf = (block: BlockId): string | null => {
     const primary = blockMembers.get(block)?.[0]
@@ -57,7 +59,11 @@ export function alignSameSubgraphSpine(
       const parentX = positions.get(block)?.x
       const spineX = positions.get(spine)?.x
       if (parentX !== undefined && spineX !== undefined && parentX !== spineX) {
-        shiftCluster(kids, blockChildren, positions, parentX - spineX)
+        const shift = parentX - spineX
+        shiftCluster(kids, blockChildren, positions, shift)
+        if (parentSg) {
+          diagnostics?.push(spineAlignedDiagnostic(block, spine, parentSg, shift))
+        }
       }
     }
     for (const c of kids) queue.push(c)


### PR DESCRIPTION
## Summary

Per-decision diagnostics so layout debugging becomes textual rather than visual. Gated behind `{ explain: true }` so production callers don't pay the verbosity cost.

New diagnostic codes (info-level):

| code | when | helps debug |
|---|---|---|
| `cycle-broken` | a primary-parent cycle was broken | which edge was dropped; the full cycle list |
| `block-join` | each node joined its block | top-level-singleton / single-emitter-subgraph / emitter-of-multi-emitter-subgraph / non-emitter-joined-nearest-emitter |
| `sibling-order` | each parent's children were sorted | which key decided the order (source-port-label / id-tiebreaker) + the sequence |
| `spine-aligned` | spine pass shifted a child onto parent's x | subgraph id + shift magnitude |

Pipeline wiring: `parents.ts`, `blocks.ts`, `sort.ts`, `outer.ts`, `spine.ts` each take an optional `Diagnostic[]` parameter. `index.ts` threads the same array through every phase only when `options.explain` is true. Input-validation diagnostics (`missing-node-size`, `link-endpoint-missing`, etc.) keep firing regardless.

Built on top of #283 (quality harness). Future PRs (adaptive sort, overlay-aware reorder) will emit additional codes when their fallback / improvement paths fire.

## Test plan

- [x] `bun run build` clean
- [x] `bun x vitest run` — 195 / 195 (190 prior + 5 new)
- [x] Default (no explain) keeps the info bucket empty on clean input — the existing assertion `result.diagnostics === []` still passes