### PR TITLE
feat(core/flat-tree): port-label-absent sibling-sort diagnostic

### DIFF
--- a/libs/@shumoku/core/src/layout/flat-tree/diagnostics.test.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/diagnostics.test.ts
@@ -169,6 +169,30 @@ describe('explainability diagnostics (opt-in via { explain: true })', () => {
     expect(joins.every((d) => d.severity === 'info')).toBe(true)
   })
 
+  test('explain emits sibling-order with port-label-absent-fallback when all port labels collide', () => {
+    // All ports are 'p' → keyOf returns 'p' for every block →
+    // port label can't distinguish → falls back diagnostic.
+    const env = setUp(
+      [node('hub'), node('l1'), node('l2'), node('l3')],
+      [
+        { from: { node: 'hub', port: 'p' }, to: { node: 'l1', port: 'p' } },
+        { from: { node: 'hub', port: 'p' }, to: { node: 'l2', port: 'p' } },
+        { from: { node: 'hub', port: 'p' }, to: { node: 'l3', port: 'p' } },
+      ],
+    )
+    const result = layoutFlatTree(
+      env.graph,
+      env.nodesById,
+      env.subgraphsById,
+      env.sizeById,
+      () => false,
+      { explain: true },
+    )
+    const ord = result.diagnostics.find((d) => d.code === 'sibling-order')
+    expect(ord).toBeDefined()
+    expect(ord?.message.includes('port-label-absent-fallback')).toBe(true)
+  })
+
   test('explain emits sibling-order with source-port-label reason when port labels differ', () => {
     const env = setUp(
       [node('p'), node('a'), node('b')],

--- a/libs/@shumoku/core/src/layout/flat-tree/diagnostics.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/diagnostics.ts
@@ -160,10 +160,25 @@ export function blockJoinDiagnostic(
 /**
  * Why a sibling-block sort ordering was chosen. Emitted at most
  * once per parent block whose children were sorted.
+ *
+ * Reasons:
+ *
+ *   - `source-port-label` — at least one pair was decided by
+ *     the parent's source-port label sequence (the primary
+ *     intended signal).
+ *   - `port-label-absent-fallback` — every sibling pair tied
+ *     on port labels (all-equal or all-null). Sort fell back
+ *     to subgraph-clustering + lexical id. The diagnostic
+ *     surfaces this so an editor / harness can flag fixtures
+ *     where the engine had no primary signal to rely on.
+ *   - `id-tiebreaker` — deprecated; emitted by the previous
+ *     diagnostics PR. New runs use `source-port-label` or
+ *     `port-label-absent-fallback`.
+ *   - `singleton` — only one child; ordering is vacuous.
  */
 export function siblingOrderDiagnostic(
   parentBlockId: string,
-  reason: 'source-port-label' | 'id-tiebreaker' | 'singleton',
+  reason: 'source-port-label' | 'port-label-absent-fallback' | 'id-tiebreaker' | 'singleton',
   order: readonly string[],
 ): Diagnostic {
   return {

--- a/libs/@shumoku/core/src/layout/flat-tree/sort.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/sort.ts
@@ -12,6 +12,24 @@
  * parent and children appear in a monotonic sequence with no
  * zig-zags, even when port labels follow non-alphabetical
  * device conventions (`Gi1/0/1`, `Gi1/0/2`, `Te1/1/1`, ...).
+ *
+ * Adaptive observability: when the port-label signal is fully
+ * absent — every sibling pair has identical keys or no key at
+ * all — the sort still falls back to the subgraph + id
+ * tiebreaker (preserving "kind-grouped" reading order: leaves
+ * cluster, switches cluster). A `sibling-order` diagnostic with
+ * reason `subtree-weight-fallback` flags the case so the
+ * harness can identify low-signal fixtures, but the engine
+ * deliberately does NOT reorder them — past experiments with a
+ * centred-fan-out heuristic broke the typical "APs together
+ * then switches together" expectation that network engineers
+ * read from network-layout output (test: 'switch with mixed
+ * downstream depths keeps leaves contiguous').
+ *
+ * If a future PR wants to actually exploit the no-port-signal
+ * case it needs a heuristic that respects kind clustering — e.g.
+ * cluster by leaf-vs-internal first, then by subtree weight
+ * within each cluster.
  */
 
 import type { Link, Node } from '../../models/types.js'
@@ -63,13 +81,16 @@ export function sortBlocksBySourcePort(
     const primary = blockMembers.get(block)?.[0] ?? block
     return nodesById.get(primary)?.parent ?? ''
   }
+
+  // Single pass: try the port-label sort. Track whether any
+  // pair was decided by port labels; when none was, mark the
+  // sort as having fallen back so the diagnostic captures it.
   let portLabelDecided = false
   const ordered = [...blockIds].sort((a, b) => {
     const ka = keyOf(a)
     const kb = keyOf(b)
-    // Blocks with no matching source link sort last.
     if (ka === null && kb === null) {
-      // Both unlinked → fall through to subgraph + id tiebreakers below.
+      // both unlinked
     } else if (ka === null) {
       return 1
     } else if (kb === null) {
@@ -85,11 +106,12 @@ export function sortBlocksBySourcePort(
     if (sgCmp !== 0) return sgCmp
     return a.localeCompare(b)
   })
+
   if (diagnostics && ordered.length > 1) {
     diagnostics.push(
       siblingOrderDiagnostic(
         parentBlockId,
-        portLabelDecided ? 'source-port-label' : 'id-tiebreaker',
+        portLabelDecided ? 'source-port-label' : 'port-label-absent-fallback',
         ordered,
       ),
     )

--- a/libs/@shumoku/core/src/layout/quality/corpus.ts
+++ b/libs/@shumoku/core/src/layout/quality/corpus.ts
@@ -63,6 +63,18 @@ function l(from: string, to: string, opts: Partial<Link> = {}): Link {
   }
 }
 
+/**
+ * Link with a fixed port name on both sides — used to build
+ * port-label-collision fixtures so the sibling-sort fallback
+ * fires and the harness's `pl_fb` column shows non-zero.
+ */
+function lp(from: string, to: string, port: string): Link {
+  return {
+    from: { node: from, port },
+    to: { node: to, port },
+  }
+}
+
 export interface CorpusFixture {
   name: string
   description: string
@@ -176,6 +188,16 @@ export const CORPUS: readonly CorpusFixture[] = [
       [n('a', 'inner'), n('b'), n('c')],
       [l('b', 'a'), l('a', 'c')],
       [sg('outer'), sg('inner', 'outer')],
+    ),
+  },
+  {
+    name: 'no-port-labels',
+    description:
+      'star with every link using the same port name → sibling sort hits port-label fallback',
+    graph: graph(
+      'no-port-labels',
+      ['hub', 'a', 'b', 'c'].map((id) => n(id)),
+      [lp('hub', 'a', 'p'), lp('hub', 'b', 'p'), lp('hub', 'c', 'p')],
     ),
   },
   {

--- a/libs/@shumoku/core/src/layout/quality/harness.test.ts
+++ b/libs/@shumoku/core/src/layout/quality/harness.test.ts
@@ -40,6 +40,7 @@ describe('layout quality harness', () => {
       'multi-emitter-sg': 0,
       'nested-subgraph': 0,
       'noc-like': 2,
+      'no-port-labels': 0,
     }
     const report = runHarness()
     for (const fx of report.fixtures) {

--- a/libs/@shumoku/core/src/layout/quality/harness.ts
+++ b/libs/@shumoku/core/src/layout/quality/harness.ts
@@ -25,6 +25,15 @@ export interface FixtureReport {
   metrics: QualityReport
   /** Wall-clock milliseconds spent in `engine.layout`. */
   elapsedMs: number
+  /**
+   * Count of sibling-sort groups that hit the
+   * `port-label-absent-fallback` path. Non-zero means the
+   * fixture didn't carry enough port-label signal to drive
+   * the primary sort — a target for future signal extraction
+   * (e.g. inferring labels from port ids, sub-graph
+   * ordering, …).
+   */
+  portLabelFallbackGroups: number
 }
 
 export interface HarnessReport {
@@ -55,8 +64,11 @@ export function runHarness(fixtures: readonly CorpusFixture[] = CORPUS): Harness
       fx.graph.nodes.map((node) => [node.id, node.size ?? { width: 80, height: 60 }]),
     )
     const t0 = performance.now()
-    const result = engine.layout(fx.graph, { sizeById })
+    const result = engine.layout(fx.graph, { sizeById, explain: true })
     const elapsedMs = performance.now() - t0
+    const portLabelFallbackGroups = result.diagnostics.filter(
+      (d) => d.code === 'sibling-order' && d.message.includes('port-label-absent-fallback'),
+    ).length
     out.push({
       name: fx.name,
       description: fx.description,
@@ -65,6 +77,7 @@ export function runHarness(fixtures: readonly CorpusFixture[] = CORPUS): Harness
       result,
       metrics: summarize(fx.graph, result),
       elapsedMs,
+      portLabelFallbackGroups,
     })
   }
   return {
@@ -114,7 +127,19 @@ function aggregate(rows: FixtureReport[]): HarnessReport['totals'] {
  * the `bun run quality` script.
  */
 export function formatReport(report: HarnessReport): string {
-  const header = ['fixture', 'N', 'L', 'edge_tot', 'area', 'ar', 'xings', 'xov', 'hull_ov', 'ms']
+  const header = [
+    'fixture',
+    'N',
+    'L',
+    'edge_tot',
+    'area',
+    'ar',
+    'xings',
+    'xov',
+    'hull_ov',
+    'pl_fb',
+    'ms',
+  ]
   const rows: string[][] = [header.map((h) => h)]
   for (const fx of report.fixtures) {
     rows.push([
@@ -127,6 +152,7 @@ export function formatReport(report: HarnessReport): string {
       String(fx.metrics.crossings.total),
       String(fx.metrics.crossings.overlay),
       fx.metrics.siblingHullOverlap.toFixed(0),
+      String(fx.portLabelFallbackGroups),
       fx.elapsedMs.toFixed(2),
     ])
   }
@@ -140,6 +166,7 @@ export function formatReport(report: HarnessReport): string {
     String(report.totals.crossingsTotal),
     String(report.totals.crossingsOverlay),
     report.totals.siblingHullOverlapTotal.toFixed(0),
+    String(report.fixtures.reduce((s, f) => s + f.portLabelFallbackGroups, 0)),
     report.totals.elapsedMs.toFixed(2),
   ])
   const widths = header.map((_, col) => Math.max(...rows.map((r) => (r[col] ?? '').length)))


### PR DESCRIPTION
## Summary

Adds observability for the case where the sibling sort had no port-label signal. Sort behaviour itself is **unchanged** — when every sibling pair ties on port labels, the engine still falls back to subgraph + lexical id, which preserves the 'leaves cluster, switches cluster' kind-grouping that network-layout depends on.

What's new:

- New `sibling-order` diagnostic reason: \`port-label-absent-fallback\`. Emitted when not a single pair was decided by source-port labels.
- Harness extension (on top of #283): `FixtureReport.portLabelFallbackGroups` count, shown as the `pl_fb` column in the report.
- New corpus fixture `no-port-labels`: a star whose every link shares port name `p`. Exercises the fallback path so the column shows non-zero in CI.

Stacked on #284 (diagnostics enrichment).

## Why not a real algorithmic change?

I tried a centred-fan-out heuristic (heavier subtrees on the outside) but it broke `network-layout.test.ts > switch with mixed downstream depths keeps leaves contiguous` — the heavier switch was intercalated into the run of APs. A smarter fallback needs to respect kind-clustering first (leaves together, switches together) before reordering by weight. Left as future work; this PR's diagnostic surfaces the cases where it would matter.

## Test plan

- [x] `bun run build` clean
- [x] `bun x vitest run` — 196 / 196 (195 prior + 1 new)
- [x] `bun run quality` shows pl_fb = 1 for `no-port-labels`, 0 elsewhere