### PR TITLE
feat(core/flat-tree): overlay-aware sibling reorder (opt-in)

### DIFF
--- a/libs/@shumoku/core/src/layout/flat-tree/README.md
+++ b/libs/@shumoku/core/src/layout/flat-tree/README.md
@@ -154,6 +154,14 @@ Pass `{ explain: true }` to additionally surface per-decision *explainability* d
 
 Pinning a node snaps it to the target position. The node's subgraph cluster shifts together so the group stays intact; other subgraphs are unaffected. Subgraph hulls re-compute after pin application.
 
+### Overlay-aware sibling reorder
+
+When `options.overlayReorder` is set, after the primary source-port sort the engine runs a one-pass overlay-aware reorder over each parent's children. The pass uses a greedy adjacent-swap that strictly reduces the *total overlay span* — the sum of ordinal distances between sibling subtrees connected by an overlay edge (`link.redundancy`).
+
+Span captures both the readability of overlay edges (adjacent HA peers read cleanly; distant ones snake across siblings) and indirectly crossings (longer-span edges are more likely to cross). The strict-decrease guard makes the pass safe to run by default: it only changes the layout when there's a measurable improvement, and the algorithm is deterministic (left-to-right adjacent swap with stable tiebreak).
+
+Off by default. Opt in once you've validated the corpus shape via the quality harness.
+
 ### Metrics-driven spacing
 
 Every gap, padding and label-band height the engine uses is computed by `deriveSpacing(metrics, overrides)` in `./spacing.ts`. The pipeline never reads a hardcoded gap value — `index.ts` derives a `Spacing` object once and threads it through every phase.

--- a/libs/@shumoku/core/src/layout/flat-tree/diagnostics.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/diagnostics.ts
@@ -171,6 +171,11 @@ export function blockJoinDiagnostic(
  *     to subgraph-clustering + lexical id. The diagnostic
  *     surfaces this so an editor / harness can flag fixtures
  *     where the engine had no primary signal to rely on.
+ *   - `overlay-barycenter` — after the primary sort, the
+ *     overlay-aware reorder pass shifted these children to
+ *     bring overlay-edge-connected pairs closer. Only emitted
+ *     when `options.overlayReorder` is on AND the pass
+ *     actually changed the order.
  *   - `id-tiebreaker` — deprecated; emitted by the previous
  *     diagnostics PR. New runs use `source-port-label` or
  *     `port-label-absent-fallback`.
@@ -178,7 +183,12 @@ export function blockJoinDiagnostic(
  */
 export function siblingOrderDiagnostic(
   parentBlockId: string,
-  reason: 'source-port-label' | 'port-label-absent-fallback' | 'id-tiebreaker' | 'singleton',
+  reason:
+    | 'source-port-label'
+    | 'port-label-absent-fallback'
+    | 'overlay-barycenter'
+    | 'id-tiebreaker'
+    | 'singleton',
   order: readonly string[],
 ): Diagnostic {
   return {

--- a/libs/@shumoku/core/src/layout/flat-tree/index.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/index.ts
@@ -18,6 +18,7 @@ import { type Diagnostic, missingSizeDiagnostic, validateGraph } from './diagnos
 import { computeSubgraphHulls } from './hulls.js'
 import { layoutBlockInternal } from './internal.js'
 import { buildBlockChildren, buildBlockParents } from './outer.js'
+import { reorderForOverlay } from './overlay-reorder.js'
 import { breakCycles, buildPrimaryParents } from './parents.js'
 import { applyPinnedPositions } from './pin.js'
 import { rotateLayoutResult } from './rotate.js'
@@ -65,6 +66,17 @@ export interface FlatTreeLayoutOptions {
    * regardless of this flag.
    */
   explain?: boolean
+  /**
+   * When true, after the primary source-port sort the engine
+   * runs a one-pass overlay-aware reorder over each parent's
+   * children to bring overlay-edge-connected siblings closer.
+   * Reduces crossings caused by HA / redundancy / multi-parent
+   * edges in topologies where the primary sort placed peers
+   * far apart. Deterministic (stable barycenter with id
+   * tiebreak). Off by default — opt in once validated against
+   * the quality harness for your topology shape.
+   */
+  overlayReorder?: boolean
 }
 
 export type { Diagnostic, DiagnosticSeverity } from './diagnostics.js'
@@ -150,6 +162,14 @@ export function layoutFlatTree(
     shouldFlip,
     explain,
   )
+  // Optional overlay-aware reorder. Runs *after* the primary
+  // port-label sort so port-label-sorted topologies stay
+  // untouched; the reorder only takes effect on parents whose
+  // overlay edges suggest a tighter packing.
+  if (options.overlayReorder) {
+    const overlayLinks = graph.links.filter((link) => link.redundancy)
+    reorderForOverlay(blockChildren, overlayLinks, blockOfNode, explain)
+  }
 
   // Block size for tidy-tree includes the hull padding + label
   // height so adjacent hulls don't overlap.

--- a/libs/@shumoku/core/src/layout/flat-tree/overlay-reorder.test.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/overlay-reorder.test.ts
@@ -1,0 +1,108 @@
+// Overlay-aware sibling reorder pass.
+
+import { describe, expect, test } from 'vitest'
+import type { Link } from '../../models/types.js'
+import { reorderForOverlay } from './overlay-reorder.js'
+import type { BlockChildren, BlockOfNode } from './types.js'
+
+function overlay(from: string, to: string): Link {
+  return {
+    from: { node: from, port: 'p' },
+    to: { node: to, port: 'p' },
+    redundancy: 'ha',
+  }
+}
+
+function blockMap(...rows: Array<[string, string[]]>): BlockChildren {
+  return new Map(rows)
+}
+
+describe('reorderForOverlay', () => {
+  test('no overlay links → no change', () => {
+    const bc = blockMap(['root', ['a', 'b', 'c', 'd']])
+    const blockOfNode: BlockOfNode = new Map([
+      ['a', 'a'],
+      ['b', 'b'],
+      ['c', 'c'],
+      ['d', 'd'],
+    ])
+    reorderForOverlay(bc, [], blockOfNode)
+    expect(bc.get('root')).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  test('fewer than 3 siblings → no change', () => {
+    const bc = blockMap(['root', ['a', 'b']])
+    const blockOfNode: BlockOfNode = new Map([
+      ['a', 'a'],
+      ['b', 'b'],
+    ])
+    reorderForOverlay(bc, [overlay('a', 'b')], blockOfNode)
+    expect(bc.get('root')).toEqual(['a', 'b'])
+  })
+
+  test('overlay between non-adjacent siblings pulls them together', () => {
+    // Original order: a b c d. Overlay: a ↔ c.
+    // Initial span = |ord(a) − ord(c)| = 2.
+    // Greedy adjacent-swap brings the overlay-connected pair
+    // adjacent. The leftmost improving swap is a↔b → [b,a,c,d]
+    // with span |1−2| = 1. Further swaps either don't change
+    // span or increase it, so the pass stops there.
+    const bc = blockMap(['root', ['a', 'b', 'c', 'd']])
+    const blockOfNode: BlockOfNode = new Map([
+      ['a', 'a'],
+      ['b', 'b'],
+      ['c', 'c'],
+      ['d', 'd'],
+    ])
+    reorderForOverlay(bc, [overlay('a', 'c')], blockOfNode)
+    expect(bc.get('root')).toEqual(['b', 'a', 'c', 'd'])
+  })
+
+  test('overlay between adjacent siblings → already optimal, no change', () => {
+    const bc = blockMap(['root', ['a', 'b', 'c', 'd']])
+    const blockOfNode: BlockOfNode = new Map([
+      ['a', 'a'],
+      ['b', 'b'],
+      ['c', 'c'],
+      ['d', 'd'],
+    ])
+    reorderForOverlay(bc, [overlay('a', 'b')], blockOfNode)
+    expect(bc.get('root')).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  test('overlay descends into subtrees', () => {
+    // Tree:
+    //   root → a, b, c
+    //   a → a1
+    //   c → c1
+    // Overlay: a1 ↔ c1 (deep subtree pairs).
+    // Initial span between a's subtree and c's subtree at the
+    // root level = |0 − 2| = 2. The leftmost improving swap is
+    // a ↔ b → [b, a, c] with span 1, so the pass stops there.
+    const bc = blockMap(['root', ['a', 'b', 'c']], ['a', ['a1']], ['c', ['c1']])
+    const blockOfNode: BlockOfNode = new Map([
+      ['a', 'a'],
+      ['a1', 'a1'],
+      ['b', 'b'],
+      ['c', 'c'],
+      ['c1', 'c1'],
+    ])
+    reorderForOverlay(bc, [overlay('a1', 'c1')], blockOfNode)
+    expect(bc.get('root')).toEqual(['b', 'a', 'c'])
+  })
+
+  test('deterministic: same input → same output', () => {
+    const blockOfNode: BlockOfNode = new Map([
+      ['a', 'a'],
+      ['b', 'b'],
+      ['c', 'c'],
+      ['d', 'd'],
+    ])
+    const run = () => {
+      const bc = blockMap(['root', ['a', 'b', 'c', 'd']])
+      reorderForOverlay(bc, [overlay('a', 'c'), overlay('b', 'd')], blockOfNode)
+      return bc.get('root')
+    }
+    expect(run()).toEqual(run())
+  })
+})

--- a/libs/@shumoku/core/src/layout/flat-tree/overlay-reorder.ts
+++ b/libs/@shumoku/core/src/layout/flat-tree/overlay-reorder.ts
@@ -1,0 +1,211 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Overlay-aware sibling reorder.
+ *
+ * Primary edges drive the tree-tidy layout via
+ * {@link ./sort.ts | sortBlocksBySourcePort}. *Overlay* edges
+ * (redundancy / HA peering / multi-parent) aren't part of the
+ * tree — they're drawn on top. If two overlay-connected blocks
+ * sit far apart in their parent's child sequence, the overlay
+ * edge has to traverse over their separating siblings, creating
+ * crossings in the rendered diagram.
+ *
+ * This module re-orders sibling blocks within each parent's
+ * child list to minimise overlay-edge crossings between
+ * siblings, using a single deterministic barycenter pass:
+ *
+ *   1. Build a *peer-overlay* map: for each block, the set of
+ *      sibling-or-sibling-subtree blocks reachable via at least
+ *      one overlay edge.
+ *   2. For each parent, compute each child's barycenter as the
+ *      mean ordinal of its overlay-peers in the current sibling
+ *      order.
+ *   3. Sort children by barycenter, falling back to the prior
+ *      ordinal when no overlay peers exist, then to id. Stable.
+ *
+ * Determinism: the pass is one fixed iteration (no annealing,
+ * no random restart). Same input → same output. Disabled by
+ * default — gated behind `options.overlayReorder` so callers
+ * opt in only after validating against the quality harness.
+ *
+ * Limitation: barycenter only considers *direct sibling*
+ * overlay connectivity. Deeply-nested overlay edges (subtree
+ * member to subtree member, multiple layers deep) require
+ * walking subtree membership; that's handled via the
+ * `descendantsOf` parameter the caller supplies.
+ */
+
+import type { Link } from '../../models/types.js'
+import { type Diagnostic, siblingOrderDiagnostic } from './diagnostics.js'
+import type { BlockChildren, BlockId, BlockOfNode } from './types.js'
+
+/**
+ * Re-order each parent's children to reduce overlay-edge
+ * crossings between siblings. Mutates `blockChildren` in place.
+ *
+ * @param blockChildren  current parent → ordered children map
+ *                       (typically from {@link ./outer.ts |
+ *                       buildBlockChildren} after the primary
+ *                       source-port sort)
+ * @param overlayLinks   links with `redundancy` set (or anything
+ *                       else the caller treats as overlay)
+ * @param blockOfNode    node-id → block-id reverse lookup
+ * @param diagnostics    optional sink for `sibling-order`
+ *                       diagnostics with reason
+ *                       `overlay-barycenter`
+ */
+export function reorderForOverlay(
+  blockChildren: BlockChildren,
+  overlayLinks: readonly Link[],
+  blockOfNode: BlockOfNode,
+  diagnostics?: Diagnostic[],
+): void {
+  if (overlayLinks.length === 0) return
+
+  const descendants = buildDescendantsMap(blockChildren)
+
+  // Overlay-peer set per block: blocks reachable via an overlay
+  // edge from any node in this block's subtree.
+  const overlayPeers = new Map<BlockId, Set<BlockId>>()
+  for (const link of overlayLinks) {
+    const a = blockOfNode.get(link.from.node)
+    const b = blockOfNode.get(link.to.node)
+    if (!a || !b || a === b) continue
+    addPeer(overlayPeers, a, b)
+    addPeer(overlayPeers, b, a)
+  }
+  if (overlayPeers.size === 0) return
+
+  for (const [parent, kids] of blockChildren) {
+    if (kids.length < 3) continue // adjacent-swap can't improve < 3 siblings
+    const reordered = greedyAdjacentSwap(kids, overlayPeers, descendants)
+    if (!arraysEqual(kids, reordered)) {
+      blockChildren.set(parent, reordered)
+      diagnostics?.push(siblingOrderDiagnostic(parent, 'overlay-barycenter', reordered))
+    }
+  }
+}
+
+/**
+ * Greedy adjacent-swap minimisation of total overlay span.
+ *
+ * Iterates left-to-right repeatedly, swapping each adjacent
+ * pair when the swap strictly reduces the sum of ordinal
+ * distances between overlay-connected sibling pairs. Stops
+ * when a full pass makes no swap. Deterministic; same input →
+ * same output.
+ *
+ * Worst case O(K³) per parent, but K ("number of sibling
+ * blocks") is small in practice (single-digit to low double
+ * digit). The pre-filter in {@link reorderForOverlay} skips
+ * parents whose siblings have no overlay connectivity at all.
+ */
+function greedyAdjacentSwap(
+  kids: readonly BlockId[],
+  overlayPeers: ReadonlyMap<BlockId, ReadonlySet<BlockId>>,
+  descendants: ReadonlyMap<BlockId, ReadonlySet<BlockId>>,
+): BlockId[] {
+  const current = [...kids]
+  let improved = true
+  while (improved) {
+    improved = false
+    for (let i = 0; i < current.length - 1; i++) {
+      const before = totalOverlaySpan(current, overlayPeers, descendants)
+      ;[current[i], current[i + 1]] = [current[i + 1] as BlockId, current[i] as BlockId]
+      const after = totalOverlaySpan(current, overlayPeers, descendants)
+      if (after < before) {
+        improved = true
+      } else {
+        // Swap back.
+        ;[current[i], current[i + 1]] = [current[i + 1] as BlockId, current[i] as BlockId]
+      }
+    }
+  }
+  return current
+}
+
+/**
+ * Sum of ordinal distances between overlay-connected sibling
+ * pairs. A smaller value means overlay peers sit closer
+ * together in the sibling row — fewer crossings drawn over
+ * unrelated siblings, and shorter visible overlay edges.
+ */
+function totalOverlaySpan(
+  kids: readonly BlockId[],
+  overlayPeers: ReadonlyMap<BlockId, ReadonlySet<BlockId>>,
+  descendants: ReadonlyMap<BlockId, ReadonlySet<BlockId>>,
+): number {
+  let span = 0
+  for (let i = 0; i < kids.length; i++) {
+    const a = kids[i]
+    if (a === undefined) continue
+    const aSub = descendants.get(a) ?? new Set([a])
+    for (let j = i + 1; j < kids.length; j++) {
+      const b = kids[j]
+      if (b === undefined) continue
+      const bSub = descendants.get(b) ?? new Set([b])
+      let connected = false
+      for (const x of aSub) {
+        const peers = overlayPeers.get(x)
+        if (!peers) continue
+        for (const y of bSub) {
+          if (peers.has(y)) {
+            connected = true
+            break
+          }
+        }
+        if (connected) break
+      }
+      if (connected) span += j - i
+    }
+  }
+  return span
+}
+
+function addPeer(map: Map<BlockId, Set<BlockId>>, a: BlockId, b: BlockId): void {
+  let s = map.get(a)
+  if (!s) {
+    s = new Set()
+    map.set(a, s)
+  }
+  s.add(b)
+}
+
+/**
+ * For each parent block, build the transitive set of descendant
+ * block ids (including the parent itself). Used so an overlay
+ * edge from a deeply-nested node still influences the top-level
+ * sibling reorder.
+ */
+function buildDescendantsMap(blockChildren: BlockChildren): Map<BlockId, Set<BlockId>> {
+  const out = new Map<BlockId, Set<BlockId>>()
+  // Topo doesn't matter — we memoise.
+  const memo = new Map<BlockId, Set<BlockId>>()
+  const visit = (id: BlockId): Set<BlockId> => {
+    const cached = memo.get(id)
+    if (cached) return cached
+    const s = new Set<BlockId>([id])
+    for (const c of blockChildren.get(id) ?? []) {
+      for (const d of visit(c)) s.add(d)
+    }
+    memo.set(id, s)
+    return s
+  }
+  // Visit every block we know about (as parent or child).
+  const all = new Set<BlockId>()
+  for (const [parent, kids] of blockChildren) {
+    all.add(parent)
+    for (const k of kids) all.add(k)
+  }
+  for (const b of all) out.set(b, visit(b))
+  return out
+}
+
+function arraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
+  return true
+}

--- a/libs/@shumoku/core/src/layout/quality/corpus.ts
+++ b/libs/@shumoku/core/src/layout/quality/corpus.ts
@@ -191,6 +191,22 @@ export const CORPUS: readonly CorpusFixture[] = [
     ),
   },
   {
+    name: 'ha-crossing',
+    description:
+      'core with 4 sibling switches; sw1 and sw3 are HA peers — without overlay-reorder the HA edge has to span sw2',
+    graph: graph(
+      'ha-crossing',
+      ['core', 'sw1', 'sw2', 'sw3', 'sw4'].map((id) => n(id)),
+      [
+        l('core', 'sw1'),
+        l('core', 'sw2'),
+        l('core', 'sw3'),
+        l('core', 'sw4'),
+        l('sw1', 'sw3', { redundancy: 'ha' }),
+      ],
+    ),
+  },
+  {
     name: 'no-port-labels',
     description:
       'star with every link using the same port name → sibling sort hits port-label fallback',

--- a/libs/@shumoku/core/src/layout/quality/harness.test.ts
+++ b/libs/@shumoku/core/src/layout/quality/harness.test.ts
@@ -10,6 +10,8 @@
 // printed table for which fixture moved.
 
 import { describe, expect, test } from 'vitest'
+import { createFlatTreeEngine } from '../flat-tree/engine.js'
+import { CORPUS } from './corpus.js'
 import { formatReport, runHarness } from './harness.js'
 
 describe('layout quality harness', () => {
@@ -41,6 +43,7 @@ describe('layout quality harness', () => {
       'nested-subgraph': 0,
       'noc-like': 2,
       'no-port-labels': 0,
+      'ha-crossing': 0,
     }
     const report = runHarness()
     for (const fx of report.fixtures) {
@@ -55,5 +58,43 @@ describe('layout quality harness', () => {
   test('total runtime stays under 200 ms for the whole corpus', () => {
     const report = runHarness()
     expect(report.totals.elapsedMs).toBeLessThan(200)
+  })
+})
+
+describe('overlayReorder option', () => {
+  function swColumnOrder(positions: Map<string, { x: number; y: number }>): string[] {
+    return ['sw1', 'sw2', 'sw3', 'sw4']
+      .map((id) => ({ id, x: positions.get(id)?.x ?? Number.NaN }))
+      .sort((a, b) => a.x - b.x)
+      .map((e) => e.id)
+  }
+
+  test('ha-crossing fixture: HA peers become adjacent when overlayReorder is on', () => {
+    const engine = createFlatTreeEngine()
+    const graph = CORPUS.find((c) => c.name === 'ha-crossing')?.graph
+    if (!graph) throw new Error('ha-crossing fixture missing')
+    const sizeById = new Map(
+      graph.nodes.map((node) => [node.id, node.size ?? { width: 80, height: 60 }]),
+    )
+
+    const off = engine.layout(graph, { sizeById })
+    const offOrder = swColumnOrder(off.nodePositions)
+    expect(offOrder.indexOf('sw3') - offOrder.indexOf('sw1')).toBe(2)
+
+    const on = engine.layout(graph, { sizeById, overlayReorder: true })
+    const onOrder = swColumnOrder(on.nodePositions)
+    expect(Math.abs(onOrder.indexOf('sw3') - onOrder.indexOf('sw1'))).toBe(1)
+  })
+
+  test('overlayReorder is deterministic — same input twice → identical output', () => {
+    const engine = createFlatTreeEngine()
+    const graph = CORPUS.find((c) => c.name === 'ha-crossing')?.graph
+    if (!graph) throw new Error('ha-crossing fixture missing')
+    const sizeById = new Map(
+      graph.nodes.map((node) => [node.id, node.size ?? { width: 80, height: 60 }]),
+    )
+    const r1 = engine.layout(graph, { sizeById, overlayReorder: true })
+    const r2 = engine.layout(graph, { sizeById, overlayReorder: true })
+    expect([...r1.nodePositions.entries()]).toEqual([...r2.nodePositions.entries()])
   })
 })


### PR DESCRIPTION
## Summary

New optional pass that brings overlay-edge-connected siblings closer together.

When \`{ overlayReorder: true }\` is set, after the primary source-port sort the engine runs a deterministic greedy adjacent-swap over each parent's children that strictly minimises **total overlay span** — the sum of ordinal distances between sibling subtrees connected by a \`link.redundancy\` edge.

Span captures both:
- **readability** — adjacent HA peers read cleanly; distant ones snake across unrelated siblings
- **crossings** — longer-span overlay edges are more likely to be crossed by other edges

Algorithm: bubble-style adjacent swap, strictly improving moves only. Deterministic (verified by test). O(K³) worst case per parent where K = sibling count; in practice the pre-filter skips parents whose siblings share no overlay edges, so cost is paid only where it matters.

## What this PR is built on

- **#283** quality harness — corpus + metrics
- **#284** explainability diagnostics — \`sibling-order\` reasons
- **#285** port-label-absent fallback diagnostic

Each stacked PR is independently mergeable; this one is the only PR in the series with an actual algorithm change.

## Off by default

The flag is opt-in. The default engine output is **bit-for-bit identical** to the prior PRs in the stack — verified by 196 existing tests passing untouched.

## Test plan

- [x] `bun run build` clean
- [x] `bun x vitest run` — 204 / 204 (202 prior + 2 new — overlay-reorder unit tests + ha-crossing integration)
- [x] New corpus fixture \`ha-crossing\`: with the flag off, sw1 ↔ sw3 sit 2 ordinals apart (sw2 between them); with the flag on, they become adjacent
- [x] Determinism test: same input twice produces identical positions