### PR TITLE
feat(core/network-layout): enable overlayReorder by default in editor wrapper

### DIFF
--- a/libs/@shumoku/core/src/layout/network-layout.ts
+++ b/libs/@shumoku/core/src/layout/network-layout.ts
@@ -485,6 +485,15 @@ export function layoutNetwork(
   // exists for future per-renderer tuning. Outer gaps and the
   // subgraph hull dimensions remain explicit UX choices owned
   // by this wrapper.
+  //
+  // `overlayReorder` is enabled here. The flat-tree engine
+  // ships it opt-in because it changes block ordering when
+  // overlay edges (link.redundancy) span sibling subtrees,
+  // and that's a meaningful default-flip. The quality harness
+  // in `../quality` verifies this doesn't increase straight-
+  // line edge crossings on any corpus fixture. For HA-heavy
+  // network topologies the win is concrete: HA peer pairs end
+  // up adjacent instead of separated by unrelated siblings.
   const result = layoutFlatTree(
     graph,
     nodesById,
@@ -500,6 +509,7 @@ export function layoutNetwork(
       metrics: {
         portLabelOuterReach: PORT_LABEL_OUTER_REACH,
       },
+      overlayReorder: true,
     },
   )
   const nodes = new Map<string, Node>()


### PR DESCRIPTION
## Summary

Flips the \`overlayReorder\` flag to \`true\` in \`network-layout.ts\` — the editor wrapper around the flat-tree engine. The engine itself keeps the flag opt-in (so library consumers can stay on the conservative default).

## Why now

The previous four PRs (#283 harness, #284 diagnostics, #285 fallback diagnostic, #286 overlay-reorder) are all infrastructure that produces **no default visual change**. This PR is the small switch that actually shows the payoff in the editor: HA peer pairs become adjacent in the rendered diagram instead of being separated by unrelated sibling switches.

## Safety

- 204 / 204 tests still pass — no snapshot fixtures move because none of them carry \`link.redundancy\` edges in a position the reorder would shift.
- The quality harness in #283 verifies that on every corpus fixture, enabling \`overlayReorder\` never increases the straight-line edge-crossing count.
- The reorder is deterministic (greedy adjacent-swap with strict-improvement acceptance, verified in #286).

## Test plan

- [x] \`bun run build\` clean
- [x] \`bun x vitest run\` — 204 / 204
- [ ] Spot-check in the editor with a 2-switch HA pair + a few hosts — the HA edge should sit between the two switches with no host in the gap

Stacked on #286.