### PR TITLE
refactor(core/layout): unified-engine uses createEngine + autoLayoutFlatTree

### DIFF
--- a/libs/@shumoku/core/src/layout/unified-engine.ts
+++ b/libs/@shumoku/core/src/layout/unified-engine.ts
@@ -5,18 +5,24 @@
 /**
  * Unified layout engine adapter
  *
- * Wraps `layoutNetwork` (custom Sugiyama with 4-alignment BK coords)
- * plus the trivial `routeEdges` pass that just attaches port-anchored
- * `ResolvedEdge` records. Edge geometry is computed in the renderer
- * as cubic Beziers from the port positions, so no routing solver is
+ * Wraps the engine-driven `autoLayoutFlatTree` plus the trivial
+ * `routeEdges` pass that attaches port-anchored `ResolvedEdge`
+ * records. Edge geometry is computed in the renderer as cubic
+ * Beziers from the port positions, so no routing solver is
  * involved at this layer anymore.
  *
- * Used by server, CLI, renderer-html, and renderer-svg for consistent layout.
+ * Used by server, CLI, renderer-html, and renderer-svg for
+ * consistent layout. The `LayoutEngine` interface here is the
+ * legacy async wrapper from `hierarchical.ts`; the underlying
+ * spatial-rule engine (`@shumoku/core/layout/engine`) is
+ * instantiated inside `computeNetworkLayout`.
  */
 
 import type { LayoutEngine } from '../hierarchical.js'
 import type { LayoutResult, NetworkGraph } from '../models/types.js'
-import { layoutNetwork, resolveNodeSize } from './network-layout.js'
+import { autoLayoutFlatTree } from './auto-placement/flat-tree/auto-layout.js'
+import { createEngine } from './engine/index.js'
+import { resolveNodeSize } from './network-layout.js'
 import type { ResolvedLayout } from './resolved-types.js'
 import { routeEdges } from './route-edges.js'
 
@@ -46,7 +52,12 @@ export async function computeNetworkLayout(graph: NetworkGraph): Promise<{
 }> {
   const direction = graph.settings?.direction ?? 'TB'
 
-  const { nodes, ports, subgraphs, bounds } = layoutNetwork(graph, { direction })
+  // Create a spatial-rule engine once per layout call. Engines
+  // are stateless beyond memoization, so this is cheap; in
+  // contexts that lay out repeatedly (drag, animation) the
+  // engine instance can be hoisted to caller scope.
+  const engine = createEngine()
+  const { nodes, ports, subgraphs, bounds } = autoLayoutFlatTree(graph, engine, { direction })
   const edges = await routeEdges(nodes, ports, graph.links, subgraphs)
 
   const resolved: ResolvedLayout = {


### PR DESCRIPTION
## Summary

Switches the single internal call site that all consumers go through (\`computeNetworkLayout\` in \`unified-engine.ts\`) from the legacy \`layoutNetwork\` to the engine-driven \`autoLayoutFlatTree\`.

\`\`\`diff
- const { nodes, ports, subgraphs, bounds } =
-   layoutNetwork(graph, { direction })
+ const engine = createEngine()
+ const { nodes, ports, subgraphs, bounds } =
+   autoLayoutFlatTree(graph, engine, { direction })
\`\`\`

## Effect

- apps/editor (via \`computeNetworkLayout\`): same output, exercises the new code path in production.
- apps/server, apps/cli, apps/docs, renderer-svg, renderer-html: same.
- After this lands, \`layoutNetwork\` is no longer reached from any consumer — only its own test file references it.

Same algorithm internally, same output shape, but the rule layer (sizes, gap math, label measurement) flows through the explicit \`LayoutEngine\` instead of being implicit in \`layoutNetwork\`.

## Test plan

- [x] \`bun run build\` clean
- [x] \`bun x vitest run\` — 176 / 176 (no change)
- [x] Editor browser session: same layout as before the swap (verified visually)

## Next in the series

- Renderer label widths via \`engine.text.measure\` (replaces \`SMALL_LABEL_CHAR_WIDTH * length\`).
- Delete the legacy entries once nothing references them: \`layoutNetwork\`, \`port-placement.ts\` (move into auto-placement), \`measure-text.ts\`, \`flat-tree-layout.ts\`, \`unified-engine.ts\` itself.