### PR TITLE
feat(editor): surface bump targets mid-drag via engine.findConflicts

### DIFF
--- a/libs/@shumoku/core/src/layout/engine/index.ts
+++ b/libs/@shumoku/core/src/layout/engine/index.ts
@@ -63,6 +63,7 @@ export function createEngine(config: EngineConfig = {}): LayoutEngine {
     tryPlace: placement.tryPlace.bind(placement),
     resolvePosition: placement.resolvePosition.bind(placement),
     resolveAgainstObstacles: placement.resolveAgainstObstacles.bind(placement),
+    findConflicts: placement.findConflicts.bind(placement),
     snapTo: placement.snapTo.bind(placement),
   }
 }

--- a/libs/@shumoku/core/src/layout/engine/placement.ts
+++ b/libs/@shumoku/core/src/layout/engine/placement.ts
@@ -76,6 +76,20 @@ export interface PlacementPolicy {
   ): Position
 
   /**
+   * Pure geometric conflict check: given a candidate rect and
+   * a list of obstacles tagged with ids, return the ids of
+   * obstacles whose rect overlaps the candidate (with `gap`).
+   * Symmetric to `resolveAgainstObstacles` — same predicate,
+   * different return shape. Used by drag-time UI to highlight
+   * which neighbour is being bumped.
+   */
+  findConflicts(
+    rect: { x: number; y: number; w: number; h: number },
+    obstacles: { id: string; rect: { x: number; y: number; w: number; h: number } }[],
+    gap?: number,
+  ): string[]
+
+  /**
    * Snap a position to the policy's grid / alignment. Default
    * is identity (no grid). Editors may install a stricter
    * policy via future config.
@@ -171,6 +185,13 @@ export function createPlacementPolicy(rules: LayoutRules): PlacementPolicy {
         }
       }
       return { x: fx, y: fy }
+    },
+    findConflicts(rect, obstacles, gap = DEFAULT_GAP) {
+      const blocked: string[] = []
+      for (const obs of obstacles) {
+        if (rectsOverlapCenter(rect, obs.rect, gap)) blocked.push(obs.id)
+      }
+      return blocked
     },
     snapTo(pos) {
       // Identity for now. Grid / alignment policy can be

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -67,6 +67,7 @@ export {
   movePort,
   moveSubgraph,
   nodesOverlap,
+  placementConflicts,
   placeNode,
   rebalanceSubgraphs,
   removePort,

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -120,6 +120,64 @@ export function resolveNodePosition(
 }
 
 /**
+ * Like `collectObstacles` but keeps the obstacle's id, so
+ * callers (drag-time feedback) can map a conflict rect back
+ * to the entity that owns it.
+ */
+function collectObstaclesWithIds(
+  excludeId: string,
+  excludeParent: string | undefined,
+  nodes: Map<string, Node>,
+  subgraphs?: Map<string, Subgraph>,
+): { id: string; rect: { x: number; y: number; w: number; h: number } }[] {
+  const obstacles: { id: string; rect: { x: number; y: number; w: number; h: number } }[] = []
+
+  for (const [nid, n] of nodes) {
+    if (nid === excludeId) continue
+    if (!n.position) continue
+    const size = resolveNodeSize(n)
+    obstacles.push({
+      id: nid,
+      rect: { x: n.position.x, y: n.position.y, w: size.width, h: size.height },
+    })
+  }
+
+  if (subgraphs) {
+    for (const [sgId, sg] of subgraphs) {
+      if (sgId === excludeId) continue
+      if (!sg.bounds) continue
+      if (excludeParent && isChildOf(excludeParent, sgId, subgraphs)) continue
+      obstacles.push({ id: sgId, rect: boundsToRect(sg.bounds) })
+    }
+  }
+
+  return obstacles
+}
+
+/**
+ * Identify which existing nodes / subgraphs would overlap the
+ * candidate placement of `id` at (`x`, `y`). The candidate is
+ * the **requested** position, not the resolved one — so this
+ * is what the editor uses to show "you're bumping against X"
+ * mid-drag, even though `moveNode` slides the node to a
+ * non-overlapping spot.
+ */
+export function placementConflicts(
+  id: string,
+  x: number,
+  y: number,
+  nodes: Map<string, Node>,
+  subgraphs?: Map<string, Subgraph>,
+  gap = DEFAULT_NODE_GAP,
+): string[] {
+  const node = nodes.get(id)
+  if (!node) return []
+  const size = resolveNodeSize(node)
+  const obstacles = collectObstaclesWithIds(id, node.parent, nodes, subgraphs)
+  return defaultEngine().findConflicts({ x, y, w: size.width, h: size.height }, obstacles, gap)
+}
+
+/**
  * **Geometric** placement for a single unpositioned node: find the
  * point nearest `initial` that doesn't overlap any existing node or
  * subgraph. The graph's link structure is deliberately ignored — this

--- a/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
+++ b/libs/@shumoku/renderer/src/components/ShumokuRenderer.svelte
@@ -20,6 +20,7 @@
     linkExists,
     moveNode,
     moveSubgraph,
+    placementConflicts,
     rebalanceSubgraphs,
     resolvePosition,
     routeEdges,
@@ -65,6 +66,15 @@
       if (!next.has(k)) target.delete(k)
     }
     for (const [k, v] of next) target.set(k, v)
+  }
+
+  /** Diff-apply for sets — same reasoning as replaceMap. */
+  function replaceSet<T>(target: Set<T>, source: Iterable<T>) {
+    const next = source instanceof Set ? source : new Set(source)
+    for (const v of [...target]) {
+      if (!next.has(v)) target.delete(v)
+    }
+    for (const v of next) target.add(v)
   }
 
   interface RendererProps extends RendererOverlaySnippets {
@@ -363,6 +373,12 @@
   // an obstacle, the entire group is held back by the dragged one.
   let multiDragOrigin: Map<string, { x: number; y: number }> | null = null
 
+  // Ids the dragged element is currently bumping into. Updated
+  // every drag tick via `placementConflicts` so neighbours can
+  // surface a "being pushed against" affordance. Cleared on
+  // dragend.
+  let bumping = $state(new SvelteSet<string>())
+
   function handleDragStart(id: string) {
     if (selection.has(id) && selection.size > 1) {
       multiDragOrigin = new Map()
@@ -383,10 +399,19 @@
 
   function handleDragEnd(id: string) {
     multiDragOrigin = null
+    bumping.clear()
     ondragend?.(id)
   }
 
   async function handleDragMove(id: string, x: number, y: number) {
+    // Update bump set against the *requested* (cursor) position
+    // — moveNode below will slide the entity to a free spot,
+    // but the user is still pushing against these neighbours.
+    if (nodes.has(id)) {
+      const conflicts = placementConflicts(id, x, y, nodes, subgraphs)
+      replaceSet(bumping, conflicts)
+    }
+
     const state = { nodes, ports, subgraphs }
     const result = nodes.has(id)
       ? await moveNode(id, x, y, state, links)
@@ -793,6 +818,7 @@
     {theme}
     {interactive}
     {selection}
+    {bumping}
     {linkedPorts}
     {subgraphOverlay}
     {linkOverlay}

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -19,6 +19,7 @@
     theme,
     interactive = false,
     selection = new Set<string>(),
+    bumping = new Set<string>(),
     linkedPorts = new Set<string>(),
     subgraphOverlay,
     linkOverlay,
@@ -57,6 +58,10 @@
     theme?: Theme
     interactive?: boolean
     selection?: Set<string>
+    /** Ids of nodes / subgraphs the dragged element is currently
+     *  pushing against. Used to flash a "being bumped" affordance
+     *  on those neighbours mid-drag. */
+    bumping?: Set<string>
     linkedPorts?: Set<string>
     linkPreview?: { fromX: number; fromY: number; toX: number; toY: number } | null
     svgEl?: SVGSVGElement | null
@@ -240,6 +245,18 @@
       vector-effect: non-scaling-stroke;
       stroke-width: 3;
     }
+
+    /* Bumping feedback. Painted only on neighbours that the
+       currently-dragged element is pushing against — surfaces a
+       red, non-scaling outline so the user can see *why* their
+       drag is being held back. */
+    .node.bumping .node-bg > *,
+    .subgraph.bumping > .subgraph-bg {
+      vector-effect: non-scaling-stroke;
+      stroke: #ef4444;
+      stroke-width: 3;
+      stroke-dasharray: 4 3;
+    }
   </style>`}
 
   <!-- Viewport group: d3-zoom applies transform here -->
@@ -265,6 +282,7 @@
         {colors}
         {theme}
         selected={selection.has(subgraph.id)}
+        bumping={bumping.has(subgraph.id)}
         {interactive}
         overlay={subgraphOverlay}
         {ondragstart}
@@ -295,6 +313,7 @@
           {node}
           {colors}
           selected={selection.has(node.id)}
+          bumping={bumping.has(node.id)}
           {interactive}
           overlay={nodeOverlay}
           {ondragstart}

--- a/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgNode.svelte
@@ -22,6 +22,7 @@
     colors,
     shadowFilterId = 'node-shadow',
     selected = false,
+    bumping = false,
     interactive = false,
     overlay,
     ondragstart,
@@ -36,6 +37,10 @@
     colors: RenderColors
     shadowFilterId?: string
     selected?: boolean
+    /** True when another element is currently being dragged
+     *  against this node — surfaces a red-ish "you're in the
+     *  way" affordance. */
+    bumping?: boolean
     interactive?: boolean
     overlay?: NodeOverlaySnippet
     /** Fires once when a drag begins — host opens an undo/sync transaction here. */
@@ -160,6 +165,7 @@
 <g
   class="node"
   class:selected
+  class:bumping
   data-id={node.id}
   data-device-type={specDeviceType(node.spec) ?? ''}
   filter="url(#{shadowFilterId})"

--- a/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgSubgraph.svelte
@@ -9,6 +9,7 @@
     colors,
     theme,
     selected = false,
+    bumping = false,
     interactive = false,
     overlay,
     ondragstart,
@@ -22,6 +23,9 @@
     colors: RenderColors
     theme?: Theme
     selected?: boolean
+    /** True when another element is being dragged against this
+     *  subgraph — surfaces a red outline as drag-time feedback. */
+    bumping?: boolean
     interactive?: boolean
     overlay?: SubgraphOverlaySnippet
     ondragstart?: (sgId: string) => void
@@ -74,7 +78,7 @@
   })
 </script>
 
-<g class="subgraph" class:selected data-id={subgraph.id}>
+<g class="subgraph" class:selected class:bumping data-id={subgraph.id}>
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
   <rect
     class="subgraph-bg"


### PR DESCRIPTION
## Summary
- `engine.placement.findConflicts(rect, obstaclesWithIds)` を追加（`resolveAgainstObstacles` の対称 primitive）
- `interaction.placementConflicts(id, x, y, nodes, subgraphs?)` でノード／サブグラフを一括で検査
- `ShumokuRenderer` がドラッグ中に `bumping: SvelteSet<string>` を更新、`SvgCanvas` → `SvgNode` / `SvgSubgraph` に伝搬
- `.node.bumping` / `.subgraph.bumping` に赤い破線アウトライン

## Why
ドラッグ中はすでに `moveNode` 内の衝突解決でノードがスライドして避けるけど、「なぜ動きが止まったか」が視覚的に分からなかった。隣のノードに当たってる瞬間、それを赤い破線で示すことで「ここに置こうとして X に当たってる」が一目で分かる。`engine.tryPlace` を実装した時の "conflict reporting" の発想を実際に編集体験に繋いだ形。

## Visual
ISP Line #1 を ISP Line #2 の方向にドラッグしている瞬間 — ISP Line #2 に赤い破線アウトライン。

## Test plan
- [x] core unit tests 173 passed
- [x] full build (17 packages) green
- [x] lefthook (biome format / lint / typecheck) green
- [x] ブラウザでドラッグして bumping クラスが付与されること確認
- [x] スクリーンショットで赤い破線アウトライン確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)