### PR TITLE
fix(auto-layout): enforce subgraph hull invariants + document constraint taxonomy

### DIFF
--- a/apps/editor/docs/design/layout-engine-architecture.md
+++ b/apps/editor/docs/design/layout-engine-architecture.md
@@ -372,6 +372,43 @@ Listed in expected order of usefulness; not part of this PR.
 
 5. **Diagnostics drive layout debugging**: when a snapshot looks wrong, the engine reports which rule was at play.
 
+## Adding a new constraint
+
+When the layout grows a new constraint (a new gap value, a "must
+stay inside region R" rule, a sibling-ordering preference, an
+edge-crossing minimiser, etc.), the wiring cost depends on what
+kind of constraint it is. This table is the decision tree —
+locate your constraint, then touch only the listed surfaces.
+
+| Constraint kind | Examples | Engine | Auto-placement | Manual placement |
+|---|---|---|---|---|
+| **Metric / spacing** | `minGap`, `subgraphPadding`, `fontSize`, `nodeBodyMinWidth` | Update the value in `engine/spacing.ts` or `engine/rules.ts` | Picks up automatically via `nodeFootprint` / `minSeparation` | Picks up automatically via the engine resolver |
+| **Obstacle / containment** | "no overlap with X", "stay inside parent", "min gap from N" | Express as a rect-vs-rect check on `engine.placement` (mirrors `findConflicts` / `resolveAgainstObstacles`) | Run as a final pass after the algorithm | Run inside the drag handler / `moveNode` |
+| **Ordering / ranking** | "siblings sorted by id", "tier-0 nodes pinned to top", "spine alignment" | Add a `rules` query if the value is reusable, otherwise leave it algorithm-local | Integrate into the algorithm itself (Buchheim's apportion step, sort key, etc.) — cannot be enforced post-hoc | Best effort: `validate` and warn; the drag UI can't undo a structural decision |
+| **Aesthetic / global** | "minimise edge crossings", "compact width / favourable aspect ratio" | Out of scope for the engine | Belongs to the algorithm's objective function | Not enforceable from a single-element drag |
+
+Two rules of thumb:
+
+1. **Does it reduce to a rect / point / distance check?** If yes,
+   it's an obstacle-class constraint — add a primitive on
+   `PlacementPolicy` and call it from both auto and manual. Single
+   source of truth in the engine, same enforcement on both paths.
+
+2. **Does it constrain the *search space* of where things can
+   go?** If yes, it's an algorithm-coupled constraint —
+   auto-placement must know about it to consider it during
+   placement, and manual placement can only validate / warn. No
+   amount of abstraction makes this free, because the algorithm
+   has to evaluate against the constraint while generating
+   candidates.
+
+The 80/20 of constraints in network diagrams (sizing, spacing,
+overlap, containment) land in the top two rows and propagate
+through both paths with minimal new wiring. The remaining 20%
+(ordering, aesthetics) genuinely need algorithm-side work;
+that's a property of the problem, not a defect of this
+architecture.
+
 ## Open questions (post-review)
 
 - **Density preset** (`compact|normal|comfortable`) — left for follow-up. Default to `normal`.

--- a/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.test.ts
+++ b/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.test.ts
@@ -1,7 +1,9 @@
 // Integration test for the new engine-driven entry.
 
 import { describe, expect, test } from 'vitest'
+import { sampleNetwork } from '../../../fixtures/index.js'
 import type { NetworkGraph, Node } from '../../../models/types.js'
+import { createMemoryFileResolver, HierarchicalParser } from '../../../parser/index.js'
 import { createEngine } from '../../engine/index.js'
 import { autoLayoutFlatTree } from './auto-layout.js'
 
@@ -90,3 +92,112 @@ describe('autoLayoutFlatTree (engine-driven entry)', () => {
     expect(placeAside.conflicts.length).toBe(0)
   })
 })
+
+// ─────────────────────────────────────────────────────────────
+// Contract invariants on the real sampleNetwork fixture.
+// These tests guard the README invariants on a realistic graph
+// (the synthetic 2-node tests above can't expose the
+// multi-subgraph interactions that broke pre-rebalance).
+// ─────────────────────────────────────────────────────────────
+
+async function parseSample(): Promise<NetworkGraph> {
+  const fileMap = new Map(sampleNetwork.map((f) => [f.name, f.content]))
+  const main = fileMap.get('main.yaml')
+  if (!main) throw new Error('sampleNetwork missing main.yaml')
+  const resolver = createMemoryFileResolver(fileMap)
+  const parser = new HierarchicalParser(resolver)
+  const result = await parser.parse(main, 'main.yaml')
+  return result.graph
+}
+
+function rectsOverlap(
+  a: { x: number; y: number; width: number; height: number },
+  b: { x: number; y: number; width: number; height: number },
+): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+}
+
+function nodeRect(n: Node): { x: number; y: number; width: number; height: number } | null {
+  if (!n.position || !n.size) return null
+  return {
+    x: n.position.x - n.size.width / 2,
+    y: n.position.y - n.size.height / 2,
+    width: n.size.width,
+    height: n.size.height,
+  }
+}
+
+describe('autoLayoutFlatTree contract invariants (sampleNetwork)', () => {
+  test('sibling subgraph hulls do not overlap', async () => {
+    const graph = await parseSample()
+    const result = autoLayoutFlatTree(graph, createEngine())
+    const offenders: Array<[string, string]> = []
+    const ids = [...result.subgraphs.keys()]
+    for (let i = 0; i < ids.length; i++) {
+      const aId = ids[i]
+      if (!aId) continue
+      const a = result.subgraphs.get(aId)
+      if (!a?.bounds) continue
+      for (let j = i + 1; j < ids.length; j++) {
+        const bId = ids[j]
+        if (!bId) continue
+        const b = result.subgraphs.get(bId)
+        if (!b?.bounds) continue
+        // Skip ancestor/descendant pairs — containment is OK.
+        if (a.parent === bId || b.parent === aId) continue
+        if (rectsOverlap(a.bounds, b.bounds)) offenders.push([aId, bId])
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+
+  test('every positioned node sits inside its parent subgraph bounds', async () => {
+    const graph = await parseSample()
+    const result = autoLayoutFlatTree(graph, createEngine())
+    const offenders: Array<{ node: string; parent: string }> = []
+    for (const [id, node] of result.nodes) {
+      if (!node.parent) continue
+      const parent = result.subgraphs.get(node.parent)
+      if (!parent?.bounds) continue
+      const r = nodeRect(node)
+      if (!r) continue
+      const inside =
+        r.x >= parent.bounds.x &&
+        r.x + r.width <= parent.bounds.x + parent.bounds.width &&
+        r.y >= parent.bounds.y &&
+        r.y + r.height <= parent.bounds.y + parent.bounds.height
+      if (!inside) offenders.push({ node: id, parent: node.parent })
+    }
+    expect(offenders).toEqual([])
+  })
+
+  test('no node spatially overlaps a subgraph it does not belong to', async () => {
+    const graph = await parseSample()
+    const result = autoLayoutFlatTree(graph, createEngine())
+    const offenders: Array<{ node: string; subgraph: string }> = []
+    for (const [nodeId, node] of result.nodes) {
+      const r = nodeRect(node)
+      if (!r) continue
+      for (const [sgId, sg] of result.subgraphs) {
+        if (!sg.bounds) continue
+        // Skip the node's own ancestor chain.
+        if (isAncestorSubgraph(sgId, node.parent, result.subgraphs)) continue
+        if (rectsOverlap(r, sg.bounds)) offenders.push({ node: nodeId, subgraph: sgId })
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})
+
+function isAncestorSubgraph(
+  candidate: string,
+  startFrom: string | undefined,
+  subgraphs: Map<string, { parent?: string }>,
+): boolean {
+  let cur = startFrom
+  while (cur) {
+    if (cur === candidate) return true
+    cur = subgraphs.get(cur)?.parent
+  }
+  return false
+}

--- a/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.ts
+++ b/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.ts
@@ -267,6 +267,16 @@ export function autoLayoutFlatTree(
 
   applyFixedOverride(nodes, ports, subgraphs, opts.fixed, graph.nodes)
 
+  // 5b. Final safety pass — recompute subgraph hulls from
+  // children, resolve sibling-subgraph overlaps via the engine,
+  // and push free nodes away from subgraphs they don't belong
+  // to. The flat-tree's own block-sizing should already satisfy
+  // invariant 2 (sibling hulls disjoint), but it currently
+  // leaks overlaps on real samples; we rely on the engine's
+  // collision resolver as the authoritative final check so
+  // layout output never violates the contract.
+  rebalanceSubgraphs(nodes, subgraphs, ports)
+
   // 6. Bounds with comfortable margin.
   const pad = 50
   const rb = result.rootBounds

--- a/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.ts
+++ b/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.ts
@@ -280,6 +280,7 @@ export function autoLayoutFlatTree(
   rebalanceSubgraphs(nodes, subgraphs, ports, {
     subgraphPadding: opts.subgraphPadding,
     subgraphLabelHeight: opts.subgraphLabelHeight,
+    direction: opts.direction,
   })
 
   // 6. Bounds with comfortable margin. Recompute from the

--- a/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.ts
+++ b/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.ts
@@ -274,21 +274,59 @@ export function autoLayoutFlatTree(
   // invariant 2 (sibling hulls disjoint), but it currently
   // leaks overlaps on real samples; we rely on the engine's
   // collision resolver as the authoritative final check so
-  // layout output never violates the contract.
-  rebalanceSubgraphs(nodes, subgraphs, ports)
+  // layout output never violates the contract. Pass through the
+  // caller-supplied subgraph spacing so the rebalance honours
+  // it instead of falling back to the interaction defaults.
+  rebalanceSubgraphs(nodes, subgraphs, ports, {
+    subgraphPadding: opts.subgraphPadding,
+    subgraphLabelHeight: opts.subgraphLabelHeight,
+  })
 
-  // 6. Bounds with comfortable margin.
-  const pad = 50
-  const rb = result.rootBounds
-  const bounds: Bounds =
-    rb.width === 0 && rb.height === 0
-      ? { x: 0, y: 0, width: 400, height: 300 }
-      : {
-          x: rb.x - pad,
-          y: rb.y - pad,
-          width: rb.width + pad * 2,
-          height: rb.height + pad * 2,
-        }
+  // 6. Bounds with comfortable margin. Recompute from the
+  // post-rebalance state — `result.rootBounds` describes the
+  // pre-rebalance layout, so any shift from 5b would otherwise
+  // leave shifted entities outside the returned bounds.
+  const bounds = computeBounds(nodes, subgraphs)
 
   return { nodes, ports, subgraphs, bounds }
+}
+
+/**
+ * Tight bbox over every positioned node + every subgraph
+ * hull, expanded by a comfortable margin so the caller's
+ * viewport doesn't clip the outermost elements.
+ */
+function computeBounds(nodes: Map<string, Node>, subgraphs: Map<string, Subgraph>): Bounds {
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  let any = false
+  for (const n of nodes.values()) {
+    if (!n.position) continue
+    const size = n.size ?? { width: 0, height: 0 }
+    const hw = size.width / 2
+    const hh = size.height / 2
+    minX = Math.min(minX, n.position.x - hw)
+    minY = Math.min(minY, n.position.y - hh)
+    maxX = Math.max(maxX, n.position.x + hw)
+    maxY = Math.max(maxY, n.position.y + hh)
+    any = true
+  }
+  for (const sg of subgraphs.values()) {
+    if (!sg.bounds) continue
+    minX = Math.min(minX, sg.bounds.x)
+    minY = Math.min(minY, sg.bounds.y)
+    maxX = Math.max(maxX, sg.bounds.x + sg.bounds.width)
+    maxY = Math.max(maxY, sg.bounds.y + sg.bounds.height)
+    any = true
+  }
+  if (!any) return { x: 0, y: 0, width: 400, height: 300 }
+  const pad = 50
+  return {
+    x: minX - pad,
+    y: minY - pad,
+    width: maxX - minX + pad * 2,
+    height: maxY - minY + pad * 2,
+  }
 }

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -228,7 +228,10 @@ export function rebalanceSubgraphs(
   nodes: Map<string, Node>,
   subgraphs: Map<string, Subgraph>,
   ports: Map<string, ResolvedPort>,
+  opts: { subgraphPadding?: number; subgraphLabelHeight?: number } = {},
 ): void {
+  const padding = opts.subgraphPadding ?? SUBGRAPH_PADDING
+  const labelHeight = opts.subgraphLabelHeight ?? SUBGRAPH_LABEL_HEIGHT
   // Build depth map
   const depthOf = (sgId: string, visited = new Set<string>()): number => {
     if (visited.has(sgId)) return 0
@@ -280,10 +283,10 @@ export function rebalanceSubgraphs(
     subgraphs.set(sgId, {
       ...sg,
       bounds: {
-        x: minX - SUBGRAPH_PADDING,
-        y: minY - SUBGRAPH_PADDING - SUBGRAPH_LABEL_HEIGHT,
-        width: maxX - minX + SUBGRAPH_PADDING * 2,
-        height: maxY - minY + SUBGRAPH_PADDING * 2 + SUBGRAPH_LABEL_HEIGHT,
+        x: minX - padding,
+        y: minY - padding - labelHeight,
+        width: maxX - minX + padding * 2,
+        height: maxY - minY + padding * 2 + labelHeight,
       },
     })
   }

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -336,70 +336,93 @@ export function rebalanceSubgraphs(
     }
   }
 
-  recomputeHulls()
+  /**
+   * Sibling-subgraph collision pass. Shallowest-first so a
+   * shift at level N propagates correctly to deeper checks.
+   * Returns true iff anything moved.
+   */
+  const resolveSiblingCollisions = (): boolean => {
+    let moved = false
+    for (const sgId of [...sorted].reverse()) {
+      const sg = subgraphs.get(sgId)
+      if (!sg?.bounds) continue
+      const parentId = sg.parent
 
-  // Second pass: resolve sibling collisions (shallowest first = reverse order)
-  // Using shallowest-first so parent-level collisions are resolved before children
-  for (const sgId of [...sorted].reverse()) {
-    // Re-fetch from map (may have been shifted by earlier iterations)
-    const sg = subgraphs.get(sgId)
-    if (!sg?.bounds) continue
-    const parentId = sg.parent
+      for (const [otherId] of subgraphs) {
+        if (otherId === sgId) continue
+        const other = subgraphs.get(otherId)
+        if (!other?.bounds || other.parent !== parentId) continue
 
-    for (const [otherId] of subgraphs) {
-      if (otherId === sgId) continue
-      const other = subgraphs.get(otherId)
-      if (!other?.bounds || other.parent !== parentId) continue
+        const a = boundsToRect(sg.bounds)
+        const b = boundsToRect(other.bounds)
+        const resolved = defaultEngine().resolveAgainstObstacles(b, [a], DEFAULT_NODE_GAP)
+        const dx = resolved.x - b.x
+        const dy = resolved.y - b.y
+        if (dx === 0 && dy === 0) continue
 
-      const a = boundsToRect(sg.bounds)
-      const b = boundsToRect(other.bounds)
-      // resolveAgainstObstacles returns the input unchanged
-      // when no overlap, so a separate nodesOverlap guard
-      // is unnecessary.
-      const resolved = defaultEngine().resolveAgainstObstacles(b, [a], DEFAULT_NODE_GAP)
-      const dx = resolved.x - b.x
-      const dy = resolved.y - b.y
-      if (dx === 0 && dy === 0) continue
-
-      subgraphs.set(otherId, {
-        ...other,
-        bounds: { ...other.bounds, x: other.bounds.x + dx, y: other.bounds.y + dy },
-      })
-      shiftContents(otherId, dx, dy, nodes, subgraphs, ports)
-    }
-  }
-
-  // Third pass: push free nodes away from subgraphs they don't belong to
-  for (const [nodeId, node] of nodes) {
-    if (!node.position) continue
-    const size = resolveNodeSize(node)
-    const obstacles = collectObstacles(nodeId, node.parent, nodes, subgraphs)
-    const resolved = resolvePosition(
-      { x: node.position.x, y: node.position.y, w: size.width, h: size.height },
-      obstacles,
-    )
-    if (resolved.x !== node.position.x || resolved.y !== node.position.y) {
-      const dx = resolved.x - node.position.x
-      const dy = resolved.y - node.position.y
-      nodes.set(nodeId, { ...node, position: resolved })
-      // Shift ports
-      for (const [portId, port] of ports) {
-        if (port.nodeId !== nodeId) continue
-        ports.set(portId, {
-          ...port,
-          absolutePosition: { x: port.absolutePosition.x + dx, y: port.absolutePosition.y + dy },
+        subgraphs.set(otherId, {
+          ...other,
+          bounds: { ...other.bounds, x: other.bounds.x + dx, y: other.bounds.y + dy },
         })
+        shiftContents(otherId, dx, dy, nodes, subgraphs, ports)
+        moved = true
       }
     }
+    return moved
   }
 
-  // Final containment safety: pass 2 (subgraph shifts) and
-  // pass 3 (free-node shifts) both mutate child positions
-  // after the initial bottom-up hull pass, so the bounds
-  // recorded above may no longer cover their children. Run
-  // the hull recompute once more so the returned subgraph
-  // bounds always contain their members. O(N+S) — cheap
-  // compared to either pass it follows.
+  /**
+   * Push free nodes away from subgraphs they don't belong to.
+   * Returns true iff anything moved.
+   */
+  const pushFreeNodes = (): boolean => {
+    let moved = false
+    for (const [nodeId, node] of nodes) {
+      if (!node.position) continue
+      const size = resolveNodeSize(node)
+      const obstacles = collectObstacles(nodeId, node.parent, nodes, subgraphs)
+      const resolved = resolvePosition(
+        { x: node.position.x, y: node.position.y, w: size.width, h: size.height },
+        obstacles,
+      )
+      if (resolved.x !== node.position.x || resolved.y !== node.position.y) {
+        const dx = resolved.x - node.position.x
+        const dy = resolved.y - node.position.y
+        nodes.set(nodeId, { ...node, position: resolved })
+        moved = true
+        for (const [portId, port] of ports) {
+          if (port.nodeId !== nodeId) continue
+          ports.set(portId, {
+            ...port,
+            absolutePosition: {
+              x: port.absolutePosition.x + dx,
+              y: port.absolutePosition.y + dy,
+            },
+          })
+        }
+      }
+    }
+    return moved
+  }
+
+  // Iterate until the layout stabilises. Each round:
+  //   1. recompute hulls (bottom-up)
+  //   2. resolve subgraph sibling collisions
+  //   3. push free nodes away from foreign subgraphs
+  // Either mutation can invalidate the other (e.g. shifting a
+  // deep child grows its parent, which may now collide with the
+  // parent's own sibling). The cap is intentionally low — for
+  // shumoku-typical nesting depth ≤3 the layout converges
+  // within 2–3 rounds; anything beyond suggests pathological
+  // input we'd rather degrade than spin on.
+  const MAX_ROUNDS = 5
+  for (let round = 0; round < MAX_ROUNDS; round++) {
+    recomputeHulls()
+    const a = resolveSiblingCollisions()
+    const b = pushFreeNodes()
+    if (!a && !b) break
+  }
+  // Final recompute so the hulls reflect the post-converge state.
   recomputeHulls()
 }
 

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -228,10 +228,20 @@ export function rebalanceSubgraphs(
   nodes: Map<string, Node>,
   subgraphs: Map<string, Subgraph>,
   ports: Map<string, ResolvedPort>,
-  opts: { subgraphPadding?: number; subgraphLabelHeight?: number } = {},
+  opts: {
+    subgraphPadding?: number
+    subgraphLabelHeight?: number
+    /**
+     * Layout direction. Decides which side the subgraph label
+     * band sits on: TB → top, BT → bottom, LR → left, RL →
+     * right. Defaults to 'TB' (the manual-placement convention).
+     */
+    direction?: 'TB' | 'BT' | 'LR' | 'RL'
+  } = {},
 ): void {
   const padding = opts.subgraphPadding ?? SUBGRAPH_PADDING
   const labelHeight = opts.subgraphLabelHeight ?? SUBGRAPH_LABEL_HEIGHT
+  const direction = opts.direction ?? 'TB'
   // Build depth map
   const depthOf = (sgId: string, visited = new Set<string>()): number => {
     if (visited.has(sgId)) return 0
@@ -280,15 +290,43 @@ export function rebalanceSubgraphs(
 
     if (!hasChildren) continue
 
-    subgraphs.set(sgId, {
-      ...sg,
-      bounds: {
-        x: minX - padding,
-        y: minY - padding - labelHeight,
-        width: maxX - minX + padding * 2,
-        height: maxY - minY + padding * 2 + labelHeight,
-      },
-    })
+    // Direction decides which side gets the label-band offset.
+    // TB → above children; BT → below; LR → left; RL → right.
+    let bounds: { x: number; y: number; width: number; height: number }
+    switch (direction) {
+      case 'BT':
+        bounds = {
+          x: minX - padding,
+          y: minY - padding,
+          width: maxX - minX + padding * 2,
+          height: maxY - minY + padding * 2 + labelHeight,
+        }
+        break
+      case 'LR':
+        bounds = {
+          x: minX - padding - labelHeight,
+          y: minY - padding,
+          width: maxX - minX + padding * 2 + labelHeight,
+          height: maxY - minY + padding * 2,
+        }
+        break
+      case 'RL':
+        bounds = {
+          x: minX - padding,
+          y: minY - padding,
+          width: maxX - minX + padding * 2 + labelHeight,
+          height: maxY - minY + padding * 2,
+        }
+        break
+      default:
+        bounds = {
+          x: minX - padding,
+          y: minY - padding - labelHeight,
+          width: maxX - minX + padding * 2,
+          height: maxY - minY + padding * 2 + labelHeight,
+        }
+    }
+    subgraphs.set(sgId, { ...sg, bounds })
   }
 
   // Second pass: resolve sibling collisions (shallowest first = reverse order)

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -370,7 +370,6 @@ export function rebalanceSubgraphs(
   }
 
   // Third pass: push free nodes away from subgraphs they don't belong to
-  let anyNodeMoved = false
   for (const [nodeId, node] of nodes) {
     if (!node.position) continue
     const size = resolveNodeSize(node)
@@ -383,7 +382,6 @@ export function rebalanceSubgraphs(
       const dx = resolved.x - node.position.x
       const dy = resolved.y - node.position.y
       nodes.set(nodeId, { ...node, position: resolved })
-      anyNodeMoved = true
       // Shift ports
       for (const [portId, port] of ports) {
         if (port.nodeId !== nodeId) continue
@@ -395,12 +393,14 @@ export function rebalanceSubgraphs(
     }
   }
 
-  // Pass 3 may have moved a node belonging to a subgraph (push
-  // it out of a sibling's hull, etc.). The parent subgraph's
-  // bounds computed in pass 1 are now stale, so re-run the
-  // bottom-up hull recompute to restore the containment
-  // contract.
-  if (anyNodeMoved) recomputeHulls()
+  // Final containment safety: pass 2 (subgraph shifts) and
+  // pass 3 (free-node shifts) both mutate child positions
+  // after the initial bottom-up hull pass, so the bounds
+  // recorded above may no longer cover their children. Run
+  // the hull recompute once more so the returned subgraph
+  // bounds always contain their members. O(N+S) — cheap
+  // compared to either pass it follows.
+  recomputeHulls()
 }
 
 export async function moveNode(

--- a/libs/@shumoku/core/src/layout/interaction.ts
+++ b/libs/@shumoku/core/src/layout/interaction.ts
@@ -254,80 +254,89 @@ export function rebalanceSubgraphs(
   // Sort subgraphs deepest-first
   const sorted = [...subgraphs.keys()].sort((a, b) => depthOf(b) - depthOf(a))
 
-  // Bottom-up pass: recompute bounds, then resolve sibling collisions
-  for (const sgId of sorted) {
-    const sg = subgraphs.get(sgId)
-    if (!sg) continue
+  /**
+   * Bottom-up hull recompute: each subgraph's bounds are the
+   * tight bbox of its positioned children + padding + a label
+   * band offset placed per `direction`. Factored out so we can
+   * run it once initially and again after pass 3 in case
+   * pushing free nodes shifted any subgraph's children.
+   */
+  const recomputeHulls = () => {
+    for (const sgId of sorted) {
+      const sg = subgraphs.get(sgId)
+      if (!sg) continue
 
-    // Recompute bounds from children (nodes + child subgraphs)
-    let minX = Number.POSITIVE_INFINITY
-    let minY = Number.POSITIVE_INFINITY
-    let maxX = Number.NEGATIVE_INFINITY
-    let maxY = Number.NEGATIVE_INFINITY
-    let hasChildren = false
+      let minX = Number.POSITIVE_INFINITY
+      let minY = Number.POSITIVE_INFINITY
+      let maxX = Number.NEGATIVE_INFINITY
+      let maxY = Number.NEGATIVE_INFINITY
+      let hasChildren = false
 
-    for (const n of nodes.values()) {
-      if (n.parent !== sgId) continue
-      if (!n.position) continue
-      hasChildren = true
-      const size = resolveNodeSize(n)
-      const hw = size.width / 2
-      const hh = size.height / 2
-      minX = Math.min(minX, n.position.x - hw)
-      minY = Math.min(minY, n.position.y - hh)
-      maxX = Math.max(maxX, n.position.x + hw)
-      maxY = Math.max(maxY, n.position.y + hh)
+      for (const n of nodes.values()) {
+        if (n.parent !== sgId) continue
+        if (!n.position) continue
+        hasChildren = true
+        const size = resolveNodeSize(n)
+        const hw = size.width / 2
+        const hh = size.height / 2
+        minX = Math.min(minX, n.position.x - hw)
+        minY = Math.min(minY, n.position.y - hh)
+        maxX = Math.max(maxX, n.position.x + hw)
+        maxY = Math.max(maxY, n.position.y + hh)
+      }
+      for (const child of subgraphs.values()) {
+        if (child.parent !== sgId) continue
+        if (!child.bounds) continue
+        hasChildren = true
+        minX = Math.min(minX, child.bounds.x)
+        minY = Math.min(minY, child.bounds.y)
+        maxX = Math.max(maxX, child.bounds.x + child.bounds.width)
+        maxY = Math.max(maxY, child.bounds.y + child.bounds.height)
+      }
+
+      if (!hasChildren) continue
+
+      // Direction decides which side gets the label-band offset.
+      // TB → above children; BT → below; LR → left; RL → right.
+      let bounds: { x: number; y: number; width: number; height: number }
+      switch (direction) {
+        case 'BT':
+          bounds = {
+            x: minX - padding,
+            y: minY - padding,
+            width: maxX - minX + padding * 2,
+            height: maxY - minY + padding * 2 + labelHeight,
+          }
+          break
+        case 'LR':
+          bounds = {
+            x: minX - padding - labelHeight,
+            y: minY - padding,
+            width: maxX - minX + padding * 2 + labelHeight,
+            height: maxY - minY + padding * 2,
+          }
+          break
+        case 'RL':
+          bounds = {
+            x: minX - padding,
+            y: minY - padding,
+            width: maxX - minX + padding * 2 + labelHeight,
+            height: maxY - minY + padding * 2,
+          }
+          break
+        default:
+          bounds = {
+            x: minX - padding,
+            y: minY - padding - labelHeight,
+            width: maxX - minX + padding * 2,
+            height: maxY - minY + padding * 2 + labelHeight,
+          }
+      }
+      subgraphs.set(sgId, { ...sg, bounds })
     }
-    for (const child of subgraphs.values()) {
-      if (child.parent !== sgId) continue
-      if (!child.bounds) continue
-      hasChildren = true
-      minX = Math.min(minX, child.bounds.x)
-      minY = Math.min(minY, child.bounds.y)
-      maxX = Math.max(maxX, child.bounds.x + child.bounds.width)
-      maxY = Math.max(maxY, child.bounds.y + child.bounds.height)
-    }
-
-    if (!hasChildren) continue
-
-    // Direction decides which side gets the label-band offset.
-    // TB → above children; BT → below; LR → left; RL → right.
-    let bounds: { x: number; y: number; width: number; height: number }
-    switch (direction) {
-      case 'BT':
-        bounds = {
-          x: minX - padding,
-          y: minY - padding,
-          width: maxX - minX + padding * 2,
-          height: maxY - minY + padding * 2 + labelHeight,
-        }
-        break
-      case 'LR':
-        bounds = {
-          x: minX - padding - labelHeight,
-          y: minY - padding,
-          width: maxX - minX + padding * 2 + labelHeight,
-          height: maxY - minY + padding * 2,
-        }
-        break
-      case 'RL':
-        bounds = {
-          x: minX - padding,
-          y: minY - padding,
-          width: maxX - minX + padding * 2 + labelHeight,
-          height: maxY - minY + padding * 2,
-        }
-        break
-      default:
-        bounds = {
-          x: minX - padding,
-          y: minY - padding - labelHeight,
-          width: maxX - minX + padding * 2,
-          height: maxY - minY + padding * 2 + labelHeight,
-        }
-    }
-    subgraphs.set(sgId, { ...sg, bounds })
   }
+
+  recomputeHulls()
 
   // Second pass: resolve sibling collisions (shallowest first = reverse order)
   // Using shallowest-first so parent-level collisions are resolved before children
@@ -361,6 +370,7 @@ export function rebalanceSubgraphs(
   }
 
   // Third pass: push free nodes away from subgraphs they don't belong to
+  let anyNodeMoved = false
   for (const [nodeId, node] of nodes) {
     if (!node.position) continue
     const size = resolveNodeSize(node)
@@ -373,6 +383,7 @@ export function rebalanceSubgraphs(
       const dx = resolved.x - node.position.x
       const dy = resolved.y - node.position.y
       nodes.set(nodeId, { ...node, position: resolved })
+      anyNodeMoved = true
       // Shift ports
       for (const [portId, port] of ports) {
         if (port.nodeId !== nodeId) continue
@@ -383,6 +394,13 @@ export function rebalanceSubgraphs(
       }
     }
   }
+
+  // Pass 3 may have moved a node belonging to a subgraph (push
+  // it out of a sibling's hull, etc.). The parent subgraph's
+  // bounds computed in pass 1 are now stale, so re-run the
+  // bottom-up hull recompute to restore the containment
+  // contract.
+  if (anyNodeMoved) recomputeHulls()
 }
 
 export async function moveNode(


### PR DESCRIPTION
## Summary
Sample 図で auto-layout が `cloud × perimeter/edge` / `dmz × campus` のサブグラフ重なり、および隣接サブグラフ bounds 内へのノードはみ出しを生んでいた。README invariant 2 ('sibling subgraph hulls do not overlap') が実際は破られている状態。

修正は **最小変更で contract enforcement を強化**:
- 既存の `rebalanceSubgraphs` を fixed-override 経路だけでなく **常に** auto-layout の最終パスで呼ぶ (a017def)
- `rebalanceSubgraphs` の bug 群を解消 (Codex 4回レビューで段階的に):
  - caller の `subgraphPadding` / `subgraphLabelHeight` を尊重 (9ff688b)
  - `result.rootBounds` を post-rebalance 状態から再計算 (9ff688b)
  - direction-aware な label-band 配置 (BT/LR/RL) (b3c8169)
  - pass 3 でのノード移動後に hull 再計算 (a790b3d)
  - 全 collision pass 後に最終 hull 再計算 (ba37cdb)
  - 衝突→hull 拡張→新衝突の連鎖を収束イテレーションで解決 (64432bc)
- 設計補強 (8507a9a):
  - `layout-engine-architecture.md` に constraint taxonomy 表を追加 — 新制約追加時の判断コストを下げる
  - sampleNetwork ベースの 3 つの invariant test 追加 — contract 逆行を CI で検知

## Why this pattern
ユーザーとの議論で、自動配置をエンジンに完全に依存させる必要はなく、'**アルゴリズムが初期配置 → エンジンの resolver が contract enforcer**' という構造が最適点と確認。Buchheim の美観を保ちつつ、不変条件は engine 経由で保証。新 LayoutConstraints 層は今回見送り (Codex の review 結論: 抽象化材料不足 + 既存3層で 80% カバー)。

## Test plan
- [x] core unit tests 173 → 176 passing (+3 sampleNetwork invariants)
- [x] full build 17 packages green
- [x] lefthook (biome / typecheck) green
- [x] ブラウザで sample auto-arrange → DOM 検証で sg-sg / sg-node / nn 重なり全て 0
- [x] Codex review 4 ラウンド → P2 指摘全消化
- [ ] **目視で 1000ノード級は未確認** — sampleNetwork (20 nodes / 9 subgraphs) は OK、スケール検証は次の話

## Notes for reviewers
- 個別 commit を残して経緯を追えるようにしてあります (squash 推奨)
- `rebalanceSubgraphs` は手動 (`moveNode`) からも呼ばれる。direction は default 'TB' で pre-PR の挙動を維持。非 TB の手動 drag 問題は pre-existing で本 PR の scope 外

🤖 Generated with [Claude Code](https://claude.com/claude-code)