### PR TITLE
docs(design): lock in architectural invariants

### DIFF
--- a/apps/editor/docs/design/data-model.md
+++ b/apps/editor/docs/design/data-model.md
@@ -208,7 +208,7 @@ classDiagram
   }
 
   class NetedProject {
-    version: 2
+    version: 1
     name: string
     products: Product[]
     diagram: NetworkGraph
@@ -328,7 +328,7 @@ snapshot のおかげで、Product を消した後も diagram は読める（壊
 
 ```ts
 interface NetedProject {
-  version: 2
+  version: 1
   name: string
   settings?: Record<string, unknown>
   products: Product[]
@@ -336,7 +336,19 @@ interface NetedProject {
 }
 ```
 
-Product は kind 毎の discriminated union。version=2 で確定。
+Product は kind 毎の discriminated union。version=1 で運用中。
+
+### 5.1 シリアライゼーションの規律
+
+`NetworkGraph` / `Product` などのデータ構造はファイル経由でユーザーの手元に残るので、進化させる際は以下の規律を守る:
+
+1. **新フィールドは optional のみ追加**。既存ファイルが新コードで開ける状態を保つ。
+2. **既存フィールドの rename / remove は禁止**（major version 内では）。値の解釈を変えるのも禁止。意味を変えたい時は新フィールドを追加して、旧フィールドは deprecated comment 付きで残す。
+3. **真に breaking な change が必要になったら、`version` を bump**。`NetedProject.version: 1 → 2` で reader を切り替え。旧版は read-only サポート or migration を提供。Docker Compose の v1/v2/v3 反省を踏まえ、bump は**極力避ける** — additive で済むなら version は据え置く。
+
+要するに `version` フィールドは「破壊的変更の保険」であって、軽い気持ちで bump しない。ほとんどの進化は additive で済むはずで、それが破綻した時に初めて version を動かす。
+
+なお、現状の `exportGraph()` は known fields のみから出力を再構成する作りなので、未知フィールドが付いたファイルを開いて再保存すると未知フィールドは drop される。「unknown を round-trip 保持する」という強い保証は今は約束していない — 必要になった時点で export 経路を保持型に改める判断とする。
 
 ---
 

--- a/apps/editor/docs/design/layout-engine-architecture.md
+++ b/apps/editor/docs/design/layout-engine-architecture.md
@@ -372,6 +372,65 @@ Listed in expected order of usefulness; not part of this PR.
 
 5. **Diagnostics drive layout debugging**: when a snapshot looks wrong, the engine reports which rule was at play.
 
+## Architectural invariants
+
+A few invariants are easy to violate by accident and expensive
+to recover from once code accumulates around the violation.
+List them here so future contributors don't have to rediscover
+them.
+
+### Coordinate convention
+
+Rotation to a user-requested direction (`BT` / `LR` / `RL`)
+happens at exactly **one place**: the end of
+`autoLayoutFlatTree` (via `rotateLayoutResult`). Everything
+else is direction-agnostic in different senses:
+
+- **Rule queries** (`nodeFootprint`, `minSeparation`,
+  `subgraphPadding`, `engine.text.measure`, …) return values
+  that are coordinate-frame independent. They don't take or
+  return direction-aware results.
+- **Placement primitives** (`tryPlace`, `resolveAgainstObstacles`,
+  …) operate in whatever coordinate frame the caller passes
+  in. Auto-placement calls them with TB-internal coords;
+  manual placement calls them with post-rotation canvas
+  coords (saved bounds already describe the final
+  orientation).
+- **Auto-placement algorithms** compute positions in TB-internal
+  coords, then rotate once at the end. No direction logic
+  inside inner passes (block partition, tidy-tree, etc.).
+- **`rebalanceSubgraphs`** takes an explicit `direction` arg
+  because it's called after rotation — it has to place the
+  label band on the correct edge of the rotated hull
+  (`TB → top`, `BT → bottom`, `LR → left`, `RL → right`).
+  Manual placement defaults to `'TB'` since the saved bounds
+  already describe the final orientation.
+
+The "one rotation, at the boundary" rule keeps every internal
+algorithm direction-agnostic. Don't introduce direction logic
+inside rule queries or inner algorithm passes; don't pre-
+transform drag coordinates before calling placement primitives
+(they're frame-agnostic).
+
+### Engine ↔ algorithm contract boundary
+
+The engine is a passive rule authority. What it provides and
+what it deliberately doesn't:
+
+| Engine provides | Engine does NOT provide |
+|---|---|
+| Node sizing (`nodeBodySize`, `nodeFootprint`) | Layout algorithm (Buchheim, force-directed, …) |
+| Spacing values (`minSeparation`, `spacing`, `subgraphPadding`) | Port-side decision (algorithm-coupled) |
+| Obstacle / placement primitives (`tryPlace`, `resolveAgainstObstacles`) | Edge routing (separate post-layout pass) |
+| Text measurement (`engine.text.measure`) | Direction / rotation logic |
+| Subgraph hull arithmetic (`subgraphLabelHeight`) | Tree / graph structure analysis (parent extraction, block partitioning) |
+
+When tempted to add something to the engine, check the right
+column first. The engine grows surface area easily; algorithm-
+coupled concepts belong next to the algorithm so a future
+second algorithm (rack layout, etc.) doesn't have to share
+the engine's flat-tree-specific scaffolding.
+
 ## Adding a new constraint
 
 When the layout grows a new constraint (a new gap value, a "must


### PR DESCRIPTION
## Summary
3つのドキュメント追加で「今やれば数十行、後だと外部影響あり」な不変条件を文書化。コード変更なし。

### 1. シリアライゼーションの規律 (`data-model.md §5.1`)
- 新フィールドは optional のみ
- rename/remove 禁止
- breaking change が必要になったら `NetedProject.version` を bump (Docker Compose の v1/v2/v3 反省を踏まえ極力避ける)
- 既存のクラス図/ファイル形式に書かれていた `version: 2` を実装の `version: 1` に修正

### 2. Coordinate convention (`layout-engine-architecture.md`)
- 回転は1箇所 (`autoLayoutFlatTree` 末尾) のみ
- Rule queries は coord-frame agnostic
- Placement primitives は caller の座標系で動作
- `rebalanceSubgraphs` のみ direction を取る（rotation 後に呼ばれるため）

### 3. Engine ↔ Algorithm 契約境界 (`layout-engine-architecture.md`)
- engine が提供するもの / 提供しないもの の対比表
- 「algorithm-coupled な概念は engine に入れない」を明文化、将来の第二アルゴリズム導入時に flat-tree 固有の足場を共有しない

## Why now
1.0 前のうちに固定しておかないと、外部 consumer や保存済みファイルが増えてから変えるのが破壊的になるカテゴリ。実コードはすでにこの不変条件で動いているので、文書化は現状の "暗黙のルール" を明示するだけ。

## Test plan
- [x] Codex review 4 ラウンド → 全指摘解消、最終 LGTM
- [x] lefthook (該当ファイルなしで skip)
- [x] 既存実装との整合性チェック (version=1, rotation 1 箇所, rebalance direction-aware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)