### PR TITLE
fix(server/web): keep stores in sync with mutations + react to route id changes

### DIFF
--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -60,7 +60,6 @@
     MagnifyingGlassMinusIcon,
     MagnifyingGlassPlusIcon,
   } from 'phosphor-svelte'
-  import { onDestroy, onMount } from 'svelte'
   import { api } from '$lib/api'
   import {
     HighlightOverlay,
@@ -162,6 +161,10 @@
 
   export function getGraph(): NetworkGraph | undefined {
     return graph
+  }
+
+  export async function refreshGraph(): Promise<void> {
+    await loadGraph()
   }
 
   export function panToNode(nodeId: string): void {
@@ -299,18 +302,24 @@
       .replace(/"/g, '&quot;')
   }
 
-  // --- Live metrics subscription ---
+  // --- Data loading: re-fetch when topologyId changes (component reused on
+  // same-route navigation) ---
 
-  onMount(async () => {
-    await loadGraph()
-    if (!readOnly && $liveUpdatesEnabled && topologyId) {
-      metricsStore.connect()
-      metricsStore.subscribeToTopology(topologyId)
-    }
+  $effect(() => {
+    // Track topologyId so the effect re-runs when the route id changes.
+    topologyId
+    loadGraph()
   })
 
-  onDestroy(() => {
-    if (!readOnly) metricsStore.unsubscribe()
+  // --- Live metrics subscription ---
+
+  $effect(() => {
+    if (readOnly || !$liveUpdatesEnabled || !topologyId) return
+    metricsStore.connect()
+    metricsStore.subscribeToTopology(topologyId)
+    return () => {
+      metricsStore.unsubscribe()
+    }
   })
 
   // --- Keyboard shortcut for search palette ---

--- a/apps/server/web/src/lib/components/TopologySettings.svelte
+++ b/apps/server/web/src/lib/components/TopologySettings.svelte
@@ -10,6 +10,7 @@
     metricsConnected,
     showNodeStatus,
     showTrafficFlow,
+    topologies,
   } from '$lib/stores'
   import type { MetricsMapping, Topology, TopologyDataSource } from '$lib/types'
 
@@ -54,7 +55,7 @@
       } else {
         delete graph.settings.splineMode
       }
-      const updatedTopology = await api.topologies.update(topology.id, {
+      const updatedTopology = await topologies.update(topology.id, {
         contentJson: JSON.stringify(graph),
       })
       if (updatedTopology && onUpdated) {
@@ -105,7 +106,7 @@
     }
     deleting = true
     try {
-      await api.topologies.delete(topology.id)
+      await topologies.delete(topology.id)
       if (onDeleted) {
         onDeleted()
       } else {

--- a/apps/server/web/src/lib/components/header.svelte
+++ b/apps/server/web/src/lib/components/header.svelte
@@ -48,7 +48,7 @@
     },
   )
 
-  $: breadcrumbs = generateBreadcrumbs($page.url.pathname, $idLabels)
+  const breadcrumbs = $derived(generateBreadcrumbs($page.url.pathname, $idLabels))
 
   function generateBreadcrumbs(pathname: string, labels: Record<string, string>): Breadcrumb[] {
     const parts = pathname.split('/').filter(Boolean)

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -19,6 +19,7 @@
 import { derived, get, writable } from 'svelte/store'
 import { api } from '$lib/api'
 import { NODE_MATCH_THRESHOLD, nodeNameMatchScore } from '$lib/auto-mapping'
+import { topologies } from '$lib/stores/topologies'
 import type { Host, HostItem, MetricsMapping, Topology, TopologyDataSource } from '$lib/types'
 
 /**
@@ -229,9 +230,13 @@ function createMappingStore() {
 
       // Save to backend
       try {
-        await api.topologies.updateNodeMapping(current.topologyId, nodeId, hostMapping)
+        const result = await api.topologies.updateNodeMapping(
+          current.topologyId,
+          nodeId,
+          hostMapping,
+        )
+        topologies.upsert(result.topology)
       } catch (e) {
-        // Revert on error
         update((s) => ({
           ...s,
           error: e instanceof Error ? e.message : 'Failed to save mapping',
@@ -328,7 +333,8 @@ function createMappingStore() {
       if (!current.topologyId) return
 
       try {
-        await api.topologies.updateMapping(current.topologyId, current.mapping)
+        const updated = await api.topologies.updateMapping(current.topologyId, current.mapping)
+        topologies.upsert(updated)
       } catch (e) {
         update((s) => ({
           ...s,

--- a/apps/server/web/src/lib/stores/topologies.ts
+++ b/apps/server/web/src/lib/stores/topologies.ts
@@ -20,6 +20,25 @@ function createTopologiesStore() {
     error: null,
   })
 
+  async function applyShareToken(id: string, shareToken: string | undefined): Promise<Topology> {
+    let updated: Topology | undefined
+    update((s) => ({
+      ...s,
+      items: s.items.map((t) => {
+        if (t.id !== id) return t
+        updated = { ...t, shareToken }
+        return updated
+      }),
+    }))
+    if (updated) return updated
+    // Item wasn't cached — fetch fresh, then ensure the just-applied shareToken
+    // wins over whatever GET happened to return.
+    const fetched = await api.topologies.get(id)
+    const merged = { ...fetched, shareToken }
+    update((s) => ({ ...s, items: [merged, ...s.items.filter((t) => t.id !== id)] }))
+    return merged
+  }
+
   return {
     subscribe,
 
@@ -79,6 +98,16 @@ function createTopologiesStore() {
         items: s.items.map((t) => (t.id === id ? topology : t)),
       }))
       return topology
+    },
+
+    async share(id: string): Promise<Topology> {
+      const result = await api.topologies.share(id)
+      return applyShareToken(id, result.shareToken)
+    },
+
+    async unshare(id: string): Promise<Topology> {
+      await api.topologies.unshare(id)
+      return applyShareToken(id, undefined)
     },
 
     async renderSvg(id: string) {

--- a/apps/server/web/src/routes/(app)/dashboards/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/dashboards/[id]/+page.svelte
@@ -42,11 +42,9 @@
   let mountedComponents = new Map<string, ReturnType<typeof mount>>()
   let gridStackReady = false
 
-  // Initialize on mount
+  // Register available widget types once (idempotent).
   onMount(() => {
     initializeWidgets()
-    dashboardStore.get(id)
-
     return () => {
       cleanupAllWidgets()
       if (grid) {
@@ -55,6 +53,21 @@
       }
       dashboardStore.clearCurrent()
     }
+  })
+
+  // Re-fetch the dashboard whenever the route id changes. SvelteKit reuses
+  // this component for navigations within /dashboards/[id], so onMount alone
+  // would leave the previous dashboard's grid on screen.
+  $effect(() => {
+    const currentId = id
+    if (!currentId) return
+    // Tear down the existing grid so the next layout rebuilds cleanly.
+    cleanupAllWidgets()
+    if (grid) {
+      grid.destroy(true)
+      grid = null
+    }
+    dashboardStore.get(currentId)
   })
 
   // --- Helper Functions ---

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -7,10 +7,10 @@
     WarningIcon,
     XCircleIcon,
   } from 'phosphor-svelte'
-  import { onMount } from 'svelte'
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
   import { api } from '$lib/api'
+  import { dataSources } from '$lib/stores'
   import type { ConnectionResult, DataSource } from '$lib/types'
 
   // Get ID from route params (always defined for this route)
@@ -37,6 +37,23 @@
   let webhookUrl = $state('')
   let webhookLoading = $state(false)
   let copied = $state(false)
+  let copiedTimer: ReturnType<typeof setTimeout> | null = null
+
+  function copyWebhookUrl() {
+    navigator.clipboard.writeText(webhookUrl)
+    copied = true
+    if (copiedTimer) clearTimeout(copiedTimer)
+    copiedTimer = setTimeout(() => {
+      copied = false
+      copiedTimer = null
+    }, 2000)
+  }
+
+  $effect(() => {
+    return () => {
+      if (copiedTimer) clearTimeout(copiedTimer)
+    }
+  })
 
   interface ParsedConfig {
     url?: string
@@ -97,25 +114,44 @@
     }
   }
 
-  onMount(async () => {
-    try {
-      dataSource = await api.dataSources.get(id)
-      formName = dataSource.name
-      const config = parseConfig(dataSource.configJson)
-      formUrl = config.url || ''
-      formToken = '' // Don't show existing token
-      formPollInterval = config.pollInterval || 30000
-      hasExistingToken = !!config.token
-      formInsecure = !!config.insecure
-      formUseWebhook = !!config.useWebhook
+  // Re-fetch whenever the route id changes (the component is reused across
+  // /datasources/[id] navigations).
+  $effect(() => {
+    const currentId = id
+    let cancelled = false
+    loading = true
+    error = ''
+    dataSource = null
+    testResult = null
+    webhookUrl = ''
 
-      if (formUseWebhook) {
-        await loadWebhookUrl()
+    ;(async () => {
+      try {
+        const ds = await api.dataSources.get(currentId)
+        if (cancelled) return
+        dataSource = ds
+        formName = ds.name
+        const config = parseConfig(ds.configJson)
+        formUrl = config.url || ''
+        formToken = ''
+        formPollInterval = config.pollInterval || 30000
+        hasExistingToken = !!config.token
+        formInsecure = !!config.insecure
+        formUseWebhook = !!config.useWebhook
+
+        if (formUseWebhook) {
+          await loadWebhookUrl()
+        }
+      } catch (e) {
+        if (cancelled) return
+        error = e instanceof Error ? e.message : 'Failed to load data source'
+      } finally {
+        if (!cancelled) loading = false
       }
-    } catch (e) {
-      error = e instanceof Error ? e.message : 'Failed to load data source'
-    } finally {
-      loading = false
+    })()
+
+    return () => {
+      cancelled = true
     }
   })
 
@@ -139,7 +175,7 @@
         configJson: getConfigFromForm(dataSource.type),
       }
 
-      dataSource = await api.dataSources.update(id, updates)
+      dataSource = await dataSources.update(id, updates)
       // Update hasExistingToken state
       const newConfig = parseConfig(dataSource.configJson)
       hasExistingToken = !!newConfig.token
@@ -177,7 +213,7 @@
       return
     }
     try {
-      await api.dataSources.delete(id)
+      await dataSources.delete(id)
       goto('/datasources')
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to delete'
@@ -315,7 +351,7 @@
                           type="button"
                           class="btn btn-secondary p-2"
                           title="Copy to clipboard"
-                          onclick={() => { navigator.clipboard.writeText(webhookUrl); copied = true; setTimeout(() => copied = false, 2000); }}
+                          onclick={copyWebhookUrl}
                         >
                           {#if copied}
                             <CheckIcon size={16} class="text-success" />

--- a/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { XIcon } from 'phosphor-svelte'
-  import { onMount } from 'svelte'
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
   import { api } from '$lib/api'
@@ -17,66 +16,78 @@
   import { mappingStore, metricsConnected, topologies } from '$lib/stores'
   import type { Topology, TopologyDataSource } from '$lib/types'
 
-  let topology: Topology | null = null
-  let renderData: { nodeCount: number; edgeCount: number } | null = null
-  let loading = true
-  let error = ''
+  let topology = $state<Topology | null>(null)
+  let renderData = $state<{ nodeCount: number; edgeCount: number } | null>(null)
+  let loading = $state(true)
+  let error = $state('')
 
   // Settings panel state
-  let settingsOpen = false
+  let settingsOpen = $state(false)
 
   // Node mapping modal state
-  let mappingModalOpen = false
-  let selectedNodeData: NodeSelectEvent | null = null
-  let netboxBaseUrl: string | undefined
+  let mappingModalOpen = $state(false)
+  let selectedNodeData = $state<NodeSelectEvent | null>(null)
+  let netboxBaseUrl = $state<string | undefined>(undefined)
 
   // Node search palette state
-  let searchPaletteOpen = false
+  let searchPaletteOpen = $state(false)
 
   // Subgraph info modal state
-  let subgraphModalOpen = false
-  let selectedSubgraphData: SubgraphSelectEvent | null = null
+  let subgraphModalOpen = $state(false)
+  let selectedSubgraphData = $state<SubgraphSelectEvent | null>(null)
 
   // Diagram component reference for drill-down
-  let diagramComponent: InteractiveSvgDiagram
+  let diagramComponent: InteractiveSvgDiagram | undefined = $state()
 
-  // Get ID from route params
-  // biome-ignore lint/style/noNonNullAssertion: using depricated $page, which is not typed
-  $: topologyId = $page.params.id!
+  // biome-ignore lint/style/noNonNullAssertion: $page.params.id is always defined for this route
+  const topologyId = $derived($page.params.id!)
+  const currentMapping = $derived($mappingStore.mapping)
 
-  // Get mapping from store
-  $: currentMapping = $mappingStore.mapping
+  // Re-fetch whenever the route id changes (SvelteKit reuses this component
+  // for navigations within /topologies/[id], so onMount alone would leave
+  // the previous topology's data on screen).
+  $effect(() => {
+    const id = topologyId
+    let cancelled = false
+    loading = true
+    error = ''
+    topology = null
+    netboxBaseUrl = undefined
 
-  onMount(async () => {
-    try {
-      const [topoData, renderResponse, sources] = await Promise.all([
-        api.topologies.get(topologyId),
-        fetch(`/api/topologies/${topologyId}/render`).then((r) => r.json()),
-        api.topologies.sources.list(topologyId),
-      ])
-      topology = topoData
-      renderData = { nodeCount: renderResponse.nodeCount, edgeCount: renderResponse.edgeCount }
-      topologies.upsert(topoData)
+    ;(async () => {
+      try {
+        const [topoData, renderResponse, sources] = await Promise.all([
+          api.topologies.get(id),
+          fetch(`/api/topologies/${id}/render`).then((r) => r.json()),
+          api.topologies.sources.list(id),
+        ])
+        if (cancelled) return
+        topology = topoData
+        renderData = { nodeCount: renderResponse.nodeCount, edgeCount: renderResponse.edgeCount }
+        topologies.upsert(topoData)
+        mappingStore.hydrate(id, topoData, sources)
 
-      // Hand off to the shared mapping store without re-fetching
-      mappingStore.hydrate(topologyId, topoData, sources)
-
-      // Find NetBox topology source for device links
-      const netboxSource = sources.find(
-        (s: TopologyDataSource) => s.purpose === 'topology' && s.dataSource?.type === 'netbox',
-      )
-      if (netboxSource?.dataSource?.configJson) {
-        try {
-          const config = JSON.parse(netboxSource.dataSource.configJson)
-          netboxBaseUrl = config.url?.replace(/\/$/, '') // Remove trailing slash
-        } catch {
-          // Ignore parse errors
+        const netboxSource = sources.find(
+          (s: TopologyDataSource) => s.purpose === 'topology' && s.dataSource?.type === 'netbox',
+        )
+        if (netboxSource?.dataSource?.configJson) {
+          try {
+            const config = JSON.parse(netboxSource.dataSource.configJson)
+            netboxBaseUrl = config.url?.replace(/\/$/, '')
+          } catch {
+            // Ignore parse errors
+          }
         }
+      } catch (e) {
+        if (cancelled) return
+        error = e instanceof Error ? e.message : 'Failed to load topology'
+      } finally {
+        if (!cancelled) loading = false
       }
-    } catch (e) {
-      error = e instanceof Error ? e.message : 'Failed to load topology'
-    } finally {
-      loading = false
+    })()
+
+    return () => {
+      cancelled = true
     }
   })
 
@@ -112,14 +123,17 @@
 
   async function handleShare() {
     if (!topology) return
-    const result = await api.topologies.share(topologyId)
-    topology = { ...topology, shareToken: result.shareToken }
+    topology = await topologies.share(topologyId)
   }
 
   async function handleUnshare() {
     if (!topology) return
-    await api.topologies.unshare(topologyId)
-    topology = { ...topology, shareToken: undefined }
+    topology = await topologies.unshare(topologyId)
+  }
+
+  function handleTopologyUpdated(updated: Topology) {
+    topology = updated
+    diagramComponent?.refreshGraph()
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -130,7 +144,7 @@
   }
 </script>
 
-<svelte:window on:keydown={handleKeydown} />
+<svelte:window onkeydown={handleKeydown} />
 
 <svelte:head> <title>{topology?.name || 'Topology'} - Shumoku</title> </svelte:head>
 
@@ -209,7 +223,12 @@
 
       <!-- Panel content -->
       <div class="flex-1 overflow-y-auto p-4">
-        <TopologySettings {topology} {renderData} onDeleted={handleDeleted} />
+        <TopologySettings
+          {topology}
+          {renderData}
+          onDeleted={handleDeleted}
+          onUpdated={handleTopologyUpdated}
+        />
       </div>
     </div>
   {/if}

--- a/apps/server/web/src/routes/(app)/topologies/[id]/edit/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/edit/+page.svelte
@@ -1,42 +1,52 @@
 <script lang="ts">
   import { YamlParser } from '@shumoku/core'
   import { ArrowLeftIcon } from 'phosphor-svelte'
-  import { onMount } from 'svelte'
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
   import { api } from '$lib/api'
   import { topologies } from '$lib/stores'
   import type { Topology } from '$lib/types'
 
-  // Get ID from route params (always defined for this route)
-  // biome-ignore lint/style/noNonNullAssertion: using depricated $page, which is not typed
-  $: id = $page.params.id!
+  // biome-ignore lint/style/noNonNullAssertion: $page.params.id is always defined for this route
+  const id = $derived($page.params.id!)
 
-  let topology: Topology | null = null
-  let loading = true
-  let error = ''
-  let saving = false
+  let topology = $state<Topology | null>(null)
+  let loading = $state(true)
+  let error = $state('')
+  let saving = $state(false)
 
   // Editor state
-  let editorMode: 'yaml' | 'json' = 'yaml'
-  let yamlContent = ''
-  let jsonContent = ''
+  let editorMode = $state<'yaml' | 'json'>('yaml')
+  let yamlContent = $state('')
+  let jsonContent = $state('')
 
-  onMount(async () => {
-    try {
-      topology = await api.topologies.get(id)
-      topologies.upsert(topology)
+  // Reload on id change (same-route navigation keeps this component mounted).
+  $effect(() => {
+    const currentId = id
+    let cancelled = false
+    loading = true
+    error = ''
+    topology = null
 
-      // Parse stored JSON and display as YAML for editing
-      const graph = JSON.parse(topology.contentJson)
-      jsonContent = JSON.stringify(graph, null, 2)
+    ;(async () => {
+      try {
+        const t = await api.topologies.get(currentId)
+        if (cancelled) return
+        topology = t
+        topologies.upsert(t)
+        const graph = JSON.parse(t.contentJson)
+        jsonContent = JSON.stringify(graph, null, 2)
+        yamlContent = graphToYaml(graph)
+      } catch (e) {
+        if (cancelled) return
+        error = e instanceof Error ? e.message : 'Failed to load topology'
+      } finally {
+        if (!cancelled) loading = false
+      }
+    })()
 
-      // Convert to YAML for display (simple conversion)
-      yamlContent = graphToYaml(graph)
-    } catch (e) {
-      error = e instanceof Error ? e.message : 'Failed to load topology'
-    } finally {
-      loading = false
+    return () => {
+      cancelled = true
     }
   })
 
@@ -145,7 +155,7 @@
         contentJson = jsonContent
       }
 
-      await api.topologies.update(id, { contentJson })
+      await topologies.update(id, { contentJson })
       goto(`/topologies/${id}`)
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to save'

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -125,6 +125,33 @@
   )
   let singleCandidateFallback = $state(true)
 
+  // Transient UI timers — tracked so we can cancel them on unmount.
+  let copiedTimer: ReturnType<typeof setTimeout> | null = null
+  let autoMapTimer: ReturnType<typeof setTimeout> | null = null
+
+  $effect(() => {
+    return () => {
+      if (copiedTimer) clearTimeout(copiedTimer)
+      if (autoMapTimer) clearTimeout(autoMapTimer)
+    }
+  })
+
+  function scheduleClearCopiedSecret() {
+    if (copiedTimer) clearTimeout(copiedTimer)
+    copiedTimer = setTimeout(() => {
+      copiedSecret = null
+      copiedTimer = null
+    }, 2000)
+  }
+
+  function scheduleClearAutoMapResult() {
+    if (autoMapTimer) clearTimeout(autoMapTimer)
+    autoMapTimer = setTimeout(() => {
+      autoMapResult = null
+      autoMapTimer = null
+    }, 5000)
+  }
+
   interface EdgeData {
     id: string
     from: EdgeEndpoint
@@ -363,7 +390,7 @@
       } else {
         delete graph.settings.splineMode
       }
-      const updated = await api.topologies.update(topology.id, {
+      const updated = await topologies.update(topology.id, {
         contentJson: JSON.stringify(graph),
       })
       if (updated) topology = updated
@@ -379,7 +406,7 @@
     if (!confirm(`Delete topology "${topology.name}"? This action cannot be undone.`)) return
     deleting = true
     try {
-      await api.topologies.delete(topology.id)
+      await topologies.delete(topology.id)
       goto('/topologies')
     } catch (e) {
       alert(e instanceof Error ? e.message : 'Failed to delete')
@@ -534,6 +561,8 @@
         optionsJson: s.optionsJson,
       }))
       hasSourceChanges = false
+      // Sources changed — mapping store's metricsSources/hosts are now stale
+      await mappingStore.load(topologyId, true)
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to save'
     } finally {
@@ -548,6 +577,10 @@
       const result = await api.topologies.sources.syncAll(topologyId)
       syncResult = { nodeCount: result.nodeCount, linkCount: result.linkCount }
       topology = result.topology
+      topologies.upsert(result.topology)
+      // Topology contentJson likely changed — mapping may reference nodes that
+      // no longer exist (or vice versa). Force a mapping reload.
+      await mappingStore.load(topologyId, true)
     } catch (e) {
       alert(e instanceof Error ? e.message : 'Sync failed')
     } finally {
@@ -562,9 +595,7 @@
   async function copyWebhookUrl(source: TopologyDataSource) {
     await navigator.clipboard.writeText(getWebhookUrl(source))
     copiedSecret = source.id
-    setTimeout(() => {
-      copiedSecret = null
-    }, 2000)
+    scheduleClearCopiedSecret()
   }
 
   // Merge functions
@@ -664,9 +695,7 @@
       ...mappingStore.autoMapNodes(parsedTopology.graph.nodes, { overwrite: false }),
       kind: 'nodes',
     }
-    setTimeout(() => {
-      autoMapResult = null
-    }, 5000)
+    scheduleClearAutoMapResult()
   }
 
   function handleClearAll() {
@@ -1636,12 +1665,12 @@
                     variant="outline"
                     size="sm"
                     onclick={() => {
-                    const matched = handleAutoMapLinks()
-                    if (matched > 0) {
-                      autoMapResult = { matched, total: edges.length, kind: 'links' }
-                      setTimeout(() => { autoMapResult = null }, 5000)
-                    }
-                  }}
+                      const matched = handleAutoMapLinks()
+                      if (matched > 0) {
+                        autoMapResult = { matched, total: edges.length, kind: 'links' }
+                        scheduleClearAutoMapResult()
+                      }
+                    }}
                   >
                     <LightningIcon size={14} class="mr-1" />
                     Auto-map

--- a/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
+++ b/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
@@ -1,35 +1,49 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
   import { page } from '$app/stores'
   import InteractiveSvgDiagram from '$lib/components/InteractiveSvgDiagram.svelte'
   import Logo from '$lib/components/Logo.svelte'
 
-  let name = ''
-  let loading = true
-  let error = ''
+  let name = $state('')
+  let loading = $state(true)
+  let error = $state('')
 
-  $: token = $page.params.token
-  $: loadShared = async () => {
+  const token = $derived($page.params.token)
+  const loadShared = $derived(async () => {
     const res = await fetch(`/api/share/topologies/${token}/graph`)
     if (!res.ok) throw new Error(`Failed to load shared topology: ${res.status}`)
     return res.json()
-  }
+  })
 
-  onMount(async () => {
-    try {
-      // Fetch context to get the name (lightweight call)
-      const res = await fetch(`/api/share/topologies/${token}`)
-      if (!res.ok) {
-        error =
-          res.status === 404 ? 'This shared link is no longer valid.' : 'Failed to load topology'
-        return
+  $effect(() => {
+    const currentToken = token
+    if (!currentToken) return
+    let cancelled = false
+    loading = true
+    error = ''
+    name = ''
+
+    ;(async () => {
+      try {
+        const res = await fetch(`/api/share/topologies/${currentToken}`)
+        if (cancelled) return
+        if (!res.ok) {
+          error =
+            res.status === 404 ? 'This shared link is no longer valid.' : 'Failed to load topology'
+          return
+        }
+        const data = await res.json()
+        if (cancelled) return
+        name = data.name || 'Shared Topology'
+      } catch {
+        if (cancelled) return
+        error = 'Failed to load topology'
+      } finally {
+        if (!cancelled) loading = false
       }
-      const data = await res.json()
-      name = data.name || 'Shared Topology'
-    } catch {
-      error = 'Failed to load topology'
-    } finally {
-      loading = false
+    })()
+
+    return () => {
+      cancelled = true
     }
   })
 </script>


### PR DESCRIPTION
## Summary

Two related classes of bug in `apps/server/web` that all surface as **"I saved but it didn't update until I reloaded the page"**:

1. **Save handlers bypassed their store.** Several routes/components called `api.*.update/delete/share` directly instead of going through the `topologies` / `dataSources` / mapping stores, so the cached lists (and any other consumer of those stores) stayed on the pre-save value.
2. **`onMount`-only fetches.** `[id]` / `[token]` routes fetched their data exclusively in `onMount`. SvelteKit reuses the same component for same-route navigation (`/topologies/abc` → `/topologies/def`), so the previous entity's data stuck around.

While in there, modernize the few remaining Svelte 4 idioms (`$:` reactive statements, raw `let` state, `on:keydown`) to runes, and clean up `setTimeout` calls that lacked unmount cleanup.

### Store ↔ mutation sync
- `topologies` store gains `share()` / `unshare()` (with cache-miss fallback that fetches the topology).
- `mapping` store's `updateNode` / `save` now `topologies.upsert(returnedTopology)` so cross-page `mappingJson` reads (sidebar stats, list view) stay fresh.
- Settings page's sources save and sync-all both call `mappingStore.load(id, true)` and `topologies.upsert(...)` so the Mapping tab and the topology list see fresh data.
- `datasources/[id]` delete now goes through `dataSources.delete()`; `topologies/[id]/edit` save through `topologies.update()`; settings page edge-style / delete through `topologies.update()` / `topologies.delete()`; `TopologySettings.svelte` same.
- `topology/[id]` page wires `onUpdated={handleTopologyUpdated}` so `TopologySettings`'s edits propagate back and call `diagramComponent.refreshGraph()`.

### Route id reactivity
- `topologies/[id]`, `topologies/[id]/edit`, `datasources/[id]`, `share/topologies/[token]` use `$effect` keyed on the route param, with a `cancelled` flag to drop racing fetches.
- `dashboards/[id]` rebuilds the GridStack when the dashboard id changes.
- `InteractiveSvgDiagram` re-runs `loadGraph()` on `topologyId` change and exposes `refreshGraph()` for explicit redraws.

### Svelte 5 cleanup
- `$:` → `$derived`, raw `let` → `$state`, `<svelte:window on:keydown>` → `onkeydown` in the touched routes.
- Removed dead `onMount` / `onDestroy` imports.

### Timer lifecycle
- Copy-confirm and auto-map result timers are now cleared on unmount via `$effect` return. Settings page consolidates them into helpers (`scheduleClearCopiedSecret`, `scheduleClearAutoMapResult`).

### Files
11 files, +322/-156. No backcompat shims kept.

## Test plan

- [ ] Edit a data source → `/datasources` list reflects the change without reload
- [ ] Delete a data source → it disappears from the list without reload
- [ ] Save mapping in topology settings → topology list's "Updated" timestamp & mapping stats refresh
- [ ] Add / remove a metrics source in topology settings → Mapping tab shows new/removed hosts without reload
- [ ] Run **Sync All** → diagram & list both reflect the new node/link count
- [ ] Save YAML/JSON in `topologies/[id]/edit` → diagram on the detail page shows updated graph after navigation back
- [ ] Share / unshare a topology → ShareButton state stays consistent
- [ ] Navigate `/topologies/abc` → `/topologies/def` directly (e.g. via search/quick-jump) → page shows `def`'s data, not stale `abc`
- [ ] Same for `/dashboards/[id]` and `/datasources/[id]`
- [ ] Open a shared topology link, change the token in URL → loads the new token without page reload
- [ ] Toggle edge style in the in-page settings panel → diagram re-renders
- [ ] Click "Copy webhook URL" then navigate away during the 2s window → no errors / dangling timers
- [ ] `bun run check` → 0 errors
- [ ] `bun x biome check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)