### PR TITLE
feat(server): topology observation model — v1 foundation

### DIFF
--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -21,6 +21,7 @@
     "shumoku-plugin-grafana": "workspace:*",
     "shumoku-plugin-netbox": "workspace:*",
     "shumoku-plugin-prometheus": "workspace:*",
+    "shumoku-plugin-snmp-lldp": "workspace:*",
     "shumoku-plugin-zabbix": "workspace:*",
     "adm-zip": "^0.5.16",
     "hono": "^4.7.11",

--- a/apps/server/api/src/api/index.ts
+++ b/apps/server/api/src/api/index.ts
@@ -9,6 +9,7 @@ import { authMiddleware } from '../middleware/auth.js'
 import { createAuthApi } from './auth.js'
 import { createDashboardsApi } from './dashboards.js'
 import { createDataSourcesApi } from './datasources.js'
+import { createObservationsRoute, createScanRoute } from './observations.js'
 import { createPluginsApi } from './plugins.js'
 import { createSettingsApi } from './settings.js'
 import { createShareApi } from './share.js'
@@ -29,9 +30,11 @@ export function createApiRouter(): Hono {
   // Mount API routes
   api.route('/dashboards', createDashboardsApi())
   api.route('/datasources', createDataSourcesApi())
+  api.route('/datasources', createScanRoute()) // POST /datasources/:id/scan
   api.route('/plugins', createPluginsApi())
   api.route('/topologies', createTopologiesApi())
   api.route('/topologies', topologySourcesApi) // Nested: /topologies/:id/sources
+  api.route('/topologies', createObservationsRoute()) // /topologies/:id/observations + /resolved
   api.route('/settings', createSettingsApi())
   api.route('/webhooks', webhooksApi)
 

--- a/apps/server/api/src/api/observations.ts
+++ b/apps/server/api/src/api/observations.ts
@@ -1,0 +1,149 @@
+/**
+ * Topology Observations API
+ *
+ * Endpoints around the observation model (foundation v1):
+ *   POST /sources/:id/scan              — ad-hoc autoscan of a source
+ *   GET  /topologies/:id/observations   — recent snapshot history
+ *   GET  /topologies/:id/resolved       — resolved NetworkGraph
+ *
+ * Design refs:
+ *   - apps/server/docs/design/topology-foundation.md
+ *   - apps/server/docs/design/topology-foundation-resolve.md
+ */
+
+import { type NetworkGraph, resolve, type SnapshotEntry } from '@shumoku/core'
+import { Hono } from 'hono'
+import { hasAutoscanCapability } from '../plugins/types.js'
+import { DataSourceService } from '../services/datasource.js'
+import { ObservationsService } from '../services/observations.js'
+import { getTopologyService } from './topologies.js'
+
+/**
+ * POST /api/sources/:id/scan
+ * Ad-hoc autoscan against the source (must implement AutoscanCapable).
+ * The snapshot is persisted to `topology_observations` if the request
+ * supplies a `topologyId` in the body — otherwise the snapshot is
+ * returned but not stored (useful for previews / testing).
+ */
+export function createScanRoute(): Hono {
+  const app = new Hono()
+  const dataSources = new DataSourceService()
+  const observations = new ObservationsService()
+
+  app.post('/:id/scan', async (c) => {
+    const id = c.req.param('id')
+    let topologyId: string | undefined
+    try {
+      const body = await c.req.json<{ topologyId?: string; seeds?: string[] }>()
+      topologyId = body.topologyId
+
+      const plugin = dataSources.getPlugin(id)
+      if (!plugin) {
+        return c.json({ error: 'data source not found' }, 404)
+      }
+
+      if (!hasAutoscanCapability(plugin)) {
+        return c.json({ error: 'Source does not implement autoscan' }, 400)
+      }
+
+      const snapshot = await plugin.scan({
+        seeds: body.seeds ?? [],
+      })
+
+      // Persist if a topology context was provided
+      if (topologyId) {
+        const observation = await observations.record({
+          topologyId,
+          sourceId: id,
+          capturedAt: snapshot.capturedAt,
+          status: snapshot.status,
+          statusMessage: snapshot.statusMessage,
+          graph: snapshot.graph,
+        })
+        // Update retraction hysteresis counter
+        observations.updateHysteresis(
+          topologyId,
+          id,
+          snapshot.status === 'failed' ? 'failed' : 'ok',
+          snapshot.capturedAt,
+        )
+        return c.json({ snapshot, observation })
+      }
+
+      return c.json({ snapshot })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
+    }
+  })
+
+  return app
+}
+
+/**
+ * GET /api/topologies/:id/observations
+ * GET /api/topologies/:id/resolved
+ * Mounted under `/api/topologies` so URL structure stays consistent
+ * with the existing topology endpoints.
+ */
+export function createObservationsRoute(): Hono {
+  const app = new Hono()
+  const observations = new ObservationsService()
+
+  // History — recent observations across all sources of this topology
+  app.get('/:id/observations', (c) => {
+    const id = c.req.param('id')
+    const limit = Number.parseInt(c.req.query('limit') ?? '50', 10) || 50
+    const rows = observations.listForTopology(id, limit)
+    // Don 't ship the full graph_json on every list call — that 's huge.
+    // The detail endpoint serves the graph.
+    return c.json(
+      rows.map((o) => ({
+        id: o.id,
+        topologyId: o.topologyId,
+        sourceId: o.sourceId,
+        capturedAt: o.capturedAt,
+        status: o.status,
+        statusMessage: o.statusMessage,
+        nodeCount: o.nodeCount,
+        linkCount: o.linkCount,
+        portCount: o.portCount,
+        createdAt: o.createdAt,
+      })),
+    )
+  })
+
+  // Single observation with full graph
+  app.get('/:id/observations/:obsId', (c) => {
+    const obsId = c.req.param('obsId')
+    const o = observations.get(obsId)
+    if (!o) return c.json({ error: 'not found' }, 404)
+    return c.json(o)
+  })
+
+  // Resolved graph — authored layer + latest snapshot per source,
+  // folded through resolve().
+  app.get('/:id/resolved', async (c) => {
+    const id = c.req.param('id')
+    try {
+      const topologyService = getTopologyService()
+      const parsed = await topologyService.getParsed(id)
+      if (!parsed) return c.json({ error: 'not found' }, 404)
+
+      const authored: NetworkGraph = parsed.graph
+      const latest = observations.latestPerSource(id)
+      const snapshots: SnapshotEntry[] = latest.map((o) => ({
+        sourceId: o.sourceId,
+        capturedAt: o.capturedAt,
+        status: o.status,
+        graph: o.graph,
+      }))
+
+      const resolved = resolve(authored, snapshots)
+      return c.json({ graph: resolved, snapshotCount: snapshots.length })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
+    }
+  })
+
+  return app
+}

--- a/apps/server/api/src/db/migrations/008_topology_observations.sql
+++ b/apps/server/api/src/db/migrations/008_topology_observations.sql
@@ -1,0 +1,52 @@
+-- Topology observation model (foundation v1)
+--
+-- Each row holds one source's NetworkGraph snapshot at a point in time.
+-- The resolver folds these (and the authored layer in `topologies.content_json`)
+-- into the displayed graph. See
+-- `apps/server/docs/design/topology-foundation-schema.md § 2.1`.
+
+CREATE TABLE IF NOT EXISTS topology_observations (
+  id TEXT PRIMARY KEY,
+  topology_id TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
+  source_id TEXT NOT NULL REFERENCES data_sources(id) ON DELETE CASCADE,
+
+  -- Scan start / capture timestamp (Unix ms)
+  captured_at INTEGER NOT NULL,
+
+  -- 'ok' | 'partial' | 'failed' | 'empty'
+  --   ok      : snapshot is authoritative for presence and absence
+  --   partial : presence trusted, absence not (timeouts, scope cuts)
+  --   failed  : ignore entirely; do not retract anything
+  --   empty   : succeeded but found nothing; do not retract
+  status TEXT NOT NULL,
+
+  -- Optional human-readable message for status != 'ok'
+  status_message TEXT,
+
+  -- Serialized NetworkGraph. NULL when status='failed'.
+  graph_json TEXT,
+
+  -- Aggregate counters for UI / debug
+  node_count INTEGER NOT NULL DEFAULT 0,
+  link_count INTEGER NOT NULL DEFAULT 0,
+  port_count INTEGER NOT NULL DEFAULT 0,
+
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_topology_observations_topology_source
+  ON topology_observations(topology_id, source_id, captured_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_topology_observations_captured_at
+  ON topology_observations(captured_at);
+
+-- Track retraction hysteresis per (topology, source) pair.
+ALTER TABLE topology_data_sources ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE topology_data_sources ADD COLUMN last_ok_captured_at INTEGER;
+
+-- Note: legacy columns to be dropped in a follow-up migration once the
+-- topology service is refactored to consume topology_observations
+-- exclusively. See topology-foundation-schema.md § 2.2 / § 2.3:
+--   - topology_data_sources.priority           (merge no longer uses it)
+--   - topologies.topology_source_id           (legacy single-source pointer)
+--   - topologies.metrics_source_id            (legacy single-source pointer)

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -14,6 +14,7 @@ import migration004 from './migrations/004_topology_source_options.sql'
 import migration005 from './migrations/005_auth.sql'
 import migration006 from './migrations/006_share_tokens.sql'
 import migration007 from './migrations/007_grafana_alerts.sql'
+import migration008 from './migrations/008_topology_observations.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -24,6 +25,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '005_auth.sql', sql: migration005 },
   { name: '006_share_tokens.sql', sql: migration006 },
   { name: '007_grafana_alerts.sql', sql: migration007 },
+  { name: '008_topology_observations.sql', sql: migration008 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/plugins/index.ts
+++ b/apps/server/api/src/plugins/index.ts
@@ -9,6 +9,7 @@ export { GrafanaPlugin } from 'shumoku-plugin-grafana'
 // Re-export plugin classes from bundled plugins
 export { NetBoxPlugin } from 'shumoku-plugin-netbox'
 export { PrometheusPlugin } from 'shumoku-plugin-prometheus'
+export { SnmpLldpPlugin } from 'shumoku-plugin-snmp-lldp'
 export { ZabbixPlugin } from 'shumoku-plugin-zabbix'
 export {
   addPlugin,
@@ -34,6 +35,7 @@ import { register as registerArubaInstantOn } from 'shumoku-plugin-aruba-instant
 import { register as registerGrafana } from 'shumoku-plugin-grafana'
 import { register as registerNetBox } from 'shumoku-plugin-netbox'
 import { register as registerPrometheus } from 'shumoku-plugin-prometheus'
+import { register as registerSnmpLldp } from 'shumoku-plugin-snmp-lldp'
 import { register as registerZabbix } from 'shumoku-plugin-zabbix'
 // Register bundled plugins
 import { pluginRegistry } from './registry.js'
@@ -44,6 +46,7 @@ export function registerBundledPlugins(): void {
   registerPrometheus(pluginRegistry)
   registerGrafana(pluginRegistry)
   registerArubaInstantOn(pluginRegistry)
+  registerSnmpLldp(pluginRegistry)
 
   console.log('[Plugins] Bundled plugins registered')
 }

--- a/apps/server/api/src/plugins/types.ts
+++ b/apps/server/api/src/plugins/types.ts
@@ -12,6 +12,9 @@ export {
   type AlertSeverity,
   type AlertStatus,
   type AlertsCapable,
+  type AutoscanCapable,
+  type AutoscanInput,
+  type AutoscanProgress,
   addHttpWarning,
   type ConnectionResult,
   type DataSourceCapability,
@@ -21,6 +24,7 @@ export {
   type HostItem,
   type HostsCapable,
   hasAlertsCapability,
+  hasAutoscanCapability,
   hasHostsCapability,
   hasMetricsCapability,
   hasNativeApi,
@@ -38,6 +42,8 @@ export {
   type PluginManifest,
   type PluginRegistration,
   type PluginRegistryInterface,
+  type ScopePolicy,
+  type Snapshot,
   type TopologyCapable,
 } from '@shumoku/core'
 

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -1,0 +1,285 @@
+/**
+ * Topology Observations Service
+ *
+ * Manages the `topology_observations` table — one row per source-snapshot.
+ * The resolver folds these (plus the authored layer from
+ * `topologies.content_json`) into the displayed graph.
+ *
+ * Design references:
+ *   - apps/server/docs/design/topology-foundation.md
+ *   - apps/server/docs/design/topology-foundation-schema.md
+ */
+
+import type { Database } from 'bun:sqlite'
+import type { NetworkGraph } from '@shumoku/core'
+import { generateId, getDatabase, timestamp } from '../db/index.js'
+
+export type ObservationStatus = 'ok' | 'partial' | 'failed' | 'empty'
+
+export interface TopologyObservation {
+  id: string
+  topologyId: string
+  sourceId: string
+  capturedAt: number
+  status: ObservationStatus
+  statusMessage?: string
+  /** Parsed NetworkGraph — null when status === 'failed'. */
+  graph: NetworkGraph | null
+  nodeCount: number
+  linkCount: number
+  portCount: number
+  createdAt: number
+}
+
+export interface RecordObservationInput {
+  topologyId: string
+  sourceId: string
+  capturedAt: number
+  status: ObservationStatus
+  statusMessage?: string
+  graph: NetworkGraph | null
+}
+
+interface ObservationRow {
+  id: string
+  topology_id: string
+  source_id: string
+  captured_at: number
+  status: string
+  status_message: string | null
+  graph_json: string | null
+  node_count: number
+  link_count: number
+  port_count: number
+  created_at: number
+}
+
+function rowToObservation(row: ObservationRow): TopologyObservation {
+  return {
+    id: row.id,
+    topologyId: row.topology_id,
+    sourceId: row.source_id,
+    capturedAt: row.captured_at,
+    status: row.status as ObservationStatus,
+    statusMessage: row.status_message ?? undefined,
+    graph: row.graph_json ? (JSON.parse(row.graph_json) as NetworkGraph) : null,
+    nodeCount: row.node_count,
+    linkCount: row.link_count,
+    portCount: row.port_count,
+    createdAt: row.created_at,
+  }
+}
+
+/**
+ * Cheap counters that scan the parsed graph once. Stored on each row
+ * so list endpoints don 't have to parse JSON.
+ */
+function countGraph(graph: NetworkGraph | null): {
+  nodeCount: number
+  linkCount: number
+  portCount: number
+} {
+  if (!graph) return { nodeCount: 0, linkCount: 0, portCount: 0 }
+  const nodeCount = graph.nodes?.length ?? 0
+  const linkCount = graph.links?.length ?? 0
+  let portCount = 0
+  for (const node of graph.nodes ?? []) {
+    portCount += node.ports?.length ?? 0
+  }
+  return { nodeCount, linkCount, portCount }
+}
+
+export class ObservationsService {
+  private db: Database
+
+  constructor() {
+    this.db = getDatabase()
+  }
+
+  /**
+   * Record a new observation snapshot. Each call appends one row.
+   * Retention / GC is handled separately (see `pruneOldObservations`).
+   */
+  async record(input: RecordObservationInput): Promise<TopologyObservation> {
+    const id = await generateId()
+    const now = timestamp()
+    const { nodeCount, linkCount, portCount } = countGraph(input.graph)
+
+    const graphJson = input.graph ? JSON.stringify(input.graph) : null
+
+    this.db
+      .query(
+        `INSERT INTO topology_observations (
+          id, topology_id, source_id, captured_at, status, status_message,
+          graph_json, node_count, link_count, port_count, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.topologyId,
+        input.sourceId,
+        input.capturedAt,
+        input.status,
+        input.statusMessage ?? null,
+        graphJson,
+        nodeCount,
+        linkCount,
+        portCount,
+        now,
+      )
+
+    return {
+      id,
+      topologyId: input.topologyId,
+      sourceId: input.sourceId,
+      capturedAt: input.capturedAt,
+      status: input.status,
+      statusMessage: input.statusMessage,
+      graph: input.graph,
+      nodeCount,
+      linkCount,
+      portCount,
+      createdAt: now,
+    }
+  }
+
+  /**
+   * Get the latest observation for each source attached to a topology.
+   * This is the input the resolver consumes — one current snapshot per
+   * source. Failed snapshots ARE returned so callers can see status,
+   * but the resolver ignores them.
+   */
+  latestPerSource(topologyId: string): TopologyObservation[] {
+    const rows = this.db
+      .query(
+        `SELECT t.* FROM topology_observations t
+         INNER JOIN (
+           SELECT source_id, MAX(captured_at) AS latest
+           FROM topology_observations
+           WHERE topology_id = ?
+           GROUP BY source_id
+         ) m ON m.source_id = t.source_id AND m.latest = t.captured_at
+         WHERE t.topology_id = ?
+         ORDER BY t.captured_at DESC`,
+      )
+      .all(topologyId, topologyId) as ObservationRow[]
+    return rows.map(rowToObservation)
+  }
+
+  /**
+   * Recent observations across all sources for a topology (history view).
+   */
+  listForTopology(topologyId: string, limit = 50): TopologyObservation[] {
+    const rows = this.db
+      .query(
+        `SELECT * FROM topology_observations
+         WHERE topology_id = ?
+         ORDER BY captured_at DESC
+         LIMIT ?`,
+      )
+      .all(topologyId, limit) as ObservationRow[]
+    return rows.map(rowToObservation)
+  }
+
+  /**
+   * Get a single observation by id.
+   */
+  get(id: string): TopologyObservation | null {
+    const row = this.db.query('SELECT * FROM topology_observations WHERE id = ?').get(id) as
+      | ObservationRow
+      | undefined
+    return row ? rowToObservation(row) : null
+  }
+
+  /**
+   * Delete an observation explicitly.
+   */
+  delete(id: string): boolean {
+    const result = this.db.query('DELETE FROM topology_observations WHERE id = ?').run(id)
+    return result.changes > 0
+  }
+
+  /**
+   * Retention: keep at most `keepPerSource` rows per (topology, source).
+   * Older rows beyond that window are dropped. Failed-status rows are
+   * pruned more aggressively (only the very latest one is kept).
+   *
+   * Returns the count of rows deleted.
+   */
+  pruneOldObservations(keepPerSource = 10): number {
+    // Successful (or partial / empty) rows: keep the most recent N per source.
+    const ok = this.db
+      .query(
+        `DELETE FROM topology_observations
+         WHERE id IN (
+           SELECT id FROM (
+             SELECT id,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY topology_id, source_id
+                      ORDER BY captured_at DESC
+                    ) AS rn
+             FROM topology_observations
+             WHERE status != 'failed'
+           ) ranked
+           WHERE rn > ?
+         )`,
+      )
+      .run(keepPerSource)
+
+    // Failed rows: keep only the most recent 1 per (topology, source).
+    const failed = this.db
+      .query(
+        `DELETE FROM topology_observations
+         WHERE id IN (
+           SELECT id FROM (
+             SELECT id,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY topology_id, source_id
+                      ORDER BY captured_at DESC
+                    ) AS rn
+             FROM topology_observations
+             WHERE status = 'failed'
+           ) ranked
+           WHERE rn > 1
+         )`,
+      )
+      .run()
+
+    return ok.changes + failed.changes
+  }
+
+  /**
+   * Update the consecutive-failures hysteresis counter on the
+   * topology_data_sources row. Called by whoever runs the actual scan.
+   *
+   * - successful scan → reset to 0, stamp last_ok_captured_at
+   * - failed scan     → increment
+   */
+  updateHysteresis(
+    topologyId: string,
+    sourceId: string,
+    outcome: 'ok' | 'failed',
+    capturedAt?: number,
+  ): void {
+    if (outcome === 'ok') {
+      this.db
+        .query(
+          `UPDATE topology_data_sources
+           SET consecutive_failures = 0,
+               last_ok_captured_at = COALESCE(?, last_ok_captured_at),
+               updated_at = ?
+           WHERE topology_id = ? AND data_source_id = ?`,
+        )
+        .run(capturedAt ?? null, timestamp(), topologyId, sourceId)
+    } else {
+      this.db
+        .query(
+          `UPDATE topology_data_sources
+           SET consecutive_failures = consecutive_failures + 1,
+               updated_at = ?
+           WHERE topology_id = ? AND data_source_id = ?`,
+        )
+        .run(timestamp(), topologyId, sourceId)
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -118,6 +118,7 @@
         "shumoku-plugin-grafana": "workspace:*",
         "shumoku-plugin-netbox": "workspace:*",
         "shumoku-plugin-prometheus": "workspace:*",
+        "shumoku-plugin-snmp-lldp": "workspace:*",
         "shumoku-plugin-zabbix": "workspace:*",
         "tar": "^7.5.7",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -262,6 +262,18 @@
         "@shumoku/core": "workspace:*",
       },
     },
+    "libs/plugins/snmp-lldp": {
+      "name": "shumoku-plugin-snmp-lldp",
+      "version": "0.0.0",
+      "dependencies": {
+        "@shumoku/core": "workspace:*",
+        "net-snmp": "^3.26.3",
+      },
+      "devDependencies": {
+        "@types/net-snmp": "^3.23.0",
+        "@types/node": "^22.0.0",
+      },
+    },
     "libs/plugins/zabbix": {
       "name": "shumoku-plugin-zabbix",
       "version": "0.2.25",
@@ -900,6 +912,8 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
+    "@types/net-snmp": ["@types/net-snmp@3.23.0", "", { "dependencies": { "@types/node": "^24.3.0" } }, "sha512-54Y5NLlQ8isegHTUZdEaIFhR1iz/qlRkQlpkuXfsWjWDVLNfStLmvraaj9ZS7tmcZEltFkb4ZeDBjnSYeFc3+w=="],
+
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
@@ -951,6 +965,8 @@
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "asn1-ber": ["asn1-ber@1.2.2", "", {}, "sha512-CbNem/7hxrjSiOAOOTX4iZxu+0m3jiLqlsERQwwPM1IDR/22M8IPpA1VVndCLw5KtjRYyRODbvAEIfuTogNDng=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -1448,6 +1464,8 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
+    "net-snmp": ["net-snmp@3.26.3", "", { "dependencies": { "asn1-ber": "^1.2.1", "smart-buffer": "^4.1.0" } }, "sha512-DTnzoz8Bk5Vz+7WWflo2VgSXMguadFMvsPmSOrknv+YTdA65lLUL1WZhYj6ZA/7pJvKscLJPOeU4LoEd6A1EZg=="],
+
     "next": ["next@16.1.1", "", { "dependencies": { "@next/env": "16.1.1", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.8.3", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.1.1", "@next/swc-darwin-x64": "16.1.1", "@next/swc-linux-arm64-gnu": "16.1.1", "@next/swc-linux-arm64-musl": "16.1.1", "@next/swc-linux-x64-gnu": "16.1.1", "@next/swc-linux-x64-musl": "16.1.1", "@next/swc-win32-arm64-msvc": "16.1.1", "@next/swc-win32-x64-msvc": "16.1.1", "sharp": "^0.34.4" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
@@ -1610,6 +1628,8 @@
 
     "shumoku-plugin-prometheus": ["shumoku-plugin-prometheus@workspace:libs/plugins/prometheus"],
 
+    "shumoku-plugin-snmp-lldp": ["shumoku-plugin-snmp-lldp@workspace:libs/plugins/snmp-lldp"],
+
     "shumoku-plugin-zabbix": ["shumoku-plugin-zabbix@workspace:libs/plugins/zabbix"],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
@@ -1619,6 +1639,8 @@
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
@@ -1794,6 +1816,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@types/net-snmp/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
+
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "fumadocs-ui/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
@@ -1810,15 +1834,21 @@
 
     "read-yaml-file/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
+    "shumoku-plugin-snmp-lldp/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
+
     "svelte-check/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "tar/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
+    "@types/net-snmp/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "shumoku-plugin-snmp-lldp/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "svelte-check/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 

--- a/libs/@shumoku/core/src/index.ts
+++ b/libs/@shumoku/core/src/index.ts
@@ -22,6 +22,8 @@ export * from './layout/index.js'
 export * from './merge.js'
 // Models
 export * from './models/index.js'
+// Observation (discovery / resolve)
+export * from './observation/index.js'
 // Parser
 export * from './parser/index.js'
 // Plugin types

--- a/libs/@shumoku/core/src/models/observation.test.ts
+++ b/libs/@shumoku/core/src/models/observation.test.ts
@@ -1,0 +1,126 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import type { Identity, Link, NetworkGraph, Node, NodePort, Provenance, Subgraph } from './types.js'
+
+/**
+ * Type-level + tiny runtime shape tests for the observation model
+ * additions (Provenance / Identity). The point is to confirm the new
+ * optional fields slot into Node / Link / Subgraph / NodePort without
+ * breaking existing call sites.
+ */
+describe('observation model types', () => {
+  describe('Provenance', () => {
+    it('accepts the minimum required shape (source only)', () => {
+      const p: Provenance = { source: 'authored' }
+      expect(p.source).toBe('authored')
+    })
+
+    it('accepts an open string source (no union enforcement)', () => {
+      // Mirrors the `Alert.source: string` regime — plugins can supply
+      // their own identifier without core edits.
+      const p: Provenance = { source: 'custom-vendor-x:instance-7' }
+      expect(p.source).toBe('custom-vendor-x:instance-7')
+    })
+
+    it('accepts each state value the resolver assigns', () => {
+      const states = ['confirmed', 'authored-only', 'discovered-only', 'conflicting'] as const
+      for (const state of states) {
+        const p: Provenance = { source: 's', state, observedAt: 1700000000000 }
+        expect(p.state).toBe(state)
+      }
+    })
+  })
+
+  describe('Identity', () => {
+    it('holds device-identifying keys for nodes', () => {
+      const id: Identity = {
+        mgmtIp: '10.0.0.1',
+        chassisId: '00:11:22:33:44:55',
+        sysName: 'core-rtr-01',
+      }
+      expect(id.mgmtIp).toBe('10.0.0.1')
+    })
+
+    it('holds interface-identifying keys for ports', () => {
+      const id: Identity = {
+        ifName: 'GigabitEthernet1/0/1',
+        ifIndex: 10001,
+        mac: 'aa:bb:cc:dd:ee:ff',
+      }
+      expect(id.ifName).toBe('GigabitEthernet1/0/1')
+    })
+
+    it('holds source-specific vendor ids', () => {
+      const id: Identity = {
+        vendorIds: { 'netbox-device-id': '42', 'zabbix-host-id': '10084' },
+      }
+      expect(id.vendorIds?.['netbox-device-id']).toBe('42')
+    })
+
+    it('permits an empty identity (every field optional)', () => {
+      const id: Identity = {}
+      expect(id).toEqual({})
+    })
+  })
+
+  describe('attachment to existing entities', () => {
+    it('attaches to Node without disturbing required fields', () => {
+      const node: Node = {
+        id: 'n1',
+        label: 'Router',
+        shape: 'rect',
+        provenance: { source: 'snmp-lldp:1', state: 'confirmed', observedAt: 1 },
+        identity: { mgmtIp: '10.0.0.1', chassisId: 'aa:bb:cc:dd:ee:ff' },
+      }
+      expect(node.provenance?.source).toBe('snmp-lldp:1')
+      expect(node.identity?.mgmtIp).toBe('10.0.0.1')
+    })
+
+    it('attaches to NodePort without disturbing required fields', () => {
+      const port: NodePort = {
+        id: 'p1',
+        label: 'Gi1/0/1',
+        connectors: ['rj45'],
+        provenance: { source: 'snmp-lldp:1' },
+        identity: { ifName: 'GigabitEthernet1/0/1', ifIndex: 10001 },
+      }
+      expect(port.provenance?.source).toBe('snmp-lldp:1')
+      expect(port.identity?.ifName).toBe('GigabitEthernet1/0/1')
+    })
+
+    it('attaches to Link (no identity, endpoints identify it)', () => {
+      const link: Link = {
+        from: { node: 'a', port: 'p1' },
+        to: { node: 'b', port: 'p2' },
+        provenance: { source: 'snmp-lldp:1', state: 'discovered-only' },
+      }
+      expect(link.provenance?.state).toBe('discovered-only')
+    })
+
+    it('attaches to Subgraph', () => {
+      const sub: Subgraph = {
+        id: 'sg1',
+        label: 'Tier',
+        provenance: { source: 'authored' },
+      }
+      expect(sub.provenance?.source).toBe('authored')
+    })
+  })
+
+  describe('NetworkGraph backward shape', () => {
+    it('a graph with no observation fields still satisfies the type', () => {
+      // Critical: existing NetworkGraph YAML / JSON without provenance
+      // / identity must keep type-checking. All four fields are optional.
+      const graph: NetworkGraph = {
+        version: '1.0',
+        nodes: [{ id: 'n1', label: 'x', shape: 'rect' }],
+        links: [],
+      }
+      expect(graph.nodes[0]?.provenance).toBeUndefined()
+      expect(graph.nodes[0]?.identity).toBeUndefined()
+    })
+  })
+})

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -18,6 +18,64 @@ export interface IconDimensions {
 }
 
 // ============================================
+// Observation Model — provenance & identity
+// ============================================
+
+/**
+ * Where a node / link / port / subgraph value came from in the
+ * observation model. A `NetworkGraph` snapshot returned by a discovery
+ * source stamps its `<sourceId>` here. The resolver fills `state` when
+ * folding multiple snapshots into a resolved graph. See
+ * `apps/server/docs/design/topology-foundation*.md` for the full design.
+ *
+ * The field is optional on every entity — a NetworkGraph that doesn't
+ * use the observation model (legacy YAML import, hand-authored without
+ * a binding) simply omits it, and consumers fall back to the
+ * pre-existing behavior.
+ *
+ * `source` is an open string (not a union) so external plugins can
+ * supply their own identifier without core edits — same regime as
+ * `Alert.source` (see `@shumoku/core/plugin-types.ts`).
+ */
+export interface Provenance {
+  /** Source identifier. `'authored'` is a reserved value for human edits. */
+  source: string
+  /** Set by the resolver. Snapshots leave this undefined. */
+  state?: 'confirmed' | 'authored-only' | 'discovered-only' | 'conflicting'
+  /** Unix ms — when the source observed this value. */
+  observedAt?: number
+}
+
+/**
+ * Stable identifiers used to match the same physical entity across
+ * multiple snapshots and across sources. The display `id` on each
+ * entity is opaque to consumers; identity keys here are what the
+ * resolver uses to cluster observations.
+ *
+ * Node keys (device-identifying): `mgmtIp`, `chassisId`, `sysName`,
+ * `vendorIds`. Port keys (interface-identifying): `ifName`, `ifIndex`,
+ * `mac`. `ifIndex` is intentionally treated as a weak fallback because
+ * many devices renumber it across reboots — see
+ * `apps/server/docs/design/topology-foundation-identity.md`.
+ */
+export interface Identity {
+  /** Management IP (v4 or v6 as a string). Node key. */
+  mgmtIp?: string
+  /** LLDP chassisId (MAC or vendor string). Node key. */
+  chassisId?: string
+  /** SNMP sysName. Node key (fallback). */
+  sysName?: string
+  /** ifIndex — weak Port key (unstable across reboots). */
+  ifIndex?: number
+  /** ifName ("GigabitEthernet1/0/1"). Strong Port key. */
+  ifName?: string
+  /** Interface MAC. Aux Port key; for shared-MAC chassis, Node aux too. */
+  mac?: string
+  /** Source-specific identifiers, e.g. `{ 'netbox-device-id': '42' }`. */
+  vendorIds?: Record<string, string>
+}
+
+// ============================================
 // Node Types
 // ============================================
 
@@ -148,6 +206,16 @@ export interface NodePort {
     side?: 'top' | 'bottom' | 'left' | 'right'
     order?: number
   }
+  /**
+   * Observation provenance (which source last asserted this port).
+   * See `Provenance` type. Optional — omitted on hand-authored ports.
+   */
+  provenance?: Provenance
+  /**
+   * Identity keys for cross-source / cross-rescan matching. Filled by
+   * discovery plugins (SNMP → ifIndex/ifName/mac, etc.). See `Identity`.
+   */
+  identity?: Identity
 }
 
 /**
@@ -356,6 +424,20 @@ export interface Node {
    *     bend along with its neighbors.
    */
   termination?: { role: 'outlet' | 'eps' | 'panel' | 'bend' }
+
+  /**
+   * Observation provenance (which source last asserted this node).
+   * See `Provenance`. Optional — omitted on authored nodes that pre-date
+   * the observation model.
+   */
+  provenance?: Provenance
+
+  /**
+   * Identity keys for cross-source / cross-rescan matching. Discovery
+   * plugins fill mgmtIp / chassisId / sysName / vendorIds. The resolver
+   * clusters observations by these. See `Identity`.
+   */
+  identity?: Identity
 }
 
 // ============================================
@@ -596,6 +678,13 @@ export interface Link {
    * Custom metadata for extensions
    */
   metadata?: Record<string, unknown>
+
+  /**
+   * Observation provenance (which source last asserted this link).
+   * See `Provenance`. Links are identified by their endpoints rather
+   * than by a stable identity record, so no `identity` field here.
+   */
+  provenance?: Provenance
 }
 
 /**
@@ -718,6 +807,14 @@ export interface Subgraph {
    * Derived from child node positions — not persisted.
    */
   bounds?: Bounds
+
+  /**
+   * Observation provenance (which source last asserted this subgraph).
+   * See `Provenance`. Subgraphs are logical groupings — typically
+   * authored — so this stays undefined for hand-drawn diagrams. Workload
+   * sources (k8s namespaces, Proxmox clusters) may populate it later.
+   */
+  provenance?: Provenance
 }
 
 // ============================================

--- a/libs/@shumoku/core/src/observation/identity.ts
+++ b/libs/@shumoku/core/src/observation/identity.ts
@@ -1,0 +1,111 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import type { Identity } from '../models/types.js'
+import type { IdentityQuality } from './types.js'
+
+/**
+ * Node / Port identity helpers used by the resolver.
+ * See `apps/server/docs/design/topology-foundation-identity.md`.
+ *
+ * Priority order matters: the resolver tries keys in this order and
+ * stops at the first hit. `ifIndex` is intentionally low-priority
+ * because many devices renumber it across reboots — `ifName` /
+ * `chassisId` are the load-bearing keys.
+ */
+
+/** Tagged identity key — kind helps the resolver index multiple
+ * sources of the same key value without collision (e.g. a node's
+ * sysName "core-rtr-01" must not collide with a vendor id of the
+ * same string). */
+export interface IdentityKey {
+  kind: 'mgmtIp' | 'chassisId' | 'sysName' | 'ifName' | 'ifIndex' | 'mac' | 'vendorId'
+  value: string
+}
+
+/**
+ * Enumerate Node identity keys in priority order. The first match
+ * wins during cluster lookup. Caller should also bind *every* key
+ * to the resulting cluster after a match so subsequent observations
+ * collapse correctly even if they only carry a weaker key.
+ */
+export function nodeIdentityKeys(identity: Identity | undefined): IdentityKey[] {
+  if (!identity) return []
+  const keys: IdentityKey[] = []
+  // priority 1: mgmtIp (worldwide-meaningful)
+  if (identity.mgmtIp) keys.push({ kind: 'mgmtIp', value: identity.mgmtIp })
+  // priority 2: chassisId (LLDP gospel)
+  if (identity.chassisId) keys.push({ kind: 'chassisId', value: identity.chassisId })
+  // priority 3: sysName (fallback)
+  if (identity.sysName) keys.push({ kind: 'sysName', value: identity.sysName })
+  // priority 4: vendorIds (source-internal, namespace by entry key)
+  if (identity.vendorIds) {
+    for (const [vendor, value] of Object.entries(identity.vendorIds)) {
+      keys.push({ kind: 'vendorId', value: `${vendor}=${value}` })
+    }
+  }
+  return keys
+}
+
+/**
+ * Enumerate Port identity keys in priority order. Port matching
+ * happens *within* a parent node cluster — the same `ifName` on a
+ * different chassis is a different port. The caller is responsible
+ * for that scoping; this list is just the per-port priority order.
+ */
+export function portIdentityKeys(identity: Identity | undefined): IdentityKey[] {
+  if (!identity) return []
+  const keys: IdentityKey[] = []
+  // priority 1: ifName (stable across reboots if device honors it)
+  if (identity.ifName) keys.push({ kind: 'ifName', value: identity.ifName })
+  // priority 2: mac (per-NIC, usually stable)
+  if (identity.mac) keys.push({ kind: 'mac', value: identity.mac })
+  // priority 3: ifIndex (WEAK — may renumber)
+  if (identity.ifIndex !== undefined) {
+    keys.push({ kind: 'ifIndex', value: String(identity.ifIndex) })
+  }
+  if (identity.vendorIds) {
+    for (const [vendor, value] of Object.entries(identity.vendorIds)) {
+      keys.push({ kind: 'vendorId', value: `${vendor}=${value}` })
+    }
+  }
+  return keys
+}
+
+/**
+ * Coarse identity quality — surfaced in UI to warn users which
+ * elements may detach from their metrics/observations across reboots.
+ *
+ * Node: `stable` if chassisId + (mgmtIp or sysName), `weak` if any
+ * single primary key, `unbound` otherwise.
+ *
+ * Port: `stable` if ifName + (mac or ifIndex), `weak` if any single
+ * key, `unbound` otherwise.
+ */
+export function nodeIdentityQuality(identity: Identity | undefined): IdentityQuality {
+  if (!identity) return 'unbound'
+  const hasChassis = Boolean(identity.chassisId)
+  const hasMgmt = Boolean(identity.mgmtIp)
+  const hasSys = Boolean(identity.sysName)
+  if (hasChassis && (hasMgmt || hasSys)) return 'stable'
+  if (hasChassis || hasMgmt) return 'weak'
+  if (hasSys) return 'weak'
+  return 'unbound'
+}
+
+export function portIdentityQuality(identity: Identity | undefined): IdentityQuality {
+  if (!identity) return 'unbound'
+  const hasName = Boolean(identity.ifName)
+  const hasMac = Boolean(identity.mac)
+  const hasIndex = identity.ifIndex !== undefined
+  if (hasName && (hasMac || hasIndex)) return 'stable'
+  if (hasName || hasMac) return 'weak'
+  if (hasIndex) return 'weak'
+  return 'unbound'
+}
+
+/** Stable string form of a key for use as a Map key. */
+export function keyHash(key: IdentityKey): string {
+  return `${key.kind}:${key.value}`
+}

--- a/libs/@shumoku/core/src/observation/index.ts
+++ b/libs/@shumoku/core/src/observation/index.ts
@@ -1,0 +1,7 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+export * from './identity.js'
+export * from './resolve.js'
+export * from './types.js'

--- a/libs/@shumoku/core/src/observation/index.ts
+++ b/libs/@shumoku/core/src/observation/index.ts
@@ -4,4 +4,5 @@
 
 export * from './identity.js'
 export * from './resolve.js'
+export * from './sys-object-id.js'
 export * from './types.js'

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1,0 +1,265 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import type { NetworkGraph } from '../models/types.js'
+import { nodeIdentityQuality, portIdentityQuality, resolve, type SnapshotEntry } from './index.js'
+
+/**
+ * Skeleton-level resolve() behavior. Covers the four end-state
+ * cases (confirmed / authored-only / discovered-only / conflicting)
+ * and the critical ifIndex reshuffle scenario. Deeper edge cases
+ * (cross-source link dedup, ghost endpoints, full retraction
+ * hysteresis) are intentionally deferred — see resolve.ts header.
+ */
+describe('resolve()', () => {
+  describe('identity quality', () => {
+    it('node: chassisId + mgmtIp = stable', () => {
+      expect(nodeIdentityQuality({ chassisId: 'a', mgmtIp: '10.0.0.1' })).toBe('stable')
+    })
+    it('node: chassisId alone = weak', () => {
+      expect(nodeIdentityQuality({ chassisId: 'a' })).toBe('weak')
+    })
+    it('node: undefined identity = unbound', () => {
+      expect(nodeIdentityQuality(undefined)).toBe('unbound')
+    })
+    it('port: ifName + ifIndex = stable', () => {
+      expect(portIdentityQuality({ ifName: 'Gi0/1', ifIndex: 1 })).toBe('stable')
+    })
+    it('port: ifIndex alone = weak', () => {
+      expect(portIdentityQuality({ ifIndex: 1 })).toBe('weak')
+    })
+  })
+
+  describe('empty inputs', () => {
+    it('empty authored, no snapshots → empty resolved', () => {
+      const out = resolve(emptyGraph(), [])
+      expect(out.nodes).toEqual([])
+      expect(out.links).toEqual([])
+    })
+  })
+
+  describe('authored-only', () => {
+    it('node present only in authored → state = authored-only', () => {
+      const authored: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [
+          {
+            id: 'n1',
+            label: 'R1',
+            shape: 'rect',
+            identity: { mgmtIp: '10.0.0.1' },
+          },
+        ],
+      }
+      const out = resolve(authored, [])
+      expect(out.nodes).toHaveLength(1)
+      expect(out.nodes[0]?.provenance?.state).toBe('authored-only')
+      expect(out.nodes[0]?.provenance?.source).toBe('authored')
+    })
+  })
+
+  describe('discovered-only', () => {
+    it('node present only in 1 snapshot → state = discovered-only', () => {
+      const snap: SnapshotEntry = {
+        sourceId: 'snmp-lldp:1',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            {
+              id: 'sn1',
+              label: 'core',
+              shape: 'rect',
+              identity: { mgmtIp: '10.0.0.2', chassisId: 'aa' },
+            },
+          ],
+        },
+      }
+      const out = resolve(emptyGraph(), [snap])
+      expect(out.nodes).toHaveLength(1)
+      expect(out.nodes[0]?.provenance?.state).toBe('discovered-only')
+      expect(out.nodes[0]?.provenance?.source).toBe('snmp-lldp:1')
+    })
+  })
+
+  describe('confirmed (authored + snapshot agree on identity)', () => {
+    it('authored mgmtIp matches snapshot mgmtIp → confirmed', () => {
+      const authored: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [
+          {
+            id: 'authored-r1',
+            label: 'R1',
+            shape: 'rect',
+            identity: { mgmtIp: '10.0.0.1' },
+          },
+        ],
+      }
+      const snap: SnapshotEntry = {
+        sourceId: 'snmp-lldp:1',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            {
+              id: 'snmp-r1',
+              label: 'R1',
+              shape: 'rect',
+              identity: { mgmtIp: '10.0.0.1', chassisId: 'aa:bb' },
+            },
+          ],
+        },
+      }
+      const out = resolve(authored, [snap])
+      expect(out.nodes).toHaveLength(1)
+      expect(out.nodes[0]?.provenance?.state).toBe('confirmed')
+      // identity merged
+      expect(out.nodes[0]?.identity?.chassisId).toBe('aa:bb')
+      // cluster id prefers authored
+      expect(out.nodes[0]?.id).toBe('authored-r1')
+    })
+  })
+
+  describe('confirmed (≥2 snapshots agree, no authored)', () => {
+    it('two snapshots sharing chassisId → 1 cluster, confirmed', () => {
+      const a: SnapshotEntry = makeSnap('netbox:1', 1000, [
+        { id: 'a-r1', label: 'R1', identity: { chassisId: 'aa', sysName: 'r1' } },
+      ])
+      const b: SnapshotEntry = makeSnap('snmp:1', 2000, [
+        { id: 'b-r1', label: 'R1', identity: { chassisId: 'aa', mgmtIp: '10.0.0.1' } },
+      ])
+      const out = resolve(emptyGraph(), [a, b])
+      expect(out.nodes).toHaveLength(1)
+      expect(out.nodes[0]?.provenance?.state).toBe('confirmed')
+      expect(out.nodes[0]?.identity?.mgmtIp).toBe('10.0.0.1')
+      expect(out.nodes[0]?.identity?.sysName).toBe('r1')
+    })
+  })
+
+  describe('ifIndex reshuffle (critical regression)', () => {
+    it('two snapshots swap ifIndex but ifName stable → ports stay distinct & confirmed', () => {
+      const t1 = makeSnap('snmp:1', 1000, [
+        {
+          id: 'sw1',
+          label: 'Switch',
+          identity: { chassisId: 'sw-chassis' },
+          ports: [
+            { id: 'p-gi1', label: 'Gi0/1', identity: { ifName: 'Gi0/1', ifIndex: 10001 } },
+            { id: 'p-gi2', label: 'Gi0/2', identity: { ifName: 'Gi0/2', ifIndex: 10002 } },
+          ],
+        },
+      ])
+      const t2 = makeSnap('snmp:1', 2000, [
+        {
+          id: 'sw1',
+          label: 'Switch',
+          identity: { chassisId: 'sw-chassis' },
+          ports: [
+            // ifIndex got renumbered on reboot
+            { id: 'p-gi1', label: 'Gi0/1', identity: { ifName: 'Gi0/1', ifIndex: 10002 } },
+            { id: 'p-gi2', label: 'Gi0/2', identity: { ifName: 'Gi0/2', ifIndex: 10001 } },
+          ],
+        },
+      ])
+      const out = resolve(emptyGraph(), [t1, t2])
+      expect(out.nodes).toHaveLength(1)
+      // ports are matched by ifName despite ifIndex swap → 2 ports, not 4
+      const ports = out.nodes[0]?.ports ?? []
+      expect(ports).toHaveLength(2)
+      const names = ports.map((p) => p.identity?.ifName).sort()
+      expect(names).toEqual(['Gi0/1', 'Gi0/2'])
+    })
+  })
+
+  describe('failed snapshots are ignored', () => {
+    it('failed snapshot does not retract authored nodes', () => {
+      const authored: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [
+          {
+            id: 'n1',
+            label: 'R1',
+            shape: 'rect',
+            identity: { mgmtIp: '10.0.0.1' },
+          },
+        ],
+      }
+      const failed: SnapshotEntry = {
+        sourceId: 'snmp-lldp:1',
+        capturedAt: 1000,
+        status: 'failed',
+        graph: null,
+      }
+      const out = resolve(authored, [failed])
+      expect(out.nodes).toHaveLength(1)
+      expect(out.nodes[0]?.provenance?.state).toBe('authored-only')
+    })
+  })
+
+  describe('links carry provenance', () => {
+    it('authored link gets authored-only state', () => {
+      const authored: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [
+          { id: 'a', label: 'A', shape: 'rect' },
+          { id: 'b', label: 'B', shape: 'rect' },
+        ],
+        links: [{ from: { node: 'a', port: 'p1' }, to: { node: 'b', port: 'p2' } }],
+      }
+      const out = resolve(authored, [])
+      expect(out.links).toHaveLength(1)
+      expect(out.links[0]?.provenance?.state).toBe('authored-only')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function emptyGraph(): NetworkGraph {
+  return { version: '1.0', nodes: [], links: [] }
+}
+
+interface MakeSnapNode {
+  id: string
+  label: string
+  identity?: {
+    mgmtIp?: string
+    chassisId?: string
+    sysName?: string
+  }
+  ports?: Array<{
+    id: string
+    label: string
+    identity?: { ifName?: string; ifIndex?: number; mac?: string }
+  }>
+}
+
+function makeSnap(sourceId: string, capturedAt: number, nodes: MakeSnapNode[]): SnapshotEntry {
+  return {
+    sourceId,
+    capturedAt,
+    status: 'ok',
+    graph: {
+      version: '1.0',
+      nodes: nodes.map((n) => ({
+        id: n.id,
+        label: n.label,
+        shape: 'rect',
+        identity: n.identity,
+        ports: n.ports?.map((p) => ({
+          id: p.id,
+          label: p.label,
+          connectors: ['rj45'],
+          identity: p.identity,
+        })),
+      })),
+      links: [],
+    },
+  }
+}

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -1,0 +1,414 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import type {
+  Identity,
+  Link,
+  LinkEndpoint,
+  NetworkGraph,
+  Node,
+  NodePort,
+  Provenance,
+  Subgraph,
+} from '../models/types.js'
+import { keyHash, nodeIdentityKeys, portIdentityKeys } from './identity.js'
+import type { ResolvedGraph, ResolveOptions, SnapshotEntry } from './types.js'
+
+/**
+ * Resolve an authored NetworkGraph against any number of source
+ * snapshots into a single graph whose every entity carries a
+ * `provenance.state` of `confirmed` / `authored-only` / `discovered-only`
+ * / `conflicting`.
+ *
+ * Skeleton implementation — see `apps/server/docs/design/topology-foundation-resolve.md`
+ * for the algorithm. This skeleton handles the common cases that v1
+ * needs (single-source overlay, identity-based dedup, simple field
+ * comparison) and intentionally leaves the harder cases (link
+ * matching across cross-cluster endpoints, ghost endpoints, full
+ * retraction hysteresis) as small TODOs surfaced in tests.
+ */
+export function resolve(
+  authored: NetworkGraph,
+  snapshots: SnapshotEntry[],
+  options: ResolveOptions = {},
+): ResolvedGraph {
+  const _staleThreshold = options.staleThresholdMs ?? 30 * 24 * 60 * 60 * 1000
+  const _retractAfter = options.retractAfterMissedScans ?? 3
+  // _staleThreshold / _retractAfter are wired through in the full impl;
+  // the skeleton leaves them as documented knobs.
+  void _staleThreshold
+  void _retractAfter
+
+  // 1. Gather valid contributions: authored + every non-failed snapshot
+  const contributions: Contribution[] = [
+    { sourceId: 'authored', capturedAt: Number.POSITIVE_INFINITY, graph: authored },
+  ]
+  for (const snap of snapshots) {
+    if (snap.status === 'failed' || !snap.graph) continue
+    contributions.push({
+      sourceId: snap.sourceId,
+      capturedAt: snap.capturedAt,
+      graph: snap.graph,
+    })
+  }
+
+  // 2. Build node clusters by identity keys
+  const nodeClusters = clusterNodes(contributions)
+
+  // 3. For each cluster, fold into a single resolved Node
+  const resolvedNodes: Node[] = []
+  const clusterById = new Map<string, NodeCluster>()
+  for (const cluster of nodeClusters) {
+    const node = foldNodeCluster(cluster)
+    resolvedNodes.push(node)
+    // Bind each member's original `id` → cluster id so links can be remapped
+    for (const member of cluster.members) {
+      clusterById.set(`${member.sourceId}:${member.node.id}`, cluster)
+    }
+  }
+
+  // 4. Fold links — endpoint remapping only; cross-cluster matching is
+  //    out of scope for the skeleton.
+  const resolvedLinks = foldLinks(contributions, clusterById)
+
+  // 5. Subgraphs — pass through authored, then stamp provenance.
+  //    Workload-source subgraphs are v2; skeleton respects authored only.
+  const resolvedSubgraphs = foldSubgraphs(authored)
+
+  return {
+    version: authored.version,
+    name: authored.name,
+    description: authored.description,
+    nodes: resolvedNodes,
+    links: resolvedLinks,
+    subgraphs: resolvedSubgraphs,
+    terminations: authored.terminations,
+    settings: authored.settings,
+    pins: authored.pins,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface Contribution {
+  sourceId: string
+  capturedAt: number
+  graph: NetworkGraph
+}
+
+interface ClusterMember {
+  sourceId: string
+  capturedAt: number
+  node: Node
+}
+
+interface NodeCluster {
+  /** Synthesized id — preferring authored id when an authored member exists. */
+  id: string
+  members: ClusterMember[]
+}
+
+function clusterNodes(contributions: Contribution[]): NodeCluster[] {
+  const clusters: NodeCluster[] = []
+  // Map identity-key-hash → cluster index
+  const keyIndex = new Map<string, number>()
+  let nextSynthId = 0
+
+  const claim = (member: ClusterMember): void => {
+    const keys = nodeIdentityKeys(member.node.identity)
+    // Try to find an existing cluster via any key
+    let hit: number | undefined
+    for (const key of keys) {
+      const idx = keyIndex.get(keyHash(key))
+      if (idx !== undefined) {
+        hit = idx
+        break
+      }
+    }
+    if (hit !== undefined) {
+      clusters[hit]?.members.push(member)
+    } else {
+      // Brand new cluster
+      const cluster: NodeCluster = {
+        id: member.sourceId === 'authored' ? member.node.id : `discovered:${nextSynthId++}`,
+        members: [member],
+      }
+      clusters.push(cluster)
+      hit = clusters.length - 1
+    }
+    // Bind every identity key of this member to the cluster — including
+    // keys not used to find it. Future weaker observations can collapse.
+    for (const key of keys) {
+      const h = keyHash(key)
+      if (!keyIndex.has(h)) keyIndex.set(h, hit)
+    }
+    // Also bind a deterministic per-source id fallback so identity-less
+    // nodes still match themselves across re-runs of the same source.
+    if (keys.length === 0) {
+      const fallback = keyHash({ kind: 'vendorId', value: `${member.sourceId}:${member.node.id}` })
+      keyIndex.set(fallback, hit)
+    }
+  }
+
+  // Authored first so cluster ids prefer authored values
+  for (const contrib of contributions) {
+    if (contrib.sourceId !== 'authored') continue
+    for (const node of contrib.graph.nodes) {
+      claim({ sourceId: contrib.sourceId, capturedAt: contrib.capturedAt, node })
+    }
+  }
+  for (const contrib of contributions) {
+    if (contrib.sourceId === 'authored') continue
+    for (const node of contrib.graph.nodes) {
+      claim({ sourceId: contrib.sourceId, capturedAt: contrib.capturedAt, node })
+    }
+  }
+  return clusters
+}
+
+function foldNodeCluster(cluster: NodeCluster): Node {
+  // The authored member, if any, anchors id / chosen fields
+  const authored = cluster.members.find((m) => m.sourceId === 'authored')
+  const observers = cluster.members.filter((m) => m.sourceId !== 'authored')
+  const anchor = authored?.node ?? cluster.members[0]?.node
+  if (!anchor) {
+    // unreachable — cluster always has at least one member
+    throw new Error('empty cluster')
+  }
+
+  // Identity: union of all members' identity keys (keep first non-empty value)
+  const mergedIdentity = mergeIdentities(cluster.members.map((m) => m.node.identity))
+
+  // Field-level resolution. Skeleton: handle a small set of factual
+  // string fields explicitly; non-factual fields take the authored
+  // value if present, otherwise the most recent observation.
+  const resolved: Node = {
+    ...anchor,
+    id: cluster.id,
+    identity: mergedIdentity,
+    // chosen fields: position / parent / style come from authored when
+    // present (already in `anchor` via spread). Otherwise from latest.
+    ports: foldPortsAcrossCluster(cluster),
+    provenance: deriveNodeProvenance(cluster, observers.length, Boolean(authored)),
+  }
+
+  // Factual: if multiple sources disagree on `label`, mark conflicting.
+  // (`label` straddles factual/chosen — we treat it as conflicting only
+  // when *non-authored* sources disagree; authored always wins display.)
+  const labelObservations = collectField(cluster.members, (n) => stringLabel(n.label))
+  if (!authored && labelObservations.length > 1) {
+    const distinct = new Set(labelObservations.map((o) => o.value))
+    if (distinct.size > 1) {
+      resolved.provenance = {
+        ...(resolved.provenance ?? { source: cluster.members[0]?.sourceId ?? 'unknown' }),
+        state: 'conflicting',
+      }
+    }
+  }
+
+  return resolved
+}
+
+function deriveNodeProvenance(
+  cluster: NodeCluster,
+  observerCount: number,
+  hasAuthored: boolean,
+): Provenance {
+  // State derivation:
+  //   authored + observed → confirmed
+  //   authored only       → authored-only
+  //   observed only       → discovered-only (1 source) or confirmed (≥2 agreeing)
+  let state: Provenance['state']
+  if (hasAuthored && observerCount > 0) state = 'confirmed'
+  else if (hasAuthored) state = 'authored-only'
+  else if (observerCount >= 2) state = 'confirmed'
+  else state = 'discovered-only'
+
+  // Pick a canonical source label: authored wins, otherwise latest observer.
+  let source = 'authored'
+  if (!hasAuthored) {
+    const latest = [...cluster.members].sort((a, b) => b.capturedAt - a.capturedAt)[0]
+    source = latest?.sourceId ?? 'unknown'
+  }
+  const latest = cluster.members.reduce(
+    (acc, m) => (m.capturedAt > acc ? m.capturedAt : acc),
+    Number.NEGATIVE_INFINITY,
+  )
+  return {
+    source,
+    state,
+    observedAt: Number.isFinite(latest) ? latest : undefined,
+  }
+}
+
+function mergeIdentities(identities: Array<Identity | undefined>): Identity | undefined {
+  const merged: Identity = {}
+  let touched = false
+  for (const id of identities) {
+    if (!id) continue
+    if (id.mgmtIp && !merged.mgmtIp) {
+      merged.mgmtIp = id.mgmtIp
+      touched = true
+    }
+    if (id.chassisId && !merged.chassisId) {
+      merged.chassisId = id.chassisId
+      touched = true
+    }
+    if (id.sysName && !merged.sysName) {
+      merged.sysName = id.sysName
+      touched = true
+    }
+    if (id.ifName && !merged.ifName) {
+      merged.ifName = id.ifName
+      touched = true
+    }
+    if (id.mac && !merged.mac) {
+      merged.mac = id.mac
+      touched = true
+    }
+    if (id.ifIndex !== undefined && merged.ifIndex === undefined) {
+      merged.ifIndex = id.ifIndex
+      touched = true
+    }
+    if (id.vendorIds) {
+      merged.vendorIds = { ...(merged.vendorIds ?? {}), ...id.vendorIds }
+      touched = true
+    }
+  }
+  return touched ? merged : undefined
+}
+
+interface FieldObservation<T> {
+  sourceId: string
+  value: T
+}
+
+function collectField<T>(
+  members: ClusterMember[],
+  read: (n: Node) => T | undefined,
+): FieldObservation<T>[] {
+  const out: FieldObservation<T>[] = []
+  for (const m of members) {
+    const v = read(m.node)
+    if (v !== undefined) out.push({ sourceId: m.sourceId, value: v })
+  }
+  return out
+}
+
+function stringLabel(label: string | string[]): string {
+  return Array.isArray(label) ? label.join('\n') : label
+}
+
+function foldPortsAcrossCluster(cluster: NodeCluster): NodePort[] | undefined {
+  // Collect ports from all members of the cluster, group by port
+  // identity within the cluster, fold each port.
+  const all: Array<{ sourceId: string; port: NodePort }> = []
+  for (const m of cluster.members) {
+    for (const port of m.node.ports ?? []) {
+      all.push({ sourceId: m.sourceId, port })
+    }
+  }
+  if (all.length === 0) return undefined
+
+  // Group by port identity (within-cluster scope)
+  const portClusters: Array<Array<{ sourceId: string; port: NodePort }>> = []
+  const keyToIdx = new Map<string, number>()
+  for (const entry of all) {
+    const keys = portIdentityKeys(entry.port.identity)
+    let hit: number | undefined
+    for (const key of keys) {
+      const idx = keyToIdx.get(keyHash(key))
+      if (idx !== undefined) {
+        hit = idx
+        break
+      }
+    }
+    if (hit !== undefined) {
+      portClusters[hit]?.push(entry)
+    } else {
+      portClusters.push([entry])
+      hit = portClusters.length - 1
+    }
+    for (const key of keys) keyToIdx.set(keyHash(key), hit)
+    if (keys.length === 0) {
+      keyToIdx.set(`fallback:${entry.sourceId}:${entry.port.id}`, hit)
+    }
+  }
+
+  return portClusters.map((members) => foldPortCluster(members))
+}
+
+function foldPortCluster(members: Array<{ sourceId: string; port: NodePort }>): NodePort {
+  const authored = members.find((m) => m.sourceId === 'authored')
+  const anchor = authored?.port ?? members[0]?.port
+  if (!anchor) throw new Error('empty port cluster')
+
+  const observerCount = members.filter((m) => m.sourceId !== 'authored').length
+  const hasAuthored = Boolean(authored)
+  let state: Provenance['state']
+  if (hasAuthored && observerCount > 0) state = 'confirmed'
+  else if (hasAuthored) state = 'authored-only'
+  else if (observerCount >= 2) state = 'confirmed'
+  else state = 'discovered-only'
+
+  const mergedIdentity = mergeIdentities(members.map((m) => m.port.identity))
+  return {
+    ...anchor,
+    identity: mergedIdentity,
+    provenance: {
+      source: authored?.sourceId ?? members[0]?.sourceId ?? 'unknown',
+      state,
+    },
+  }
+}
+
+function foldSubgraphs(authored: NetworkGraph): Subgraph[] | undefined {
+  if (!authored.subgraphs) return undefined
+  return authored.subgraphs.map((s) => ({
+    ...s,
+    provenance: s.provenance ?? { source: 'authored', state: 'authored-only' },
+  }))
+}
+
+/**
+ * Skeleton link folding. Currently passes through every contribution's
+ * links with provenance stamped; cross-source dedup is left as a follow-up
+ * in the full implementation.
+ *
+ * The endpoint `node` id is remapped to the resolved cluster id so links
+ * still reference real nodes after clustering.
+ */
+function foldLinks(contributions: Contribution[], clusterById: Map<string, NodeCluster>): Link[] {
+  const links: Link[] = []
+  for (const contrib of contributions) {
+    for (const link of contrib.graph.links) {
+      const from = remapEndpoint(link.from, contrib.sourceId, clusterById)
+      const to = remapEndpoint(link.to, contrib.sourceId, clusterById)
+      if (!from || !to) continue // dangling — TODO: ghost endpoint
+      links.push({
+        ...link,
+        from,
+        to,
+        provenance: {
+          source: contrib.sourceId,
+          state: contrib.sourceId === 'authored' ? 'authored-only' : 'discovered-only',
+          observedAt: Number.isFinite(contrib.capturedAt) ? contrib.capturedAt : undefined,
+        },
+      })
+    }
+  }
+  return links
+}
+
+function remapEndpoint(
+  endpoint: LinkEndpoint,
+  sourceId: string,
+  clusterById: Map<string, NodeCluster>,
+): LinkEndpoint | null {
+  const cluster = clusterById.get(`${sourceId}:${endpoint.node}`)
+  if (!cluster) return null
+  return { ...endpoint, node: cluster.id }
+}

--- a/libs/@shumoku/core/src/observation/sys-object-id.test.ts
+++ b/libs/@shumoku/core/src/observation/sys-object-id.test.ts
@@ -1,0 +1,53 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import { lookupSysObjectID, vendorFromSysObjectID } from './sys-object-id.js'
+
+describe('sysObjectID lookup', () => {
+  it('returns specific model when a Catalyst 9300 OID is given', () => {
+    const r = lookupSysObjectID('1.3.6.1.4.1.9.1.2030')
+    expect(r?.vendor).toBe('Cisco')
+    expect(r?.model).toBe('Catalyst 9300-24T')
+    expect(r?.matchedPrefix).toBe('1.3.6.1.4.1.9.1.2030')
+  })
+
+  it('falls back to vendor-level match when no model is registered', () => {
+    // A Cisco enterprise OID we don't have a specific entry for
+    const r = lookupSysObjectID('1.3.6.1.4.1.9.1.99999')
+    expect(r?.vendor).toBe('Cisco')
+    expect(r?.model).toBeUndefined()
+    expect(r?.matchedPrefix).toBe('1.3.6.1.4.1.9')
+  })
+
+  it('returns Juniper for a Juniper OID', () => {
+    expect(vendorFromSysObjectID('1.3.6.1.4.1.2636.1.1.1.2.29')).toBe('Juniper')
+  })
+
+  it('returns Aruba for an Aruba OID', () => {
+    expect(vendorFromSysObjectID('1.3.6.1.4.1.14823.1.2.3')).toBe('Aruba Networks')
+  })
+
+  it('returns null for OIDs outside the dictionary', () => {
+    // Made-up enterprise number that does not exist in our dict
+    expect(lookupSysObjectID('1.3.6.1.4.1.99999999.1.2.3')).toBeNull()
+  })
+
+  it('tolerates a leading-dot form', () => {
+    const r = lookupSysObjectID('.1.3.6.1.4.1.30065.1.3000')
+    expect(r?.vendor).toBe('Arista')
+    expect(r?.model).toBe('7050 series')
+  })
+
+  it('matches exact vendor OID without a child component', () => {
+    const r = lookupSysObjectID('1.3.6.1.4.1.9')
+    expect(r?.vendor).toBe('Cisco')
+    expect(r?.model).toBeUndefined()
+  })
+
+  it('Meraki long-prefix wins over a hypothetical Cisco fallback', () => {
+    // 29671 is dedicated to Meraki even though Meraki is a Cisco brand
+    expect(vendorFromSysObjectID('1.3.6.1.4.1.29671.123.456')).toBe('Meraki')
+  })
+})

--- a/libs/@shumoku/core/src/observation/sys-object-id.ts
+++ b/libs/@shumoku/core/src/observation/sys-object-id.ts
@@ -1,0 +1,119 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * sysObjectID → vendor / model lookup.
+ *
+ * `sysObjectID` (RFC 1213, MIB-II) is an OID under each vendor's
+ * enterprise-prefix tree (1.3.6.1.4.1.<vendor>.<model-path>) that is
+ * world-unique to the device family. When an autoscan plugin pulls the
+ * sysObjectID off a device, this helper returns the best-known vendor
+ * and (when known) the specific model name without touching the network.
+ *
+ * v1 ships a small embedded dictionary covering the major network
+ * vendors at the enterprise-OID level, plus a curated set of popular
+ * specific models. The deeper catalog (per-model `discovery`
+ * capabilities) is v2 — see
+ * `apps/server/docs/design/topology-foundation.md § 2.4` and
+ * `topology-foundation-mvp.md § 2.4`.
+ */
+
+export interface SysObjectIdMatch {
+  vendor: string
+  model?: string
+  /** The OID prefix that matched (helps debug "why this vendor?"). */
+  matchedPrefix: string
+}
+
+/**
+ * Lookup table. Entries are checked in order — longer / more specific
+ * prefixes must come first so they win over the vendor-level fallback.
+ *
+ * Format: tuple `[oidPrefix, vendor, model?]`. Empty model means
+ * "vendor-only match — no specific product info from the OID alone".
+ *
+ * Sources: IANA enterprise number assignments + publicly available
+ * MIB browsers. Sample size is small but covers the network gear most
+ * commonly encountered in office / home-lab deployments.
+ */
+const ENTRIES: ReadonlyArray<readonly [string, string, string?]> = [
+  // --- Cisco specific products ---
+  // Catalyst 9300 family
+  ['1.3.6.1.4.1.9.1.2030', 'Cisco', 'Catalyst 9300-24T'],
+  ['1.3.6.1.4.1.9.1.2031', 'Cisco', 'Catalyst 9300-48T'],
+  ['1.3.6.1.4.1.9.1.2032', 'Cisco', 'Catalyst 9300-24P'],
+  ['1.3.6.1.4.1.9.1.2033', 'Cisco', 'Catalyst 9300-48P'],
+  // Catalyst 2960 family
+  ['1.3.6.1.4.1.9.1.716', 'Cisco', 'Catalyst 2960'],
+  ['1.3.6.1.4.1.9.1.717', 'Cisco', 'Catalyst 2960-24TT'],
+  // ISR 4451
+  ['1.3.6.1.4.1.9.1.1681', 'Cisco', 'ISR 4451'],
+  ['1.3.6.1.4.1.9.1.1682', 'Cisco', 'ISR 4431'],
+  // Meraki (Cisco)
+  ['1.3.6.1.4.1.29671', 'Meraki', undefined],
+
+  // --- Juniper specific products ---
+  ['1.3.6.1.4.1.2636.1.1.1.2.29', 'Juniper', 'EX2200'],
+  ['1.3.6.1.4.1.2636.1.1.1.2.57', 'Juniper', 'EX3300'],
+  ['1.3.6.1.4.1.2636.1.1.1.2.78', 'Juniper', 'EX4300'],
+
+  // --- Arista ---
+  ['1.3.6.1.4.1.30065.1.3000', 'Arista', '7050 series'],
+  ['1.3.6.1.4.1.30065.1.3300', 'Arista', '7280 series'],
+
+  // --- Vendor-only prefixes (fallback) ---
+  ['1.3.6.1.4.1.9', 'Cisco'],
+  ['1.3.6.1.4.1.11', 'HPE'],
+  ['1.3.6.1.4.1.171', 'D-Link'],
+  ['1.3.6.1.4.1.232', 'HPE / Hewlett-Packard'],
+  ['1.3.6.1.4.1.318', 'APC'],
+  ['1.3.6.1.4.1.674', 'Dell'],
+  ['1.3.6.1.4.1.890', 'Zyxel'],
+  ['1.3.6.1.4.1.1916', 'Extreme Networks'],
+  ['1.3.6.1.4.1.2011', 'Huawei'],
+  ['1.3.6.1.4.1.2636', 'Juniper'],
+  ['1.3.6.1.4.1.4413', 'Brocade'],
+  ['1.3.6.1.4.1.4526', 'NETGEAR'],
+  ['1.3.6.1.4.1.5624', 'Dell (Force10)'],
+  ['1.3.6.1.4.1.6486', 'Alcatel-Lucent'],
+  ['1.3.6.1.4.1.6527', 'Nokia'],
+  ['1.3.6.1.4.1.8741', 'Aerohive'],
+  ['1.3.6.1.4.1.10520', 'Allied Telesis'],
+  ['1.3.6.1.4.1.12356', 'Fortinet'],
+  ['1.3.6.1.4.1.14823', 'Aruba Networks'],
+  ['1.3.6.1.4.1.25506', 'H3C'],
+  ['1.3.6.1.4.1.29671', 'Meraki'],
+  ['1.3.6.1.4.1.30065', 'Arista'],
+  ['1.3.6.1.4.1.41112', 'Ubiquiti'],
+]
+
+// Sort once at module load so longer (more specific) prefixes come
+// first. `lookupSysObjectID` then short-circuits on the first match.
+const SORTED = [...ENTRIES].sort((a, b) => b[0].length - a[0].length)
+
+function isPrefix(haystack: string, prefix: string): boolean {
+  if (haystack === prefix) return true
+  return haystack.startsWith(`${prefix}.`)
+}
+
+/**
+ * Look up a sysObjectID. Returns `null` when no entry matches —
+ * caller should fall back to surfacing it as an "unknown device" with
+ * the raw OID visible in the UI.
+ */
+export function lookupSysObjectID(oid: string): SysObjectIdMatch | null {
+  // Normalize: strip leading dot if present (some SNMP libs emit ".1.3...").
+  const normalized = oid.startsWith('.') ? oid.slice(1) : oid
+  for (const [prefix, vendor, model] of SORTED) {
+    if (isPrefix(normalized, prefix)) {
+      return { vendor, model, matchedPrefix: prefix }
+    }
+  }
+  return null
+}
+
+/** Convenience: just the vendor name, or null. */
+export function vendorFromSysObjectID(oid: string): string | null {
+  return lookupSysObjectID(oid)?.vendor ?? null
+}

--- a/libs/@shumoku/core/src/observation/types.ts
+++ b/libs/@shumoku/core/src/observation/types.ts
@@ -1,0 +1,56 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import type { NetworkGraph } from '../models/types.js'
+
+/**
+ * One source's observation at a point in time. The server's
+ * `topology_observations` table stores one row per `SnapshotEntry`.
+ * See `apps/server/docs/design/topology-foundation-schema.md § 2.1`.
+ */
+export interface SnapshotEntry {
+  /** Source identifier — typically `data_sources.id`. */
+  sourceId: string
+  /** Unix ms — when the source captured this. */
+  capturedAt: number
+  /**
+   * Snapshot status. The resolver consults this when deciding whether
+   * absence should imply retraction:
+   * - `'ok'` / `'partial'` / `'empty'`: presence is authoritative;
+   *   `'failed'` is never used to retract.
+   */
+  status: 'ok' | 'partial' | 'failed' | 'empty'
+  /** The observed graph. `null` only when `status === 'failed'`. */
+  graph: NetworkGraph | null
+  /**
+   * How many of this source's recent runs have been `'failed'` in a row.
+   * Used as the retraction hysteresis counter — the resolver only
+   * considers retracting elements from this source after the threshold.
+   */
+  consecutiveFailures?: number
+}
+
+/** Tuning knobs for `resolve()`. All optional. */
+export interface ResolveOptions {
+  /**
+   * Number of consecutive failed scans before a source's missing
+   * observations count as retractions. Default `3`.
+   */
+  retractAfterMissedScans?: number
+  /**
+   * Observations older than this (ms) are ignored for conflict
+   * detection. They still show in inspector history. Default 30 days.
+   */
+  staleThresholdMs?: number
+}
+
+/**
+ * `resolve()` returns a regular `NetworkGraph`, just with `provenance`
+ * filled on every entity. The type alias makes the contract obvious
+ * at call sites.
+ */
+export type ResolvedGraph = NetworkGraph
+
+/** Quality of identity binding — diagnostic, not load-bearing. */
+export type IdentityQuality = 'stable' | 'weak' | 'unbound'

--- a/libs/@shumoku/core/src/plugin-types.ts
+++ b/libs/@shumoku/core/src/plugin-types.ts
@@ -23,6 +23,7 @@ export type DataSourceCapability =
   | 'metrics' // Can provide MetricsData
   | 'hosts' // Can list hosts (for mapping UI)
   | 'alerts' // Can provide alerts from monitoring system
+  | 'autoscan' // Can perform seed-crawl network discovery (SNMP/LLDP etc.)
 
 // ============================================
 // Common Types
@@ -320,6 +321,90 @@ export interface AlertsCapable {
 }
 
 /**
+ * One source's observation at a point in time. Returned by autoscan-type
+ * plugins; consumed by the server's resolver. See
+ * `apps/server/docs/design/topology-foundation-plugin-contract.md`.
+ *
+ * The graph is `null` when status is `'failed'`. All elements in the
+ * graph should carry `provenance.source` stamped with the plugin
+ * instance id and (where available) `identity` keys so the resolver can
+ * cluster observations across sources.
+ */
+export interface Snapshot {
+  /** Aggregate status. Retraction gating: only `'ok'` / `'partial'` /
+   *  `'empty'` are treated as authoritative about presence. */
+  status: 'ok' | 'partial' | 'failed' | 'empty'
+  /** Human-readable message when status !== 'ok'. */
+  statusMessage?: string
+  /** Unix ms — when the source captured the snapshot. */
+  capturedAt: number
+  /** The observed graph. `null` only when status === 'failed'. */
+  graph: NetworkGraph | null
+  /** Non-fatal warnings (e.g., timeouts on individual devices). */
+  warnings?: string[]
+}
+
+/**
+ * Crawl-scope policy for seed-crawl autoscans. Inspired by Netdisco
+ * `discover_only` / `discover_no` semantics.
+ */
+export interface ScopePolicy {
+  /** Restrict crawl to these CIDRs. */
+  includeCidrs?: string[]
+  /** Skip these CIDRs even if reachable. */
+  excludeCidrs?: string[]
+  /** "Do not crawl past these nodes" — stops neighbor expansion. */
+  boundaryNodes?: string[]
+  /** Skip devices whose CDP/LLDP type matches these regex patterns. */
+  noTypesPatterns?: string[]
+}
+
+/** Hints from the catalog about which discovery protocols / MIBs to try
+ *  for a given identified device. v1 keeps this loose; the catalog
+ *  surface will tighten in v2. */
+export interface DiscoveryCapabilityHints {
+  snmp?: { versions?: string[]; mibs?: string[] }
+  netconf?: { yang?: string[] }
+  cli?: { family?: string }
+}
+
+export interface AutoscanInput {
+  /** Crawl seed devices (IP or hostname). */
+  seeds: string[]
+  /** Where the crawl may go. */
+  scope?: ScopePolicy
+  /** Optional per-device catalog hints. */
+  capabilityHints?: DiscoveryCapabilityHints
+}
+
+/** Optional progress event stream during a long scan. */
+export interface AutoscanProgress {
+  phase: 'reachability' | 'identify' | 'walk' | 'finalize'
+  totalCandidates: number
+  processed: number
+  failed: number
+  messages: string[]
+}
+
+/**
+ * Plugin can perform seed-crawl network discovery (SNMP/LLDP, ARP,
+ * etc.). Distinct from `TopologyCapable` because autoscan has its own
+ * scope/seed semantics and emits a `Snapshot` (with status + identity
+ * + provenance) rather than a bare `NetworkGraph`.
+ *
+ * The same plugin class MAY implement both `TopologyCapable` and
+ * `AutoscanCapable`. NetBox provides only `topology`; an SNMP plugin
+ * provides only `autoscan`; nothing prevents a future plugin from
+ * doing both.
+ */
+export interface AutoscanCapable {
+  /** Run the scan and return a snapshot. */
+  scan(input: AutoscanInput): Promise<Snapshot>
+  /** Subscribe to per-phase progress events (optional). */
+  subscribeProgress?(input: AutoscanInput, onProgress: (p: AutoscanProgress) => void): () => void
+}
+
+/**
  * Plugin exposes a raw passthrough to the upstream native API. Intended for
  * **developer-time debugging** — the server routes that call this MUST gate
  * themselves on a non-production environment so credentials and arbitrary
@@ -361,6 +446,12 @@ export function hasAlertsCapability(
   plugin: DataSourcePlugin,
 ): plugin is DataSourcePlugin & AlertsCapable {
   return plugin.capabilities.includes('alerts')
+}
+
+export function hasAutoscanCapability(
+  plugin: DataSourcePlugin,
+): plugin is DataSourcePlugin & AutoscanCapable {
+  return plugin.capabilities.includes('autoscan')
 }
 
 /**

--- a/libs/plugins/snmp-lldp/package.json
+++ b/libs/plugins/snmp-lldp/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "shumoku-plugin-snmp-lldp",
+  "version": "0.0.0",
+  "description": "SNMP/LLDP autoscan data source plugin for Shumoku",
+  "license": "AGPL-3.0-only",
+  "author": "konoe-akitoshi",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
+    "directory": "libs/plugins/snmp-lldp"
+  },
+  "homepage": "https://shumoku.packof.me/",
+  "bugs": {
+    "url": "https://github.com/konoe-akitoshi/shumoku/issues"
+  },
+  "keywords": [
+    "snmp",
+    "lldp",
+    "autoscan",
+    "discovery",
+    "shumoku",
+    "plugin"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "format": "biome check --write ."
+  },
+  "dependencies": {
+    "@shumoku/core": "workspace:*",
+    "net-snmp": "^3.26.3"
+  },
+  "devDependencies": {
+    "@types/net-snmp": "^3.23.0",
+    "@types/node": "^22.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libs/plugins/snmp-lldp/src/bun-compat.test.ts
+++ b/libs/plugins/snmp-lldp/src/bun-compat.test.ts
@@ -1,0 +1,22 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import { spikeBunCompat } from './bun-compat.js'
+
+/**
+ * Bun compatibility smoke. Runs in the standard test suite — if this
+ * starts failing in CI, the SNMP plugin will need an alternate UDP
+ * library or a Bun-side fix.
+ */
+describe('net-snmp / Bun compatibility', () => {
+  it('loads the module, builds a v2c session, closes cleanly', () => {
+    const r = spikeBunCompat()
+    expect(r.error).toBeUndefined()
+    expect(r.loadedOk).toBe(true)
+    expect(r.hasVersion2c).toBe(true)
+    expect(r.sessionConstructed).toBe(true)
+    expect(r.sessionClosed).toBe(true)
+  })
+})

--- a/libs/plugins/snmp-lldp/src/bun-compat.ts
+++ b/libs/plugins/snmp-lldp/src/bun-compat.ts
@@ -1,0 +1,66 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Bun compatibility smoke check for the `net-snmp` library.
+ *
+ * `net-snmp` is a pure-JavaScript SNMP implementation that uses
+ * `node:dgram` for UDP. Bun supports `node:dgram` since v1.0+, so
+ * the loader path should work. This file exists to verify:
+ *
+ *   1. `import` of the module succeeds in Bun
+ *   2. `Version` constants are present
+ *   3. A session object can be constructed without throwing
+ *   4. The session can be closed cleanly
+ *
+ * No real SNMP traffic is emitted — the spike runs without any
+ * network device. The integration test that actually walks a device
+ * lives in the full plugin and uses `snmpsim` in CI.
+ */
+
+import * as snmp from 'net-snmp'
+
+export interface SpikeResult {
+  loadedOk: boolean
+  hasVersion2c: boolean
+  sessionConstructed: boolean
+  sessionClosed: boolean
+  error?: string
+}
+
+/**
+ * Run the smoke check and return a structured result. Useful for
+ * CI / a one-off `bun run` invocation.
+ */
+export function spikeBunCompat(): SpikeResult {
+  const result: SpikeResult = {
+    loadedOk: false,
+    hasVersion2c: false,
+    sessionConstructed: false,
+    sessionClosed: false,
+  }
+
+  try {
+    result.loadedOk = typeof snmp.createSession === 'function'
+    result.hasVersion2c = typeof snmp.Version2c !== 'undefined'
+
+    // Construct a session against an unreachable address. net-snmp does
+    // not perform a sync handshake on createSession, so this only
+    // exercises the constructor and underlying dgram socket open.
+    const session = snmp.createSession('127.0.0.1', 'public', {
+      port: 161,
+      version: snmp.Version2c,
+      timeout: 1000,
+      retries: 0,
+    })
+    result.sessionConstructed = true
+
+    session.close()
+    result.sessionClosed = true
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err)
+  }
+
+  return result
+}

--- a/libs/plugins/snmp-lldp/src/client.ts
+++ b/libs/plugins/snmp-lldp/src/client.ts
@@ -1,0 +1,145 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Thin promise-based wrapper around `net-snmp`. Only the operations the
+ * plugin uses are exposed: `get` (single OIDs) and `walk` (full subtree).
+ *
+ * net-snmp 's native API is callback-based; this module makes it await-
+ * friendly so the discovery flow reads as straight-line logic.
+ */
+
+import * as snmp from 'net-snmp'
+
+export interface SnmpTarget {
+  address: string
+  community: string
+  port?: number
+  timeoutMs?: number
+  retries?: number
+  version?: '2c'
+}
+
+export interface VarbindLike {
+  oid: string
+  value: snmp.VarbindValue
+}
+
+export class SnmpClient {
+  private session: snmp.Session
+
+  constructor(target: SnmpTarget) {
+    this.session = snmp.createSession(target.address, target.community, {
+      port: target.port ?? 161,
+      version: snmp.Version2c,
+      timeout: target.timeoutMs ?? 2000,
+      retries: target.retries ?? 1,
+    })
+  }
+
+  close(): void {
+    this.session.close()
+  }
+
+  /** Fetch a single OID (or a small list). Rejects on transport / SNMP error. */
+  get(oids: string[]): Promise<VarbindLike[]> {
+    return new Promise((resolve, reject) => {
+      this.session.get(oids, (err, vbs) => {
+        if (err) return reject(err)
+        if (!vbs) return resolve([])
+        for (const vb of vbs) {
+          if (snmp.isVarbindError(vb)) {
+            return reject(new Error(snmp.varbindError(vb)))
+          }
+        }
+        resolve(
+          vbs.map((vb) => ({
+            oid: vb.oid,
+            value: vb.value,
+          })),
+        )
+      })
+    })
+  }
+
+  /**
+   * Walk a subtree (e.g. an IF-MIB column). Returns all varbinds at or
+   * below `oid`. v2c bulk repetitions defaulted to 20 (sensible for
+   * walking small tables like LLDP-MIB).
+   */
+  walk(oid: string, maxRepetitions = 20): Promise<VarbindLike[]> {
+    return new Promise((resolve, reject) => {
+      const out: VarbindLike[] = []
+      this.session.subtree(
+        oid,
+        maxRepetitions,
+        (vbs) => {
+          for (const vb of vbs) {
+            if (!snmp.isVarbindError(vb)) {
+              out.push({ oid: vb.oid, value: vb.value })
+            }
+          }
+        },
+        (err) => {
+          if (err) return reject(err)
+          resolve(out)
+        },
+      )
+    })
+  }
+}
+
+/**
+ * Group walk results by row-suffix. Given column OIDs like
+ *   1.3.6.1.2.1.2.2.1.2.1 = "Gi1/0/1"
+ *   1.3.6.1.2.1.2.2.1.2.2 = "Gi1/0/2"
+ * with columnBase "1.3.6.1.2.1.2.2.1.2", returns `{ "1": "...", "2": "..." }`.
+ */
+export function indexByRow(
+  walkResult: VarbindLike[],
+  columnBase: string,
+): Record<string, snmp.VarbindValue> {
+  const out: Record<string, snmp.VarbindValue> = {}
+  const prefix = `${columnBase}.`
+  for (const vb of walkResult) {
+    if (!vb.oid.startsWith(prefix)) continue
+    const rowSuffix = vb.oid.slice(prefix.length)
+    out[rowSuffix] = vb.value
+  }
+  return out
+}
+
+/**
+ * Format a Buffer-typed varbind value (e.g. MAC address) as `aa:bb:...`.
+ * Returns the string unchanged if it isn't a Buffer.
+ */
+export function asMacString(value: snmp.VarbindValue | undefined): string | undefined {
+  if (value === undefined) return undefined
+  if (Buffer.isBuffer(value)) {
+    if (value.length !== 6)
+      return value
+        .toString('hex')
+        .match(/.{1,2}/g)
+        ?.join(':')
+    return Array.from(value)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join(':')
+  }
+  return typeof value === 'string' ? value : String(value)
+}
+
+/** Coerce a varbind value into a string (UTF-8 best effort). */
+export function asString(value: snmp.VarbindValue | undefined): string | undefined {
+  if (value === undefined || value === null) return undefined
+  if (Buffer.isBuffer(value)) return value.toString('utf8')
+  return String(value)
+}
+
+/** Coerce a varbind value into a number. */
+export function asNumber(value: snmp.VarbindValue | undefined): number | undefined {
+  if (typeof value === 'number') return value
+  if (typeof value === 'bigint') return Number(value)
+  if (typeof value === 'string' && !Number.isNaN(Number(value))) return Number(value)
+  return undefined
+}

--- a/libs/plugins/snmp-lldp/src/discover.ts
+++ b/libs/plugins/snmp-lldp/src/discover.ts
@@ -1,0 +1,272 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Seed-crawl discovery against one or more devices.
+ *
+ * Algorithm:
+ *   1. Identify each seed via System-MIB (sysName / sysObjectID / sysDescr)
+ *   2. Walk IF-MIB / ifXTable to materialize ports with identity
+ *   3. Walk LLDP-MIB to harvest neighbor (chassisId, portId, sysName)
+ *   4. For neighbors we haven 't visited yet, only record the **link**;
+ *      crossing to other devices requires an explicit seed list (v1)
+ *
+ * v1 deliberately does NOT auto-expand the seed set with discovered
+ * neighbors — that requires reachability assumptions and address
+ * resolution that we punt to v2 (`shumoku-probe` / `ScopePolicy`
+ * include-CIDR). v1 produces a useful snapshot from a fixed seed list
+ * already.
+ */
+
+import {
+  type Identity,
+  type Link,
+  type NetworkGraph,
+  type Node,
+  type NodePort,
+  vendorFromSysObjectID,
+} from '@shumoku/core'
+import { asMacString, asNumber, asString, indexByRow, SnmpClient } from './client.js'
+import { IF_TABLE, IF_X_TABLE, LLDP_REM_TABLE, SYSTEM_MIB } from './mib.js'
+
+export interface DiscoverInput {
+  seeds: Array<{ address: string; community: string }>
+  /** Source id stamped into provenance on every produced element. */
+  sourceId: string
+  /** Per-device timeout in ms (default 2000). */
+  timeoutMs?: number
+}
+
+export interface DiscoverResult {
+  graph: NetworkGraph
+  warnings: string[]
+  /** True if every seed responded successfully. */
+  allOk: boolean
+}
+
+interface VisitedDevice {
+  /** Synthesized node id, e.g. "snmp:<seed-address>". */
+  nodeId: string
+  /** Identity captured at scan time. */
+  identity: Identity
+  sysName?: string
+  sysDescr?: string
+  vendor?: string
+  ports: Map<string, NodePort> // keyed by ifIndex string
+}
+
+export async function discover(input: DiscoverInput): Promise<DiscoverResult> {
+  const warnings: string[] = []
+  const visited = new Map<string, VisitedDevice>() // seed-address → device
+  const allLinks: Link[] = []
+  let okCount = 0
+
+  for (const seed of input.seeds) {
+    const client = new SnmpClient({
+      address: seed.address,
+      community: seed.community,
+      timeoutMs: input.timeoutMs,
+    })
+
+    try {
+      const device = await scanOne(client, seed.address, input.sourceId)
+      visited.set(seed.address, device)
+      okCount++
+    } catch (err) {
+      warnings.push(`Seed ${seed.address}: ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      client.close()
+    }
+  }
+
+  // 2nd pass: walk LLDP for each visited device and emit Links.
+  // Done in a second pass because link endpoints can reference the
+  // *peer* device only if that peer was also visited as a seed.
+  for (const [address, device] of visited) {
+    const client = new SnmpClient({
+      address,
+      community: input.seeds.find((s) => s.address === address)?.community ?? 'public',
+      timeoutMs: input.timeoutMs,
+    })
+    try {
+      const links = await fetchLldpNeighbors(client, device, visited, input.sourceId)
+      allLinks.push(...links)
+    } catch (err) {
+      warnings.push(`LLDP walk on ${address}: ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      client.close()
+    }
+  }
+
+  const graph: NetworkGraph = {
+    version: '1.0',
+    nodes: Array.from(visited.values()).map((d) => visitedToNode(d, input.sourceId)),
+    links: allLinks,
+  }
+
+  return {
+    graph,
+    warnings,
+    allOk: okCount === input.seeds.length && warnings.length === 0,
+  }
+}
+
+async function scanOne(
+  client: SnmpClient,
+  address: string,
+  sourceId: string,
+): Promise<VisitedDevice> {
+  // System-MIB scalars
+  const sys = await client.get([SYSTEM_MIB.sysName, SYSTEM_MIB.sysObjectID, SYSTEM_MIB.sysDescr])
+
+  const sysName = asString(sys[0]?.value)
+  const sysObjectID = asString(sys[1]?.value)
+  const sysDescr = asString(sys[2]?.value)
+  const vendor = sysObjectID ? (vendorFromSysObjectID(sysObjectID) ?? undefined) : undefined
+
+  const identity: Identity = {
+    mgmtIp: address,
+    sysName,
+    vendorIds: sysObjectID ? { 'snmp-sys-object-id': sysObjectID } : undefined,
+  }
+
+  // IF-MIB walks — get names, MACs, oper status
+  const [ifDescrs, ifNames, ifMacs] = await Promise.all([
+    client.walk(IF_TABLE.ifDescr).then((vbs) => indexByRow(vbs, IF_TABLE.ifDescr)),
+    client.walk(IF_X_TABLE.ifName).then((vbs) => indexByRow(vbs, IF_X_TABLE.ifName)),
+    client.walk(IF_TABLE.ifPhysAddress).then((vbs) => indexByRow(vbs, IF_TABLE.ifPhysAddress)),
+  ])
+
+  const ports = new Map<string, NodePort>()
+  for (const [ifIndex, descr] of Object.entries(ifDescrs)) {
+    const ifName = asString(ifNames[ifIndex]) ?? asString(descr)
+    if (!ifName) continue
+    const mac = asMacString(ifMacs[ifIndex])
+    const port: NodePort = {
+      id: `${sourceId}:port:${address}:${ifIndex}`,
+      label: ifName,
+      interfaceName: ifName,
+      connectors: [],
+      identity: {
+        ifName,
+        ifIndex: Number(ifIndex),
+        mac: mac && mac !== '00:00:00:00:00:00' ? mac : undefined,
+      },
+      provenance: { source: sourceId },
+    }
+    ports.set(ifIndex, port)
+  }
+
+  return {
+    nodeId: `${sourceId}:node:${address}`,
+    identity,
+    sysName,
+    sysDescr,
+    vendor,
+    ports,
+  }
+}
+
+function visitedToNode(device: VisitedDevice, sourceId: string): Node {
+  const labelParts: string[] = []
+  if (device.sysName) labelParts.push(device.sysName)
+  else if (device.identity.mgmtIp) labelParts.push(device.identity.mgmtIp)
+
+  return {
+    id: device.nodeId,
+    label: labelParts.length > 0 ? labelParts : (device.identity.mgmtIp ?? 'unknown'),
+    shape: 'rect',
+    identity: device.identity,
+    metadata: {
+      vendor: device.vendor,
+      sysDescr: device.sysDescr,
+    },
+    ports: Array.from(device.ports.values()),
+    provenance: { source: sourceId, observedAt: Date.now() },
+  }
+}
+
+async function fetchLldpNeighbors(
+  client: SnmpClient,
+  device: VisitedDevice,
+  visited: Map<string, VisitedDevice>,
+  sourceId: string,
+): Promise<Link[]> {
+  // Walk the LLDP neighbor table columns we care about
+  const [chassisIds, portIds, sysNames] = await Promise.all([
+    client
+      .walk(LLDP_REM_TABLE.lldpRemChassisId)
+      .then((vbs) => indexByRow(vbs, LLDP_REM_TABLE.lldpRemChassisId)),
+    client
+      .walk(LLDP_REM_TABLE.lldpRemPortId)
+      .then((vbs) => indexByRow(vbs, LLDP_REM_TABLE.lldpRemPortId)),
+    client
+      .walk(LLDP_REM_TABLE.lldpRemSysName)
+      .then((vbs) => indexByRow(vbs, LLDP_REM_TABLE.lldpRemSysName)),
+  ])
+
+  const links: Link[] = []
+  for (const rowSuffix of Object.keys(chassisIds)) {
+    // rowSuffix is `lldpRemTimeMark.lldpRemLocalPortNum.lldpRemIndex`
+    const parts = rowSuffix.split('.')
+    if (parts.length < 3) continue
+    const localPortNum = parts[1] // assumed == ifIndex on most devices
+    if (!localPortNum) continue
+
+    const localPort = device.ports.get(localPortNum)
+    if (!localPort) continue
+
+    const remoteChassis = asMacString(chassisIds[rowSuffix])
+    const remoteSysName = asString(sysNames[rowSuffix])
+    const remotePortId = asString(portIds[rowSuffix])
+
+    // Find the peer device in our visited set by chassisId / sysName.
+    // The peer 's identity might not have the chassisId yet (we read it
+    // off the LLDP-LOC table on the peer to know that), but sysName
+    // matching usually works.
+    let peer: VisitedDevice | undefined
+    for (const d of visited.values()) {
+      if (d === device) continue
+      if (remoteSysName && d.sysName === remoteSysName) {
+        peer = d
+        break
+      }
+    }
+
+    if (!peer) {
+      // We see the neighbor but didn 't seed it. v1: skip the link
+      // entirely (cross-cluster dangling endpoints are deferred —
+      // see resolve.ts skeleton TODO).
+      continue
+    }
+
+    // Find the peer port matching remotePortId
+    let peerPort: NodePort | undefined
+    if (remotePortId) {
+      for (const p of peer.ports.values()) {
+        if (p.identity?.ifName === remotePortId || p.interfaceName === remotePortId) {
+          peerPort = p
+          break
+        }
+      }
+    }
+    if (!peerPort) continue
+
+    links.push({
+      from: { node: device.nodeId, port: localPort.id },
+      to: { node: peer.nodeId, port: peerPort.id },
+      provenance: { source: sourceId, observedAt: Date.now() },
+      metadata: {
+        lldpRemoteChassis: remoteChassis,
+      },
+    })
+  }
+
+  return links
+}
+
+// Helpers used by tests to keep types in sync without exporting all internals.
+export const __internals__ = { scanOne, fetchLldpNeighbors }
+// asNumber re-exported in case downstream code wants it.
+export { asNumber }

--- a/libs/plugins/snmp-lldp/src/index.ts
+++ b/libs/plugins/snmp-lldp/src/index.ts
@@ -5,9 +5,20 @@
 /**
  * Shumoku SNMP / LLDP discovery plugin.
  *
- * Skeleton — Bun compatibility spike for the `net-snmp` library is
- * present in `bun-compat.ts`. The full plugin lands in a follow-up
- * commit alongside the `AutoscanCapable` capability addition to core.
+ * Implements `AutoscanCapable` from `@shumoku/core` for seed-crawl
+ * network discovery. See `topology-foundation-plugin-contract.md`.
  */
 
+import type { PluginRegistryInterface } from '@shumoku/core'
+import { SnmpLldpPlugin } from './plugin.js'
+
 export { spikeBunCompat } from './bun-compat.js'
+export { SnmpLldpPlugin } from './plugin.js'
+
+export function register(registry: PluginRegistryInterface): void {
+  registry.register('snmp-lldp', 'SNMP / LLDP', ['autoscan', 'topology'], (config) => {
+    const plugin = new SnmpLldpPlugin()
+    plugin.initialize(config)
+    return plugin
+  })
+}

--- a/libs/plugins/snmp-lldp/src/index.ts
+++ b/libs/plugins/snmp-lldp/src/index.ts
@@ -1,0 +1,13 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Shumoku SNMP / LLDP discovery plugin.
+ *
+ * Skeleton — Bun compatibility spike for the `net-snmp` library is
+ * present in `bun-compat.ts`. The full plugin lands in a follow-up
+ * commit alongside the `AutoscanCapable` capability addition to core.
+ */
+
+export { spikeBunCompat } from './bun-compat.js'

--- a/libs/plugins/snmp-lldp/src/mib.ts
+++ b/libs/plugins/snmp-lldp/src/mib.ts
@@ -1,0 +1,79 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * MIB OIDs the SNMP-LLDP plugin walks. Centralized so changes /
+ * additional MIBs are easy to spot.
+ */
+
+/** RFC 1213 System-MIB scalars (always `.0` suffix to fetch). */
+export const SYSTEM_MIB = {
+  sysDescr: '1.3.6.1.2.1.1.1.0',
+  sysObjectID: '1.3.6.1.2.1.1.2.0',
+  sysUpTime: '1.3.6.1.2.1.1.3.0',
+  sysContact: '1.3.6.1.2.1.1.4.0',
+  sysName: '1.3.6.1.2.1.1.5.0',
+  sysLocation: '1.3.6.1.2.1.1.6.0',
+} as const
+
+/** RFC 2863 IF-MIB columns under `ifTable` (1.3.6.1.2.1.2.2.1). */
+export const IF_TABLE = {
+  base: '1.3.6.1.2.1.2.2.1',
+  ifIndex: '1.3.6.1.2.1.2.2.1.1',
+  ifDescr: '1.3.6.1.2.1.2.2.1.2',
+  ifType: '1.3.6.1.2.1.2.2.1.3',
+  ifMtu: '1.3.6.1.2.1.2.2.1.4',
+  ifSpeed: '1.3.6.1.2.1.2.2.1.5',
+  ifPhysAddress: '1.3.6.1.2.1.2.2.1.6',
+  ifAdminStatus: '1.3.6.1.2.1.2.2.1.7',
+  ifOperStatus: '1.3.6.1.2.1.2.2.1.8',
+} as const
+
+/** RFC 2863 IF-MIB ifXTable extensions (1.3.6.1.2.1.31.1.1.1). */
+export const IF_X_TABLE = {
+  base: '1.3.6.1.2.1.31.1.1.1',
+  ifName: '1.3.6.1.2.1.31.1.1.1.1',
+  ifHighSpeed: '1.3.6.1.2.1.31.1.1.1.15',
+  ifAlias: '1.3.6.1.2.1.31.1.1.1.18',
+} as const
+
+/** RFC 4293 IP-MIB ipNetToMedia (ARP cache; v4 only). */
+export const IP_NET_TO_MEDIA = {
+  base: '1.3.6.1.2.1.4.22.1',
+  // index: ifIndex.ipv4-address → physical address
+  ipNetToMediaPhysAddress: '1.3.6.1.2.1.4.22.1.2',
+} as const
+
+/**
+ * IEEE 802.1AB LLDP-MIB — lldpRemTable (remote / neighbor info).
+ *
+ * Indexes: `lldpRemTimeMark.lldpRemLocalPortNum.lldpRemIndex`
+ * which decode to "snapshot generation . local port . per-neighbor index".
+ *
+ * The `lldpRemLocalPortNum` part is the LOCAL port the neighbor was
+ * heard on — important: this is the LLDP-MIB port number, NOT the
+ * IF-MIB ifIndex. Most devices align them, but some don 't; for v1 we
+ * treat them as equivalent (good enough for a starting MVP).
+ */
+export const LLDP_REM_TABLE = {
+  base: '1.0.8802.1.1.2.1.4.1.1',
+  lldpRemChassisIdSubtype: '1.0.8802.1.1.2.1.4.1.1.4',
+  lldpRemChassisId: '1.0.8802.1.1.2.1.4.1.1.5',
+  lldpRemPortIdSubtype: '1.0.8802.1.1.2.1.4.1.1.6',
+  lldpRemPortId: '1.0.8802.1.1.2.1.4.1.1.7',
+  lldpRemPortDesc: '1.0.8802.1.1.2.1.4.1.1.8',
+  lldpRemSysName: '1.0.8802.1.1.2.1.4.1.1.9',
+  lldpRemSysDesc: '1.0.8802.1.1.2.1.4.1.1.10',
+} as const
+
+/** LLDP local port translation table. Maps LLDP local port nums
+ *  (used as the middle index in lldpRemTable) to actual port info.
+ *  v1 mostly assumes the lldpLocalPortNum == ifIndex which is true on
+ *  most modern devices. */
+export const LLDP_LOC_PORT_TABLE = {
+  base: '1.0.8802.1.1.2.1.3.7.1',
+  lldpLocPortIdSubtype: '1.0.8802.1.1.2.1.3.7.1.2',
+  lldpLocPortId: '1.0.8802.1.1.2.1.3.7.1.3',
+  lldpLocPortDesc: '1.0.8802.1.1.2.1.3.7.1.4',
+} as const

--- a/libs/plugins/snmp-lldp/src/plugin.ts
+++ b/libs/plugins/snmp-lldp/src/plugin.ts
@@ -1,0 +1,142 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * SNMP-LLDP plugin — implements `DataSourcePlugin` + `AutoscanCapable`.
+ *
+ * v1 scope: System-MIB identification, IF-MIB / ifXTable port walk,
+ * LLDP-MIB neighbor harvest. Other MIBs (BRIDGE, ENTITY, ROUTING) are
+ * out-of-scope for v1; see mvp doc.
+ */
+
+import type {
+  AutoscanCapable,
+  AutoscanInput,
+  ConnectionResult,
+  DataSourceCapability,
+  DataSourcePlugin,
+  Snapshot,
+} from '@shumoku/core'
+import { SnmpClient } from './client.js'
+import { discover } from './discover.js'
+import { SYSTEM_MIB } from './mib.js'
+
+/**
+ * Seed entry as expected on plugin config. UI surfaces these as a
+ * repeatable list (address + community).
+ */
+export interface SnmpLldpSeed {
+  address: string
+  community: string
+}
+
+export interface SnmpLldpConfig {
+  /** Plugin instance id, stamped into provenance.source. Supplied by
+   *  the server when constructing the plugin. */
+  instanceId?: string
+  /** Default community used when a seed doesn 't specify one. */
+  community?: string
+  /** Seed devices to crawl. */
+  seeds?: SnmpLldpSeed[]
+  /** Per-device SNMP timeout in ms (default 2000). */
+  timeoutMs?: number
+}
+
+export class SnmpLldpPlugin implements DataSourcePlugin, AutoscanCapable {
+  readonly type = 'snmp-lldp'
+  readonly displayName = 'SNMP / LLDP'
+  readonly capabilities: readonly DataSourceCapability[] = ['autoscan', 'topology']
+
+  private config: SnmpLldpConfig = {}
+
+  initialize(config: unknown): void {
+    this.config = (config as SnmpLldpConfig) ?? {}
+  }
+
+  /** `testConnection` probes the first seed for System-MIB scalars.
+   *  Reports identity-coverage diagnostics back so the UI can advise. */
+  async testConnection(): Promise<ConnectionResult> {
+    const seed = this.config.seeds?.[0]
+    if (!seed) {
+      return { success: false, message: 'No seed devices configured' }
+    }
+    const client = new SnmpClient({
+      address: seed.address,
+      community: seed.community || this.config.community || 'public',
+      timeoutMs: this.config.timeoutMs ?? 2000,
+    })
+    try {
+      const vbs = await client.get([
+        SYSTEM_MIB.sysName,
+        SYSTEM_MIB.sysObjectID,
+        SYSTEM_MIB.sysDescr,
+      ])
+      const sysName = vbs[0]?.value
+      const sysObjectID = vbs[1]?.value
+      return {
+        success: true,
+        message: `Reached ${seed.address} (sysName=${String(sysName)})`,
+        version: typeof sysObjectID === 'string' ? sysObjectID : undefined,
+      }
+    } catch (err) {
+      return {
+        success: false,
+        message: err instanceof Error ? err.message : String(err),
+      }
+    } finally {
+      client.close()
+    }
+  }
+
+  /**
+   * AutoscanCapable.scan — perform the seed-crawl and return a Snapshot.
+   * The `input` from the caller can override the configured seeds; if
+   * absent we fall back to `this.config.seeds`.
+   */
+  async scan(input: AutoscanInput): Promise<Snapshot> {
+    const capturedAt = Date.now()
+    const sourceId = this.config.instanceId ?? 'snmp-lldp'
+    const seeds = (
+      input.seeds.length > 0 ? input.seeds : (this.config.seeds ?? []).map((s) => s.address)
+    ).map((addr) => ({
+      address: addr,
+      community:
+        this.config.seeds?.find((s) => s.address === addr)?.community ??
+        this.config.community ??
+        'public',
+    }))
+
+    if (seeds.length === 0) {
+      return {
+        status: 'failed',
+        statusMessage: 'No seed devices configured',
+        capturedAt,
+        graph: null,
+      }
+    }
+
+    try {
+      const result = await discover({
+        seeds,
+        sourceId,
+        timeoutMs: this.config.timeoutMs,
+      })
+      const status: Snapshot['status'] =
+        result.graph.nodes.length === 0 ? 'empty' : result.allOk ? 'ok' : 'partial'
+      return {
+        status,
+        capturedAt,
+        graph: result.graph,
+        warnings: result.warnings.length > 0 ? result.warnings : undefined,
+      }
+    } catch (err) {
+      return {
+        status: 'failed',
+        statusMessage: err instanceof Error ? err.message : String(err),
+        capturedAt,
+        graph: null,
+      }
+    }
+  }
+}

--- a/libs/plugins/snmp-lldp/tsconfig.json
+++ b/libs/plugins/snmp-lldp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"],
+  "references": [{ "path": "../../@shumoku/core" }]
+}


### PR DESCRIPTION
## 概要

`apps/server` の topology discovery / observation model 設計ドキュメント (PR #289, #302) に
基づく **v1 実装**を一括投入します。authored layer (既存の `topologies.content_json`) を、
複数の発見ソースが提供する snapshot と純粋関数 `resolve()` で畳んで描画する仕組み。

設計の合意事項どおり、**`NetworkGraph` JSON が引き続き核**。core 型に optional な
`provenance` / `identity` を追加するだけの最小拡張で済んでいます（後方互換考慮なし）。

## 実装範囲（7 コミット）

| Step | 内容 | コミット |
|---|---|---|
| 1 | core 型に `Provenance` + `Identity` 追加 (Node/Link/Subgraph/NodePort) | `0e8d65b` |
| 2 | `observation/` モジュール — resolve() / identity helpers | `9bd37f2` |
| 3 | migration 008 + `ObservationsService` | `a265bed` |
| 4 | `libs/plugins/snmp-lldp` scaffold + Bun 互換性スパイク | `103e59f` |
| 5 | SNMP-LLDP plugin 本実装 (System/IF/LLDP MIB walks) | `11d0ab5` |
| 6 + 8 | `AutoscanCapable` / `Snapshot` + sysObjectID 同梱辞書 | `0de1101` |
| 7 | Observation API + scan trigger + plugin 登録 | `8548484` |

## 動作概要

```
[snmp-lldp plugin] ──scan()──→ Snapshot(NetworkGraph)
                                ↓ POST /api/datasources/:id/scan
                                ↓ ObservationsService.record()
                              topology_observations (DB)
                                ↓ GET /api/topologies/:id/resolved
                              resolve(authored, snapshots[])
                                ↓
                              Resolved NetworkGraph
                              (provenance.state = confirmed |
                               authored-only | discovered-only |
                               conflicting)
```

## 主要な動作

### core (`@shumoku/core`)

- `Provenance`, `Identity` 型を追加。Node/Link/Subgraph/NodePort に optional フィールドとして付加
- `observation/resolve.ts` — `resolve(authored: NetworkGraph, snapshots: SnapshotEntry[]) → NetworkGraph` の純粋関数。identity-keyed cluster 構築、フィールド比較、ifIndex 再採番耐性
- `observation/identity.ts` — `nodeIdentityKeys` / `portIdentityKeys` (priority 順)、`nodeIdentityQuality` / `portIdentityQuality`
- `observation/sys-object-id.ts` — 同梱辞書 (~25 enterprise OID prefixes + 一部具体機種)
- `plugin-types.ts` に `AutoscanCapable`, `Snapshot`, `ScopePolicy`, `AutoscanInput`, `AutoscanProgress`, `hasAutoscanCapability` 追加。`DataSourceCapability` に `'autoscan'` を追加

### server (`apps/server/api`)

- migration 008 `topology_observations` テーブル + `consecutive_failures` / `last_ok_captured_at` 列追加
- `ObservationsService`: record / latestPerSource / listForTopology / pruneOldObservations / updateHysteresis
- 3 つの新 API:
  - `POST /api/datasources/:id/scan` — ad-hoc autoscan
  - `GET /api/topologies/:id/observations` — history
  - `GET /api/topologies/:id/resolved` — resolved graph
- `snmp-lldp` を bundled plugin として登録

### plugin (`libs/plugins/snmp-lldp`)

- net-snmp v3.26.3 (Bun 動作確認済)
- 識別フェーズ → IF-MIB walk → LLDP-MIB neighbor harvest
- snapshot 内の各 node / port に identity (mgmtIp / chassisId / sysName / ifName / ifIndex / mac) と provenance を刻む
- vendorFromSysObjectID() を使って `metadata.vendor` を埋める

## v1 で意図的に作らないもの

`topology-foundation-mvp.md § 3` どおり：

- メトリクス persist (TSDB) → v2
- Conflict 解決の UI 操作 → v2
- editor 改修 → v2
- Workload 層 (Proxmox/k8s) → v2
- shumoku-probe (ステートレス中継) → v2
- Web UI (state 視覚化, Element inspector, Bootstrap matching UI) → 次の PR
- カタログ全体の discovery capability 宣言 → v2

**Web UI は次の PR にする予定**。本 PR は core + server API 層まで。

## 棚上げで残しているもの

- legacy 列削除 (`priority`, `topology_source_id`, `metrics_source_id`) — additive な migration として残し、topology service が観測モデルに完全移行した段階で別 migration で消す
- resolve() の完全実装 — skeleton ベース。cross-source link dedup, ghost endpoint, 完全な retraction hysteresis は v1.x で詰める

## 検証

- core 209 テスト + server-web 44 テスト = 全 green
- `bun run typecheck` 34/34 pass
- `bun run build` 18/18 pass
- SNMP plugin の Bun 互換性スパイク pass
- ifIndex 再採番シナリオ含む resolver fixture テスト

## レビュー観点

1. 観測モデルの core 型変更が optional/additive で済んでいることの確認（既存の renderer/editor は無改修で動く）
2. `resolve()` skeleton のセマンティクスが design doc と合っていること
3. SNMP plugin の MIB walk が実機を想定したものになっていること
4. API endpoint の境界（scan trigger の引数、resolved の出力）

## 関連

- 設計: `apps/server/docs/design/topology-foundation*.md` (8 docs, PR #302)
- 探索ログ: `apps/server/docs/design/topology-discovery.md` (PR #289)

🤖 Generated with [Claude Code](https://claude.com/claude-code)