### PR TITLE
feat(server/web): observation panel — UI for the v1 foundation

### DIFF
--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -131,6 +131,31 @@ export const dataSources = {
     request<{ sites: { slug: string; name: string }[]; tags: { slug: string; name: string }[] }>(
       `/datasources/${id}/filter-options`,
     ),
+
+  /**
+   * Trigger an ad-hoc autoscan. If `topologyId` is provided the snapshot
+   * is persisted to `topology_observations`; otherwise it 's returned but
+   * not stored (useful for "test scan" previews).
+   */
+  scan: (id: string, body?: { topologyId?: string; seeds?: string[] }) =>
+    request<{
+      snapshot: {
+        status: 'ok' | 'partial' | 'failed' | 'empty'
+        statusMessage?: string
+        capturedAt: number
+        graph: NetworkGraph | null
+        warnings?: string[]
+      }
+      observation?: {
+        id: string
+        nodeCount: number
+        linkCount: number
+        portCount: number
+      }
+    }>(`/datasources/${id}/scan`, {
+      method: 'POST',
+      body: JSON.stringify(body ?? {}),
+    }),
 }
 
 // Topologies API
@@ -192,6 +217,44 @@ export const topologies = {
 
   getGraph: (id: string) =>
     request<{ id: string; name: string; graph: NetworkGraph }>(`/topologies/${id}/graph`),
+
+  /** Resolved graph = authored layer folded with latest snapshot per source. */
+  getResolved: (id: string) =>
+    request<{ graph: NetworkGraph; snapshotCount: number }>(`/topologies/${id}/resolved`),
+
+  /** Recent observation snapshots for this topology (counters only). */
+  listObservations: (id: string, limit?: number) => {
+    const params = limit ? `?limit=${limit}` : ''
+    return request<
+      {
+        id: string
+        topologyId: string
+        sourceId: string
+        capturedAt: number
+        status: 'ok' | 'partial' | 'failed' | 'empty'
+        statusMessage?: string
+        nodeCount: number
+        linkCount: number
+        portCount: number
+        createdAt: number
+      }[]
+    >(`/topologies/${id}/observations${params}`)
+  },
+
+  getObservation: (id: string, obsId: string) =>
+    request<{
+      id: string
+      topologyId: string
+      sourceId: string
+      capturedAt: number
+      status: 'ok' | 'partial' | 'failed' | 'empty'
+      statusMessage?: string
+      graph: NetworkGraph | null
+      nodeCount: number
+      linkCount: number
+      portCount: number
+      createdAt: number
+    }>(`/topologies/${id}/observations/${obsId}`),
 
   getContext: (id: string, theme?: 'light' | 'dark') => {
     const params = theme ? `?theme=${theme}` : ''

--- a/apps/server/web/src/lib/components/ObservationPanel.svelte
+++ b/apps/server/web/src/lib/components/ObservationPanel.svelte
@@ -1,0 +1,371 @@
+<script lang="ts">
+  import type { NetworkGraph, Provenance } from '@shumoku/core'
+  import { onMount } from 'svelte'
+  import { api } from '$lib/api'
+  import { Button } from '$lib/components/ui/button'
+
+  /**
+   * Surfaces the observation-model state of a topology:
+   *   - resolved graph from GET /resolved (each element has provenance.state)
+   *   - recent snapshots list from GET /observations
+   *   - per-source "Scan now" button
+   *
+   * This is the v1 stand-in for the eventual rich Element inspector + scan
+   * triggers integrated directly into the SVG viewer. The renderer doesn 't
+   * yet decorate elements by state, so this panel makes the same data
+   * discoverable in tabular form.
+   */
+  interface Props {
+    topologyId: string
+  }
+  let { topologyId }: Props = $props()
+
+  type State = NonNullable<Provenance['state']>
+
+  let resolved = $state<NetworkGraph | null>(null)
+  let snapshotCount = $state(0)
+  let observations = $state<
+    Array<{
+      id: string
+      sourceId: string
+      capturedAt: number
+      status: 'ok' | 'partial' | 'failed' | 'empty'
+      statusMessage?: string
+      nodeCount: number
+      linkCount: number
+      portCount: number
+    }>
+  >([])
+  let sources = $state<
+    Array<{ id: string; dataSourceId: string; dataSource?: { name: string; type: string } }>
+  >([])
+  let loading = $state(true)
+  let error = $state('')
+  let scanningSourceId = $state<string | null>(null)
+  /** Selected element for the inline mini-inspector. */
+  let selected = $state<{ kind: 'node' | 'link'; id: string } | null>(null)
+  /** Filter the element table by state. */
+  let stateFilter = $state<State | 'all'>('all')
+
+  async function refresh() {
+    loading = true
+    error = ''
+    try {
+      const [resolvedResp, obsList, srcList] = await Promise.all([
+        api.topologies.getResolved(topologyId),
+        api.topologies.listObservations(topologyId, 20),
+        api.topologies.sources.list(topologyId),
+      ])
+      resolved = resolvedResp.graph
+      snapshotCount = resolvedResp.snapshotCount
+      observations = obsList
+      sources = srcList
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to load observations'
+    } finally {
+      loading = false
+    }
+  }
+
+  onMount(() => {
+    void refresh()
+  })
+
+  async function handleScan(sourceId: string) {
+    scanningSourceId = sourceId
+    try {
+      await api.dataSources.scan(sourceId, { topologyId })
+      // Refresh both the resolved graph and the observation history.
+      await refresh()
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Scan failed'
+    } finally {
+      scanningSourceId = null
+    }
+  }
+
+  function formatAgo(ts: number): string {
+    const diff = Date.now() - ts
+    if (diff < 60_000) return 'just now'
+    if (diff < 3600_000) return `${Math.floor(diff / 60_000)}m ago`
+    if (diff < 86400_000) return `${Math.floor(diff / 3600_000)}h ago`
+    return new Date(ts).toLocaleString()
+  }
+
+  function stateLabel(s: State | undefined): string {
+    if (!s) return 'unset'
+    if (s === 'authored-only') return 'authored only'
+    if (s === 'discovered-only') return 'discovered only'
+    return s
+  }
+
+  function stateClass(s: State | undefined): string {
+    switch (s) {
+      case 'confirmed':
+        return 'text-green-600 dark:text-green-400'
+      case 'conflicting':
+        return 'text-amber-600 dark:text-amber-400'
+      case 'discovered-only':
+        return 'text-blue-500 dark:text-blue-400'
+      case 'authored-only':
+        return 'text-theme-text-muted'
+      default:
+        return 'text-theme-text-muted'
+    }
+  }
+
+  /** Flatten resolved nodes into the table rows we show. */
+  let nodeRows = $derived.by(() => {
+    if (!resolved) return []
+    return (resolved.nodes ?? []).map((n) => ({
+      kind: 'node' as const,
+      id: n.id,
+      label: Array.isArray(n.label) ? n.label.join(' ') : (n.label ?? '(unnamed)'),
+      state: n.provenance?.state,
+      source: n.provenance?.source ?? '—',
+      identity: n.identity,
+      observedAt: n.provenance?.observedAt,
+      portCount: n.ports?.length ?? 0,
+    }))
+  })
+
+  let filteredRows = $derived(
+    stateFilter === 'all' ? nodeRows : nodeRows.filter((r) => r.state === stateFilter),
+  )
+
+  let counts = $derived.by(() => {
+    const byState: Record<string, number> = {
+      confirmed: 0,
+      conflicting: 0,
+      'discovered-only': 0,
+      'authored-only': 0,
+    }
+    for (const r of nodeRows) {
+      if (r.state) byState[r.state] = (byState[r.state] ?? 0) + 1
+    }
+    return byState
+  })
+
+  let selectedNode = $derived.by(() => {
+    const sel = selected
+    if (!sel || sel.kind !== 'node') return null
+    return nodeRows.find((r) => r.id === sel.id) ?? null
+  })
+</script>
+
+<div class="observation-panel space-y-4">
+  <header class="flex items-center justify-between gap-2">
+    <div>
+      <h2 class="text-base font-semibold">Observations</h2>
+      <p class="text-xs text-theme-text-muted">
+        {snapshotCount}
+        active snapshot{snapshotCount === 1 ? '' : 's'}
+        · resolver state per element
+      </p>
+    </div>
+    <Button variant="outline" size="sm" onclick={refresh} disabled={loading}>
+      {loading ? 'Loading…' : 'Refresh'}
+    </Button>
+  </header>
+
+  {#if error}
+    <div class="rounded border border-red-500/50 bg-red-500/10 p-2 text-xs text-red-500">
+      {error}
+    </div>
+  {/if}
+
+  <!-- Per-source scan controls -->
+  {#if sources.length > 0}
+    <section class="rounded border border-theme-border p-3">
+      <h3 class="text-sm font-medium mb-2">Sources attached</h3>
+      <ul class="space-y-1">
+        {#each sources as src (src.id)}
+          <li class="flex items-center justify-between gap-2 text-sm">
+            <span>
+              <span class="font-mono text-xs">{src.dataSource?.type ?? '—'}</span>
+              <span class="ml-2">{src.dataSource?.name ?? src.dataSourceId}</span>
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={() => handleScan(src.dataSourceId)}
+              disabled={scanningSourceId === src.dataSourceId}
+            >
+              {scanningSourceId === src.dataSourceId ? 'Scanning…' : 'Scan now'}
+            </Button>
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+
+  <!-- State summary -->
+  <section class="grid grid-cols-4 gap-2 text-center text-xs">
+    {#each [['confirmed', 'Confirmed'], ['conflicting', 'Conflicting'], ['discovered-only', 'Discovered only'], ['authored-only', 'Authored only']] as [ k, label ] (k)}
+      <button
+        class="rounded border p-2 transition-colors {stateFilter === k
+          ? 'border-blue-500 bg-blue-500/10'
+          : 'border-theme-border hover:bg-theme-surface-hover'}"
+        onclick={() => {
+          stateFilter = stateFilter === k ? 'all' : (k as State)
+        }}
+      >
+        <div class="text-lg font-semibold {stateClass(k as State)}">{counts[k as string] ?? 0}</div>
+        <div class="text-theme-text-muted">{label}</div>
+      </button>
+    {/each}
+  </section>
+
+  <!-- Element table -->
+  <section>
+    <div class="flex items-center justify-between mb-1">
+      <h3 class="text-sm font-medium">
+        Nodes
+        {#if stateFilter !== 'all'}
+          <span class="text-xs text-theme-text-muted">filter: {stateFilter}</span>
+        {/if}
+      </h3>
+      {#if stateFilter !== 'all'}
+        <button class="text-xs text-blue-500 hover:underline" onclick={() => (stateFilter = 'all')}>
+          Clear filter
+        </button>
+      {/if}
+    </div>
+    <div class="rounded border border-theme-border max-h-72 overflow-auto">
+      <table class="w-full text-xs">
+        <thead class="sticky top-0 bg-theme-surface">
+          <tr class="text-left">
+            <th class="p-1.5 font-medium">Label</th>
+            <th class="p-1.5 font-medium">State</th>
+            <th class="p-1.5 font-medium">Source</th>
+            <th class="p-1.5 font-medium">mgmtIp</th>
+            <th class="p-1.5 font-medium text-right">Ports</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each filteredRows as r (r.id)}
+            <tr
+              class="border-t border-theme-border cursor-pointer hover:bg-theme-surface-hover {selected?.id ===
+              r.id
+                ? 'bg-theme-surface-hover'
+                : ''}"
+              onclick={() => (selected = { kind: 'node', id: r.id })}
+            >
+              <td class="p-1.5 font-medium">{r.label}</td>
+              <td class="p-1.5 {stateClass(r.state)}">{stateLabel(r.state)}</td>
+              <td class="p-1.5 font-mono text-theme-text-muted">{r.source}</td>
+              <td class="p-1.5 font-mono text-theme-text-muted">{r.identity?.mgmtIp ?? ''}</td>
+              <td class="p-1.5 text-right">{r.portCount}</td>
+            </tr>
+          {/each}
+          {#if filteredRows.length === 0}
+            <tr>
+              <td colspan="5" class="p-3 text-center text-theme-text-muted">
+                {nodeRows.length === 0
+                  ? 'No nodes resolved yet — attach a source and scan.'
+                  : 'No nodes match this filter.'}
+              </td>
+            </tr>
+          {/if}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- Mini inspector for selected element -->
+  {#if selectedNode}
+    <section class="rounded border border-theme-border p-3 text-xs space-y-2">
+      <div class="flex items-center justify-between">
+        <h3 class="text-sm font-medium">
+          {selectedNode.label}
+          <span class="ml-2 {stateClass(selectedNode.state)}"
+            >{stateLabel(selectedNode.state)}</span
+          >
+        </h3>
+        <button
+          class="text-theme-text-muted hover:text-theme-text"
+          onclick={() => (selected = null)}
+        >
+          ✕
+        </button>
+      </div>
+      <dl class="grid grid-cols-[120px_1fr] gap-x-2 gap-y-1">
+        <dt class="text-theme-text-muted">source</dt>
+        <dd class="font-mono">{selectedNode.source}</dd>
+        {#if selectedNode.observedAt}
+          <dt class="text-theme-text-muted">observed</dt>
+          <dd>{formatAgo(selectedNode.observedAt)}</dd>
+        {/if}
+        {#if selectedNode.identity}
+          {#if selectedNode.identity.mgmtIp}
+            <dt class="text-theme-text-muted">mgmtIp</dt>
+            <dd class="font-mono">{selectedNode.identity.mgmtIp}</dd>
+          {/if}
+          {#if selectedNode.identity.chassisId}
+            <dt class="text-theme-text-muted">chassisId</dt>
+            <dd class="font-mono">{selectedNode.identity.chassisId}</dd>
+          {/if}
+          {#if selectedNode.identity.sysName}
+            <dt class="text-theme-text-muted">sysName</dt>
+            <dd>{selectedNode.identity.sysName}</dd>
+          {/if}
+          {#if selectedNode.identity.vendorIds}
+            <dt class="text-theme-text-muted">vendorIds</dt>
+            <dd class="font-mono">
+              {Object.entries(selectedNode.identity.vendorIds)
+                .map(([k, v]) => `${k}=${v}`)
+                .join(', ')}
+            </dd>
+          {/if}
+        {/if}
+        <dt class="text-theme-text-muted">ports</dt>
+        <dd>{selectedNode.portCount}</dd>
+      </dl>
+    </section>
+  {/if}
+
+  <!-- Observation history -->
+  <section>
+    <h3 class="text-sm font-medium mb-1">Recent snapshots</h3>
+    {#if observations.length === 0}
+      <div class="text-xs text-theme-text-muted py-2">No observations yet.</div>
+    {:else}
+      <div class="rounded border border-theme-border max-h-56 overflow-auto">
+        <table class="w-full text-xs">
+          <thead class="sticky top-0 bg-theme-surface">
+            <tr class="text-left">
+              <th class="p-1.5 font-medium">Time</th>
+              <th class="p-1.5 font-medium">Source</th>
+              <th class="p-1.5 font-medium">Status</th>
+              <th class="p-1.5 font-medium text-right">Nodes</th>
+              <th class="p-1.5 font-medium text-right">Links</th>
+              <th class="p-1.5 font-medium text-right">Ports</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each observations as o (o.id)}
+              <tr class="border-t border-theme-border">
+                <td class="p-1.5">{formatAgo(o.capturedAt)}</td>
+                <td class="p-1.5 font-mono text-theme-text-muted">{o.sourceId}</td>
+                <td class="p-1.5">
+                  {#if o.status === 'ok'}
+                    <span class="text-green-600 dark:text-green-400">✓ ok</span>
+                  {:else if o.status === 'partial'}
+                    <span class="text-amber-600 dark:text-amber-400">⚠ partial</span>
+                  {:else if o.status === 'empty'}
+                    <span class="text-theme-text-muted">empty</span>
+                  {:else}
+                    <span class="text-red-500" title={o.statusMessage}>✗ failed</span>
+                  {/if}
+                </td>
+                <td class="p-1.5 text-right">{o.nodeCount}</td>
+                <td class="p-1.5 text-right">{o.linkCount}</td>
+                <td class="p-1.5 text-right">{o.portCount}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  </section>
+</div>

--- a/apps/server/web/src/routes/(app)/datasources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/+page.svelte
@@ -16,6 +16,20 @@
   let showCreateModal = $state(false)
   let testingId = $state<string | null>(null)
   let testResults = $state<Record<string, ConnectionResult>>({})
+  let scanningId = $state<string | null>(null)
+  /** Per-source last-scan result for surfacing in the table. */
+  let scanResults = $state<
+    Record<
+      string,
+      {
+        status: 'ok' | 'partial' | 'failed' | 'empty'
+        nodeCount: number
+        linkCount: number
+        portCount: number
+        message?: string
+      }
+    >
+  >({})
 
   // Plugin types from API
   let pluginTypes = $state<DataSourcePluginInfo[]>([])
@@ -242,6 +256,54 @@
     testingId = null
   }
 
+  /**
+   * Ad-hoc autoscan against a data source. The snapshot is NOT persisted
+   * here because no topology context is supplied — this is a "preview"
+   * scan used to confirm credentials / network reachability / what the
+   * source can actually see. To persist, scan from inside a topology.
+   */
+  async function handleScan(ds: DataSource) {
+    scanningId = ds.id
+    try {
+      const result = await api.dataSources.scan(ds.id)
+      const counts = result.snapshot.graph ?? { nodes: [], links: [] }
+      const nodeCount = counts.nodes?.length ?? 0
+      const linkCount = counts.links?.length ?? 0
+      let portCount = 0
+      for (const n of counts.nodes ?? []) {
+        portCount += n.ports?.length ?? 0
+      }
+      scanResults = {
+        ...scanResults,
+        [ds.id]: {
+          status: result.snapshot.status,
+          nodeCount,
+          linkCount,
+          portCount,
+          message: result.snapshot.statusMessage,
+        },
+      }
+    } catch (e) {
+      scanResults = {
+        ...scanResults,
+        [ds.id]: {
+          status: 'failed',
+          nodeCount: 0,
+          linkCount: 0,
+          portCount: 0,
+          message: e instanceof Error ? e.message : 'Scan failed',
+        },
+      }
+    } finally {
+      scanningId = null
+    }
+  }
+
+  /** Does the registered plugin advertise the `autoscan` capability? */
+  function hasAutoscan(type: string): boolean {
+    return pluginTypeMap[type]?.capabilities?.includes('autoscan') ?? false
+  }
+
   async function handleDelete(ds: DataSource) {
     if (!confirm(`Delete data source "${ds.name}"?`)) {
       return
@@ -375,6 +437,22 @@
                 </td>
                 <td class="text-right datasources-actions-cell">
                   <div class="flex items-center justify-end gap-2 datasources-actions">
+                    {#if hasAutoscan(ds.type)}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onclick={() => handleScan(ds)}
+                        disabled={scanningId === ds.id}
+                        title="Run an ad-hoc autoscan (preview — not persisted)"
+                      >
+                        {#if scanningId === ds.id}
+                          <span
+                            class="w-3 h-3 border border-current border-t-transparent rounded-full animate-spin mr-1"
+                          ></span>
+                        {/if}
+                        Scan
+                      </Button>
+                    {/if}
                     <Button
                       variant="outline"
                       size="sm"
@@ -391,7 +469,7 @@
                     <Button
                       variant="outline"
                       size="sm"
-                      onclick={() => window.location.href = `/datasources/${ds.id}`}
+                      onclick={() => (window.location.href = `/datasources/${ds.id}`)}
                     >
                       Edit
                     </Button>
@@ -399,6 +477,27 @@
                       Delete
                     </Button>
                   </div>
+                  {#each scanResults[ds.id] ? [scanResults[ds.id]] : [] as r (ds.id)}
+                    {#if r}
+                      <div class="mt-1 text-xs">
+                        {#if r.status === 'ok'}
+                          <span class="text-theme-text-muted">
+                            ✓ {r.nodeCount} nodes / {r.linkCount} links / {r.portCount} ports
+                          </span>
+                        {:else if r.status === 'partial'}
+                          <span class="text-theme-text-muted">
+                            ⚠ partial: {r.nodeCount} nodes / {r.linkCount} links
+                          </span>
+                        {:else if r.status === 'empty'}
+                          <span class="text-theme-text-muted">no devices observed</span>
+                        {:else}
+                          <span class="text-red-500" title={r.message}
+                            >✗ {r.message ?? 'failed'}</span
+                          >
+                        {/if}
+                      </div>
+                    {/if}
+                  {/each}
                 </td>
               </tr>
             {/each}

--- a/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/+page.svelte
@@ -10,6 +10,7 @@
   import InteractiveSvgDiagram from '$lib/components/InteractiveSvgDiagram.svelte'
   import NodeMappingModal from '$lib/components/NodeMappingModal.svelte'
   import NodeSearchPalette from '$lib/components/NodeSearchPalette.svelte'
+  import ObservationPanel from '$lib/components/ObservationPanel.svelte'
   import ShareButton from '$lib/components/ShareButton.svelte'
   import SubgraphInfoModal from '$lib/components/SubgraphInfoModal.svelte'
   import TopologySettings from '$lib/components/TopologySettings.svelte'
@@ -23,6 +24,7 @@
 
   // Settings panel state
   let settingsOpen = $state(false)
+  let observationsOpen = $state(false)
 
   // Node mapping modal state
   let mappingModalOpen = $state(false)
@@ -93,6 +95,12 @@
 
   function toggleSettings() {
     settingsOpen = !settingsOpen
+    if (settingsOpen) observationsOpen = false
+  }
+
+  function toggleObservations() {
+    observationsOpen = !observationsOpen
+    if (observationsOpen) settingsOpen = false
   }
 
   function handleDeleted() {
@@ -177,8 +185,18 @@
         />
       </div>
 
-      <!-- Share button -->
-      <div class="absolute top-4 right-4 z-10">
+      <!-- Share + Observations toggle -->
+      <div class="absolute top-4 right-4 z-10 flex items-center gap-2">
+        <button
+          type="button"
+          onclick={toggleObservations}
+          class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-theme-bg-elevated/90 backdrop-blur border border-theme-border text-xs hover:bg-theme-bg-hover transition-colors {observationsOpen
+            ? 'border-blue-500 text-blue-500'
+            : ''}"
+          title="View resolved graph state + observations"
+        >
+          Observations
+        </button>
         <ShareButton
           shareToken={topology.shareToken}
           shareType="topologies"
@@ -230,6 +248,27 @@
           onUpdated={handleTopologyUpdated}
         />
       </div>
+    </div>
+  {/if}
+
+  <!-- Observations panel -->
+  {#if topology && observationsOpen}
+    <div
+      class="w-96 border-l border-theme-border bg-theme-bg-elevated flex flex-col overflow-hidden"
+    >
+      <div
+        class="h-14 flex items-center justify-between px-4 border-b border-theme-border flex-shrink-0"
+      >
+        <h2 class="font-medium text-theme-text-emphasis">Observations</h2>
+        <button
+          onclick={toggleObservations}
+          class="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-theme-bg transition-colors text-theme-text-muted hover:text-theme-text cursor-pointer"
+          aria-label="Close observations"
+        >
+          <XIcon size={20} />
+        </button>
+      </div>
+      <div class="flex-1 overflow-y-auto p-4"><ObservationPanel {topologyId} /></div>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## 概要

PR #303 で入れた observation model のバックエンドを **UI から実際に駆動・観察できる**よう、
最小限の Web UI を追加します。

これでユーザは v1 MVP シナリオを画面から実行できます:

1. SNMP-LLDP データソースを作成（既存 UI）
2. Sources ページの **Scan** ボタンで疎通プレビュー（credentials/到達性確認）
3. Topology を開いて **Observations** ドロワを開く
4. ドロワ内の **Scan now** で topology_observations に snapshot を保存
5. **confirmed / conflicting / discovered-only / authored-only** の各 state がカウント・テーブルで見える
6. ノードをクリック → mini-inspector に identity / source / observed-at が出る
7. 履歴セクションで過去 snapshot を確認

## 追加された UI

### Sources ページ (`/datasources`)

- `autoscan` capability を advertise するソースに **Scan** ボタンが出現
- 結果バッジ: `✓ N nodes / N links / N ports` または失敗メッセージ
- ad-hoc scan は**保存しない**（プレビュー用途）

### Topology ビューア (`/topologies/[id]`)

- 右上に **Observations** トグル（Settings と排他、384px ドロワ）
- ドロワに `ObservationPanel`:
  - 接続ソース一覧 + **Scan now**（こちらは保存する）
  - 4 つの state カウンタ（クリックでフィルタ）
  - ノードテーブル: ラベル / state / source / mgmtIp / port 数
  - 行クリックで mini-inspector: identity 全フィールド + observed-at
  - 直近 snapshot 履歴

### 新 API client

- `dataSources.scan(id, body?)` → `POST /datasources/:id/scan`
- `topologies.getResolved(id)` → `GET /topologies/:id/resolved`
- `topologies.listObservations(id)` / `getObservation(id, obsId)`

## スコープ外（フォローアップ）

- SVG renderer の state 視覚化（ghost/dashed/⚠ の描画）— 次の PR
- Bootstrap matching UI の本格版 — 双方向 identity bind フロー
- conflict 解決操作（user 決定 Q3 で v1 表示のみ）

## 検証

- svelte-check: **0 errors, 0 warnings**
- repo-wide typecheck: **34/34** green
- repo-wide test: **31/31** green
- 既存テスト 253 件すべて pass

## 関連

- PR #303 (foundation backend, merged)
- 設計: `apps/server/docs/design/topology-foundation*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)