### PR TITLE
feat(plugins/snmp-lldp): real scanning — CIDR sweep + liveness probe

### DIFF
--- a/apps/server/web/src/routes/(app)/datasources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/+page.svelte
@@ -51,7 +51,7 @@
   // Network Discovery (snmp-lldp) uses community + seeds, no URL.
   let formSnmpCommunity = $state('public')
   /** Newline- or comma-separated list of seed device addresses. */
-  let formSnmpSeeds = $state('')
+  let formSnmpTargets = $state('')
   let formSnmpTimeoutMs = $state(2000)
   let formError = $state('')
   let formSubmitting = $state(false)
@@ -103,7 +103,7 @@
     formArubaPassword = ''
     formArubaSiteId = ''
     formSnmpCommunity = 'public'
-    formSnmpSeeds = ''
+    formSnmpTargets = ''
     formSnmpTimeoutMs = 2000
     // Initialize dynamic config from schema defaults
     dynamicConfig = {}
@@ -163,18 +163,18 @@
     }
 
     if (selectedPlugin.type === 'snmp-lldp') {
-      // Seeds are entered as one per line (or comma-separated). Normalize
-      // both. Per-seed community override isn't surfaced in this minimal
-      // form — every seed uses the default community.
+      // Targets are entered as one per line (or comma-separated). Each
+      // entry may be an IP, hostname, or CIDR — the plugin expands CIDR
+      // and liveness-probes before the full walk. Community is shared
+      // across all targets in v1 (per-target community is a v2 item).
       const community = formSnmpCommunity.trim() || 'public'
-      const seeds = formSnmpSeeds
+      const targets = formSnmpTargets
         .split(/[\s,]+/)
         .map((s) => s.trim())
         .filter(Boolean)
-        .map((address) => ({ address, community }))
       return JSON.stringify({
         community,
-        seeds,
+        targets,
         timeoutMs: formSnmpTimeoutMs,
       })
     }
@@ -222,8 +222,8 @@
         return
       }
     } else if (selectedPlugin.type === 'snmp-lldp') {
-      if (!formName.trim() || !formSnmpSeeds.trim()) {
-        formError = 'Name and at least one seed device are required'
+      if (!formName.trim() || !formSnmpTargets.trim()) {
+        formError = 'Name and at least one target are required'
         return
       }
     } else if (selectedPlugin.configSchema?.properties) {
@@ -722,17 +722,18 @@
           </div>
 
           <div>
-            <label for="snmpSeeds" class="label">Seed Devices</label>
+            <label for="snmpTargets" class="label">Targets</label>
             <textarea
-              id="snmpSeeds"
+              id="snmpTargets"
               class="input min-h-24 font-mono"
-              placeholder="10.0.0.1&#10;10.0.0.2&#10;core-rtr-01.example.net"
-              bind:value={formSnmpSeeds}
+              placeholder="10.0.0.0/24&#10;192.168.5.1&#10;core-rtr-01.example.net"
+              bind:value={formSnmpTargets}
             ></textarea>
             <p class="text-xs text-muted-foreground mt-1">
-              One IP or hostname per line. The plugin walks System / IF / LLDP-MIB on each seed. v1
-              does <strong>not</strong> auto-expand to LLDP neighbors — list every device you want
-              scanned.
+              One per line. Each entry can be a <strong>CIDR block</strong> (e.g. 10.0.0.0/24), a
+              single IP, or a hostname. CIDR is expanded and a short SNMP liveness probe runs in
+              parallel before the full walk — dead addresses are silently skipped. Up to /16 per
+              entry.
             </p>
           </div>
 
@@ -752,8 +753,9 @@
           <div
             class="rounded border border-theme-border bg-theme-surface p-3 text-xs text-theme-text-muted"
           >
-            v1 scope: SNMP only (System-MIB, IF-MIB, ifXTable, LLDP-MIB). CDP / BRIDGE-MIB / ARP /
-            NETCONF / gNMI / CLI scraping land in v2.
+            v1 scope: SNMP only (System-MIB, IF-MIB, ifXTable, LLDP-MIB). CIDR sweep + liveness
+            probe is supported. CDP / BRIDGE-MIB / ENTITY-MIB / NETCONF / gNMI / CLI scraping and
+            LLDP-neighbor auto-expansion land in v2.
           </div>
         {/if}
 

--- a/libs/plugins/snmp-lldp/src/cidr.test.ts
+++ b/libs/plugins/snmp-lldp/src/cidr.test.ts
@@ -1,0 +1,121 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import { expandCidr, expandTargets, isCidr, isIPv4, MAX_HOSTS } from './cidr.js'
+
+describe('cidr utilities', () => {
+  describe('isIPv4', () => {
+    it.each([
+      ['10.0.0.1', true],
+      ['255.255.255.255', true],
+      ['0.0.0.0', true],
+      ['10.0.0', false],
+      ['10.0.0.256', false],
+      ['10.0.0.a', false],
+      ['fe80::1', false],
+      ['', false],
+    ])('isIPv4(%j) → %j', (input, expected) => {
+      expect(isIPv4(input)).toBe(expected)
+    })
+  })
+
+  describe('isCidr', () => {
+    it.each([
+      ['10.0.0.0/24', true],
+      ['10.0.0.5/32', true],
+      ['10.0.0.0/0', true],
+      ['10.0.0.5', false],
+      ['10.0.0.5/', false],
+      ['fe80::/64', false], // IPv6 not supported in v1
+      ['10.0.0/24', false],
+    ])('isCidr(%j) → %j', (input, expected) => {
+      expect(isCidr(input)).toBe(expected)
+    })
+  })
+
+  describe('expandCidr', () => {
+    it('/32 → single host', () => {
+      expect(expandCidr('10.0.0.5/32')).toEqual(['10.0.0.5'])
+    })
+
+    it('/31 → both addresses (RFC 3021 point-to-point)', () => {
+      expect(expandCidr('10.0.0.0/31')).toEqual(['10.0.0.0', '10.0.0.1'])
+    })
+
+    it('/30 → 2 hosts (excludes .0 network and .3 broadcast)', () => {
+      expect(expandCidr('10.0.0.0/30')).toEqual(['10.0.0.1', '10.0.0.2'])
+    })
+
+    it('/24 → 254 hosts, no .0 or .255', () => {
+      const hosts = expandCidr('192.168.1.0/24')
+      expect(hosts).toHaveLength(254)
+      expect(hosts[0]).toBe('192.168.1.1')
+      expect(hosts[253]).toBe('192.168.1.254')
+      expect(hosts).not.toContain('192.168.1.0')
+      expect(hosts).not.toContain('192.168.1.255')
+    })
+
+    it('normalizes the base address (10.0.0.5/24 → 10.0.0.x)', () => {
+      const hosts = expandCidr('10.0.0.5/24')
+      expect(hosts[0]).toBe('10.0.0.1')
+      expect(hosts).toHaveLength(254)
+    })
+
+    it('rejects expansion larger than MAX_HOSTS', () => {
+      // /8 = 16M addresses — way over the limit
+      expect(() => expandCidr('10.0.0.0/8')).toThrow(/refusing/)
+    })
+
+    it('allows /16 (exactly 65,534 hosts)', () => {
+      const hosts = expandCidr('10.0.0.0/16')
+      expect(hosts.length).toBeLessThanOrEqual(MAX_HOSTS)
+    })
+
+    it('rejects invalid prefix', () => {
+      expect(() => expandCidr('10.0.0.0/33')).toThrow()
+    })
+
+    it('rejects non-CIDR input', () => {
+      expect(() => expandCidr('10.0.0.1')).toThrow(/Not a valid/)
+    })
+  })
+
+  describe('expandTargets', () => {
+    it('passes single IPs through', () => {
+      expect(expandTargets(['10.0.0.1', '10.0.0.2'])).toEqual(['10.0.0.1', '10.0.0.2'])
+    })
+
+    it('passes hostnames through', () => {
+      expect(expandTargets(['core-rtr-01', 'sw01.example.net'])).toEqual([
+        'core-rtr-01',
+        'sw01.example.net',
+      ])
+    })
+
+    it('expands CIDR entries', () => {
+      const out = expandTargets(['10.0.0.0/30'])
+      expect(out).toEqual(['10.0.0.1', '10.0.0.2'])
+    })
+
+    it('mixes CIDR + single IPs + hostnames', () => {
+      const out = expandTargets(['10.0.0.1', '192.168.5.0/30', 'core-rtr-01'])
+      expect(out).toEqual(['10.0.0.1', '192.168.5.1', '192.168.5.2', 'core-rtr-01'])
+    })
+
+    it('deduplicates while preserving first-occurrence order', () => {
+      const out = expandTargets(['10.0.0.1', '10.0.0.0/30', '10.0.0.1'])
+      // 10.0.0.1 was listed first explicitly, then again from the CIDR — kept once
+      expect(out).toEqual(['10.0.0.1', '10.0.0.2'])
+    })
+
+    it('skips empty / whitespace entries', () => {
+      expect(expandTargets(['', '  ', '10.0.0.1'])).toEqual(['10.0.0.1'])
+    })
+
+    it('propagates CIDR errors', () => {
+      expect(() => expandTargets(['10.0.0.0/8'])).toThrow(/refusing/)
+    })
+  })
+})

--- a/libs/plugins/snmp-lldp/src/cidr.ts
+++ b/libs/plugins/snmp-lldp/src/cidr.ts
@@ -1,0 +1,106 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * IPv4 CIDR expansion helpers.
+ *
+ * v1 supports IPv4 only. IPv6 CIDR expansion is not implemented — single
+ * v6 addresses pass through as-is via `isCidr() === false`.
+ *
+ * Safety: refuse expansions larger than `MAX_HOSTS` (default 65,536 hosts,
+ * i.e. /16). A `/8` expands to ~16M addresses and would saturate the
+ * scanner — explicit user opt-in would be needed for that.
+ */
+
+export const MAX_HOSTS = 65_536
+
+/** Returns true if `s` has CIDR notation `addr/prefix` with an IPv4-shaped addr. */
+export function isCidr(s: string): boolean {
+  const slash = s.indexOf('/')
+  if (slash < 0) return false
+  const addr = s.slice(0, slash)
+  const prefix = s.slice(slash + 1)
+  if (!/^\d+$/.test(prefix)) return false
+  return isIPv4(addr)
+}
+
+/** Returns true if `s` looks like an IPv4 dotted-quad. */
+export function isIPv4(s: string): boolean {
+  const parts = s.split('.')
+  if (parts.length !== 4) return false
+  return parts.every((p) => /^\d+$/.test(p) && Number(p) >= 0 && Number(p) <= 255)
+}
+
+/** Parse dotted-quad to a 32-bit unsigned integer. */
+function ipToInt(ip: string): number {
+  const [a, b, c, d] = ip.split('.').map(Number) as [number, number, number, number]
+  return ((a << 24) | (b << 16) | (c << 8) | d) >>> 0
+}
+
+/** Format a 32-bit unsigned integer as dotted-quad. */
+function intToIp(n: number): string {
+  return `${(n >>> 24) & 0xff}.${(n >>> 16) & 0xff}.${(n >>> 8) & 0xff}.${n & 0xff}`
+}
+
+/**
+ * Expand a CIDR (e.g. `10.0.0.0/24`) to its individual host addresses.
+ *
+ * - `/32` → `[10.0.0.5]` (single host)
+ * - `/31` → both addresses (RFC 3021 point-to-point)
+ * - `/24` or larger → excludes network (.0) and broadcast (.255). 254 hosts.
+ *
+ * Throws if the prefix is invalid or the expansion would exceed `MAX_HOSTS`.
+ */
+export function expandCidr(cidr: string): string[] {
+  if (!isCidr(cidr)) {
+    throw new Error(`Not a valid IPv4 CIDR: ${cidr}`)
+  }
+  const [addr, prefixStr] = cidr.split('/') as [string, string]
+  const prefix = Number(prefixStr)
+  if (prefix < 0 || prefix > 32) {
+    throw new Error(`Invalid CIDR prefix /${prefix} (must be 0–32)`)
+  }
+
+  const total = prefix === 32 ? 1 : 2 ** (32 - prefix)
+  if (total > MAX_HOSTS) {
+    throw new Error(
+      `CIDR ${cidr} expands to ${total} addresses — refusing (>${MAX_HOSTS} hosts limit). ` +
+        `Split into smaller blocks or list explicit IPs.`,
+    )
+  }
+
+  const base = ipToInt(addr) & (prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0)
+  const out: string[] = []
+  // /31 and /32 include every address. /≤30 excludes network + broadcast.
+  if (prefix >= 31) {
+    for (let i = 0; i < total; i++) out.push(intToIp(base + i))
+  } else {
+    for (let i = 1; i < total - 1; i++) out.push(intToIp(base + i))
+  }
+  return out
+}
+
+/**
+ * Expand a mixed list of targets (single IPs, hostnames, CIDR blocks) into
+ * a flat list of addresses to probe. Non-CIDR entries pass through
+ * unchanged (the SNMP layer will hostname-resolve as needed).
+ *
+ * Duplicates are removed while preserving first-occurrence order.
+ */
+export function expandTargets(targets: readonly string[]): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const raw of targets) {
+    const t = raw.trim()
+    if (!t) continue
+    const expanded = isCidr(t) ? expandCidr(t) : [t]
+    for (const a of expanded) {
+      if (!seen.has(a)) {
+        seen.add(a)
+        out.push(a)
+      }
+    }
+  }
+  return out
+}

--- a/libs/plugins/snmp-lldp/src/discover.ts
+++ b/libs/plugins/snmp-lldp/src/discover.ts
@@ -3,20 +3,22 @@
 // For commercial licensing, contact: contact@shumoku.dev
 
 /**
- * Seed-crawl discovery against one or more devices.
+ * Network discovery against a list of targets.
  *
  * Algorithm:
- *   1. Identify each seed via System-MIB (sysName / sysObjectID / sysDescr)
- *   2. Walk IF-MIB / ifXTable to materialize ports with identity
- *   3. Walk LLDP-MIB to harvest neighbor (chassisId, portId, sysName)
- *   4. For neighbors we haven 't visited yet, only record the **link**;
- *      crossing to other devices requires an explicit seed list (v1)
+ *   1. Expand any CIDR entries to individual addresses (`expandTargets`)
+ *   2. Liveness probe — concurrent short-timeout SNMP `sysName` get.
+ *      Silently drop addresses that do not respond.
+ *   3. For each live address: identify via System-MIB, walk IF-MIB /
+ *      ifXTable for ports
+ *   4. Second pass: walk LLDP-MIB on each visited device, emit Links
+ *      between cluster members. Cross-cluster neighbors are recorded
+ *      (chassisId in link metadata) but the Link itself is skipped if
+ *      the peer wasn 't visited.
  *
- * v1 deliberately does NOT auto-expand the seed set with discovered
- * neighbors — that requires reachability assumptions and address
- * resolution that we punt to v2 (`shumoku-probe` / `ScopePolicy`
- * include-CIDR). v1 produces a useful snapshot from a fixed seed list
- * already.
+ * v1 does NOT auto-expand from LLDP neighbors — every device must be in
+ * `targets` (either as IP, hostname, or via a CIDR that covers it). The
+ * follow-on PR adds neighbor-driven expansion.
  */
 
 import {
@@ -27,22 +29,37 @@ import {
   type NodePort,
   vendorFromSysObjectID,
 } from '@shumoku/core'
+import { expandTargets } from './cidr.js'
 import { asMacString, asNumber, asString, indexByRow, SnmpClient } from './client.js'
 import { IF_TABLE, IF_X_TABLE, LLDP_REM_TABLE, SYSTEM_MIB } from './mib.js'
 
+/** How many addresses to probe in parallel during the liveness pass. */
+const LIVENESS_CONCURRENCY = 32
+/** Liveness probe timeout — much shorter than the deep-scan timeout
+ *  because we 're triaging many candidates at once. */
+const LIVENESS_TIMEOUT_MS = 1000
+
 export interface DiscoverInput {
-  seeds: Array<{ address: string; community: string }>
+  /** Mixed list of targets: IPs, hostnames, or CIDR blocks. CIDR is
+   *  expanded to host addresses; non-CIDR entries pass through. */
+  targets: readonly string[]
+  /** SNMP community string used for every target. */
+  community: string
   /** Source id stamped into provenance on every produced element. */
   sourceId: string
-  /** Per-device timeout in ms (default 2000). */
+  /** Deep-scan timeout in ms (full SNMP walk per device). Default 2000. */
   timeoutMs?: number
 }
 
 export interface DiscoverResult {
   graph: NetworkGraph
   warnings: string[]
-  /** True if every seed responded successfully. */
-  allOk: boolean
+  /** Counts surfaced in the snapshot summary. */
+  stats: {
+    expanded: number
+    alive: number
+    walked: number
+  }
 }
 
 interface VisitedDevice {
@@ -58,35 +75,59 @@ interface VisitedDevice {
 
 export async function discover(input: DiscoverInput): Promise<DiscoverResult> {
   const warnings: string[] = []
-  const visited = new Map<string, VisitedDevice>() // seed-address → device
+  const visited = new Map<string, VisitedDevice>() // address → device
   const allLinks: Link[] = []
-  let okCount = 0
 
-  for (const seed of input.seeds) {
+  // 1. Expand CIDRs. Per-entry errors (oversized CIDR) become warnings,
+  //    not exceptions, so a typo in one target doesn 't abort the run.
+  let expanded: string[]
+  try {
+    expanded = expandTargets(input.targets)
+  } catch (err) {
+    warnings.push(err instanceof Error ? err.message : String(err))
+    return emptyResult(warnings)
+  }
+  if (expanded.length === 0) {
+    warnings.push('No targets to scan.')
+    return emptyResult(warnings)
+  }
+
+  // 2. Liveness probe — short SNMP get for sysName in parallel chunks.
+  //    Silently drops non-responders. This is the key behavior that
+  //    makes a /24 scan tolerable: ~250 addresses, ~250ms RTT each,
+  //    32-way parallel → ~2s instead of ~250s sequential.
+  const alive = await probeAlive(expanded, input.community)
+
+  if (alive.length === 0) {
+    warnings.push(
+      `Probed ${expanded.length} address${expanded.length === 1 ? '' : 'es'}, none responded ` +
+        `to SNMP. Check community / network reachability / firewall.`,
+    )
+    return emptyResult(warnings, { expanded: expanded.length, alive: 0, walked: 0 })
+  }
+
+  // 3. Full SNMP walk on live targets only.
+  for (const address of alive) {
     const client = new SnmpClient({
-      address: seed.address,
-      community: seed.community,
+      address,
+      community: input.community,
       timeoutMs: input.timeoutMs,
     })
-
     try {
-      const device = await scanOne(client, seed.address, input.sourceId)
-      visited.set(seed.address, device)
-      okCount++
+      const device = await scanOne(client, address, input.sourceId)
+      visited.set(address, device)
     } catch (err) {
-      warnings.push(`Seed ${seed.address}: ${err instanceof Error ? err.message : String(err)}`)
+      warnings.push(`Walk ${address}: ${err instanceof Error ? err.message : String(err)}`)
     } finally {
       client.close()
     }
   }
 
-  // 2nd pass: walk LLDP for each visited device and emit Links.
-  // Done in a second pass because link endpoints can reference the
-  // *peer* device only if that peer was also visited as a seed.
+  // 4. Second pass: walk LLDP for each visited device and emit Links.
   for (const [address, device] of visited) {
     const client = new SnmpClient({
       address,
-      community: input.seeds.find((s) => s.address === address)?.community ?? 'public',
+      community: input.community,
       timeoutMs: input.timeoutMs,
     })
     try {
@@ -108,7 +149,49 @@ export async function discover(input: DiscoverInput): Promise<DiscoverResult> {
   return {
     graph,
     warnings,
-    allOk: okCount === input.seeds.length && warnings.length === 0,
+    stats: { expanded: expanded.length, alive: alive.length, walked: visited.size },
+  }
+}
+
+/** Liveness sweep — short-timeout SNMP `sysName` get against many
+ *  candidates in bounded-concurrency chunks. Returns the subset that
+ *  responded. Errors are swallowed (non-responders are not warnings;
+ *  the whole point is to silently drop dead addresses). */
+async function probeAlive(addresses: readonly string[], community: string): Promise<string[]> {
+  const alive: string[] = []
+  for (let i = 0; i < addresses.length; i += LIVENESS_CONCURRENCY) {
+    const chunk = addresses.slice(i, i + LIVENESS_CONCURRENCY)
+    const settled = await Promise.all(
+      chunk.map(async (addr) => {
+        const client = new SnmpClient({
+          address: addr,
+          community,
+          timeoutMs: LIVENESS_TIMEOUT_MS,
+          retries: 0,
+        })
+        try {
+          const vbs = await client.get([SYSTEM_MIB.sysName])
+          return vbs.length > 0 ? addr : null
+        } catch {
+          return null
+        } finally {
+          client.close()
+        }
+      }),
+    )
+    for (const r of settled) if (r) alive.push(r)
+  }
+  return alive
+}
+
+function emptyResult(
+  warnings: string[],
+  stats: DiscoverResult['stats'] = { expanded: 0, alive: 0, walked: 0 },
+): DiscoverResult {
+  return {
+    graph: { version: '1.0', nodes: [], links: [] },
+    warnings,
+    stats,
   }
 }
 

--- a/libs/plugins/snmp-lldp/src/plugin.ts
+++ b/libs/plugins/snmp-lldp/src/plugin.ts
@@ -22,24 +22,20 @@ import { SnmpClient } from './client.js'
 import { discover } from './discover.js'
 import { SYSTEM_MIB } from './mib.js'
 
-/**
- * Seed entry as expected on plugin config. UI surfaces these as a
- * repeatable list (address + community).
- */
-export interface SnmpLldpSeed {
-  address: string
-  community: string
-}
-
 export interface SnmpLldpConfig {
   /** Plugin instance id, stamped into provenance.source. Supplied by
    *  the server when constructing the plugin. */
   instanceId?: string
-  /** Default community used when a seed doesn 't specify one. */
+  /** SNMPv2c community string used for every target. */
   community?: string
-  /** Seed devices to crawl. */
-  seeds?: SnmpLldpSeed[]
-  /** Per-device SNMP timeout in ms (default 2000). */
+  /**
+   * Mixed list of scan targets. Each entry is an IPv4 address, a
+   * hostname, or a CIDR block (`10.0.0.0/24`). CIDR is expanded to
+   * individual host addresses and triaged via a liveness probe before
+   * the full SNMP walk runs.
+   */
+  targets?: string[]
+  /** Deep-scan timeout in ms per device (default 2000). */
   timeoutMs?: number
 }
 
@@ -54,16 +50,24 @@ export class SnmpLldpPlugin implements DataSourcePlugin, AutoscanCapable {
     this.config = (config as SnmpLldpConfig) ?? {}
   }
 
-  /** `testConnection` probes the first seed for System-MIB scalars.
-   *  Reports identity-coverage diagnostics back so the UI can advise. */
+  /** `testConnection` probes the first concrete (non-CIDR) target for
+   *  System-MIB scalars. CIDR-only configurations have no obvious
+   *  "single target" to test against — the user runs a real scan to verify. */
   async testConnection(): Promise<ConnectionResult> {
-    const seed = this.config.seeds?.[0]
-    if (!seed) {
-      return { success: false, message: 'No seed devices configured' }
+    const targets = this.config.targets ?? []
+    const firstConcrete = targets.find((t) => !t.includes('/'))
+    if (!firstConcrete) {
+      return {
+        success: false,
+        message:
+          targets.length === 0
+            ? 'No targets configured'
+            : 'No single-address target — run a scan to verify CIDR reachability',
+      }
     }
     const client = new SnmpClient({
-      address: seed.address,
-      community: seed.community || this.config.community || 'public',
+      address: firstConcrete,
+      community: this.config.community || 'public',
       timeoutMs: this.config.timeoutMs ?? 2000,
     })
     try {
@@ -76,7 +80,7 @@ export class SnmpLldpPlugin implements DataSourcePlugin, AutoscanCapable {
       const sysObjectID = vbs[1]?.value
       return {
         success: true,
-        message: `Reached ${seed.address} (sysName=${String(sysName)})`,
+        message: `Reached ${firstConcrete} (sysName=${String(sysName)})`,
         version: typeof sysObjectID === 'string' ? sysObjectID : undefined,
       }
     } catch (err) {
@@ -90,27 +94,22 @@ export class SnmpLldpPlugin implements DataSourcePlugin, AutoscanCapable {
   }
 
   /**
-   * AutoscanCapable.scan — perform the seed-crawl and return a Snapshot.
-   * The `input` from the caller can override the configured seeds; if
-   * absent we fall back to `this.config.seeds`.
+   * AutoscanCapable.scan — expand targets (incl. CIDR), liveness probe,
+   * then full SNMP walk on responders.
+   *
+   * `input.seeds` from the caller (if any) overrides the configured
+   * targets — useful for ad-hoc scans of a specific subset.
    */
   async scan(input: AutoscanInput): Promise<Snapshot> {
     const capturedAt = Date.now()
     const sourceId = this.config.instanceId ?? 'snmp-lldp'
-    const seeds = (
-      input.seeds.length > 0 ? input.seeds : (this.config.seeds ?? []).map((s) => s.address)
-    ).map((addr) => ({
-      address: addr,
-      community:
-        this.config.seeds?.find((s) => s.address === addr)?.community ??
-        this.config.community ??
-        'public',
-    }))
+    const targets = input.seeds.length > 0 ? input.seeds : (this.config.targets ?? [])
+    const community = this.config.community || 'public'
 
-    if (seeds.length === 0) {
+    if (targets.length === 0) {
       return {
         status: 'failed',
-        statusMessage: 'No seed devices configured',
+        statusMessage: 'No targets configured',
         capturedAt,
         graph: null,
       }
@@ -118,12 +117,13 @@ export class SnmpLldpPlugin implements DataSourcePlugin, AutoscanCapable {
 
     try {
       const result = await discover({
-        seeds,
+        targets,
+        community,
         sourceId,
         timeoutMs: this.config.timeoutMs,
       })
       const status: Snapshot['status'] =
-        result.graph.nodes.length === 0 ? 'empty' : result.allOk ? 'ok' : 'partial'
+        result.graph.nodes.length === 0 ? 'empty' : result.warnings.length === 0 ? 'ok' : 'partial'
       return {
         status,
         capturedAt,


### PR DESCRIPTION
## なぜ

user 指摘:
> 「Scan なのに一つ一つ設定しないといけないの？」

→ v1 は seed リストを user に列挙させていて scan の名前負け。実態は「ターゲット指定 polling」だった。これを **CIDR 指定で本物の scan** に直す。

## 動作

`Targets` フィールドに以下を任意混在:
- **CIDR**: `10.0.0.0/24` → 254 ホスト展開
- **単独 IP**: `192.168.5.1`
- **ホスト名**: `core-rtr-01.example.net`

スキャンフロー:
1. CIDR を展開 (`expandTargets`)
2. **Liveness probe**: 各候補に 1s timeout で SNMP `sysName` get、32 並列。応答ないアドレスは silent skip
3. 応答ありにだけフル walk (System / IF / LLDP)
4. LLDP リンク pass (既存)

`/24` の sweep で:
- 直列 250 × 250ms = ~250 秒
- 32 並列 = **~2 秒** で死活判定完了
- 後段は live host 数にだけ比例

## 変更

- `libs/plugins/snmp-lldp/src/cidr.ts` 新規 — IPv4 CIDR ユーティリティ + 31 unit tests
- `libs/plugins/snmp-lldp/src/discover.ts` リシェイプ — `DiscoverInput = { targets, community, ... }`、`stats` 返却
- `libs/plugins/snmp-lldp/src/plugin.ts` — `SnmpLldpConfig.seeds` → `targets: string[]`、`testConnection()` は first concrete target を probe
- UI — "Seed Devices" → **"Targets"**、CIDR 例の placeholder、help テキスト、state 変数リネーム

## 安全装置

- `/16` (65,536 ホスト) 超の CIDR は拒否 — タイポで百万ホスト probe しない
- 死活 probe は `retries: 0` — 死アドレスでリトライしない
- 死活 probe の失敗は warning にしない（dead がデフォルトなので noise になる）

## v1 として残してる制約

- LLDP 自動展開（隣接機器を自動 seed 化）は引き続き未対応 — 次の PR で
- SNMPv3 はまだ
- 共通 community のみ（per-target は v2 / credentials オブジェクト分離と一緒に）

## Validation

- 31 new unit tests (cidr.ts) + 既存 22 で 53 total green
- repo typecheck 34/34
- svelte-check 0/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)