### PR TITLE
fix(snmp): subnet inference emits a segment node instead of a pairwise mesh

### DIFF
--- a/libs/@shumoku/core/src/icons/generated-icons.ts
+++ b/libs/@shumoku/core/src/icons/generated-icons.ts
@@ -47,6 +47,10 @@ const deviceTypeToIcon: Record<DeviceType, string> = {
   [DeviceType.Internet]: 'internet',
   [DeviceType.VPN]: 'vpn',
   [DeviceType.Database]: 'database',
+  // No dedicated icon yet — segments are synthetic L2 transit nodes
+  // produced by SNMP subnet inference. Fall back to the cloud icon
+  // until a proper "bus segment" icon lands.
+  [DeviceType.Segment]: 'cloud',
   [DeviceType.Generic]: 'generic',
 }
 

--- a/libs/@shumoku/core/src/layout/role-tiers.ts
+++ b/libs/@shumoku/core/src/layout/role-tiers.ts
@@ -72,6 +72,9 @@ export const DEVICE_TYPE_TIER: Readonly<Record<DeviceType, number>> = Object.fre
   [DeviceType.Database]: 70,
   [DeviceType.AccessPoint]: 50,
   [DeviceType.CPE]: 50,
+  // Synthetic L2 segment from subnet inference — same tier as a
+  // physical L2 switch since that 's what it stands in for.
+  [DeviceType.Segment]: 40,
   [DeviceType.Generic]: 60,
 })
 

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -1146,6 +1146,15 @@ export enum DeviceType {
   Internet = 'internet',
   VPN = 'vpn',
   Database = 'database',
+  /**
+   * Layer-2 broadcast domain / subnet. Used by discovery plugins that
+   * can see a set of devices on the same IP subnet but can 't see the
+   * physical L2 switch in the middle. Modeled as a virtual transit
+   * node so each device 's link to "the segment" stays a clean 1-port
+   * = 1-link relationship, instead of producing a mesh that violates
+   * the editor / renderer 's "1 port owns 1 link endpoint" invariant.
+   */
+  Segment = 'segment',
   Generic = 'generic',
 }
 

--- a/libs/plugins/snmp-lldp/src/discover.ts
+++ b/libs/plugins/snmp-lldp/src/discover.ts
@@ -34,7 +34,7 @@ import {
   LLDP_REM_TABLE,
   SYSTEM_MIB,
 } from './mib.js'
-import { type DeviceInterfaceIp, groupBySubnet, inferLinksFromSubnets } from './subnet-inference.js'
+import { buildSegmentInference, type DeviceInterfaceIp, groupBySubnet } from './subnet-inference.js'
 
 /** How many addresses to probe in parallel during the liveness pass. */
 const LIVENESS_CONCURRENCY = 32
@@ -216,18 +216,8 @@ export async function discover(input: DiscoverInput): Promise<DiscoverResult> {
     }
   }
   const subnetGroups = groupBySubnet(allIfaceIps)
-  const inferredLinks = inferLinksFromSubnets(subnetGroups)
-  for (const link of inferredLinks) {
-    allLinks.push({
-      from: { node: link.from.nodeId, port: link.from.portId },
-      to: { node: link.to.nodeId, port: link.to.portId },
-      provenance: { source: input.sourceId, observedAt: Date.now() },
-      metadata: {
-        linkType: 'subnet-inferred',
-        subnet: link.subnet,
-      },
-    })
-  }
+  const inference = buildSegmentInference(subnetGroups, input.sourceId)
+  for (const link of inference.spokeLinks) allLinks.push(link)
 
   // Diagnostic warnings. The distinction matters: "LLDP errored" means
   // configure your community / view permissions; "LLDP empty" means
@@ -239,8 +229,8 @@ export async function discover(input: DiscoverInput): Promise<DiscoverResult> {
       )
     } else if (lldpDevicesEmpty === visited.size - lldpDevicesErrored) {
       warnings.push(
-        inferredLinks.length > 0
-          ? `LLDP returned no neighbors on any device — falling back to subnet-membership inference (${inferredLinks.length} logical link(s) from ${subnetGroups.length} shared subnet(s)).`
+        inference.segmentNodes.length > 0
+          ? `LLDP returned no neighbors on any device — synthesised ${inference.segmentNodes.length} L2 segment node(s) from shared subnets (${inference.spokeLinks.length} spoke link(s)).`
           : `LLDP returned no neighbors and no shared IP subnets across the scanned devices — no links could be derived.`,
       )
     }
@@ -248,7 +238,10 @@ export async function discover(input: DiscoverInput): Promise<DiscoverResult> {
 
   const graph: NetworkGraph = {
     version: '1.0',
-    nodes: Array.from(visited.values()).map((d) => visitedToNode(d, input.sourceId)),
+    nodes: [
+      ...Array.from(visited.values()).map((d) => visitedToNode(d, input.sourceId)),
+      ...inference.segmentNodes,
+    ],
     links: allLinks,
   }
 

--- a/libs/plugins/snmp-lldp/src/subnet-inference.test.ts
+++ b/libs/plugins/snmp-lldp/src/subnet-inference.test.ts
@@ -1,11 +1,12 @@
 // Copyright (C) 2026-present Akitoshi Saeki
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { DeviceType } from '@shumoku/core'
 import { describe, expect, it } from 'vitest'
 import {
+  buildSegmentInference,
   type DeviceInterfaceIp,
   groupBySubnet,
-  inferLinksFromSubnets,
   subnetCidr,
 } from './subnet-inference.js'
 
@@ -13,7 +14,7 @@ describe('subnetCidr', () => {
   it('computes the CIDR of a /24', () => {
     expect(subnetCidr('192.168.13.15', '255.255.255.0')).toBe('192.168.13.0/24')
   })
-  it('computes the CIDR of a /22 (the actual lab subnet)', () => {
+  it('computes the CIDR of a /22 (the lab subnet)', () => {
     expect(subnetCidr('192.168.13.15', '255.255.252.0')).toBe('192.168.12.0/22')
   })
   it('skips loopback', () => {
@@ -31,10 +32,7 @@ describe('subnetCidr', () => {
   })
 })
 
-describe('groupBySubnet + inferLinksFromSubnets', () => {
-  // Mirrors the lab setup: four devices all on 192.168.12.0/22, plus
-  // one device with a second interface in its own /24 (a router
-  // interface that doesn 't see anyone else in the scan).
+describe('groupBySubnet', () => {
   const ifaces: DeviceInterfaceIp[] = [
     { nodeId: 'ix', portId: 'ix:p1', ip: '192.168.13.15', netmask: '255.255.252.0', ifIndex: 1314 },
     {
@@ -50,13 +48,6 @@ describe('groupBySubnet + inferLinksFromSubnets', () => {
       ip: '192.168.13.22',
       netmask: '255.255.252.0',
       ifIndex: 2,
-    },
-    {
-      nodeId: 'vyos',
-      portId: 'vyos:eth5',
-      ip: '192.168.20.13',
-      netmask: '255.255.255.0',
-      ifIndex: 5,
     },
     {
       nodeId: 'qnas-02',
@@ -76,53 +67,81 @@ describe('groupBySubnet + inferLinksFromSubnets', () => {
     { nodeId: 'vyos', portId: 'vyos:lo', ip: '127.0.0.1', netmask: '255.0.0.0', ifIndex: 1 },
   ]
 
-  it('groups all four devices into the shared /22 and drops singletons', () => {
+  it('groups all four devices into the shared /22 and drops singleton subnets', () => {
     const groups = groupBySubnet(ifaces)
     expect(groups).toHaveLength(1)
     expect(groups[0]?.cidr).toBe('192.168.12.0/22')
     expect(groups[0]?.members).toHaveLength(4)
-    // 163.220.228.32/29 and 192.168.20.0/24 each have only one device → dropped.
     expect(groups.map((g) => g.cidr)).toEqual(['192.168.12.0/22'])
   })
+})
 
-  it('emits a mesh of pairwise inferred links across distinct devices', () => {
+describe('buildSegmentInference', () => {
+  const ifaces: DeviceInterfaceIp[] = [
+    { nodeId: 'ix', portId: 'ix:p1', ip: '192.168.13.15', netmask: '255.255.252.0', ifIndex: 1314 },
+    {
+      nodeId: 'vyos',
+      portId: 'vyos:eth0',
+      ip: '192.168.13.22',
+      netmask: '255.255.252.0',
+      ifIndex: 2,
+    },
+    {
+      nodeId: 'qnas-02',
+      portId: 'qnas-02:eth0',
+      ip: '192.168.13.27',
+      netmask: '255.255.252.0',
+      ifIndex: 2,
+    },
+    {
+      nodeId: 'qnas-03',
+      portId: 'qnas-03:eth0',
+      ip: '192.168.13.28',
+      netmask: '255.255.252.0',
+      ifIndex: 2,
+    },
+  ]
+
+  it('emits one segment node + one spoke link per device for each shared subnet', () => {
     const groups = groupBySubnet(ifaces)
-    const links = inferLinksFromSubnets(groups)
-    // 4 distinct nodes on the shared subnet → 4·3/2 = 6 unordered pairs.
-    expect(links).toHaveLength(6)
-    const pairs = new Set(links.map((l) => [l.from.nodeId, l.to.nodeId].sort().join('|')))
-    expect(pairs).toEqual(
-      new Set([
-        'ix|vyos',
-        'ix|qnas-02',
-        'ix|qnas-03',
-        'qnas-02|vyos',
-        'qnas-03|vyos',
-        'qnas-02|qnas-03',
-      ]),
-    )
-    // Every link declares the subnet it was inferred from.
-    for (const link of links) expect(link.subnet).toBe('192.168.12.0/22')
+    const inference = buildSegmentInference(groups, 'snmp-lldp')
+    expect(inference.segmentNodes).toHaveLength(1)
+    expect(inference.spokeLinks).toHaveLength(4)
+    const seg = inference.segmentNodes[0]
+    expect(seg?.spec?.kind).toBe('hardware')
+    expect((seg?.spec as { type?: string })?.type).toBe(DeviceType.Segment)
+    expect(seg?.label).toBe('192.168.12.0/22')
+    expect(seg?.ports).toHaveLength(4)
   })
 
-  it('skips intra-device pairs even when both interfaces share a subnet', () => {
-    const intra: DeviceInterfaceIp[] = [
-      {
-        nodeId: 'bridge',
-        portId: 'bridge:a',
-        ip: '10.0.0.1',
-        netmask: '255.255.255.0',
-        ifIndex: 1,
-      },
-      {
-        nodeId: 'bridge',
-        portId: 'bridge:b',
-        ip: '10.0.0.2',
-        netmask: '255.255.255.0',
-        ifIndex: 2,
-      },
-    ]
-    expect(groupBySubnet(intra)).toEqual([])
-    expect(inferLinksFromSubnets(groupBySubnet(intra))).toEqual([])
+  it('respects the "1 port = 1 link endpoint" invariant', () => {
+    const groups = groupBySubnet(ifaces)
+    const inference = buildSegmentInference(groups, 'snmp-lldp')
+    // No port id should appear twice across the spoke links — both the
+    // device-side and the segment-side.
+    const portUses = new Map<string, number>()
+    for (const link of inference.spokeLinks) {
+      for (const endpoint of [link.from, link.to]) {
+        const key = `${endpoint.node}|${endpoint.port}`
+        portUses.set(key, (portUses.get(key) ?? 0) + 1)
+      }
+    }
+    for (const [_, count] of portUses) expect(count).toBe(1)
+  })
+
+  it('stamps subnet metadata on the segment node and each spoke link', () => {
+    const groups = groupBySubnet(ifaces)
+    const inference = buildSegmentInference(groups, 'snmp-lldp')
+    expect(inference.segmentNodes[0]?.metadata?.['subnet']).toBe('192.168.12.0/22')
+    for (const link of inference.spokeLinks) {
+      expect(link.metadata?.['linkType']).toBe('subnet-inferred')
+      expect(link.metadata?.['subnet']).toBe('192.168.12.0/22')
+    }
+  })
+
+  it('produces deterministic segment node ids from the CIDR', () => {
+    const groups = groupBySubnet(ifaces)
+    const inference = buildSegmentInference(groups, 'snmp-lldp')
+    expect(inference.segmentNodes[0]?.id).toBe('snmp-lldp:segment:192.168.12.0_22')
   })
 })

--- a/libs/plugins/snmp-lldp/src/subnet-inference.ts
+++ b/libs/plugins/snmp-lldp/src/subnet-inference.ts
@@ -8,33 +8,36 @@
  * When the scanned devices don 't run LLDP / CDP (NEC routers, VyOS
  * boxes, NAS appliances, …) we still have the IP layer to lean on.
  * Every device 's `ipAddrTable` returns the IPv4 addresses and netmasks
- * bound to each interface. Two interfaces sitting in the same subnet
- * are reachable through some Layer-2 segment — usually a direct cable
- * or a passive switch — so the simplest useful topology approximation
- * is: "if interface A and interface B share a subnet, draw a link
- * between their parent devices."
+ * bound to each interface. Devices whose interfaces sit in the same
+ * subnet share a Layer-2 broadcast domain — usually some
+ * unmanaged-switch fabric the scan can 't observe directly.
  *
- * Caveats called out in the produced link metadata:
- *   - Inferred — not observed. A passive switch between A and B is
- *     invisible. Two devices in the same broadcast domain via several
- *     hops will still look directly connected.
- *   - For subnets with N participating interfaces this produces N·(N-1)/2
- *     pairwise links (a logical mesh). That 's accurate as "any of these
- *     can reach any other on this subnet" but visually busy on the
- *     diagram. Operators are expected to overlay a Manual source that
- *     describes the actual cabling — `resolve()` will merge the two.
+ * **Why a segment node, not a mesh of pairwise links:** the rest of
+ * the codebase relies on a "one port owns at most one link endpoint"
+ * invariant (enforced in the editor, the renderer 's drag-create
+ * flow rejects drops on linked ports, etc). A naive pair-wise mesh
+ * of N nodes would attach N-1 links to each device 's single
+ * IP-bearing interface and violate that invariant — visually it
+ * shows up as several lines fanning out of one port, which is
+ * physically impossible (one cable, one peer). Instead we synthesise
+ * a virtual "segment" node for each shared subnet and emit one
+ * spoke link from each member interface to a unique port on the
+ * segment node. Result is a star topology that respects the
+ * invariant and matches reality ("there is some L2 fabric in the
+ * middle even if we can 't see it"). If an LLDP-aware discovery
+ * later finds the actual switch and reports it, identity matching
+ * lets the segment node be replaced or merged.
  *
  * Loopback (127.0.0.0/8) and link-local (169.254.0.0/16) ranges are
  * skipped — they 're per-device and don 't model connectivity.
  */
 
+import { DeviceType, type Link, type Node, type NodeSpec } from '@shumoku/core'
+
 /** One interface 's IPv4 binding as harvested from `ipAddrTable`. */
 export interface InterfaceIp {
-  /** Dotted-quad address (e.g. `192.168.13.15`). */
   ip: string
-  /** Dotted-quad netmask (e.g. `255.255.252.0`). */
   netmask: string
-  /** ifIndex on the parent device. */
   ifIndex: number
 }
 
@@ -42,7 +45,7 @@ export interface InterfaceIp {
 export interface DeviceInterfaceIp extends InterfaceIp {
   /** Stable node id of the parent device (e.g. `snmp-lldp:node:192.168.13.15`). */
   nodeId: string
-  /** Stable port id for the link endpoints to point at. */
+  /** Stable port id on the parent device for the spoke endpoint. */
   portId: string
 }
 
@@ -54,12 +57,12 @@ export interface SubnetGroup {
   members: DeviceInterfaceIp[]
 }
 
-/** A single inferred link between two device interfaces. */
-export interface InferredLink {
-  from: { nodeId: string; portId: string }
-  to: { nodeId: string; portId: string }
-  /** Subnet that justified the inference. */
-  subnet: string
+/** Final inference output: virtual segment nodes plus their spoke links. */
+export interface SegmentInference {
+  /** Virtual segment nodes — one per shared subnet. */
+  segmentNodes: Node[]
+  /** Spoke links from each device 's interface to its segment node. */
+  spokeLinks: Link[]
 }
 
 /** Parse a dotted-quad to a 32-bit unsigned integer. Returns null on malformed input. */
@@ -82,13 +85,8 @@ function dottedQuad(n: number): string {
 
 /** Count the leading 1-bits in a netmask integer (CIDR prefix length). */
 function prefixLength(mask: number): number {
-  // The mask is a contiguous block of 1s followed by 0s. Bit-twiddle to
-  // count by complementing and asking how many trailing zeros it has.
-  // We accept non-contiguous masks defensively (count popcount) but
-  // most devices return contiguous masks anyway.
   let count = 0
   let m = mask
-  // Mask & 0xff for each octet
   for (let i = 0; i < 32; i++) {
     if (m & 0x80000000) count++
     m = (m << 1) >>> 0
@@ -99,19 +97,15 @@ function prefixLength(mask: number): number {
 /**
  * Compute the (subnet, prefix) for an (ip, netmask) pair. Returns null
  * if either component is malformed or if the address is in a range we
- * intentionally skip (loopback, link-local, 0.0.0.0).
+ * intentionally skip (loopback, link-local, 0.0.0.0, /32 host-only).
  */
 export function subnetCidr(ip: string, netmask: string): string | null {
   const ipN = parseDottedQuad(ip)
   const maskN = parseDottedQuad(netmask)
   if (ipN === null || maskN === null) return null
   if (ipN === 0) return null
-  // Skip loopback 127.0.0.0/8 and link-local 169.254.0.0/16
   if ((ipN & 0xff000000) === 127 << 24) return null
   if ((ipN & 0xffff0000) === ((169 << 24) | (254 << 16))) return null
-  // Skip /32 (host-only — e.g. loopbacks declared with full mask).
-  // /32 carries no link information and would produce singleton groups
-  // we 'd just skip anyway downstream.
   const prefix = prefixLength(maskN)
   if (prefix === 32) return null
   const network = (ipN & maskN) >>> 0
@@ -120,8 +114,8 @@ export function subnetCidr(ip: string, netmask: string): string | null {
 
 /**
  * Group device interfaces by the IPv4 subnet they sit in. Subnets with
- * only one member (a private subnet on a single device) are dropped —
- * they 're not links by themselves.
+ * only one device 's interfaces are dropped — a segment with one
+ * member isn 't a segment, just a stub network on that device.
  */
 export function groupBySubnet(ifaces: DeviceInterfaceIp[]): SubnetGroup[] {
   const byCidr = new Map<string, DeviceInterfaceIp[]>()
@@ -134,7 +128,6 @@ export function groupBySubnet(ifaces: DeviceInterfaceIp[]): SubnetGroup[] {
   }
   const groups: SubnetGroup[] = []
   for (const [cidr, members] of byCidr) {
-    // Need ≥ 2 *distinct devices* on the subnet for an actual link.
     const distinctNodes = new Set(members.map((m) => m.nodeId))
     if (distinctNodes.size < 2) continue
     groups.push({ cidr, members })
@@ -143,31 +136,65 @@ export function groupBySubnet(ifaces: DeviceInterfaceIp[]): SubnetGroup[] {
 }
 
 /**
- * Emit pairwise inferred links for every subnet group. For a subnet
- * containing N interfaces across M ≥ 2 distinct devices, we walk every
- * unordered pair of *interfaces from different devices* — the
- * "logical mesh" representation of the segment. Same-device pairs are
- * skipped (those aren 't a link between devices, just two of the
- * device 's own interfaces happening to share a subnet, which only
- * shows up when the device deliberately bridges two segments).
+ * Build a deterministic, URL-safe id fragment from a CIDR.
+ * `192.168.12.0/22` → `192.168.12.0_22`.
  */
-export function inferLinksFromSubnets(groups: SubnetGroup[]): InferredLink[] {
-  const out: InferredLink[] = []
+function cidrToIdFragment(cidr: string): string {
+  return cidr.replace('/', '_')
+}
+
+/**
+ * Emit one virtual segment Node per group and one spoke Link from each
+ * member device 's interface to a unique per-spoke port on the segment
+ * node. The "1 port = 1 link endpoint" invariant is preserved on both
+ * sides:
+ *   - Each member interface owns one spoke (its IP-bearing ifIndex
+ *     terminates exactly one link).
+ *   - The segment node has one port per spoke, each owning exactly
+ *     one link.
+ *
+ * Same-device pairs are not an issue here — a device contributes one
+ * spoke per interface it has in this subnet, and those interfaces
+ * already have distinct port ids on the device.
+ *
+ * Each segment node carries `spec.kind="hardware", spec.type="segment"`
+ * so renderers / catalog code can recognise the synthetic transit
+ * node. `metadata.subnet` carries the CIDR for downstream tooling.
+ */
+export function buildSegmentInference(groups: SubnetGroup[], sourceId: string): SegmentInference {
+  const segmentNodes: Node[] = []
+  const spokeLinks: Link[] = []
   for (const group of groups) {
-    for (let i = 0; i < group.members.length; i++) {
-      const a = group.members[i]
-      if (!a) continue
-      for (let j = i + 1; j < group.members.length; j++) {
-        const b = group.members[j]
-        if (!b) continue
-        if (a.nodeId === b.nodeId) continue
-        out.push({
-          from: { nodeId: a.nodeId, portId: a.portId },
-          to: { nodeId: b.nodeId, portId: b.portId },
-          subnet: group.cidr,
-        })
-      }
+    const cidrFragment = cidrToIdFragment(group.cidr)
+    const segmentNodeId = `${sourceId}:segment:${cidrFragment}`
+    const spec: NodeSpec = { kind: 'hardware', type: DeviceType.Segment }
+    const segmentNode: Node = {
+      id: segmentNodeId,
+      label: group.cidr,
+      spec,
+      metadata: { subnet: group.cidr, linkType: 'subnet-inferred' },
+      provenance: { source: sourceId, observedAt: Date.now(), state: 'discovered-only' },
+      ports: [],
     }
+    for (const member of group.members) {
+      const segmentPortId = `${segmentNodeId}:spoke:${member.nodeId}:${member.ifIndex}`
+      segmentNode.ports?.push({
+        id: segmentPortId,
+        // Label the segment-side port with the peer 's interface
+        // identifier so the renderer can show "→ Gig3.0" or "→ eth0"
+        // without having to chase the link back.
+        label: '',
+        connectors: [],
+        provenance: { source: sourceId },
+      })
+      spokeLinks.push({
+        from: { node: member.nodeId, port: member.portId },
+        to: { node: segmentNodeId, port: segmentPortId },
+        provenance: { source: sourceId, observedAt: Date.now() },
+        metadata: { linkType: 'subnet-inferred', subnet: group.cidr },
+      })
+    }
+    segmentNodes.push(segmentNode)
   }
-  return out
+  return { segmentNodes, spokeLinks }
 }


### PR DESCRIPTION
@-