### PR TITLE
refactor(core/discovery-policy): drop manual-only mode

### DIFF
--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -342,28 +342,32 @@ export function specDeviceType(spec: NodeSpec | undefined): DeviceType | undefin
 /**
  * How a node / subgraph / topology participates in discovery.
  *
- * The enum is intentionally broader than a boolean: codex's review
- * of the discovery-policy design called out that lab / vendor-managed
- * / decommissioned / virtual nodes need different *meanings*, not just
- * "off". Mode determines scheduler behaviour, drift / freshness
- * semantics, and alert suppression downstream.
+ * Mode determines scheduler behaviour, drift / freshness semantics,
+ * and alert suppression downstream. Display behaviour is *separate* —
+ * a `disabled` node still renders if any authored / observed data
+ * exists for it; hiding from the diagram is a future `display` axis.
  *
- *   - `auto`         — scheduled discovery target; freshness and drift
- *                      are tracked, alerts may fire on stale / failure.
- *   - `observe`      — discover, but do NOT auto-adopt observation
- *                      values. Discoveries surface as drift candidates
- *                      that the operator reconciles. Useful for
- *                      "we want to see what 's there but don 't trust
- *                      it as truth yet."
- *   - `manual-only`  — do not discover. Authored / manual content is
- *                      the source of truth. Absence in a source 's
- *                      snapshot does NOT retract this node.
- *   - `disabled`     — unmanaged / excluded. No discovery, no
- *                      freshness ageing, no drift noise. Use for
- *                      vendor-managed gear, decommissioned hardware,
- *                      lab segments you want quiet.
+ *   - `auto`     — scheduled discovery target; freshness and drift
+ *                  are tracked, alerts may fire on stale / failure.
+ *   - `observe`  — discover, but do NOT auto-adopt observation values.
+ *                  Discoveries surface as drift candidates that the
+ *                  operator reconciles.
+ *   - `disabled` — unmanaged / excluded. No probing, no freshness
+ *                  ageing, no drift noise, no stale alerts. Use for
+ *                  vendor-managed gear, decommissioned hardware, lab
+ *                  segments you want quiet. If you want the node to
+ *                  keep displaying with curated values, add it to a
+ *                  Manual source — the authored layer carries through
+ *                  the resolver regardless of mode.
+ *
+ * History: an earlier revision had a fourth mode `manual-only` meaning
+ * "authored content is authoritative". That collapses onto `disabled`
+ * once you realise the authored layer is independent of discovery
+ * mode — the resolver always folds it in. Keeping `manual-only`
+ * around invited an impossible state (the mode is meaningless without
+ * a Manual source attached).
  */
-export type DiscoveryMode = 'auto' | 'observe' | 'manual-only' | 'disabled'
+export type DiscoveryMode = 'auto' | 'observe' | 'disabled'
 
 /**
  * Discovery policy applied to a node, a subgraph (inherited by its
@@ -381,8 +385,7 @@ export interface DiscoveryPolicy {
   /**
    * Expected freshness budget in milliseconds. A node is considered
    * fresh when `lastObservedAt + intervalMs ≥ now`. Only meaningful
-   * for `auto` and `observe` modes — ignored for `manual-only` /
-   * `disabled`.
+   * for `auto` and `observe` modes — ignored for `disabled`.
    */
   intervalMs?: number
 }

--- a/libs/@shumoku/core/src/observation/discovery-policy.test.ts
+++ b/libs/@shumoku/core/src/observation/discovery-policy.test.ts
@@ -54,11 +54,11 @@ describe('computeEffectivePolicy', () => {
   it('node override beats subgraph and topology', () => {
     const subgraphs = new Map([sg('prod', undefined, { mode: 'auto', intervalMs: 60_000 })])
     const e = computeEffectivePolicy({
-      node: { parent: 'prod', discovery: { mode: 'manual-only' } },
+      node: { parent: 'prod', discovery: { mode: 'disabled' } },
       subgraphs,
       topologyDefault: { mode: 'observe', intervalMs: 600_000 },
     })
-    expect(e.mode).toBe('manual-only')
+    expect(e.mode).toBe('disabled')
     expect(e.source.mode).toBe('node')
     // intervalMs not overridden by node — comes from subgraph.
     expect(e.intervalMs).toBe(60_000)
@@ -104,22 +104,15 @@ describe('computeEffectivePolicy', () => {
     const e = computeEffectivePolicy({
       node: { parent: 'ghost' },
       subgraphs: new Map(),
-      topologyDefault: { mode: 'manual-only' },
+      topologyDefault: { mode: 'disabled' },
     })
-    expect(e.mode).toBe('manual-only')
+    expect(e.mode).toBe('disabled')
     expect(e.source.mode).toBe('topology')
   })
 })
 
 describe('isExcluded', () => {
-  it('excludes manual-only and disabled', () => {
-    expect(
-      isExcluded({
-        mode: 'manual-only',
-        intervalMs: 0,
-        source: { mode: 'default', intervalMs: 'default' },
-      }),
-    ).toBe(true)
+  it('excludes disabled', () => {
     expect(
       isExcluded({
         mode: 'disabled',
@@ -167,9 +160,9 @@ describe('effectivePolicyForNode (NetworkGraph context)', () => {
   it('node override beats the subgraph chain', () => {
     const e = effectivePolicyForNode(graph, {
       parent: 'prod-core',
-      discovery: { mode: 'manual-only' },
+      discovery: { mode: 'disabled' },
     })
-    expect(e.mode).toBe('manual-only')
+    expect(e.mode).toBe('disabled')
     expect(e.source.mode).toBe('node')
   })
 
@@ -213,14 +206,7 @@ describe('absenceImpliesRetraction', () => {
       }),
     ).toBe(true)
   })
-  it('absence is meaningless for manual-only / disabled', () => {
-    expect(
-      absenceImpliesRetraction({
-        mode: 'manual-only',
-        intervalMs: 0,
-        source: { mode: 'default', intervalMs: 'default' },
-      }),
-    ).toBe(false)
+  it('absence is meaningless for disabled', () => {
     expect(
       absenceImpliesRetraction({
         mode: 'disabled',

--- a/libs/@shumoku/core/src/observation/discovery-policy.ts
+++ b/libs/@shumoku/core/src/observation/discovery-policy.ts
@@ -127,7 +127,7 @@ export function computeEffectivePolicy(ctx: PolicyContext): EffectiveDiscoveryPo
  * the mode comparison from callers that just need a yes/no answer.
  */
 export function isExcluded(policy: EffectiveDiscoveryPolicy): boolean {
-  return policy.mode === 'disabled' || policy.mode === 'manual-only'
+  return policy.mode === 'disabled'
 }
 
 /**

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -40,11 +40,10 @@ export function resolve(
   //
   // !!! When retraction logic lands here, gate it on
   //     `absenceImpliesRetraction(effectivePolicyForNode(authored, node))`.
-  // A node whose effective policy is `manual-only` or `disabled` must
-  // survive being missing from a `status='ok'` snapshot — for those
-  // modes the source was either never asked (manual-only) or the
-  // operator opted out entirely (disabled), so the absence carries
-  // no information. Codex 's review of the discovery-policy design
+  // A node whose effective policy is `disabled` must survive being
+  // missing from a `status='ok'` snapshot — the operator opted out,
+  // the source was never asked, the absence carries no information.
+  // Codex 's review of the discovery-policy design
   // flagged this as the highest-impact footgun in the area; see
   // `discovery-policy.ts` for the gate predicate and rationale.
   void _staleThreshold


### PR DESCRIPTION
## Why

`manual-only` presupposed that a Manual source was attached to the topology — but Manual is optional. With no Manual source, the mode collapses into "do nothing", which is exactly what `disabled` already expresses. Two names for the same effective behavior was a footgun.

The resolver always folds the authored (Manual) layer regardless of discovery mode, so authored content still wins when a node is marked `disabled` — the "manual-only behavior" emerges naturally from `disabled` + authored entries, without a dedicated enum value.

## What changed

- `DiscoveryMode`: `'auto' | 'observe' | 'manual-only' | 'disabled'` → `'auto' | 'observe' | 'disabled'`
- `isExcluded()` simplified to `policy.mode === 'disabled'`
- `absenceImpliesRetraction()` unchanged (still `auto | observe`)
- Updated tests and the resolver's retraction-gate comment
- Added a History note in `types.ts` explaining the removal

## Test

`bun test src/observation/discovery-policy.test.ts` — 17 pass, 0 fail.
`bun run typecheck` — clean across all 34 tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)