### PR TITLE
feat(server-api): discovery-policy GET / PATCH endpoints (Phase A1)

### DIFF
--- a/apps/server/api/src/api/discovery-policy.ts
+++ b/apps/server/api/src/api/discovery-policy.ts
@@ -1,0 +1,225 @@
+/**
+ * Discovery-policy API
+ *
+ * Reads and mutates the per-node / per-subgraph / topology-default
+ * discovery configuration that drives the scheduler and the Discovery
+ * tab UI.
+ *
+ *   GET   /api/topologies/:id/discovery-policy
+ *     → full view: topology default + effective policy for every node
+ *       and subgraph in the resolved graph.
+ *
+ *   PATCH /api/topologies/:id/discovery-policy
+ *     body: { scope: 'topology' | 'node' | 'subgraph',
+ *             id?: string,           // required for node / subgraph
+ *             discovery: DiscoveryPolicy | null }  // null clears the override
+ *     → { effective: EffectiveDiscoveryPolicy }
+ *
+ * The override lives on the authored (Manual) layer. PATCH auto-attaches
+ * a Manual source on first use so the operator doesn 't have to do it
+ * manually from the data-sources tab — same affordance the editor uses.
+ *
+ * Per-node overrides on a node that exists ONLY in a discovered snapshot
+ * (no authored entry yet) return 409 — "adoption" semantics are tracked
+ * separately and intentionally out of scope here.
+ */
+
+import {
+  computeEffectivePolicy,
+  type DiscoveryMode,
+  type DiscoveryPolicy,
+  type EffectiveDiscoveryPolicy,
+  RUNTIME_DEFAULT,
+} from '@shumoku/core'
+import { Hono } from 'hono'
+import { getTopologyService } from './topologies.js'
+
+const VALID_MODES: ReadonlySet<DiscoveryMode> = new Set(['auto', 'observe', 'disabled'])
+
+interface PatchBody {
+  scope?: string
+  id?: string
+  discovery?: DiscoveryPolicy | null
+}
+
+/** Validate the discovery patch body. Returns the parsed policy on
+ *  success, or a string with the reason on failure. */
+function parseDiscoveryPolicy(
+  raw: DiscoveryPolicy | null | undefined,
+): { policy: DiscoveryPolicy | null } | { error: string } {
+  if (raw === null) return { policy: null }
+  if (raw === undefined || typeof raw !== 'object') {
+    return { error: 'discovery must be an object or null' }
+  }
+  const policy: DiscoveryPolicy = {}
+  if (raw.mode !== undefined) {
+    if (!VALID_MODES.has(raw.mode as DiscoveryMode)) {
+      return { error: `mode must be one of ${[...VALID_MODES].join(', ')}` }
+    }
+    policy.mode = raw.mode as DiscoveryMode
+  }
+  if (raw.intervalMs !== undefined) {
+    if (
+      typeof raw.intervalMs !== 'number' ||
+      !Number.isFinite(raw.intervalMs) ||
+      raw.intervalMs < 0
+    ) {
+      return { error: 'intervalMs must be a non-negative number' }
+    }
+    policy.intervalMs = raw.intervalMs
+  }
+  return { policy }
+}
+
+export function createDiscoveryPolicyApi(): Hono {
+  const app = new Hono()
+  const service = getTopologyService()
+
+  app.get('/:id/discovery-policy', async (c) => {
+    const id = c.req.param('id')
+    const parsed = await service.getParsed(id)
+    if (!parsed) return c.json({ error: 'Topology not found' }, 404)
+
+    const graph = parsed.graph
+    const subgraphLookup = new Map(
+      (graph.subgraphs ?? []).map((sg) => [sg.id, { parent: sg.parent, discovery: sg.discovery }]),
+    )
+
+    const nodes: Record<string, EffectiveDiscoveryPolicy> = {}
+    for (const node of graph.nodes) {
+      nodes[node.id] = computeEffectivePolicy({
+        node: { discovery: node.discovery, parent: node.parent },
+        subgraphs: subgraphLookup,
+        topologyDefault: graph.discovery,
+      })
+    }
+
+    const subgraphs: Record<string, EffectiveDiscoveryPolicy> = {}
+    for (const sg of graph.subgraphs ?? []) {
+      // Effective at the subgraph itself: walk *its* parent chain.
+      subgraphs[sg.id] = computeEffectivePolicy({
+        node: { discovery: sg.discovery, parent: sg.parent },
+        subgraphs: subgraphLookup,
+        topologyDefault: graph.discovery,
+      })
+    }
+
+    return c.json({
+      topologyDefault: graph.discovery ?? null,
+      runtimeDefault: RUNTIME_DEFAULT,
+      nodes,
+      subgraphs,
+    })
+  })
+
+  app.patch('/:id/discovery-policy', async (c) => {
+    const topologyId = c.req.param('id')
+    const body = (await c.req.json()) as PatchBody
+
+    if (body.scope !== 'topology' && body.scope !== 'node' && body.scope !== 'subgraph') {
+      return c.json({ error: "scope must be 'topology', 'node', or 'subgraph'" }, 400)
+    }
+    if ((body.scope === 'node' || body.scope === 'subgraph') && !body.id) {
+      return c.json({ error: `id is required when scope is '${body.scope}'` }, 400)
+    }
+
+    const parsedBody = parseDiscoveryPolicy(body.discovery)
+    if ('error' in parsedBody) return c.json({ error: parsedBody.error }, 400)
+    const newPolicy = parsedBody.policy
+
+    const topology = service.get(topologyId)
+    if (!topology) return c.json({ error: 'Topology not found' }, 404)
+
+    // The override has to land on the authored Manual graph. If no Manual
+    // source is attached yet, auto-attach one — same affordance the editor
+    // would have used on first edit.
+    const manualId = await service.ensureManualSource(topologyId)
+    const authored = service.readManualGraph(manualId) ?? {
+      version: '1' as const,
+      name: topology.name,
+      nodes: [],
+      links: [],
+    }
+
+    // Apply the mutation. We copy the graph (and the touched array) so we
+    // never mutate the JSON we 'll round-trip back into config_json.
+    const next = { ...authored }
+
+    if (body.scope === 'topology') {
+      if (newPolicy === null) delete next.discovery
+      else next.discovery = newPolicy
+    } else if (body.scope === 'subgraph') {
+      const id = body.id as string
+      const subgraphs = [...(next.subgraphs ?? [])]
+      const idx = subgraphs.findIndex((sg) => sg.id === id)
+      if (idx === -1) {
+        return c.json(
+          { error: `subgraph '${id}' is not in the authored graph`, reason: 'discovered-only' },
+          409,
+        )
+      }
+      const current = subgraphs[idx]
+      if (!current) return c.json({ error: 'subgraph index lost' }, 500)
+      const target = { ...current }
+      if (newPolicy === null) delete target.discovery
+      else target.discovery = newPolicy
+      subgraphs[idx] = target
+      next.subgraphs = subgraphs
+    } else {
+      // scope === 'node'
+      const id = body.id as string
+      const nodes = [...next.nodes]
+      const idx = nodes.findIndex((n) => n.id === id)
+      if (idx === -1) {
+        return c.json(
+          {
+            error: `node '${id}' is not in the authored graph — pin it to Manual before overriding discovery`,
+            reason: 'discovered-only',
+          },
+          409,
+        )
+      }
+      const current = nodes[idx]
+      if (!current) return c.json({ error: 'node index lost' }, 500)
+      const target = { ...current }
+      if (newPolicy === null) delete target.discovery
+      else target.discovery = newPolicy
+      nodes[idx] = target
+      next.nodes = nodes
+    }
+
+    service.writeManualGraph(manualId, next)
+    service.clearCacheEntry(topologyId)
+
+    // Recompute the affected effective policy for the response.
+    const subgraphLookup = new Map(
+      (next.subgraphs ?? []).map((sg) => [sg.id, { parent: sg.parent, discovery: sg.discovery }]),
+    )
+    let effective: EffectiveDiscoveryPolicy
+    if (body.scope === 'topology') {
+      effective = computeEffectivePolicy({
+        node: { discovery: undefined, parent: undefined },
+        subgraphs: subgraphLookup,
+        topologyDefault: next.discovery,
+      })
+    } else if (body.scope === 'subgraph') {
+      const sg = next.subgraphs?.find((s) => s.id === body.id)
+      effective = computeEffectivePolicy({
+        node: { discovery: sg?.discovery, parent: sg?.parent },
+        subgraphs: subgraphLookup,
+        topologyDefault: next.discovery,
+      })
+    } else {
+      const node = next.nodes.find((n) => n.id === body.id)
+      effective = computeEffectivePolicy({
+        node: { discovery: node?.discovery, parent: node?.parent },
+        subgraphs: subgraphLookup,
+        topologyDefault: next.discovery,
+      })
+    }
+
+    return c.json({ effective })
+  })
+
+  return app
+}

--- a/apps/server/api/src/api/index.ts
+++ b/apps/server/api/src/api/index.ts
@@ -9,6 +9,7 @@ import { authMiddleware } from '../middleware/auth.js'
 import { createAuthApi } from './auth.js'
 import { createDashboardsApi } from './dashboards.js'
 import { createDataSourcesApi } from './datasources.js'
+import { createDiscoveryPolicyApi } from './discovery-policy.js'
 import { createObservationsRoute, createScanRoute } from './observations.js'
 import { createPluginsApi } from './plugins.js'
 import { createSettingsApi } from './settings.js'
@@ -35,6 +36,7 @@ export function createApiRouter(): Hono {
   api.route('/topologies', createTopologiesApi())
   api.route('/topologies', topologySourcesApi) // Nested: /topologies/:id/sources
   api.route('/topologies', createObservationsRoute()) // /topologies/:id/observations + /resolved
+  api.route('/topologies', createDiscoveryPolicyApi()) // /topologies/:id/discovery-policy
   api.route('/settings', createSettingsApi())
   api.route('/webhooks', webhooksApi)
 

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -541,8 +541,11 @@ export class TopologyService {
    * Read the graph stored on a Manual data source 's config_json.
    * Returns null when the source doesn 't exist, isn 't Manual, or has
    * no graph (e.g. freshly attached then config cleared by hand).
+   *
+   * Public so the discovery-policy API can compute / mutate the authored
+   * layer without poking the data_sources table directly.
    */
-  private readManualGraph(sourceId: string): NetworkGraph | null {
+  readManualGraph(sourceId: string): NetworkGraph | null {
     const row = this.db
       .query('SELECT type, config_json FROM data_sources WHERE id = ?')
       .get(sourceId) as { type: string; config_json: string } | undefined
@@ -553,6 +556,43 @@ export class TopologyService {
     } catch {
       return null
     }
+  }
+
+  /**
+   * Persist a new authored graph onto a Manual data source 's config_json.
+   * Preserves any sibling keys we don 't own. Caller is responsible for
+   * invalidating the topology cache (`clearCacheEntry`).
+   */
+  writeManualGraph(sourceId: string, graph: NetworkGraph): void {
+    const row = this.db
+      .query('SELECT type, config_json FROM data_sources WHERE id = ?')
+      .get(sourceId) as { type: string; config_json: string } | undefined
+    if (!row || row.type !== 'manual') {
+      throw new Error(`Data source ${sourceId} is not a Manual source`)
+    }
+    let config: Record<string, unknown> = {}
+    try {
+      config = JSON.parse(row.config_json) as Record<string, unknown>
+    } catch {
+      // Corrupted config — start fresh.
+    }
+    config['graph'] = graph
+    this.db
+      .query('UPDATE data_sources SET config_json = ?, updated_at = ? WHERE id = ?')
+      .run(JSON.stringify(config), timestamp(), sourceId)
+  }
+
+  /**
+   * Find-or-create the Manual data source attached to this topology.
+   * Returns the data-source id. Used by the discovery-policy PATCH
+   * endpoint when the first override on a topology lands before the
+   * operator has explicitly attached Manual.
+   */
+  async ensureManualSource(topologyId: string): Promise<string> {
+    const existing = this.findManualSourceId(topologyId)
+    if (existing) return existing
+    const { dataSourceId } = await this.attachManualSource(topologyId, 'topology')
+    return dataSourceId
   }
 
   /**

--- a/libs/@shumoku/core/src/observation/discovery-policy.ts
+++ b/libs/@shumoku/core/src/observation/discovery-policy.ts
@@ -59,7 +59,7 @@ export interface EffectiveDiscoveryPolicy {
  *     scheduled SNMP scan can comfortably catch up, tight enough that
  *     a missed re-poll surfaces inside an hour.
  */
-const RUNTIME_DEFAULT: { mode: DiscoveryMode; intervalMs: number } = {
+export const RUNTIME_DEFAULT: { mode: DiscoveryMode; intervalMs: number } = {
   mode: 'auto',
   intervalMs: 30 * 60 * 1000,
 }


### PR DESCRIPTION
## Why

Phase A1 of the discovery-policy refresh. The override surface needs to be addressable from outside the editor — the Discovery tab UI (Phase A2) and the scheduler (Phase B) both consume the same shape.

## Endpoints

\`\`\`
GET   /api/topologies/:id/discovery-policy
  → { topologyDefault, runtimeDefault, nodes, subgraphs }

PATCH /api/topologies/:id/discovery-policy
  body: { scope: 'topology' | 'node' | 'subgraph',
          id?: string,
          discovery: DiscoveryPolicy | null }
  → { effective: EffectiveDiscoveryPolicy }
\`\`\`

Each \`nodes\` / \`subgraphs\` entry is the fully-resolved \`EffectiveDiscoveryPolicy\` (mode + intervalMs + per-field origin trace), so the UI doesn't have to re-implement the inheritance walk — that's the seam Codex called out as "effective policy はフロントで都度推測せず、API が返す".

## Behavior worth knowing

- The override lands on the authored (Manual) layer. PATCH **auto-attaches a Manual source** on first use, matching the editor's affordance — the operator never has to remember to attach Manual just to flip a mode.
- Per-node PATCH on a node that exists only in a discovered snapshot returns **409 with \`reason: 'discovered-only'\`**. Adoption ("pin this observed node into Manual so I can override it") is its own design problem and is intentionally out of scope here. The Phase A2 UI will show such cells as disabled with a "Pin to Manual" CTA.
- \`null\` clears the override (falls back through the inheritance chain).
- Validation rejects unknown modes and non-finite / negative intervals.

## Touched

- \`apps/server/api/src/api/discovery-policy.ts\` — new file
- \`apps/server/api/src/api/index.ts\` — route wiring
- \`apps/server/api/src/services/topology.ts\` — \`readManualGraph\` made public; new \`writeManualGraph\` and \`ensureManualSource\` helpers
- \`libs/@shumoku/core/src/observation/discovery-policy.ts\` — export \`RUNTIME_DEFAULT\` so the API doesn't duplicate the constant

## Test

\`bun run typecheck\` — 34/34 clean. The policy logic itself is covered by \`discovery-policy.test.ts\` (17 tests, green). The new endpoints are thin glue over already-tested helpers; no new unit tests added because server-api has no test harness yet.

## Up next

- **Phase A2**: Discovery tab UI refresh (summary strip, filter, search, badges, bulk actions, modal with effective-policy view).
- **Phase B**: Full scheduler (timestamps, cron, retry, backoff, alert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)