### PR TITLE
feat(server-web): discovery policy in the Discovery tab (Phase A2)

### DIFF
--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -406,6 +406,48 @@ export const topologies = {
         body: JSON.stringify({ type: 'manual', purpose: 'topology' }),
       }),
   },
+
+  /**
+   * Discovery policy — per-node / per-subgraph / topology-default
+   * overrides for what the scheduler does (auto / observe / disabled)
+   * and how often. The server folds the inheritance chain and returns
+   * the *effective* policy for every entity; the UI just renders it.
+   * See `apps/server/api/src/api/discovery-policy.ts` for the route.
+   */
+  discoveryPolicy: {
+    get: (topologyId: string) =>
+      request<{
+        topologyDefault: { mode?: DiscoveryMode; intervalMs?: number } | null
+        runtimeDefault: { mode: DiscoveryMode; intervalMs: number }
+        nodes: Record<string, EffectivePolicy>
+        subgraphs: Record<string, EffectivePolicy>
+      }>(`/topologies/${topologyId}/discovery-policy`),
+
+    patch: (
+      topologyId: string,
+      body:
+        | { scope: 'topology'; discovery: { mode?: DiscoveryMode; intervalMs?: number } | null }
+        | {
+            scope: 'node' | 'subgraph'
+            id: string
+            discovery: { mode?: DiscoveryMode; intervalMs?: number } | null
+          },
+    ) =>
+      request<{ effective: EffectivePolicy }>(`/topologies/${topologyId}/discovery-policy`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      }),
+  },
+}
+
+export type DiscoveryMode = 'auto' | 'observe' | 'disabled'
+export interface EffectivePolicy {
+  mode: DiscoveryMode
+  intervalMs: number
+  source: {
+    mode: 'node' | 'subgraph' | 'topology' | 'default'
+    intervalMs: 'node' | 'subgraph' | 'topology' | 'default'
+  }
 }
 
 // Settings API

--- a/apps/server/web/src/lib/components/DiscoveryNodeDetail.svelte
+++ b/apps/server/web/src/lib/components/DiscoveryNodeDetail.svelte
@@ -12,6 +12,17 @@
    * component does no fetching of its own.
    */
 
+  type DiscoveryMode = 'auto' | 'observe' | 'disabled'
+
+  interface EffectivePolicy {
+    mode: DiscoveryMode
+    intervalMs: number
+    source: {
+      mode: 'node' | 'subgraph' | 'topology' | 'default'
+      intervalMs: 'node' | 'subgraph' | 'topology' | 'default'
+    }
+  }
+
   interface Props {
     open: boolean
     onOpenChange: (open: boolean) => void
@@ -36,9 +47,42 @@
     probing: boolean
     onProbe: () => void
     formatAgo: (ts: number) => string
+    /** Effective discovery policy for this node — null while loading
+     *  or when the GET hasn 't run yet. */
+    effectivePolicy?: EffectivePolicy | null
+    /** Patch in-flight, drives the spinner on the mode buttons. */
+    patchingPolicy?: boolean
+    /** Change mode (or 'inherit' to clear the per-node override). */
+    onSetMode?: (mode: DiscoveryMode | 'inherit') => void | Promise<void>
   }
 
-  let { open, onOpenChange, node, probing, onProbe, formatAgo }: Props = $props()
+  let {
+    open,
+    onOpenChange,
+    node,
+    probing,
+    onProbe,
+    formatAgo,
+    effectivePolicy = null,
+    patchingPolicy = false,
+    onSetMode,
+  }: Props = $props()
+
+  function originLabel(o: EffectivePolicy['source']['mode']): string {
+    if (o === 'node') return 'this node'
+    if (o === 'subgraph') return 'subgraph'
+    if (o === 'topology') return 'topology default'
+    return 'runtime default'
+  }
+
+  const MODE_OPTIONS: DiscoveryMode[] = ['auto', 'observe', 'disabled']
+
+  function formatInterval(ms: number): string {
+    if (ms < 1000) return `${ms}ms`
+    if (ms < 60_000) return `${Math.round(ms / 1000)}s`
+    if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`
+    return `${Math.round(ms / 3_600_000)}h`
+  }
 
   const qualityColor = $derived(
     node?.quality === 'stable'
@@ -114,6 +158,75 @@
               <dd>{node.observedAt ? formatAgo(node.observedAt) : '—'}</dd>
             </div>
           </dl>
+        </section>
+
+        <!-- Discovery policy. The effective mode + interval the
+             scheduler will use for this node, with the per-field
+             origin so the operator can tell "this came from my
+             override" apart from "this came from the subgraph". The
+             three buttons either pin the override (auto / observe /
+             disabled) or clear it (Inherit). 409 from a discovered-only
+             node is surfaced via the parent 's console warn for now —
+             Phase A2.1 will show it inline. -->
+        <section>
+          <div class="flex items-center justify-between mb-2">
+            <h3 class="text-xs font-medium text-theme-text-muted uppercase tracking-wide">
+              Discovery policy
+            </h3>
+            {#if effectivePolicy}
+              <span class="text-[10px] text-theme-text-muted">
+                from {originLabel(effectivePolicy.source.mode)}
+              </span>
+            {/if}
+          </div>
+          {#if effectivePolicy}
+            <dl class="space-y-1 mb-3">
+              <div class="flex justify-between gap-3">
+                <dt class="text-theme-text-muted">Mode</dt>
+                <dd class="font-mono">{effectivePolicy.mode}</dd>
+              </div>
+              <div class="flex justify-between gap-3">
+                <dt class="text-theme-text-muted">Interval</dt>
+                <dd class="font-mono">
+                  {formatInterval(effectivePolicy.intervalMs)}
+                  <span class="text-theme-text-muted ml-1 text-xs">
+                    ({originLabel(effectivePolicy.source.intervalMs)})
+                  </span>
+                </dd>
+              </div>
+            </dl>
+            <div class="flex gap-1.5 flex-wrap">
+              {#each MODE_OPTIONS as m (m)}
+                {@const active = effectivePolicy.mode === m && effectivePolicy.source.mode === 'node'}
+                <button
+                  type="button"
+                  class="text-xs px-2 py-1 rounded border transition-colors {active
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-theme-border hover:border-primary'}"
+                  disabled={patchingPolicy}
+                  onclick={() => onSetMode?.(m)}
+                >
+                  {m}
+                </button>
+              {/each}
+              <button
+                type="button"
+                class="text-xs px-2 py-1 rounded border border-theme-border hover:border-primary transition-colors text-theme-text-muted"
+                disabled={patchingPolicy || effectivePolicy.source.mode !== 'node'}
+                title={effectivePolicy.source.mode !== 'node'
+                  ? 'No per-node override — already inheriting'
+                  : 'Clear per-node override and inherit'}
+                onclick={() => onSetMode?.('inherit')}
+              >
+                Inherit
+              </button>
+              {#if patchingPolicy}
+                <span class="text-xs text-theme-text-muted self-center ml-1">saving…</span>
+              {/if}
+            </div>
+          {:else}
+            <p class="text-xs text-theme-text-muted">Policy view loading…</p>
+          {/if}
         </section>
 
         <!-- Catalog. Set when sysObjectID or chassis part number

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -198,6 +198,28 @@
     }>
   >([])
   let discoveryLoading = $state(false)
+  /**
+   * Effective-policy view from `GET /discovery-policy`. The server folds
+   * topology default → subgraph chain → node override once; the UI just
+   * renders. Keyed by node id and subgraph id.
+   *
+   * We also keep the topology default + runtime default separately so
+   * the summary strip can display them and the modal can attribute
+   * "Inherits from: topology default" without re-walking the chain.
+   */
+  let policyView = $state<{
+    topologyDefault: { mode?: import('$lib/api').DiscoveryMode; intervalMs?: number } | null
+    runtimeDefault: { mode: import('$lib/api').DiscoveryMode; intervalMs: number }
+    nodes: Record<string, import('$lib/api').EffectivePolicy>
+    subgraphs: Record<string, import('$lib/api').EffectivePolicy>
+  } | null>(null)
+  /** Discovery-grid filters. The grid + summary strip share these. */
+  let discoverySearch = $state('')
+  let modeFilter = $state<'all' | 'auto' | 'observe' | 'disabled'>('all')
+  let qualityFilter = $state<'all' | 'stable' | 'weak' | 'unbound'>('all')
+  /** Patch in-flight, keyed by node id, so the modal can show a spinner
+   *  without blocking other interactions. */
+  let policyPatching = $state<Record<string, boolean>>({})
 
   // Filter options cache
   let filterOptionsCache = $state<
@@ -694,10 +716,12 @@
   async function refreshDiscovery() {
     discoveryLoading = true
     try {
-      const [graphResp, obsList] = await Promise.all([
+      const [graphResp, obsList, policy] = await Promise.all([
         api.topologies.getGraph(topologyId),
         api.topologies.listObservations(topologyId, 20),
+        api.topologies.discoveryPolicy.get(topologyId),
       ])
+      policyView = policy
       // Count identity quality + collect per-node card data.
       // Segment nodes (synthetic L2 transit, from subnet inference)
       // are not "grabbed" devices — they 're virtual stand-ins for
@@ -790,6 +814,88 @@
    * endpoint; the UI affordance is per-card so a future targeted
    * scan can land transparently.
    */
+  /**
+   * Filter + search applied to the grabbed-node card grid. The summary
+   * strip 's counters are derived from `discoveredNodes` (the
+   * unfiltered set) so they always reflect the topology total, not
+   * "what survived my filter".
+   */
+  let filteredDiscoveredNodes = $derived.by(() => {
+    const q = discoverySearch.trim().toLowerCase()
+    return discoveredNodes.filter((c) => {
+      if (qualityFilter !== 'all' && c.quality !== qualityFilter) return false
+      if (modeFilter !== 'all') {
+        const eff = policyView?.nodes[c.id]
+        if ((eff?.mode ?? policyView?.runtimeDefault.mode) !== modeFilter) return false
+      }
+      if (!q) return true
+      const hay = [c.label, c.model, c.vendor, c.mgmtIp, c.sysName]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+      return hay.includes(q)
+    })
+  })
+
+  /** Per-mode counters for the summary strip — derived from the full
+   *  set, not the filtered set, on purpose (filter = "what to view",
+   *  summary = "what the topology is"). */
+  let modeCounts = $derived.by(() => {
+    const out = { auto: 0, observe: 0, disabled: 0 }
+    for (const c of discoveredNodes) {
+      const m = policyView?.nodes[c.id]?.mode ?? policyView?.runtimeDefault.mode ?? 'auto'
+      if (m === 'auto' || m === 'observe' || m === 'disabled') out[m]++
+    }
+    return out
+  })
+
+  /**
+   * Patch the discovery override for a single node. The server returns
+   * the new effective policy; we splice it into `policyView` so the
+   * grid + modal update without a full refresh. On 409 (discovered-only
+   * node), surface the message — the API contract documents this and
+   * the user has to "pin to Manual" first (Phase A2 next).
+   */
+  async function setNodeDiscoveryMode(
+    nodeId: string,
+    discovery: { mode?: import('$lib/api').DiscoveryMode; intervalMs?: number } | null,
+  ): Promise<{ ok: true } | { ok: false; reason: string }> {
+    policyPatching = { ...policyPatching, [nodeId]: true }
+    try {
+      const { effective } = await api.topologies.discoveryPolicy.patch(topologyId, {
+        scope: 'node',
+        id: nodeId,
+        discovery,
+      })
+      if (policyView) {
+        policyView = {
+          ...policyView,
+          nodes: { ...policyView.nodes, [nodeId]: effective },
+        }
+      }
+      return { ok: true }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'patch failed'
+      return { ok: false, reason: msg }
+    } finally {
+      policyPatching = { ...policyPatching, [nodeId]: false }
+    }
+  }
+
+  /** Modal callback: change the node's discovery mode. `null` clears
+   *  the per-node override (falls back through the inheritance chain). */
+  async function handleSetMode(mode: import('$lib/api').DiscoveryMode | 'inherit'): Promise<void> {
+    if (!detailNode) return
+    const result = await setNodeDiscoveryMode(detailNode.id, mode === 'inherit' ? null : { mode })
+    if (!result.ok) {
+      // 409 / discovered-only landing: surface the reason in the modal.
+      // The card row in the grid still shows the inherited mode; nothing
+      // visibly broke, but the operator needs to know why their click
+      // didn 't stick.
+      console.warn('[Discovery] policy patch failed:', result.reason)
+    }
+  }
+
   let probingNodeId = $state<string | null>(null)
   async function handleProbeNode(card: (typeof discoveredNodes)[number]) {
     if (!card.sourceId || !card.mgmtIp) return
@@ -1805,40 +1911,111 @@
             </div>
           </div>
         {:else}
-          <!-- Identity binding (掴み) gauge — top of the tab. Counts every
-               resolved node by how reliably it can be re-matched across
-               sources / re-scans. -->
+          <!-- Summary strip — combines identity-binding (how reliably
+               each node is locked-on across re-scans) with the policy
+               distribution (how the scheduler is configured to treat
+               it). One row, six clickable chips that double as filters
+               so the operator sees the topology shape AND drills down
+               in the same gesture. -->
           <div class="card">
-            <div class="card-header">
-              <h2 class="font-medium text-theme-text-emphasis">Identity binding (掴み)</h2>
-              <p class="text-xs text-theme-text-muted mt-0.5">
-                How well each resolved node is locked-on. More identity keys (mgmtIp / chassisId /
-                sysName / vendorIds) → more reliable across re-scans and source changes.
-              </p>
+            <div class="card-header flex items-center justify-between gap-3">
+              <div>
+                <h2 class="font-medium text-theme-text-emphasis">Overview</h2>
+                <p class="text-xs text-theme-text-muted mt-0.5">
+                  Identity binding (掴み) on the left, scheduler policy on the right. Click a chip
+                  to filter the grid below.
+                </p>
+              </div>
+              {#if policyView}
+                {@const def =
+                  policyView.topologyDefault?.mode ?? policyView.runtimeDefault.mode}
+                <span class="text-xs text-theme-text-muted whitespace-nowrap">
+                  topology default: <span class="font-mono">{def}</span>
+                </span>
+              {/if}
             </div>
             <div class="card-body">
-              <div class="grid grid-cols-3 gap-3 text-center">
-                <div class="rounded-lg border border-theme-border p-3">
+              <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 text-center">
+                <button
+                  type="button"
+                  class="rounded-lg border p-3 transition-colors cursor-pointer text-left {qualityFilter ===
+                  'stable'
+                    ? 'border-primary ring-1 ring-primary/40'
+                    : 'border-theme-border hover:border-theme-text-muted'}"
+                  onclick={() =>
+                    (qualityFilter = qualityFilter === 'stable' ? 'all' : 'stable')}
+                >
                   <p class="text-2xl font-semibold text-green-600 dark:text-green-400">
                     {identityQuality.stable}
                   </p>
                   <p class="text-xs text-theme-text-muted mt-1">🟢 stable</p>
-                  <p class="text-[10px] text-theme-text-muted mt-0.5">multiple keys</p>
-                </div>
-                <div class="rounded-lg border border-theme-border p-3">
+                </button>
+                <button
+                  type="button"
+                  class="rounded-lg border p-3 transition-colors cursor-pointer text-left {qualityFilter ===
+                  'weak'
+                    ? 'border-primary ring-1 ring-primary/40'
+                    : 'border-theme-border hover:border-theme-text-muted'}"
+                  onclick={() => (qualityFilter = qualityFilter === 'weak' ? 'all' : 'weak')}
+                >
                   <p class="text-2xl font-semibold text-amber-600 dark:text-amber-400">
                     {identityQuality.weak}
                   </p>
                   <p class="text-xs text-theme-text-muted mt-1">🟡 weak</p>
-                  <p class="text-[10px] text-theme-text-muted mt-0.5">single key</p>
-                </div>
-                <div class="rounded-lg border border-theme-border p-3">
+                </button>
+                <button
+                  type="button"
+                  class="rounded-lg border p-3 transition-colors cursor-pointer text-left {qualityFilter ===
+                  'unbound'
+                    ? 'border-primary ring-1 ring-primary/40'
+                    : 'border-theme-border hover:border-theme-text-muted'}"
+                  onclick={() =>
+                    (qualityFilter = qualityFilter === 'unbound' ? 'all' : 'unbound')}
+                >
                   <p class="text-2xl font-semibold text-theme-text-muted">
                     {identityQuality.unbound}
                   </p>
                   <p class="text-xs text-theme-text-muted mt-1">🔴 unbound</p>
-                  <p class="text-[10px] text-theme-text-muted mt-0.5">no identity</p>
-                </div>
+                </button>
+                <button
+                  type="button"
+                  class="rounded-lg border p-3 transition-colors cursor-pointer text-left {modeFilter ===
+                  'auto'
+                    ? 'border-primary ring-1 ring-primary/40'
+                    : 'border-theme-border hover:border-theme-text-muted'}"
+                  onclick={() => (modeFilter = modeFilter === 'auto' ? 'all' : 'auto')}
+                >
+                  <p class="text-2xl font-semibold text-sky-600 dark:text-sky-400">
+                    {modeCounts.auto}
+                  </p>
+                  <p class="text-xs text-theme-text-muted mt-1">auto</p>
+                </button>
+                <button
+                  type="button"
+                  class="rounded-lg border p-3 transition-colors cursor-pointer text-left {modeFilter ===
+                  'observe'
+                    ? 'border-primary ring-1 ring-primary/40'
+                    : 'border-theme-border hover:border-theme-text-muted'}"
+                  onclick={() =>
+                    (modeFilter = modeFilter === 'observe' ? 'all' : 'observe')}
+                >
+                  <p class="text-2xl font-semibold text-violet-600 dark:text-violet-400">
+                    {modeCounts.observe}
+                  </p>
+                  <p class="text-xs text-theme-text-muted mt-1">observe</p>
+                </button>
+                <button
+                  type="button"
+                  class="rounded-lg border p-3 transition-colors cursor-pointer text-left {modeFilter ===
+                  'disabled'
+                    ? 'border-primary ring-1 ring-primary/40'
+                    : 'border-theme-border hover:border-theme-text-muted'}"
+                  onclick={() =>
+                    (modeFilter = modeFilter === 'disabled' ? 'all' : 'disabled')}
+                >
+                  <p class="text-2xl font-semibold text-theme-text-muted">{modeCounts.disabled}</p>
+                  <p class="text-xs text-theme-text-muted mt-1">disabled</p>
+                </button>
               </div>
               {#if identityQuality.total === 0 && !discoveryLoading}
                 <p class="text-xs text-theme-text-muted text-center mt-3">
@@ -1853,60 +2030,118 @@
                filtered out (they 're stand-ins, not grabbed devices). -->
           {#if discoveredNodes.length > 0}
             <div class="card">
-              <div class="card-header">
-                <h2 class="font-medium text-theme-text-emphasis">
-                  Grabbed nodes
-                  <span class="text-xs text-theme-text-muted ml-2">({discoveredNodes.length})</span>
-                </h2>
-                <p class="text-xs text-theme-text-muted mt-0.5">
-                  Each device discovery has locked-on to. Probe re-runs the source 's scan; the card
-                  updates on next sync.
-                </p>
-              </div>
-              <div class="card-body">
-                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                  {#each discoveredNodes as card (card.id)}
-                    {@const qualityColor =
-                      card.quality === 'stable'
-                        ? 'bg-green-500'
-                        : card.quality === 'weak'
-                          ? 'bg-amber-500'
-                          : 'bg-neutral-500'}
+              <div class="card-header flex items-center justify-between gap-3 flex-wrap">
+                <div>
+                  <h2 class="font-medium text-theme-text-emphasis">
+                    Grabbed nodes
+                    <span class="text-xs text-theme-text-muted ml-2">
+                      {#if filteredDiscoveredNodes.length === discoveredNodes.length}
+                        ({discoveredNodes.length})
+                      {:else}
+                        ({filteredDiscoveredNodes.length}
+                        of {discoveredNodes.length})
+                      {/if}
+                    </span>
+                  </h2>
+                  <p class="text-xs text-theme-text-muted mt-0.5">
+                    Click to see identity / probe / change discovery mode.
+                  </p>
+                </div>
+                <div class="flex items-center gap-2">
+                  <input
+                    type="text"
+                    bind:value={discoverySearch}
+                    placeholder="Search by name, IP, model…"
+                    class="text-sm rounded border border-theme-border bg-theme-bg px-2 py-1 w-56 placeholder:text-theme-text-muted/70"
+                  >
+                  {#if modeFilter !== 'all' || qualityFilter !== 'all' || discoverySearch}
                     <button
                       type="button"
-                      class="text-left rounded-lg border border-theme-border p-3 hover:border-primary hover:bg-theme-bg-canvas/30 transition-colors cursor-pointer"
+                      class="text-xs text-theme-text-muted hover:text-theme-text-emphasis"
                       onclick={() => {
-                        detailNode = card
+                        modeFilter = 'all'
+                        qualityFilter = 'all'
+                        discoverySearch = ''
                       }}
                     >
-                      <div class="flex items-start gap-2">
-                        <span
-                          class="inline-block w-2 h-2 rounded-full mt-1.5 flex-shrink-0 {qualityColor}"
-                          title={card.quality}
-                        ></span>
-                        <div class="min-w-0 flex-1">
-                          <p class="font-medium text-sm text-theme-text-emphasis truncate">
-                            {card.label}
-                          </p>
-                          <p class="text-xs text-theme-text-muted truncate">
-                            {card.model ?? card.vendor ?? card.sysDescr?.split(',')[0] ?? '—'}
-                          </p>
-                          <p class="text-xs text-theme-text-muted font-mono mt-0.5">
-                            {card.mgmtIp ?? '—'}
-                          </p>
-                        </div>
-                      </div>
-                      <div
-                        class="mt-3 pt-2 border-t border-theme-border/50 text-xs text-theme-text-muted"
-                      >
-                        {card.quality}
-                        {#if card.observedAt}
-                          · {formatAgo(card.observedAt)}
-                        {/if}
-                      </div>
+                      Clear filters
                     </button>
-                  {/each}
+                  {/if}
                 </div>
+              </div>
+              <div class="card-body">
+                {#if filteredDiscoveredNodes.length === 0}
+                  <p class="text-xs text-theme-text-muted text-center py-6">
+                    No nodes match the current filters.
+                  </p>
+                {:else}
+                  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {#each filteredDiscoveredNodes as card (card.id)}
+                      {@const qualityColor =
+                        card.quality === 'stable'
+                          ? 'bg-green-500'
+                          : card.quality === 'weak'
+                            ? 'bg-amber-500'
+                            : 'bg-neutral-500'}
+                      {@const eff = policyView?.nodes[card.id]}
+                      {@const effMode = eff?.mode ?? policyView?.runtimeDefault.mode ?? 'auto'}
+                      {@const modeTone =
+                        effMode === 'disabled'
+                          ? 'text-theme-text-muted bg-theme-bg-canvas/60'
+                          : effMode === 'observe'
+                            ? 'text-violet-700 dark:text-violet-300 bg-violet-500/10'
+                            : 'text-sky-700 dark:text-sky-300 bg-sky-500/10'}
+                      {@const inherited = eff && eff.source.mode !== 'node'}
+                      <button
+                        type="button"
+                        class="text-left rounded-lg border border-theme-border p-3 hover:border-primary hover:bg-theme-bg-canvas/30 transition-colors cursor-pointer {effMode ===
+                        'disabled'
+                          ? 'opacity-70'
+                          : ''}"
+                        onclick={() => {
+                          detailNode = card
+                        }}
+                      >
+                        <div class="flex items-start gap-2">
+                          <span
+                            class="inline-block w-2 h-2 rounded-full mt-1.5 flex-shrink-0 {qualityColor}"
+                            title={card.quality}
+                          ></span>
+                          <div class="min-w-0 flex-1">
+                            <p class="font-medium text-sm text-theme-text-emphasis truncate">
+                              {card.label}
+                            </p>
+                            <p class="text-xs text-theme-text-muted truncate">
+                              {card.model ?? card.vendor ?? card.sysDescr?.split(',')[0] ?? '—'}
+                            </p>
+                            <p class="text-xs text-theme-text-muted font-mono mt-0.5">
+                              {card.mgmtIp ?? '—'}
+                            </p>
+                          </div>
+                          <span
+                            class="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded {modeTone} whitespace-nowrap"
+                            title={inherited
+                              ? `inherited from ${eff?.source.mode}`
+                              : 'per-node override'}
+                          >
+                            {effMode}
+                            {#if inherited}
+                              <span class="ml-0.5 opacity-60">·inh</span>
+                            {/if}
+                          </span>
+                        </div>
+                        <div
+                          class="mt-3 pt-2 border-t border-theme-border/50 text-xs text-theme-text-muted"
+                        >
+                          {card.quality}
+                          {#if card.observedAt}
+                            · {formatAgo(card.observedAt)}
+                          {/if}
+                        </div>
+                      </button>
+                    {/each}
+                  </div>
+                {/if}
               </div>
             </div>
           {/if}
@@ -2395,8 +2630,11 @@
   }}
   node={detailNode}
   probing={detailNode !== null && probingNodeId === detailNode.id}
+  effectivePolicy={detailNode ? (policyView?.nodes[detailNode.id] ?? null) : null}
+  patchingPolicy={detailNode !== null && policyPatching[detailNode.id] === true}
   {formatAgo}
   onProbe={() => {
     if (detailNode) handleProbeNode(detailNode)
   }}
+  onSetMode={handleSetMode}
 />


### PR DESCRIPTION
## Why

Phase A2 of the discovery refresh. The GET / PATCH endpoints from #322 are now reachable from the Discovery tab — the operator can see and change the scheduler policy where they already live (the Settings → Discovery surface), not in a separate "Policy" tab.

This follows the design feedback from the prior thread: "いちいち分けるUIあんまり直感的じゃない". One grid, state-encoded visuals, filter on top.

## What changed

### Summary strip (was: identity-binding gauge)
- 6 clickable chips in one row: 3 identity-binding counters (stable / weak / unbound) + 3 scheduler-mode counters (auto / observe / disabled).
- Click a chip to filter the grid below. Active chip gets a primary ring.
- Header shows the topology default mode as a small annotation.

### Card grid
- Each card carries a mode badge (`auto` / `observe` / `disabled`), with an `inh` suffix when the effective mode came from the subgraph chain / topology default rather than a per-node override.
- Disabled cards dim slightly so the eye skips them naturally.
- Added a search input — name / IP / model / sysName.
- "Clear filters" link only appears when something is filtered.
- Counter shows "N of M" while filtered.

### Detail modal
- New "Discovery policy" section: effective mode + interval with per-field origin ("from subgraph" / "from topology default").
- Three pin buttons (auto / observe / disabled) call PATCH; the active one is highlighted when the override lives on this node.
- "Inherit" clears the per-node override (disabled when there isn't one).
- 409 / discovered-only landings are logged to console for now — inline surfacing tracked for A2.1 alongside the "Pin to Manual" CTA.

### API client
- `api.topologies.discoveryPolicy.get(id)` and `.patch(id, body)`.
- `DiscoveryMode` and `EffectivePolicy` types exported.

## Design note

Counters in the summary strip are derived from the **unfiltered** set on purpose — the strip answers "what is the topology" and shouldn't shift when the operator narrows the grid view. The grid counter does change with filters; the summary doesn't.

## Test

\`bun run typecheck\` — 34/34 clean. Biome lint clean (one pre-existing comma-operator warning in DiscoveryNodeDetail.svelte's Dialog.Root bind, unrelated).

## Up next

- **Phase A2.1**: inline 409 surfacing + "Pin to Manual" affordance for discovered-only nodes; bulk actions ("set mode for selection").
- **Phase B**: full scheduler — timestamps, cron, retry, backoff, alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)