### PR TITLE
fix(server-api): scheduler skips Manual sources

### DIFF
--- a/apps/server/api/src/services/discovery-scheduler.ts
+++ b/apps/server/api/src/services/discovery-scheduler.ts
@@ -220,6 +220,14 @@ export class DiscoveryScheduler {
 
         const intervalMs = Math.max(effective.intervalMs, MIN_SYNC_INTERVAL_MS)
         for (const source of sources) {
+          // Manual is the authored layer, not an observed one — there's
+          // no `scan()` or `fetchTopology()` to call. The plugin
+          // capability check in `syncSource()` would catch this too,
+          // but the catch-all would record a `failed` observation
+          // (misleading: it's not a discovery failure, this source
+          // just doesn't do discovery). Skip at the scheduler instead
+          // so the observation history stays meaningful.
+          if (source.dataSource?.type === 'manual') continue
           if (source.lastSyncedAt && now - source.lastSyncedAt < intervalMs) continue
 
           const consecutiveFailures = this.readConsecutiveFailures(source.id)


### PR DESCRIPTION
## Why

Caught in the dev-tool walkthrough right after merging #325. The scheduler was recording a \`failed\` observation against the Manual source every tick — Manual has neither \`scan()\` nor \`fetchTopology()\`, so \`syncSource()\`'s capability check threw, the catch recorded the throw as failed, and the operator saw "Manual ✗ failed" in the history table.

Misleading: that's not a discovery failure. The authored layer simply doesn't do discovery.

## Fix

Skip Manual at the scheduler level (before \`syncSource\` is called) so the observation history stays meaningful.

## Blast radius

The authored layer is read separately from \`data_sources.config_json\`, not from observations, so rendering was never affected — only the history table looked wrong.

Old \`failed\` rows already in the DB will age out under the 20-row \`recentObservations\` limit. No one-shot cleanup needed.

## Test

\`bun run typecheck\` — 34/34 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)