### PR TITLE
fix(server-web): page titles + dedupe breadcrumb on topology subroutes

### DIFF
--- a/apps/server/web/src/lib/components/header.svelte
+++ b/apps/server/web/src/lib/components/header.svelte
@@ -20,6 +20,14 @@
     plugins: 'Plugins',
     settings: 'Settings',
     edit: 'Edit',
+    // Topology subroute tabs (post routes refactor — each is a real
+    // page, so the breadcrumb needs labels for them). Otherwise the
+    // ID_PATTERN heuristic below treats "discovery"/"resolved" as an
+    // ID and shows "…".
+    sources: 'Sources',
+    discovery: 'Discovery',
+    mapping: 'Mapping',
+    resolved: 'Resolved',
   }
 
   // ID-shaped segments (e.g. "msy3HM05AczI") get resolved via the

--- a/apps/server/web/src/routes/(app)/topologies/[id]/+layout.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/+layout.svelte
@@ -127,31 +127,25 @@
   }
 </script>
 
+<svelte:head>
+  {#if ctx.topology}
+    {@const tab = TABS.find((t) => t.slug === activeSlug)}
+    <title>{ctx.topology.name}{tab && tab.slug ? ` · ${tab.label}` : ''} - Shumoku</title>
+  {/if}
+</svelte:head>
+
 <div class="h-full flex flex-col min-h-0">
   {#if !isDiagram}
-    <!-- Header — only on subroutes. Diagram keeps the full canvas. -->
-    <header class="border-b border-theme-border bg-theme-bg-canvas px-6 pt-4">
-      <div class="flex items-baseline gap-3 mb-1">
-        <a
-          href="/topologies"
-          class="text-sm text-theme-text-muted hover:text-theme-text transition-colors"
-        >
-          Topologies
-        </a>
-        <span class="text-theme-text-muted">/</span>
-        <a
-          href="/topologies/{ctx.topologyId}"
-          class="text-lg font-semibold text-theme-text-emphasis hover:underline"
-        >
-          {ctx.topology?.name ?? ctx.topologyId}
-        </a>
-        {#if ctx.loading}
-          <span class="text-xs text-theme-text-muted inline-flex items-center gap-1">
-            <ArrowsClockwiseIcon size={12} class="animate-spin" />
-            loading
-          </span>
-        {/if}
-      </div>
+    <!-- Tab bar — the only chrome subroutes need; the (app) layout's
+         breadcrumb already carries "Topologies › <name>", so a second
+         in-page breadcrumb would just be noise. -->
+    <header class="border-b border-theme-border bg-theme-bg-canvas px-6 pt-3">
+      {#if ctx.loading}
+        <div class="text-xs text-theme-text-muted inline-flex items-center gap-1 mb-1">
+          <ArrowsClockwiseIcon size={12} class="animate-spin" />
+          loading
+        </div>
+      {/if}
       <nav class="flex gap-1 -mb-px">
         {#each TABS as tab (tab.slug)}
           {@const href = `/topologies/${ctx.topologyId}${tab.slug ? `/${tab.slug}` : ''}`}


### PR DESCRIPTION
## Why

Three small cleanups noticed via the dev-tools walkthrough right after #327 landed:

## What

1. **Empty `<title>`** on topology subroutes. The old monolithic page set one via `<svelte:head>`; the layout took over but didn't restore it. Now reads `<name> · <Tab> - Shumoku`.

2. **Two breadcrumbs stacking** — the global header's `Topologies › <name> › …` plus the topology layout's own in-page `Topologies / <name>`. The global one is fine; the in-page one was redundant. Removed. The tab bar carries the "current section" cue.

3. **Header showed `…` for `discovery` and `resolved`**. The breadcrumb's `ID_PATTERN` heuristic (8+ alnum chars) was treating the tab slugs as topology IDs. Added all tab slugs to `routeLabels`.

## Test

\`bun run typecheck\` — 34/34 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)