### PR TITLE
fix(discovery): Last seen survives human edits + mode selector is mode-toned (not green)

### DIFF
--- a/apps/server/web/src/lib/components/DiscoveryNodeDetail.svelte
+++ b/apps/server/web/src/lib/components/DiscoveryNodeDetail.svelte
@@ -103,6 +103,14 @@
   }
 
   const MODE_OPTIONS: DiscoveryMode[] = ['auto', 'observe', 'disabled']
+  // Selected-mode highlight, toned per mode (same hues as the grid cards) so
+  // the color carries the mode — not the app's green `primary`, which reads as
+  // "healthy" on a not-readable node and would even paint "disabled" green.
+  const MODE_SELECTED_CLASS: Record<DiscoveryMode, string> = {
+    auto: 'bg-sky-500 text-white shadow-sm',
+    observe: 'bg-violet-500 text-white shadow-sm',
+    disabled: 'bg-neutral-500 text-white shadow-sm',
+  }
 
   // Keyed on the actual read protocol (from snapshot `readVia`), not the
   // source type — so the label is real data, not a guess.
@@ -510,7 +518,7 @@
                     type="button"
                     class="flex-1 rounded-[5px] px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50
                       {selected
-                      ? 'bg-primary text-primary-foreground shadow-sm'
+                      ? MODE_SELECTED_CLASS[m]
                       : 'text-muted-foreground hover:text-foreground'}
                       {selected && !hasPolicy ? 'opacity-80' : ''}"
                     disabled={patchingPolicy}

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1231,6 +1231,42 @@ describe('resolve()', () => {
       ).toBe(true)
     })
   })
+
+  // -------------------------------------------------------------------------
+  // Status reflects reality, not decoration: `observedAt` ("Last seen") is the
+  // latest real observation time and must survive a human edit (the human
+  // contribution's capturedAt is +Infinity and must not poison it).
+  // -------------------------------------------------------------------------
+  describe('observedAt reflects the last observation, not the human edit', () => {
+    it('a human-touched node still reports the observed time (not blank)', () => {
+      const observed: SnapshotEntry = {
+        sourceId: 'network-scan:1',
+        capturedAt: 1_700_000_000_000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            { id: 'discovered:0', label: 'sw', shape: 'rect', identity: { mgmtIp: '10.0.0.7' } },
+          ],
+        },
+      }
+      const human: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [{ id: 'discovered:0', label: 'MY-NAME', identity: { mgmtIp: '10.0.0.7' } }],
+      }
+      const n = resolve(human, [observed]).nodes[0]
+      expect(n?.provenance?.observedAt).toBe(1_700_000_000_000)
+    })
+
+    it('an authored-only node (never observed) has no observedAt', () => {
+      const human: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [{ id: 'n', label: 'X', identity: { mgmtIp: '10.0.0.8' } }],
+      }
+      const n = resolve(human, []).nodes[0]
+      expect(n?.provenance?.observedAt).toBeUndefined()
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -447,14 +447,19 @@ function deriveNodeProvenance(
     const latest = [...cluster.members].sort((a, b) => b.capturedAt - a.capturedAt)[0]
     source = latest?.sourceId ?? 'unknown'
   }
-  const latest = cluster.members.reduce(
-    (acc, m) => (m.capturedAt > acc ? m.capturedAt : acc),
+  // `observedAt` = the latest real OBSERVATION time. Consider only finite
+  // capturedAt — the human contribution carries `+Infinity` (it's not an
+  // observation), and including it would poison the max and drop observedAt
+  // (→ "Last seen" blanks out the moment a node is renamed / given a
+  // community). An authored-only node has no finite time → undefined.
+  const latestObserved = cluster.members.reduce(
+    (acc, m) => (Number.isFinite(m.capturedAt) && m.capturedAt > acc ? m.capturedAt : acc),
     Number.NEGATIVE_INFINITY,
   )
   return {
     source,
     state,
-    observedAt: Number.isFinite(latest) ? latest : undefined,
+    observedAt: Number.isFinite(latestObserved) ? latestObserved : undefined,
   }
 }
 


### PR DESCRIPTION
Two discovery-status fixes found by inspecting a real node (192.168.13.28,
NOTICE after its SNMP was deleted): the status was misleading, not real.

## fix(core): observedAt survives a human edit — "Last seen" is not cosmetic

`deriveNodeProvenance` computed `observedAt` as `max(capturedAt)` over ALL
cluster members, but the human contribution carries `capturedAt = +Infinity`.
So the moment a node was renamed / given a community / had an access deleted,
the max went to `+Infinity` → `!isFinite` → `observedAt` dropped to undefined,
and the discovery card's "· {ago}" and the detail "Last seen" blanked out.

Take the max over **finite** capturedAt only (real observations). An
authored-only node still has no observedAt (never observed). Confirmed live:
nodes without a human edit show "7m ago", while the SNMP-deleted node showed
"—". (observedAt is computed server-side, so it shows once the API runs this
core build.)

## fix(server-web): discovery-policy mode selector is mode-toned, not green

The segmented control highlighted the selected mode with `bg-primary` (green
in this theme), so on a NOTICE node the green "auto" read as "healthy", and
selecting "disabled" would have been green too. Tone it like the grid card
badges: auto = sky, observe = violet, disabled = neutral. Green no longer
implies health.

## Verification

resolve tests 48 green (2 new: observedAt survives a human edit / authored-only
has none) · svelte-check 0/0 · lint + build pass · the blue "auto" confirmed in
the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
