### PR TITLE
fix(server): plugins Reload no longer drops the Bundled section

### DIFF
--- a/apps/server/api/src/api/plugins.ts
+++ b/apps/server/api/src/api/plugins.ts
@@ -139,7 +139,11 @@ export function createPluginsApi(): Hono {
   // Reload all plugins (hot reload)
   app.post('/reload', async (c) => {
     try {
-      const plugins = await reloadPlugins()
+      // reloadPlugins() returns only the freshly-loaded external plugins. The UI
+      // shows bundled + external in one list, so respond with the full set from
+      // getAllPlugins() — otherwise the "Bundled Plugins" section vanishes on reload.
+      await reloadPlugins()
+      const plugins = getAllPlugins()
       return c.json({
         success: true,
         plugins,

--- a/apps/server/web/src/routes/(app)/plugins/+page.svelte
+++ b/apps/server/web/src/routes/(app)/plugins/+page.svelte
@@ -61,9 +61,15 @@
 
   async function handleReload() {
     reloading = true
+    error = null
     try {
-      const result = await api.plugins.reload()
-      plugins = result.plugins
+      // Re-scan external plugins on the server, then re-read the canonical full
+      // list (bundled + external) — the same source as the initial load and the
+      // add/remove/toggle handlers. Don't bind state to the action's own response:
+      // it only carries what *it* reloaded (externals), which is how the
+      // "Bundled Plugins" section used to vanish on reload.
+      await api.plugins.reload()
+      plugins = await api.plugins.list()
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to reload plugins'
     } finally {


### PR DESCRIPTION
## Symptom

On the Plugins page, clicking **Reload** made the entire **Bundled Plugins**
section disappear (until a full page refresh brought it back).

## Why it happened (and why it was an "individual" bug)

The page renders two sections from one `$state` list, split by a `$derived`:

```ts
let bundledPlugins  = $derived(plugins.filter((p) =>  p.bundled))
let externalPlugins = $derived(plugins.filter((p) => !p.bundled))
```

The derivation is fine. The problem was **how the source `plugins` state gets
refreshed** — it was done ad-hoc, per handler:

| handler | refresh | correct? |
|---|---|---|
| `handleAdd` | `await loadPlugins()` | ✅ |
| `handleToggleEnabled` | `await loadPlugins()` | ✅ |
| `handleDelete` | `await loadPlugins()` | ✅ |
| `handleReload` | `plugins = result.plugins` | ❌ |

`loadPlugins()` reads the canonical full list (`GET /plugins` →
`getAllPlugins()` = **bundled + external**). But `handleReload` bound state to
the *action's own* response, and `POST /plugins/reload` returned only the
freshly re-scanned **external** plugins. So `plugins` became externals-only and
the bundled section emptied.

Two reasons it survived:

1. **The types don't encode it.** `reload()`'s `plugins` field and `list()`'s
   return are both `PluginInfo[]`. "Subset vs union" is a *runtime* distinction —
   TypeScript sees identical shapes, so nothing flagged the swap.
2. **No single refresh path.** Three of four handlers happened to use the
   canonical loader; one didn't. By contrast the **discovery** page never had
   this class of bug because every action funnels through one refresh
   (`refreshDiscovery()` + a full topology re-fetch) and derives everything from
   that. One writer ⇒ can't drift.

Pre-existing since `86659af3` (bundled-plugin architecture) — not introduced by
#337.

## Fix (both layers, so the class can't recur)

- **web** (`plugins/+page.svelte`): `handleReload` performs the reload
  side-effect, then re-reads the canonical full list via `api.plugins.list()`.
  No handler binds list state to a mutation response anymore — all four refresh
  from the same source.
- **api** (`api/plugins.ts`): `POST /plugins/reload` returns `getAllPlugins()`
  (bundled + external) so the endpoint's response is honest regardless of caller.

## Verification

- Live (dev server): clicking Reload keeps all 7 bundled plugins (Manual,
  NetBox, Zabbix, Prometheus, Grafana, Aruba Instant On, Network Discovery);
  `POST /reload` bundled count 0 → 7, matching `GET /plugins`.
- Swept the rest of the app for the same shape (action response replacing a
  filter-split list): discovery sync/rebuild/probe and sources save already
  re-read the full object — plugins Reload was the only instance.
- typecheck + svelte-check 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
