### PR TITLE
fix(core): resolver folds source subgraphs so grouped topology renders

### DIFF
--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1267,6 +1267,149 @@ describe('resolve()', () => {
       expect(n?.provenance?.observedAt).toBeUndefined()
     })
   })
+
+  describe('source subgraphs (fold + namespacing)', () => {
+    it('folds a source subgraph and namespaces its id + node.parent so membership resolves', () => {
+      const snap: SnapshotEntry = {
+        sourceId: 'src-a:1',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            {
+              id: 'n1',
+              label: 'web',
+              shape: 'rect',
+              identity: { mgmtIp: '10.0.0.1' },
+              parent: 'sg-2',
+            },
+          ],
+          subgraphs: [{ id: 'sg-2', label: 'Rack 2' }],
+        },
+      }
+      const out = resolve(emptyGraph(), [snap])
+      expect(out.subgraphs).toHaveLength(1)
+      expect(out.subgraphs?.[0]?.id).toBe('src-a:1:sg-2')
+      expect(out.subgraphs?.[0]?.label).toBe('Rack 2')
+      expect(out.subgraphs?.[0]?.provenance?.source).toBe('src-a:1')
+      // the resolved node's parent points at the namespaced id → not dangling
+      expect(out.nodes[0]?.parent).toBe('src-a:1:sg-2')
+    })
+
+    it('keeps same-id subgraphs from two sources distinct (collision-safe)', () => {
+      const a: SnapshotEntry = {
+        sourceId: 'src-a:1',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            {
+              id: 'a',
+              label: 'a',
+              shape: 'rect',
+              identity: { mgmtIp: '10.0.0.1' },
+              parent: 'sg-2',
+            },
+          ],
+          subgraphs: [{ id: 'sg-2', label: 'Source A rack' }],
+        },
+      }
+      const b: SnapshotEntry = {
+        sourceId: 'netbox:1',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            {
+              id: 'b',
+              label: 'b',
+              shape: 'rect',
+              identity: { mgmtIp: '10.0.0.2' },
+              parent: 'sg-2',
+            },
+          ],
+          subgraphs: [{ id: 'sg-2', label: 'NetBox site' }],
+        },
+      }
+      const out = resolve(emptyGraph(), [a, b])
+      const ids = out.subgraphs?.map((s) => s.id) ?? []
+      expect(ids).toContain('src-a:1:sg-2')
+      expect(ids).toContain('netbox:1:sg-2')
+      expect(new Set(ids).size).toBe(2)
+      const parentByLabel = new Map(out.nodes.map((n) => [n.label, n.parent]))
+      expect(parentByLabel.get('a')).toBe('src-a:1:sg-2')
+      expect(parentByLabel.get('b')).toBe('netbox:1:sg-2')
+    })
+
+    it('namespaces nested subgraph parent/children refs together', () => {
+      const snap: SnapshotEntry = {
+        sourceId: 'src-a:1',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          subgraphs: [
+            { id: 'site', label: 'Site', children: ['rack'] },
+            { id: 'rack', label: 'Rack', parent: 'site' },
+          ],
+        },
+      }
+      const out = resolve(emptyGraph(), [snap])
+      const site = out.subgraphs?.find((s) => s.label === 'Site')
+      const rack = out.subgraphs?.find((s) => s.label === 'Rack')
+      expect(site?.id).toBe('src-a:1:site')
+      expect(site?.children).toEqual(['src-a:1:rack'])
+      expect(rack?.id).toBe('src-a:1:rack')
+      expect(rack?.parent).toBe('src-a:1:site')
+    })
+
+    it('leaves authored subgraph ids raw, and authored parent wins on a shared node', () => {
+      const authored: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [
+          {
+            id: 'r1',
+            label: 'R1',
+            shape: 'rect',
+            identity: { mgmtIp: '10.0.0.1' },
+            parent: 'authored-sg',
+          },
+        ],
+        subgraphs: [{ id: 'authored-sg', label: 'Authored group' }],
+      }
+      const snap: SnapshotEntry = {
+        sourceId: 'src-a:1',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            {
+              id: 'x',
+              label: 'R1',
+              shape: 'rect',
+              identity: { mgmtIp: '10.0.0.1' },
+              parent: 'sg-2',
+            },
+          ],
+          subgraphs: [{ id: 'sg-2', label: 'Source A group' }],
+        },
+      }
+      const out = resolve(authored, [snap])
+      const ids = out.subgraphs?.map((s) => s.id) ?? []
+      expect(ids).toContain('authored-sg') // raw — authored owns the id space
+      expect(ids).toContain('src-a:1:sg-2')
+      // same identity (10.0.0.1) clusters into one node; authored parent wins
+      const r1 = out.nodes.find((n) => n.label === 'R1')
+      expect(r1?.parent).toBe('authored-sg')
+      expect(out.subgraphs?.find((s) => s.id === 'authored-sg')?.provenance?.source).toBe(
+        'authored',
+      )
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -91,7 +91,10 @@ export function resolve(
       sourceId: snap.sourceId,
       priority: snap.priority ?? 0,
       capturedAt: snap.capturedAt,
-      graph: snap.graph,
+      // Namespace this source's subgraph ids (and the node.parent refs into
+      // them) so groups from different sources can't collide. Authored keeps
+      // the raw id space (it's the top-priority, human-owned layer).
+      graph: namespaceSourceSubgraphs(snap.graph, snap.sourceId),
     })
   }
 
@@ -124,9 +127,12 @@ export function resolve(
   //    out of scope for the skeleton.
   const resolvedLinks = foldLinks(contributions, clusterById)
 
-  // 5. Subgraphs — pass through authored, then stamp provenance.
-  //    Workload-source subgraphs are v2; skeleton respects authored only.
-  const resolvedSubgraphs = foldSubgraphs(authored)
+  // 5. Subgraphs — fold from every contribution (authored + each source), not
+  //    just authored. Source subgraph ids were namespaced per source above, and
+  //    resolved nodes carry the matching namespaced `parent`, so membership
+  //    resolves without cross-source collisions. (No cross-source dedup yet:
+  //    subgraphs have no identity key like nodes do — each source keeps its own.)
+  const resolvedSubgraphs = foldSubgraphs(contributions)
 
   return {
     version: authored.version,
@@ -669,12 +675,57 @@ function foldPortCluster(members: PortMember[]): NodePort {
   return folded
 }
 
-function foldSubgraphs(authored: NetworkGraph): Subgraph[] | undefined {
-  if (!authored.subgraphs) return undefined
-  return authored.subgraphs.map((s) => ({
-    ...s,
-    provenance: s.provenance ?? { source: 'authored', state: 'authored-only' },
-  }))
+/**
+ * Namespace a source contribution's subgraph references so groups from
+ * different sources can't collide. A subgraph `id`, a node's `parent`, and a
+ * subgraph's `parent`/`children` are all subgraph ids — prefix every one with
+ * the source id. Mirrors the node-id namespacing already used for link
+ * endpoints (`${sourceId}:${node}` in remapEndpoint / clusterById).
+ *
+ * Returns the graph unchanged when there is nothing to namespace, and never
+ * mutates the input.
+ */
+function namespaceSourceSubgraphs(graph: NetworkGraph, sourceId: string): NetworkGraph {
+  const tag = (id: string) => `${sourceId}:${id}`
+  const hasSubgraphs = (graph.subgraphs?.length ?? 0) > 0
+  const hasNodeParent = graph.nodes.some((n) => n.parent)
+  if (!hasSubgraphs && !hasNodeParent) return graph
+
+  const nodes = hasNodeParent
+    ? graph.nodes.map((n) => (n.parent ? { ...n, parent: tag(n.parent) } : n))
+    : graph.nodes
+
+  const subgraphs = graph.subgraphs?.map((s) => {
+    const next: Subgraph = { ...s, id: tag(s.id) }
+    if (s.parent) next.parent = tag(s.parent)
+    if (s.children) next.children = s.children.map(tag)
+    return next
+  })
+
+  return { ...graph, nodes, subgraphs }
+}
+
+/**
+ * Fold subgraphs from EVERY contribution (authored + each source), stamping
+ * provenance. Source subgraph ids were namespaced per source at contribution
+ * time (see namespaceSourceSubgraphs), and resolved nodes carry the matching
+ * namespaced `parent`, so membership resolves without collisions. No
+ * cross-source dedup yet — subgraphs have no identity key, so each source keeps
+ * its own groups; a subgraph that already carries provenance is left as-is.
+ */
+function foldSubgraphs(contributions: Contribution[]): Subgraph[] | undefined {
+  const all: Subgraph[] = []
+  for (const contrib of contributions) {
+    if (!contrib.graph.subgraphs) continue
+    const state = contrib.sourceId === 'authored' ? 'authored-only' : 'discovered-only'
+    for (const s of contrib.graph.subgraphs) {
+      all.push({
+        ...s,
+        provenance: s.provenance ?? { source: contrib.sourceId, state },
+      })
+    }
+  }
+  return all.length > 0 ? all : undefined
 }
 
 /**


### PR DESCRIPTION
## Symptom

A topology source that emits subgraphs + `node.parent` (a new plugin under
development; also netbox's `groupBy`) renders as a **flat line of nodes** — the
group boxes never draw.

## Root cause (verified in `resolve.ts`)

`resolve()` merges `node.parent` from every contribution (`parentWin`, line 341),
but only passed subgraph **definitions** from the authored graph:

```ts
// resolve.ts — before
const resolvedSubgraphs = foldSubgraphs(authored)  // authored.subgraphs only
// comment: "Workload-source subgraphs are v2; skeleton respects authored only."
```

So a discovered node keeps `parent: "sg-2"` but `sg-2` has no definition in the
resolved graph → dangling reference → renderer draws no box. **Every** topology
source goes through this path (`services/topology.ts` → `parseTopology` →
`resolveObservations`), so **netbox's site/tag/location/prefix grouping is
silently dropped too** — this isn't plugin-specific, it's a pre-existing resolver
limitation (deferred as "v2").

## Fix

Fold subgraphs from **every** contribution. To stay collision-safe when two
sources emit the same id (`sg-2`), namespace each source's subgraph ids — and the
`node.parent` / `subgraph.parent` / `subgraph.children` refs into them — with
`${sourceId}:` at contribution time. This mirrors the `${sourceId}:${node}`
namespacing already used for link endpoints (`remapEndpoint`). The **authored**
graph keeps the raw id space (human-owned, top priority) so "human wins" still
governs grouping.

**Scope / limits:** no cross-source subgraph dedup yet — subgraphs have no
identity key like nodes (mgmtIp/chassisId), so each source keeps its own groups.
Cross-source merge is a follow-up (ties into the element-unification direction).

## Verification

- +4 `resolve` tests: source fold + namespacing, multi-source collision, nested
  `parent`/`children`, authored-wins-on-shared-node. Full core suite green (284).
- typecheck + biome clean.
- **Pending:** live-verify against a real grouped topology (this fixes the
  resolve() data — boxes should now draw since `node.parent` matches a real
  namespaced subgraph id).

Context: came out of making a new plugin a topology source. The plugin itself was
correct (emitting `node.parent` + subgraph defs, same convention as netbox) — the
wall was the host resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
