### PR TITLE
fix(zabbix): support insecure TLS via shared HttpClient

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -289,6 +289,7 @@
       "version": "0.2.25",
       "dependencies": {
         "@shumoku/core": "workspace:*",
+        "@shumoku/plugin-sdk": "workspace:*",
       },
     },
     "libs/shumoku": {

--- a/libs/plugins/zabbix/package.json
+++ b/libs/plugins/zabbix/package.json
@@ -44,7 +44,8 @@
     "format": "biome check --write ."
   },
   "dependencies": {
-    "@shumoku/core": "workspace:*"
+    "@shumoku/core": "workspace:*",
+    "@shumoku/plugin-sdk": "workspace:*"
   },
   "devDependencies": {},
   "publishConfig": {

--- a/libs/plugins/zabbix/src/index.ts
+++ b/libs/plugins/zabbix/src/index.ts
@@ -16,6 +16,12 @@ const configSchema: PluginConfigSchema = {
       placeholder: 'https://zabbix.example.com',
     },
     token: { type: 'string', format: 'password', title: 'API token' },
+    insecure: {
+      type: 'boolean',
+      title: 'Skip TLS verification',
+      default: false,
+      warning: 'Disables certificate validation. Self-signed certs in trusted networks only.',
+    },
     pollInterval: {
       type: 'number',
       title: 'Polling interval',

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -25,6 +25,7 @@ import type {
   NodeMetrics,
 } from '@shumoku/core'
 import { addHttpWarning, mapWithConcurrency } from '@shumoku/core'
+import { createHttpClient, type HttpClient } from '@shumoku/plugin-sdk'
 import type { ZabbixHost, ZabbixItem, ZabbixPluginConfig } from './types.js'
 
 /** Max in-flight Zabbix API calls during a metrics poll (was fully sequential). */
@@ -58,13 +59,23 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
 
   private config: ZabbixPluginConfig | null = null
   private requestId = 0
+  /** Shared SDK client: timeout, Node-compatible insecure TLS, no credential logging. */
+  private http: HttpClient | null = null
 
   initialize(config: unknown): void {
     this.config = config as ZabbixPluginConfig
+    // Zabbix auth is per-method (apiinfo.version etc. must be unauthenticated),
+    // so the client carries no global auth — the Bearer header is set per request.
+    this.http = createHttpClient({
+      baseUrl: this.config.url,
+      insecure: this.config.insecure ?? false,
+      defaultHeaders: { 'Content-Type': 'application/json-rpc' },
+    })
   }
 
   dispose(): void {
     this.config = null
+    this.http = null
   }
 
   // ============================================
@@ -466,40 +477,28 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
   ])
 
   private async apiRequest<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
-    if (!this.config) {
+    if (!this.config || !this.http) {
       throw new Error('Plugin not initialized')
     }
 
     const id = ++this.requestId
-    const url = `${this.config.url.replace(/\/$/, '')}/api_jsonrpc.php`
 
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json-rpc',
-    }
-
+    const headers: Record<string, string> = {}
     if (!ZabbixPlugin.UNAUTHENTICATED_METHODS.has(method)) {
       headers['Authorization'] = `Bearer ${this.config.token}`
     }
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        method,
-        params,
-        id,
-      }),
-    })
-
-    if (!response.ok) {
-      throw new Error(`Zabbix API request failed: ${response.status} ${response.statusText}`)
-    }
-
-    const result = (await response.json()) as {
+    // JSON-RPC always returns HTTP 200 with an `error` envelope on failure, so
+    // HttpClient won't throw — we inspect the body below. HttpClient still
+    // handles transport, timeout, and Node-compatible insecure TLS.
+    const result = await this.http.json<{
       result?: T
       error?: { message: string; data: string }
-    }
+    }>('/api_jsonrpc.php', {
+      method: 'POST',
+      headers,
+      body: { jsonrpc: '2.0', method, params, id },
+    })
 
     if (result.error) {
       throw new Error(`Zabbix API error: ${result.error.message} - ${result.error.data}`)

--- a/libs/plugins/zabbix/src/types.ts
+++ b/libs/plugins/zabbix/src/types.ts
@@ -3,6 +3,8 @@ export interface ZabbixPluginConfig {
   url: string
   token: string
   pollInterval?: number
+  /** Skip TLS certificate verification (self-signed / private-CA upstreams). */
+  insecure?: boolean
 }
 
 // Zabbix API types


### PR DESCRIPTION
## What

Zabbix プラグインが自己署名 / プライベートCA 証明書の Zabbix に接続できず、`Test-zabbix` で **`unable to verify the first certificate`** になっていた問題を修正。

## Why

Zabbix プラグインは唯一 `HttpClient` に移行できていない hand-rolled `fetch` ラッパーで（`http-client.ts` の冒頭コメントが名指しで負債として記載）、TLS 検証スキップの手段が無く、リクエストタイムアウトも無かった。NetBox など他プラグインは既に共有クライアント済み。

## Changes

- `apiRequest` を共有 `@shumoku/plugin-sdk` の `HttpClient` 経由に変更（NetBox と同じ形）
  - Node 互換の insecure TLS（undici dispatcher）/ デフォルトタイムアウト / 資格情報を出さないログを獲得
  - Zabbix の認証はメソッド単位なので Bearer は **リクエスト毎** に付与（`apiinfo.version` 等は無認証必須）
  - JSON-RPC は失敗でも HTTP 200 を返すため、`error` エンベロープは従来どおり手動検査
- `ZabbixPluginConfig` + `configSchema` に `insecure` を追加 → UI に NetBox 同様の "Skip TLS verification" トグルが出る

## Verify

- [x] `typecheck` / `biome check` / `build` 通過（lefthook 全パス）
- [ ] dev サーバーで自己署名 Zabbix に対し insecure=ON で `Test-zabbix` 成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
