### PR TITLE
fix(zabbix): raise request timeout to 30s

### DIFF
--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -31,6 +31,14 @@ import type { ZabbixHost, ZabbixItem, ZabbixPluginConfig } from './types.js'
 /** Max in-flight Zabbix API calls during a metrics poll (was fully sequential). */
 const POLL_CONCURRENCY = 8
 
+/**
+ * Per-request timeout. The shared HttpClient defaults to 10s, but Zabbix
+ * frontends behind a reverse proxy (or polling a large host) can take longer,
+ * and the pre-HttpClient code had no timeout at all — 10s was a regression.
+ * Matches the NetBox client's 30s.
+ */
+const REQUEST_TIMEOUT_MS = 30_000
+
 /** Zabbix-specific link mapping with item IDs for direct item reference */
 interface ZabbixLinkMapping extends LinkMetricsMapping {
   in?: string
@@ -69,6 +77,7 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
     this.http = createHttpClient({
       baseUrl: this.config.url,
       insecure: this.config.insecure ?? false,
+      timeoutMs: REQUEST_TIMEOUT_MS,
       defaultHeaders: { 'Content-Type': 'application/json-rpc' },
     })
   }


### PR DESCRIPTION
## What

Zabbix プラグインのリクエストタイムアウトを **10s → 30s** に引き上げ（NetBox クライアントと同値）。

## Why

#344 で Zabbix を共有 `HttpClient` に移行した際、`HttpClient` のデフォルト 10s タイムアウトをそのまま使っていた。移行前の生 `fetch` 実装は **タイムアウト無し** だったため、10s は遅い upstream に対する実質的なリグレッションだった。

実環境でも、リバースプロキシ配下の Zabbix フロントエンドや大きなホストへの poll が 10s を超え、`request timed out after 10000ms` で打ち切られるケースを確認。

## Changes

- `createHttpClient` に `timeoutMs: 30_000` を明示指定（`REQUEST_TIMEOUT_MS` 定数 + 理由コメント）

到達性・パス・TLS とは独立した、タイムアウト値だけの調整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
