### PR TITLE
fix(renderer): adaptive max zoom so large graphs stay zoomable

### DIFF
--- a/.changeset/adaptive-camera-zoom.md
+++ b/.changeset/adaptive-camera-zoom.md
@@ -1,0 +1,5 @@
+---
+'@shumoku/renderer': patch
+---
+
+Derive the default maximum camera zoom from the graph and viewport dimensions so large diagrams can reach readable scale. Preserve explicit zoom bounds and the existing pan/zoom performance optimizations, and refresh dimensions on resize or sheet changes.

--- a/libs/@shumoku/renderer/package.json
+++ b/libs/@shumoku/renderer/package.json
@@ -42,6 +42,7 @@
     "dev": "vite dev",
     "build": "svelte-package -i src && vite build --outDir dist/wc --emptyOutDir",
     "typecheck": "svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run --passWithNoTests",
     "lint": "biome check .",
     "format": "biome check --write ."
   },

--- a/libs/@shumoku/renderer/src/lib/camera.test.ts
+++ b/libs/@shumoku/renderer/src/lib/camera.test.ts
@@ -1,0 +1,35 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import { deriveMaxScale } from './camera'
+
+describe('deriveMaxScale', () => {
+  it('raises the max for content larger than the viewport (big graph)', () => {
+    // 40000-wide layout in a 1280px viewport → ~31× natural, ×1.5 overzoom
+    const max = deriveMaxScale(40000, 24000, 1280, 800, 10)
+    expect(max).toBeGreaterThan(10)
+    expect(max).toBeCloseTo((40000 / 1280) * 1.5, 1)
+  })
+
+  it('floors at the fixed default for content smaller than the viewport (small graph)', () => {
+    // natural ratio < 1 → floored at the fixed default
+    expect(deriveMaxScale(500, 300, 1280, 800, 10)).toBe(10)
+  })
+
+  it('uses the larger of the width / height ratio', () => {
+    // tall + skinny: the height ratio dominates
+    expect(deriveMaxScale(1000, 16000, 1280, 800, 10)).toBeCloseTo((16000 / 800) * 1.5, 1)
+  })
+
+  it('returns the fixed default when measurements are not ready (any zero)', () => {
+    expect(deriveMaxScale(0, 0, 0, 0, 10)).toBe(10)
+    expect(deriveMaxScale(40000, 24000, 0, 800, 10)).toBe(10)
+    expect(deriveMaxScale(40000, 0, 1280, 800, 10)).toBe(10)
+  })
+
+  it('honors a custom overzoom factor', () => {
+    expect(deriveMaxScale(40000, 24000, 1280, 800, 10, 2)).toBeCloseTo((40000 / 1280) * 2, 1)
+  })
+})

--- a/libs/@shumoku/renderer/src/lib/camera.test.ts
+++ b/libs/@shumoku/renderer/src/lib/camera.test.ts
@@ -1,0 +1,50 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import { deriveMaxScale } from './camera'
+
+describe('deriveMaxScale', () => {
+  it('raises the max for content larger than the viewport (big graph)', () => {
+    // 40000-wide layout in a 1280px viewport → ~31× natural, ×1.5 overzoom
+    const max = deriveMaxScale(40000, 24000, 1280, 800, 10)
+    expect(max).toBeGreaterThan(10)
+    expect(max).toBeCloseTo((40000 / 1280) * 1.5, 1)
+  })
+
+  it('floors at the fixed default for content smaller than the viewport (small graph)', () => {
+    // natural ratio < 1 → floored at the fixed default
+    expect(deriveMaxScale(500, 300, 1280, 800, 10)).toBe(10)
+  })
+
+  it('uses the larger of the width / height ratio', () => {
+    // tall + skinny: the height ratio dominates
+    expect(deriveMaxScale(1000, 16000, 1280, 800, 10)).toBeCloseTo((16000 / 800) * 1.5, 1)
+  })
+
+  it('returns the fixed default when measurements are not ready (any zero)', () => {
+    expect(deriveMaxScale(0, 0, 0, 0, 10)).toBe(10)
+    expect(deriveMaxScale(40000, 24000, 0, 800, 10)).toBe(10)
+    expect(deriveMaxScale(40000, 0, 1280, 800, 10)).toBe(10)
+  })
+
+  it('honors a custom overzoom factor', () => {
+    expect(deriveMaxScale(40000, 24000, 1280, 800, 10, 2)).toBeCloseTo((40000 / 1280) * 2, 1)
+  })
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    -1,
+  ])('keeps a finite bound when a measurement is invalid: %s', (value) => {
+    expect(deriveMaxScale(value, 800, 1280, 800, 10)).toBe(10)
+    expect(deriveMaxScale(40000, value, 1280, 800, 10)).toBe(10)
+    expect(deriveMaxScale(40000, 800, value, 800, 10)).toBe(10)
+    expect(deriveMaxScale(40000, 800, 1280, value, 10)).toBe(10)
+  })
+
+  it('keeps a finite bound if the content-to-viewport ratio overflows', () => {
+    expect(deriveMaxScale(Number.MAX_VALUE, 800, Number.MIN_VALUE, 800, 10)).toBe(10)
+  })
+})

--- a/libs/@shumoku/renderer/src/lib/camera.ts
+++ b/libs/@shumoku/renderer/src/lib/camera.ts
@@ -40,7 +40,13 @@ import { type WheelEventState, WheelGestures } from 'wheel-gestures'
 export type PanFilter = (event: PointerEvent | MouseEvent) => boolean
 
 export interface CameraOptions {
-  /** Zoom scale bounds. Default: [0.2, 10]. */
+  /**
+   * Zoom scale bounds `[min, max]`. When omitted, `min` is 0.2 and `max` is
+   * **adaptive**: derived from the content/viewport ratio (floored at 10) and
+   * kept in sync as the viewBox / viewport change, so a graph far larger than
+   * the screen can still be zoomed in until nodes reach a readable size. Pass an
+   * explicit pair to pin both bounds (opts out of the adaptive max).
+   */
   scaleExtent?: [number, number]
   /**
    * Predicate: pointer-down events that should start a pan. Default:
@@ -93,6 +99,34 @@ const DEFAULT_PAN_FILTER: PanFilter = (e) =>
 const MOUSE_TICK_THRESHOLD = 50
 
 /**
+ * How far past 1:1 (natural pixel size) the adaptive max zoom allows. 1.5 lets
+ * you push a node to ~1.5× its natural size before hitting the cap.
+ */
+const ADAPTIVE_OVERZOOM = 1.5
+
+/**
+ * Derive the max zoom from how much larger the content (viewBox) is than the
+ * viewport. At `k = viewBox/viewport`, 1 user unit ≈ 1 CSS px (content at
+ * natural size); `overzoom` lets you go a bit past that. `fixedMax` is the
+ * floor, so a graph SMALLER than the viewport keeps its normal zoom-in. Returns
+ * `fixedMax` when there's nothing to derive from yet (pre-layout / unmeasured).
+ *
+ * Pure (no DOM) so it's unit-testable; `attachCamera` feeds it live measurements.
+ */
+export function deriveMaxScale(
+  viewBoxW: number,
+  viewBoxH: number,
+  clientW: number,
+  clientH: number,
+  fixedMax: number,
+  overzoom = ADAPTIVE_OVERZOOM,
+): number {
+  if (viewBoxW <= 0 || viewBoxH <= 0 || clientW <= 0 || clientH <= 0) return fixedMax
+  const naturalK = Math.max(viewBoxW / clientW, viewBoxH / clientH)
+  return Math.max(fixedMax, naturalK * overzoom)
+}
+
+/**
  * Classify the very first event of a gesture. Only called at
  * `state.isStart === true`, so the verdict doesn't flip within the
  * gesture no matter what individual frames look like.
@@ -115,11 +149,29 @@ function detectDevice(e: WheelEvent, axisDeltaX: number, axisDeltaY: number): 'm
  */
 export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): Camera {
   const {
-    scaleExtent = [0.2, 10],
+    scaleExtent: explicitScaleExtent,
     panFilter = DEFAULT_PAN_FILTER,
     wheelZoomSensitivity = 1.0015,
     pinchZoomSensitivity = 1.01,
   } = options
+
+  // A caller-pinned scaleExtent is honored verbatim. Otherwise min stays at the
+  // default and max is derived from the content/viewport ratio (floored at the
+  // default) so huge graphs stay zoomable to a readable node size. The adaptive
+  // max is recomputed as the viewBox / viewport change (observers below).
+  const minScale = explicitScaleExtent?.[0] ?? 0.2
+  const fixedMaxScale = explicitScaleExtent?.[1] ?? 10
+  const adaptiveMax = explicitScaleExtent === undefined
+  const currentMaxScale = (): number =>
+    adaptiveMax
+      ? deriveMaxScale(
+          svg.viewBox.baseVal.width,
+          svg.viewBox.baseVal.height,
+          svg.clientWidth,
+          svg.clientHeight,
+          fixedMaxScale,
+        )
+      : fixedMaxScale
 
   const viewportEl = svg.querySelector<SVGGElement>('.viewport')
   if (!viewportEl) {
@@ -149,7 +201,7 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
 
   const svgSel = select(svg)
   const zoomBehavior: ZoomBehavior<SVGSVGElement, unknown> = zoom<SVGSVGElement, unknown>()
-    .scaleExtent(scaleExtent)
+    .scaleExtent([minScale, currentMaxScale()])
     .extent((): [[number, number], [number, number]] => {
       const vb = svg.viewBox.baseVal
       if (vb.width === 0 || vb.height === 0) {
@@ -178,6 +230,24 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
 
   svgSel.call(zoomBehavior)
   svgSel.on('contextmenu.zoom', null)
+
+  // Keep the adaptive max in sync: the viewBox changes when a new layout/sheet
+  // loads, and clientWidth/Height change on container resize. d3-zoom clamps
+  // subsequent gestures to the updated extent. (Skipped when scaleExtent is
+  // pinned — the caller owns the bounds then.)
+  let viewBoxObserver: MutationObserver | null = null
+  let sizeObserver: ResizeObserver | null = null
+  if (adaptiveMax) {
+    const refreshScaleExtent = () => {
+      zoomBehavior.scaleExtent([minScale, currentMaxScale()])
+    }
+    viewBoxObserver = new MutationObserver(refreshScaleExtent)
+    viewBoxObserver.observe(svg, { attributes: true, attributeFilter: ['viewBox'] })
+    if (typeof ResizeObserver !== 'undefined') {
+      sizeObserver = new ResizeObserver(refreshScaleExtent)
+      sizeObserver.observe(svg)
+    }
+  }
 
   // Sticky per-gesture device verdict — set at `isStart`, read on
   // every subsequent event in the same gesture.
@@ -267,9 +337,9 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
       const vbCy = vb.y + vb.height / 2
 
       const targetK = Math.max(
-        scaleExtent[0],
+        minScale,
         Math.min(
-          scaleExtent[1],
+          currentMaxScale(),
           Math.sqrt((vb.width * vb.height * areaRatio) / (bbox.width * bbox.height)),
         ),
       )
@@ -290,6 +360,8 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
     detach() {
       offWheel()
       unobserve()
+      viewBoxObserver?.disconnect()
+      sizeObserver?.disconnect()
       svgSel.on('.zoom', null)
       viewportEl.removeAttribute('transform')
     },

--- a/libs/@shumoku/renderer/src/lib/camera.ts
+++ b/libs/@shumoku/renderer/src/lib/camera.ts
@@ -40,7 +40,13 @@ import { type WheelEventState, WheelGestures } from 'wheel-gestures'
 export type PanFilter = (event: PointerEvent | MouseEvent) => boolean
 
 export interface CameraOptions {
-  /** Zoom scale bounds. Default: [0.2, 10]. */
+  /**
+   * Zoom scale bounds `[min, max]`. When omitted, `min` is 0.2 and `max` is
+   * **adaptive**: derived from the content/viewport ratio (floored at 10) and
+   * kept in sync as the viewBox / viewport change, so a graph far larger than
+   * the screen can still be zoomed in until nodes reach a readable size. Pass an
+   * explicit pair to pin both bounds (opts out of the adaptive max).
+   */
   scaleExtent?: [number, number]
   /**
    * Predicate: pointer-down events that should start a pan. Default:
@@ -93,6 +99,39 @@ const DEFAULT_PAN_FILTER: PanFilter = (e) =>
 const MOUSE_TICK_THRESHOLD = 50
 
 /**
+ * How far past 1:1 (natural pixel size) the adaptive max zoom allows. 1.5 lets
+ * you push a node to ~1.5× its natural size before hitting the cap.
+ */
+const ADAPTIVE_OVERZOOM = 1.5
+
+/**
+ * Derive the max zoom from how much larger the content (viewBox) is than the
+ * viewport. At `k = viewBox/viewport`, 1 user unit ≈ 1 CSS px (content at
+ * natural size); `overzoom` lets you go a bit past that. `fixedMax` is the
+ * floor, so a graph SMALLER than the viewport keeps its normal zoom-in. Returns
+ * `fixedMax` when there's nothing to derive from yet (pre-layout / unmeasured).
+ *
+ * Pure (no DOM) so it's unit-testable; `attachCamera` feeds it live measurements.
+ */
+export function deriveMaxScale(
+  viewBoxW: number,
+  viewBoxH: number,
+  clientW: number,
+  clientH: number,
+  fixedMax: number,
+  overzoom = ADAPTIVE_OVERZOOM,
+): number {
+  if (
+    [viewBoxW, viewBoxH, clientW, clientH].some((value) => !Number.isFinite(value) || value <= 0)
+  ) {
+    return fixedMax
+  }
+  const naturalK = Math.max(viewBoxW / clientW, viewBoxH / clientH)
+  const maxScale = Math.max(fixedMax, naturalK * overzoom)
+  return Number.isFinite(maxScale) ? maxScale : fixedMax
+}
+
+/**
  * Classify the very first event of a gesture. Only called at
  * `state.isStart === true`, so the verdict doesn't flip within the
  * gesture no matter what individual frames look like.
@@ -115,11 +154,29 @@ function detectDevice(e: WheelEvent, axisDeltaX: number, axisDeltaY: number): 'm
  */
 export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): Camera {
   const {
-    scaleExtent = [0.2, 10],
+    scaleExtent: explicitScaleExtent,
     panFilter = DEFAULT_PAN_FILTER,
     wheelZoomSensitivity = 1.0015,
     pinchZoomSensitivity = 1.01,
   } = options
+
+  // A caller-pinned scaleExtent is honored verbatim. Otherwise min stays at the
+  // default and max is derived from the content/viewport ratio (floored at the
+  // default) so huge graphs stay zoomable to a readable node size. The adaptive
+  // max is recomputed as the viewBox / viewport change (observers below).
+  const minScale = explicitScaleExtent?.[0] ?? 0.2
+  const fixedMaxScale = explicitScaleExtent?.[1] ?? 10
+  const adaptiveMax = explicitScaleExtent === undefined
+  const currentMaxScale = (): number =>
+    adaptiveMax
+      ? deriveMaxScale(
+          svg.viewBox.baseVal.width,
+          svg.viewBox.baseVal.height,
+          svg.clientWidth,
+          svg.clientHeight,
+          fixedMaxScale,
+        )
+      : fixedMaxScale
 
   const viewportEl = svg.querySelector<SVGGElement>('.viewport')
   if (!viewportEl) {
@@ -162,7 +219,7 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
 
   const svgSel = select(svg)
   const zoomBehavior: ZoomBehavior<SVGSVGElement, unknown> = zoom<SVGSVGElement, unknown>()
-    .scaleExtent(scaleExtent)
+    .scaleExtent([minScale, currentMaxScale()])
     .extent((): [[number, number], [number, number]] => {
       const vb = svg.viewBox.baseVal
       if (vb.width === 0 || vb.height === 0) {
@@ -201,6 +258,26 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
 
   svgSel.call(zoomBehavior)
   svgSel.on('contextmenu.zoom', null)
+
+  // Keep the adaptive max in sync: the viewBox changes when a new layout/sheet
+  // loads, and clientWidth/Height change on container resize. d3-zoom clamps
+  // subsequent gestures to the updated extent. (Skipped when scaleExtent is
+  // pinned — the caller owns the bounds then.)
+  let viewBoxObserver: MutationObserver | null = null
+  let sizeObserver: ResizeObserver | null = null
+  if (adaptiveMax) {
+    const refreshScaleExtent = () => {
+      // The root coordinate transform also changes with these dimensions.
+      cachedCtm = null
+      zoomBehavior.scaleExtent([minScale, currentMaxScale()])
+    }
+    viewBoxObserver = new MutationObserver(refreshScaleExtent)
+    viewBoxObserver.observe(svg, { attributes: true, attributeFilter: ['viewBox'] })
+    if (typeof ResizeObserver !== 'undefined') {
+      sizeObserver = new ResizeObserver(refreshScaleExtent)
+      sizeObserver.observe(svg)
+    }
+  }
 
   // Sticky per-gesture device verdict — set at `isStart`, read on
   // every subsequent event in the same gesture.
@@ -325,9 +402,9 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
       const vbCy = vb.y + vb.height / 2
 
       const targetK = Math.max(
-        scaleExtent[0],
+        minScale,
         Math.min(
-          scaleExtent[1],
+          currentMaxScale(),
           Math.sqrt((vb.width * vb.height * areaRatio) / (bbox.width * bbox.height)),
         ),
       )
@@ -353,6 +430,8 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
       endGesture()
       offWheel()
       unobserve()
+      viewBoxObserver?.disconnect()
+      sizeObserver?.disconnect()
       svgSel.on('.zoom', null)
       viewportEl.removeAttribute('transform')
     },


### PR DESCRIPTION
## Problem

With many nodes, the diagram became huge and **you couldn't zoom in** to read
anything.

The renderer sizes the SVG `viewBox` to the layout bounds, so `k=1` = "the whole
layout fits the viewport", and the camera's fixed `scaleExtent` max was `10`.
For a graph far larger than the screen, fit-all already shrinks each node to a
few px, so even 10× left nodes unreadable — you hit the cap and couldn't go
further.

## Fix

When `scaleExtent` isn't pinned, derive the max from the content/viewport ratio:

```
deriveMaxScale = max(fixed=10, (viewBox/viewport) × 1.5)
```

so you can always zoom until nodes reach ~natural pixel size. Details:

- The fixed `10` stays a **floor** — a graph smaller than the viewport keeps its
  normal zoom-in. `min` stays `0.2`.
- Recomputed as the **viewBox** (new layout/sheet) or **viewport** (resize)
  change, via `MutationObserver` + `ResizeObserver`; d3-zoom clamps later
  gestures to the updated extent.
- An explicit `scaleExtent` option **opts out** (caller owns the bounds).

## Scope

`attachCamera` is shared, so this fixes **both** the server topology viewer and
the **editor diagram** view (same `viewBox`=bounds model). The **editor scene**
is a separate system (Svelte Flow, absolute coords) and is unaffected.

## Tests / verification

- `deriveMaxScale` extracted as a pure exported fn + **5 unit tests** (adds a
  minimal vitest `test` script to the renderer, which had none).
- `svelte-check` 0 errors; renderer builds.
- **Pending:** live zoom check on a large topology (the web dev server imports
  the renderer source, so it picks this up on reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)