### PR TITLE
feat(plugin-zabbix): generate topology from hosts + LLDP neighbor items (#341)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ libs/
     grafana/                 ← Grafana plugin (alerts)
     netbox/                  ← NetBox plugin (topology, hosts)
     prometheus/              ← Prometheus plugin (metrics, hosts, alerts)
-    zabbix/                  ← Zabbix plugin (metrics, hosts, auto-mapping, alerts)
+    zabbix/                  ← Zabbix plugin (topology, metrics, hosts, auto-mapping, alerts)
 
 apps/
   cli/     ← CLI tool (shumoku render)
@@ -67,7 +67,8 @@ apps/
 - Device:port notation, type aliases, bandwidth normalization
 
 **Layout Engines** (`src/layout/`): Automatic positioning algorithms
-- `HierarchicalLayout` - ELK-based hierarchical layout
+- Custom tiered (Sugiyama-style) engine — `computeNetworkLayout()` (`unified-engine.ts`
+  + `engine/` role-tiers/placement/spacing). ELK was removed; do not reintroduce it.
 - Produces `LayoutResult` with positioned nodes, links, subgraphs
 
 **Plugin Types** (`src/plugin-types.ts`): All capability interfaces
@@ -107,7 +108,7 @@ Plugins implement `DataSourcePlugin` from `@shumoku/core` and depend only on cor
 - **grafana**: Alerts via Alertmanager API or webhook
 - **netbox**: Topology and hosts from NetBox DCIM/IPAM
 - **prometheus**: Metrics, hosts, alerts from Prometheus/Alertmanager
-- **zabbix**: Metrics, hosts, auto-mapping, alerts from Zabbix
+- **zabbix**: Topology (network maps / sysmaps), metrics, hosts, auto-mapping, alerts from Zabbix
 - **aruba-instant-on**: Hosts, metrics, alerts from the (unofficial) Aruba Instant On portal API
 
 **Plugin contract invariants** (see `docs/plugin-authoring.md` for the full reference):
@@ -140,7 +141,7 @@ YAML input → YamlParser.parse() → NetworkGraph → prepareRender() → Prepa
 
 Pipeline internally handles:
 1. Icon dimension resolution (CDN fetch with caching)
-2. Layout computation (HierarchicalLayout)
+2. Layout computation (custom tiered engine — `computeNetworkLayout`)
 3. Rendering with proper icon aspect ratios
 
 ## Versioning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Plugins implement `DataSourcePlugin` from `@shumoku/core` and depend only on cor
 - **grafana**: Alerts via Alertmanager API or webhook
 - **netbox**: Topology and hosts from NetBox DCIM/IPAM
 - **prometheus**: Metrics, hosts, alerts from Prometheus/Alertmanager
-- **zabbix**: Topology (network maps / sysmaps), metrics, hosts, auto-mapping, alerts from Zabbix
+- **zabbix**: Topology (hosts + LLDP neighbor links), metrics, hosts, auto-mapping, alerts from Zabbix
 - **aruba-instant-on**: Hosts, metrics, alerts from the (unofficial) Aruba Instant On portal API
 
 **Plugin contract invariants** (see `docs/plugin-authoring.md` for the full reference):

--- a/apps/server/docs/design/zabbix-lldp-topology.md
+++ b/apps/server/docs/design/zabbix-lldp-topology.md
@@ -88,6 +88,16 @@ templates.
    dropping, so topology stays complete and future-clusters.
 3. **identity.sysName = host.name** (the map version used `host.host`=IP — a bug for
    clustering; fixed here).
+3b. **`metadata.hostname = host.name`** — the compound layout
+   (`layout/auto-placement/flat-tree/compound.ts`) reads `metadata.hostname` (FQDN)
+   to (a) tell a real device from an information-less *ghost* and (b) band link-less
+   members by domain (`.noc` / `.sec` / …). Without it every link-less host (the
+   majority — only backbone gear has LLDP) is treated as a ghost and dumped into the
+   "未マップ" grid, discarding the topology subgraphs. NOTE: the compound layout then
+   groups by hostname **domain**, which overrides the host-group `parent` this
+   converter sets — so `groupBy` currently affects the resolved graph but not the
+   compound-rendered diagram. (No production plugin set `metadata.hostname` before
+   this — the compound layout's hostname features were effectively dormant.)
 4. **Template coupling** — auto-detect `lldp.rem.*`; absent → nodes-only. Don't hard-fail.
 5. **Bidirectional LLDP** — de-dup links.
 

--- a/apps/server/docs/design/zabbix-lldp-topology.md
+++ b/apps/server/docs/design/zabbix-lldp-topology.md
@@ -1,0 +1,107 @@
+# Zabbix LLDP Topology Source — Design
+
+Status: spec (2026-06-05). Supersedes the initial map-import approach (#341).
+
+## Goal
+
+Make the Zabbix plugin a **topology source that generates nodes + links from
+standard Zabbix data** — no dependency on Zabbix maps or the custom netmap/L2DM
+map-generation module, and **no direct SNMP reach** from shumoku (Zabbix is the
+collector).
+
+- **nodes** ← `host.get` (scoped by host group)
+- **links** ← per-host **LLDP-MIB** neighbor items (`lldp.rem.*` / `lldp.loc.*`)
+
+## Why this works (verified 2026-06-05 against zabbix-test, Zabbix 7.0.23)
+
+- Zabbix has no native topology object, but LLDP neighbor data is collected as
+  **standard SNMP items** (SNMP_walk of IF-MIB `1.3.6.1.2.1.2.2.1.*` + LLDP-MIB
+  `1.0.8802.1.1.2.*` → LLD → dependent items). See `reference_zabbix_lldp_topology`.
+- Reconstructed real adjacency from items alone: mx304.noc 4/4 neighbors resolved
+  to other Zabbix hosts; ptx10002-60mr.noc 6/8 (2 neighbors aren't Zabbix hosts).
+- The resolver already folds cross-source nodes+links by identity
+  (`foldLinks`/`remapEndpoint`), so this composes with other sources.
+
+## Config (per-attachment `optionsSchema` → `optionsJson`)
+
+| key | type | note |
+|-----|------|------|
+| `hostGroups` | string[] (`optionsSource:'hostgroup'`, freeSolo) | **Scope.** Strongly recommended — instances have 1000s of hosts (zabbix-test: 1386). Empty = all (guarded/limited). |
+| `groupBy` | `'hostgroup'` \| `'none'` (default `hostgroup`) | Subgraphs from host groups (most-specific). Reused from the map version. |
+| `includeExternalNeighbors` | boolean (default `true`) | Synthesize nodes for LLDP neighbors that aren't Zabbix hosts. |
+
+`getConfigOptions('hostgroup')` supplies candidates via `hostgroup.get`.
+
+## LLDP item families (per host, joined by the item NAME `[ifName]` suffix)
+
+Joining by the trailing `[ifName]` in the item **name** is reliable; the item
+**keys** are inconsistent across families (some keyed by ifName, some ifIndex,
+some carry template macro params) so do NOT parse keys.
+
+| family | use |
+|--------|-----|
+| `lldp.rem.sysname` | remote neighbor system name → resolve to a node |
+| `lldp.rem.port.id` | remote port id (may be a port name or a MAC) |
+| `lldp.rem.chassisid` | remote chassis id (identity for external nodes) |
+| `lldp.neighbor.present` | "has neighbor" (or treat `rem.sysname` ∉ {`* No Info *`,`-`,`unknown`,``}) |
+| `lldp.loc.if.ifSpeed` / `ifHighSpeed` | local port speed → `Link` bandwidth |
+
+**Detection:** if a host has no `lldp.rem.sysname` items, it contributes a node
+only (no links). Future: make the family prefix configurable for non-L2DM LLDP
+templates.
+
+## Algorithm
+
+1. `host.get({ groupids, output:[host,name,status], selectInterfaces, selectInventory:[hardware], selectHostGroups })`.
+   For each host → **Node**:
+   - `id = ${sourceId}:host:${hostid}`
+   - `label = host.name`
+   - `identity = { mgmtIp: pickMgmtIp(interfaces), sysName: host.name, vendorIds:{'zabbix-hostid':hostid} }`
+     — **`sysName = host.name`** (the real hostname), NOT `host.host` (often the IP
+     here). This is what makes neighbor sysnames resolve and what clusters with
+     other sources.
+   - `spec = deriveSpec(inventory.hardware)` (reused)
+   - `parent` = most-specific host group (reused grouping)
+2. For each host, `item.get` the LLDP families above (search by key family, output
+   `[name,lastvalue]`). Join values by `[ifName]`. For each ifName with a neighbor:
+   - ensure a local **NodePort** on the host node: `id=${nodeId}:port:${ifName}`,
+     `label=ifName`, `speed` from ifSpeed/ifHighSpeed.
+   - resolve neighbor `rem.sysname` → a host node (match against `host.name`);
+     if unresolved and `includeExternalNeighbors`, synthesize an **external node**
+     (`identity.sysName = rem.sysname`, `metadata.external = true`) so a later
+     discovery of that device clusters with it; else skip the link.
+   - ensure a remote NodePort (label from `rem.port.id` when it looks like a port
+     name, else synthesized).
+   - create **Link** `from {hostNode, localPort}` `to {neighborNode, remPort}`,
+     `rateBps`/bandwidth from local ifSpeed, `metadata.discoveredVia='zabbix-lldp'`.
+3. **De-dup** (LLDP is bidirectional): canonical key = `sorted([`${aNode}:${aPort}`, `${bNode}:${bPort}`])`,
+   keep first. Known limit: when `rem.port.id` is a MAC (not the peer's ifName) the
+   mirror may not collapse — acceptable for v1, refine later (e.g. de-dup by node
+   pair + chassisId).
+4. Subgraphs from host groups (reused). Return graph.
+
+## Pitfalls folded into this spec
+
+1. **Scale** — `hostGroups` filter; fetch only the needed `lldp.*` families, not all
+   ~3000 items/host; batch per host with bounded concurrency.
+2. **Unresolved neighbors** — synthesize external nodes (identity-keyed) instead of
+   dropping, so topology stays complete and future-clusters.
+3. **identity.sysName = host.name** (the map version used `host.host`=IP — a bug for
+   clustering; fixed here).
+4. **Template coupling** — auto-detect `lldp.rem.*`; absent → nodes-only. Don't hard-fail.
+5. **Bidirectional LLDP** — de-dup links.
+
+## Deferred
+
+- Node positions, VLANs, link aggregation grouping.
+- Configurable LLDP key prefix for non-L2DM templates (v1 auto-detects the common one).
+- A general "links from source B complement nodes from source A" Discovery-tab UX —
+  the resolver engine already merges; the orchestration/auto-adopt UX is a separate track.
+
+## Code changes
+
+- `types.ts` — drop sysmap types; add an LLDP item helper type + `ZabbixTopologyOptions {hostGroups, groupBy, includeExternalNeighbors}`.
+- `topology.ts` — rewrite: hosts+LLDP → graph; keep `deriveSpec` + hostgroup grouping helpers.
+- `plugin.ts` — `fetchTopology` = host.get + batched LLDP item.get → converter; `getConfigOptions('hostgroup')`.
+- `index.ts` — `optionsSchema { hostGroups, groupBy, includeExternalNeighbors }`.
+- tests — LLDP converter unit tests.

--- a/apps/server/docs/design/zabbix-lldp-topology.md
+++ b/apps/server/docs/design/zabbix-lldp-topology.md
@@ -1,6 +1,8 @@
-# Zabbix LLDP Topology Source — Design
+# Zabbix Topology Source — Design
 
-Status: spec (2026-06-05). Supersedes the initial map-import approach (#341).
+Status: implemented (2026-06-05). Supersedes the initial map-import approach (#341).
+Rebuilt by cross-referencing the Zabbix 7.0 API spec, the live `zabbix-test` data,
+and the human-built ShowNet sysmaps.
 
 ## Goal
 
@@ -9,8 +11,14 @@ standard Zabbix data** — no dependency on Zabbix maps or the custom netmap/L2D
 map-generation module, and **no direct SNMP reach** from shumoku (Zabbix is the
 collector).
 
-- **nodes** ← `host.get` (scoped by host group)
-- **links** ← per-host **LLDP-MIB** neighbor items (`lldp.rem.*` / `lldp.loc.*`)
+- **nodes** ← `host.get` (scoped by host group). Keyed on `name` (the real
+  hostname; `host.host` is the management IP in this data).
+- **links** ← per-host **LLDP-MIB** neighbor items (`lldp.rem.*` / `lldp.loc.*`),
+  plus a **`PARENT` host-tag** fallback where LLDP saw no neighbor.
+- **groups** ← host groups, honoring the Zabbix `/` nesting convention.
+- **device type/vendor/model** ← `inventory.{type,vendor,model}` (spec, usually
+  empty) → parse `inventory.hardware` / SNMP **sysDescr** (`lldp.sys.desc` /
+  `system.descr`).
 
 ## Why this works (verified 2026-06-05 against zabbix-test, Zabbix 7.0.23)
 
@@ -26,11 +34,41 @@ collector).
 
 | key | type | note |
 |-----|------|------|
-| `hostGroups` | string[] (`optionsSource:'hostgroup'`, freeSolo) | **Scope.** Strongly recommended — instances have 1000s of hosts (zabbix-test: 1386). Empty = all (guarded/limited). |
-| `groupBy` | `'hostgroup'` \| `'none'` (default `hostgroup`) | Subgraphs from host groups (most-specific). Reused from the map version. |
-| `includeExternalNeighbors` | boolean (default `true`) | Synthesize nodes for LLDP neighbors that aren't Zabbix hosts. |
+| `hostGroups` | string[] (`optionsSource:'hostgroup'`, freeSolo) | **Scope.** Strongly recommended — instances have 1000s of hosts (zabbix-test: 1386). Empty = all. |
+| `groupBy` | `'hostgroup'` \| `'none'` (default `hostgroup`) | Subgraphs from host groups (most-specific, `/`-nested). |
+| `groupExclude` | string[] (freeSolo) | Host-group names to never use as a subgraph (admin / catch-all groups). |
+| `includeExternalNeighbors` | boolean (default `true`) | Synthesize nodes for LLDP/tag neighbors that aren't Zabbix hosts. |
+| `parentTag` | string (default `'PARENT'`) | Host-tag name whose value names an upstream device → fallback link where LLDP saw nothing. Empty disables. |
 
 `getConfigOptions('hostgroup')` supplies candidates via `hostgroup.get`.
+
+## Grouping (Zabbix host groups, `/`-nested)
+
+Zabbix host groups nest via the **`/`** separator (`A/B/C` → `A ⊃ A/B ⊃ A/B/C`);
+parent levels aren't real objects, so synthesize them by splitting the name. A
+node lands in its **most-specific** group: deepest `/` path, then fewest members
+(so an admin/catch-all group that contains everyone loses), then name.
+`groupExclude` drops named admin groups. (ShowNet groups are flat dotted names —
+`016.000.Backbone Routers` — with no `/`, so nesting is inert there but spec-correct.)
+There is **no "primary group"** in Zabbix — this most-specific policy is ours.
+
+## Device type / vendor / model
+
+Zabbix has no device-role enum. Order: structured `inventory.{vendor,model,type}`
+(spec-faithful but ~0% populated here) → parse the most informative of
+`inventory.hardware` / SNMP **sysDescr** (skipping a value that just echoes the
+hostname). sysDescr comes from `lldp.sys.desc` / `lldp.loc.sys.desc` / `system.descr`
+items fetched alongside the LLDP data. Maps to `DeviceType` (router / l3-switch /
+l2-switch / firewall / server / access-point) by keyword. Coverage on zabbix-test
+group 98: 33/63 typed, 35/63 vendor (vs ~10% from inventory.hardware alone).
+
+## Links: LLDP + PARENT-tag fallback
+
+LLDP neighbors are the authoritative edges (blue in the ShowNet maps). Where a
+host has no LLDP neighbor, a `PARENT` host-tag (value = upstream device name; the
+green links in the maps) adds a fallback edge — but only if that node-pair isn't
+already LLDP-linked. Tag links carry `metadata.discoveredVia='zabbix-parent-tag'`
+(LLDP: `'zabbix-lldp'`).
 
 ## LLDP item families (per host, joined by the item NAME `[ifName]` suffix)
 

--- a/apps/server/docs/zabbix-integration.md
+++ b/apps/server/docs/zabbix-integration.md
@@ -43,12 +43,13 @@ Authorization: Bearer <token>
 
 | メソッド | 用途 | 現状 |
 |---------|------|------|
-| `apiinfo.version` | API バージョン確認 | ✅ 実装済 |
-| `host.get` | ホスト一覧取得 | ✅ 実装済 |
+| `apiinfo.version` | API バージョン確認 (無認証) | ✅ 実装済 |
+| `host.get` | ホスト一覧取得 (interfaces/inventory/hostgroups/templates) | ✅ 実装済 |
 | `item.get` | アイテム(メトリクス)取得 | ✅ 実装済 |
-| `hostinterface.get` | ホストインターフェース | ❌ 未実装 |
+| `event.get` | 障害イベント取得 (アラート) | ✅ 実装済 |
+| `map.get` | ネットワークマップ(sysmap)取得 | ✅ 実装済 (トポロジー) |
+| `hostgroup.get` | ホストグループ | （host.get の selectHostGroups で代替） |
 | `trigger.get` | トリガー(障害定義) | ❌ 未実装 |
-| `problem.get` | 現在の障害一覧 | ❌ 未実装 |
 | `history.get` | 過去データ | ❌ 未実装 |
 
 ---
@@ -138,6 +139,54 @@ Authorization: Bearer <token>
 ```
 
 **用途**: 現在発生中の障害表示
+
+---
+
+## トポロジー取り込み (Network Maps / sysmaps)
+
+Zabbix の **ネットワークマップ (sysmap)** を 1 枚選んで shumoku の `NetworkGraph`
+に変換する (`topology` capability / `fetchTopology`)。**標準の `map.get` のみ**に依存し、
+自作マップ生成モジュール (例: ShowNet の `/zabbix/netmap`) のラベル/アイコン規約には
+依存しない。
+
+### 設定 (アタッチ単位 / `optionsJson`)
+
+マップ選択はデータソース config ではなく **トポロジーへのアタッチ時オプション**
+(`optionsSchema`)。1 つの Zabbix ソースを複数トポロジーに別マップで使える。
+
+| キー | 説明 |
+|------|------|
+| `sysmapId` | 取り込む sysmap の ID。候補は `getConfigOptions('map')` が `map.get` で動的供給 |
+| `groupBy` | `hostgroup` (既定) / `none`。下記参照 |
+| `groupExclude` | サブグラフに使わないホストグループ名 (管理/全体グループの除外) |
+
+### 変換マッピング
+
+| Zabbix | shumoku | 備考 |
+|--------|---------|------|
+| selement `elementtype:0` (host) | `Node` | `elements[0].hostid` を `host.get` でバッチ解決 |
+| host `name` | `Node.label` | selement.label は `{HOST.NAME}` マクロ (API では未展開) なので使わない |
+| 既定インターフェース IP | `identity.mgmtIp` / `Node` ip | `main==='1'` 優先 |
+| host id / sysName | `identity.vendorIds['zabbix-hostid']` / `sysName` | リゾルバのクラスタリング用 |
+| `inventory.hardware` | `spec.vendor` / `model` / `type` | best-effort パース。空なら Generic |
+| link `selementid1/2` | `Link.from/to.node` | 端点ごとに **ポートを合成** (1 port = 1 endpoint 不変条件) |
+| link `drawtype` / `color` | `Link.type` / `style.stroke` | 0=solid,2=thick,3/4=dashed |
+| host group | `Subgraph` | `groupBy` 参照 |
+
+### グルーピング (`groupBy`)
+
+- **`hostgroup`** (既定): 各ノードを **最も具体的なホストグループ**(マップ上メンバー数が
+  最小のグループ)に入れる。全ホストを含む管理/全体グループは自動的に負けるので、
+  ベンダ固有の命名規則に依存せずセグメント単位に分かれる。`groupExclude` で
+  特定グループを明示除外。
+- **`none`**: マップ上の標準ホストグループ要素 (`elementtype:3`) のみをサブグラフ化。
+  素の Zabbix マップはこの形式だが、自動生成マップは持たないことが多い (= フラット)。
+
+### 現時点の非対応 (今後)
+
+- selement の x/y 座標は `Node.position` に未反映 (レイアウト保持は別途検討)。
+- submap (`type:1`) / trigger (`type:2`) / image (`type:4`) 要素はスキップ。
+- リンクのポート名 / 帯域 / VLAN は標準マップに無いため未対応 (`item.get` で別途付与の余地)。
 
 ---
 

--- a/apps/server/docs/zabbix-integration.md
+++ b/apps/server/docs/zabbix-integration.md
@@ -142,51 +142,48 @@ Authorization: Bearer <token>
 
 ---
 
-## トポロジー取り込み (Network Maps / sysmaps)
+## トポロジー生成 (LLDP)
 
-Zabbix の **ネットワークマップ (sysmap)** を 1 枚選んで shumoku の `NetworkGraph`
-に変換する (`topology` capability / `fetchTopology`)。**標準の `map.get` のみ**に依存し、
-自作マップ生成モジュール (例: ShowNet の `/zabbix/netmap`) のラベル/アイコン規約には
-依存しない。
+Zabbix から **ノード＋リンク**を生成する (`topology` capability / `fetchTopology`)。
+**ノードはホスト (`host.get`)、リンクは各ホストの LLDP 隣接アイテム**から。Zabbix の
+マップ (sysmap) や自作マップ生成モジュールには依存せず、**shumoku からの直接 SNMP も不要**
+(Zabbix が収集済み)。詳細は `docs/design/zabbix-lldp-topology.md`。
+
+リンクの出どころは**標準 LLDP-MIB** (`lldpRemSysName` 等、OID `1.0.8802.1.1.2…`) を
+SNMP_walk → LLD → dependent item で取り込んだもの。アイテムキー命名 (`lldp.rem.*`) は
+LLDP テンプレ依存なので、**`lldp.rem.sysname` が無いホストはノードのみ**になる (graceful)。
 
 ### 設定 (アタッチ単位 / `optionsJson`)
 
-マップ選択はデータソース config ではなく **トポロジーへのアタッチ時オプション**
-(`optionsSchema`)。1 つの Zabbix ソースを複数トポロジーに別マップで使える。
-
 | キー | 説明 |
 |------|------|
-| `sysmapId` | 取り込む sysmap の ID。候補は `getConfigOptions('map')` が `map.get` で動的供給 |
-| `groupBy` | `hostgroup` (既定) / `none`。下記参照 |
-| `groupExclude` | サブグラフに使わないホストグループ名 (管理/全体グループの除外) |
+| `hostGroups` | 取り込み対象のホストグループ id (`getConfigOptions('hostgroup')` が動的供給)。**大規模インスタンスでは必須級** (数千ホスト)。空=全件 |
+| `groupBy` | `hostgroup` (既定, 最も具体的なグループに入れる) / `none` |
+| `groupExclude` | サブグラフに使わないホストグループ名 |
+| `includeExternalNeighbors` | Zabbix ホストでない LLDP 隣接にノードを合成 (既定 true) |
 
 ### 変換マッピング
 
 | Zabbix | shumoku | 備考 |
 |--------|---------|------|
-| selement `elementtype:0` (host) | `Node` | `elements[0].hostid` を `host.get` でバッチ解決 |
-| host `name` | `Node.label` | selement.label は `{HOST.NAME}` マクロ (API では未展開) なので使わない |
-| 既定インターフェース IP | `identity.mgmtIp` / `Node` ip | `main==='1'` 優先 |
-| host id / sysName | `identity.vendorIds['zabbix-hostid']` / `sysName` | リゾルバのクラスタリング用 |
-| `inventory.hardware` | `spec.vendor` / `model` / `type` | best-effort パース。空なら Generic |
-| link `selementid1/2` | `Link.from/to.node` | 端点ごとに **ポートを合成** (1 port = 1 endpoint 不変条件) |
-| link `drawtype` / `color` | `Link.type` / `style.stroke` | 0=solid,2=thick,3/4=dashed |
-| host group | `Subgraph` | `groupBy` 参照 |
+| `host.get` host | `Node` | `id=<src>:host:<hostid>` |
+| host `name` | `Node.label` / `identity.sysName` | **sysName は host.name** (host.host は IP のことがあり不可) |
+| 既定 IF の IP | `identity.mgmtIp` | `main==='1'` 優先 |
+| host id | `identity.vendorIds['zabbix-hostid']` | |
+| `inventory.hardware` | `spec.vendor/model/type` | best-effort パース |
+| LLDP 隣接 (`lldp.rem.sysname` 等) | `Link` | local IF + 隣接機器/ポートで端点。**実ポート名**つき |
+| `lldp.loc.if.ifSpeed` | port `speed` / link `metadata.speedBps` | |
+| ホストグループ | `Subgraph` | `groupBy` 参照 |
 
-### グルーピング (`groupBy`)
-
-- **`hostgroup`** (既定): 各ノードを **最も具体的なホストグループ**(マップ上メンバー数が
-  最小のグループ)に入れる。全ホストを含む管理/全体グループは自動的に負けるので、
-  ベンダ固有の命名規則に依存せずセグメント単位に分かれる。`groupExclude` で
-  特定グループを明示除外。
-- **`none`**: マップ上の標準ホストグループ要素 (`elementtype:3`) のみをサブグラフ化。
-  素の Zabbix マップはこの形式だが、自動生成マップは持たないことが多い (= フラット)。
+### 要点
+- アイテムは host id バッチで `item.get`、IF ごとに**アイテム名の `[ifName]` サフィックス**で join (キーはファミリ間で形が揃っていないため)。
+- LLDP は双方向に出るので**リンクを de-dup** (端点ペアの正規化キー)。
+- 解決できない隣接は**外部ノードを合成** (identity.sysName 付き)。後で当該機器を別グループ/別ソースで取り込むと resolver が identity で**自動統合**。
 
 ### 現時点の非対応 (今後)
-
-- selement の x/y 座標は `Node.position` に未反映 (レイアウト保持は別途検討)。
-- submap (`type:1`) / trigger (`type:2`) / image (`type:4`) 要素はスキップ。
-- リンクのポート名 / 帯域 / VLAN は標準マップに無いため未対応 (`item.get` で別途付与の余地)。
+- ノード座標、VLAN、リンクアグリゲーションのまとめ。
+- 非 L2DM な LLDP テンプレ向けのキー接頭辞設定 (現状は共通命名を自動検出)。
+- リモートポート id が MAC のとき de-dup が緩むケース。
 
 ---
 

--- a/apps/server/web/src/lib/components/SchemaForm.svelte
+++ b/apps/server/web/src/lib/components/SchemaForm.svelte
@@ -60,11 +60,12 @@
     }
   })
 
-  // Load candidates for visible optionsSource fields.
+  // Load candidates for visible optionsSource fields — both array (multi-select)
+  // and single-value string (single-select) fields.
   $effect(() => {
     if (!getOptions) return
     for (const prop of Object.values(schema.properties)) {
-      if (prop.type === 'array' && prop.optionsSource && isVisible(prop)) {
+      if (prop.optionsSource && prop.type !== 'object' && isVisible(prop)) {
         void ensureOptions(prop.optionsSource)
       }
     }
@@ -225,12 +226,28 @@
               {onChange}
             />
           </fieldset>
+        {:else if prop.optionsSource && (candidates[prop.optionsSource]?.length ?? 0) > 0}
+          <!-- Single-select from dynamic candidates (e.g. a Zabbix map). When no
+               candidates are available (connection not ready), this falls through
+               to the free-text input below — the documented freeSolo fallback. -->
+          <select
+            id={`sf-${key}`}
+            class="input"
+            {disabled}
+            value={(value[key] ?? prop.default ?? '') as string}
+            onchange={(e) => onSelect(key, prop, e)}
+          >
+            <option value="">{prop.placeholder ?? 'Select…'}</option>
+            {#each candidates[prop.optionsSource] ?? [] as o (o.value)}
+              <option value={o.value}>{o.label}</option>
+            {/each}
+          </select>
         {:else}
           <input
             id={`sf-${key}`}
             class="input"
             type={inputType(prop)}
-            placeholder={prop.placeholder}
+            placeholder={loadingOptions[prop.optionsSource ?? ''] ? 'Loading…' : prop.placeholder}
             {disabled}
             value={(value[key] ?? prop.default ?? '') as string}
             oninput={(e) => onText(key, e)}

--- a/libs/@shumoku/core/src/layout/auto-placement/flat-tree/compound.ts
+++ b/libs/@shumoku/core/src/layout/auto-placement/flat-tree/compound.ts
@@ -81,7 +81,9 @@ export function layoutCompound(
     const h = (n.metadata as { hostname?: unknown } | undefined)?.hostname
     return typeof h === 'string' ? h : ''
   }
-  const isGhost = (n: Node): boolean => !(deg.get(n.id) ?? 0) && hostnameOf(n) === ''
+  // A node the source explicitly grouped (`parent`) is never an information-less
+  // ghost — it has a place to go.
+  const isGhost = (n: Node): boolean => !(deg.get(n.id) ?? 0) && hostnameOf(n) === '' && !n.parent
   const ghosts = homed.nodes.filter(isGhost)
   if (ghosts.length === 0) return layoutCompoundCore(homed, engine, options, 0)
 
@@ -155,8 +157,18 @@ function layoutCompoundCore(
           .trim()
           .toLowerCase()
   }
-  const keyOf = (node: Node): string => `dom:${domainOf(node)}`
-  const labelOf = (key: string): string => (key.startsWith('dom:') ? key.slice(4) : key)
+  // A source's explicit subgraph (`node.parent`) is authoritative grouping —
+  // honor it (e.g. Zabbix host groups, NetBox sites). Functional-domain banding
+  // is the fallback for nodes the source left ungrouped.
+  const subgraphLabel = new Map((graph.subgraphs ?? []).map((s) => [s.id, s.label]))
+  const keyOf = (node: Node): string =>
+    node.parent ? `sg:${node.parent}` : `dom:${domainOf(node)}`
+  const labelOf = (key: string): string =>
+    key.startsWith('sg:')
+      ? (subgraphLabel.get(key.slice(3)) ?? key.slice(3))
+      : key.startsWith('dom:')
+        ? key.slice(4)
+        : key
 
   // 1. Partition by this level's key ('' → its own singleton box).
   const groups = new Map<string, Node[]>()

--- a/libs/plugins/zabbix/src/index.ts
+++ b/libs/plugins/zabbix/src/index.ts
@@ -37,13 +37,51 @@ const configSchema: PluginConfigSchema = {
   },
 }
 
+/**
+ * Per-attachment topology options (rendered on the Sources page, stored as the
+ * attachment's `optionsJson`). `sysmapId` picks which Zabbix map to import; its
+ * candidates come from `getConfigOptions('map')`, with free entry when a
+ * connection isn't available yet.
+ */
+const optionsSchema: PluginConfigSchema = {
+  type: 'object',
+  required: ['sysmapId'],
+  properties: {
+    sysmapId: {
+      type: 'string',
+      title: 'Map',
+      help: 'The Zabbix network map (sysmap) to import as topology.',
+      optionsSource: 'map',
+      freeSolo: true,
+    },
+    groupBy: {
+      type: 'string',
+      title: 'Group by',
+      default: 'hostgroup',
+      help: 'Subgraphs from host groups (most-specific per host), or only from standard host-group elements drawn on the map.',
+      oneOf: [
+        { const: 'hostgroup', title: 'Host group' },
+        { const: 'none', title: 'Map host-group elements only' },
+      ],
+    },
+    groupExclude: {
+      type: 'array',
+      items: { type: 'string' },
+      title: 'Exclude groups',
+      help: 'Host-group names to never use as a subgraph (admin / catch-all groups).',
+      freeSolo: true,
+    },
+  },
+}
+
 export function register(registry: PluginRegistryInterface): void {
   registry.registerDescriptor(
     {
       type: 'zabbix',
       displayName: 'Zabbix',
-      capabilities: ['metrics', 'hosts', 'alerts'],
+      capabilities: ['metrics', 'hosts', 'alerts', 'topology'],
       configSchema,
+      optionsSchema,
     },
     (config) => {
       const plugin = new ZabbixPlugin()

--- a/libs/plugins/zabbix/src/index.ts
+++ b/libs/plugins/zabbix/src/index.ts
@@ -39,29 +39,28 @@ const configSchema: PluginConfigSchema = {
 
 /**
  * Per-attachment topology options (rendered on the Sources page, stored as the
- * attachment's `optionsJson`). `sysmapId` picks which Zabbix map to import; its
- * candidates come from `getConfigOptions('map')`, with free entry when a
- * connection isn't available yet.
+ * attachment's `optionsJson`). Topology is generated from hosts (nodes) + LLDP
+ * neighbor items (links); see the design doc.
  */
 const optionsSchema: PluginConfigSchema = {
   type: 'object',
-  required: ['sysmapId'],
   properties: {
-    sysmapId: {
-      type: 'string',
-      title: 'Map',
-      help: 'The Zabbix network map (sysmap) to import as topology.',
-      optionsSource: 'map',
+    hostGroups: {
+      type: 'array',
+      items: { type: 'string' },
+      title: 'Host groups',
+      help: 'Limit the import to these host groups. Strongly recommended — large instances have thousands of hosts. Empty = all.',
+      optionsSource: 'hostgroup',
       freeSolo: true,
     },
     groupBy: {
       type: 'string',
       title: 'Group by',
       default: 'hostgroup',
-      help: 'Subgraphs from host groups (most-specific per host), or only from standard host-group elements drawn on the map.',
+      help: 'Nest each node under its most-specific host group, or emit a flat graph.',
       oneOf: [
         { const: 'hostgroup', title: 'Host group' },
-        { const: 'none', title: 'Map host-group elements only' },
+        { const: 'none', title: 'No grouping' },
       ],
     },
     groupExclude: {
@@ -70,6 +69,12 @@ const optionsSchema: PluginConfigSchema = {
       title: 'Exclude groups',
       help: 'Host-group names to never use as a subgraph (admin / catch-all groups).',
       freeSolo: true,
+    },
+    includeExternalNeighbors: {
+      type: 'boolean',
+      title: 'Include external neighbors',
+      default: true,
+      help: 'Add nodes for LLDP neighbors that are not Zabbix hosts, so their links still render.',
     },
   },
 }

--- a/libs/plugins/zabbix/src/index.ts
+++ b/libs/plugins/zabbix/src/index.ts
@@ -76,6 +76,12 @@ const optionsSchema: PluginConfigSchema = {
       default: true,
       help: 'Add nodes for LLDP neighbors that are not Zabbix hosts, so their links still render.',
     },
+    parentTag: {
+      type: 'string',
+      title: 'Parent tag',
+      default: 'PARENT',
+      help: 'Host-tag name whose value names an upstream device — draws a link where LLDP saw no neighbor. Empty to disable.',
+    },
   },
 }
 

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -31,7 +31,7 @@ import type {
 } from '@shumoku/core'
 import { addHttpWarning, mapWithConcurrency } from '@shumoku/core'
 import { createHttpClient, type HttpClient } from '@shumoku/plugin-sdk'
-import { convertLldpToGraph } from './topology.js'
+import { convertZabbixToGraph } from './topology.js'
 import type {
   ZabbixHost,
   ZabbixItem,
@@ -557,32 +557,41 @@ export class ZabbixPlugin
       ...(groupIds && groupIds.length > 0 ? { groupids: groupIds } : {}),
       output: ['hostid', 'host', 'name', 'status'],
       selectInterfaces: ['ip', 'dns', 'main', 'type', 'useip'],
-      selectInventory: ['hardware'],
+      selectInventory: ['type', 'vendor', 'model', 'hardware', 'os', 'serialno_a', 'location'],
       selectHostGroups: ['groupid', 'name'],
+      selectTags: 'extend',
     })
 
-    const neighborsByHostId = await this.fetchLldpNeighbors(hosts.map((h) => h.hostid))
+    const { neighborsByHostId, sysDescrByHostId } = await this.fetchLldpData(
+      hosts.map((h) => h.hostid),
+    )
 
     const sourceId = this.config?.instanceId ?? 'zabbix'
-    return convertLldpToGraph(hosts, neighborsByHostId, {
+    return convertZabbixToGraph(hosts, neighborsByHostId, sysDescrByHostId, {
       sourceId,
       observedAt: Date.now(),
       groupBy: opts?.groupBy,
       groupExclude: opts?.groupExclude,
       includeExternalNeighbors: opts?.includeExternalNeighbors,
+      parentTag: opts?.parentTag,
     })
   }
 
   /**
-   * Assemble per-host LLDP adjacencies from the standard LLDP-MIB items
-   * (`lldp.rem.*` + `lldp.loc.if.ifSpeed`). Items are fetched in host-id batches
-   * and joined per interface by the `[ifName]` suffix in the item NAME (item keys
-   * are inconsistently shaped across families). Hosts without `lldp.rem.*` items
-   * yield no neighbors (→ nodes-only).
+   * Assemble, per host: (a) LLDP adjacencies from the standard LLDP-MIB items
+   * (`lldp.rem.*` + `lldp.loc.if.ifSpeed`), joined per interface by the `[ifName]`
+   * suffix in the item NAME (item keys are inconsistently shaped across families);
+   * and (b) the host's own SNMP sysDescr (`lldp.sys.desc` / `system.descr`) for
+   * device-type derivation. Items are fetched in host-id batches. Hosts without
+   * `lldp.rem.*` items yield no neighbors (→ nodes-only).
    */
-  private async fetchLldpNeighbors(hostIds: string[]): Promise<Map<string, ZabbixLldpNeighbor[]>> {
-    const result = new Map<string, ZabbixLldpNeighbor[]>()
-    if (hostIds.length === 0) return result
+  private async fetchLldpData(hostIds: string[]): Promise<{
+    neighborsByHostId: Map<string, ZabbixLldpNeighbor[]>
+    sysDescrByHostId: Map<string, string>
+  }> {
+    const neighborsByHostId = new Map<string, ZabbixLldpNeighbor[]>()
+    const sysDescrByHostId = new Map<string, string>()
+    if (hostIds.length === 0) return { neighborsByHostId, sysDescrByHostId }
 
     const families = [
       'lldp.rem.sysname',
@@ -590,7 +599,13 @@ export class ZabbixPlugin
       'lldp.rem.chassisid',
       'lldp.loc.if.ifSpeed',
       'lldp.loc.if.ifHighSpeed',
+      'lldp.sys.desc',
+      'lldp.loc.sys.desc',
+      'system.descr',
+      'sysDescr',
     ]
+    // the host's OWN sysDescr (NOT the per-neighbor lldp.rem.sys.desc)
+    const sysDescrKeys = new Set(['lldp.sys.desc', 'lldp.loc.sys.desc'])
     const batches = Array.from({ length: Math.ceil(hostIds.length / LLDP_HOST_BATCH) }, (_, i) =>
       hostIds.slice(i * LLDP_HOST_BATCH, (i + 1) * LLDP_HOST_BATCH),
     )
@@ -608,13 +623,26 @@ export class ZabbixPlugin
       ),
     )
 
-    // group: hostid → ifName → { family: value }
+    // group LLDP per-IF data: hostid → ifName → { family: value }; capture sysDescr.
     const byHostIf = new Map<string, Map<string, Record<string, string>>>()
     for (const items of itemArrays) {
       for (const it of items) {
+        const family = it.key_.split('[')[0] ?? ''
+        if (
+          sysDescrKeys.has(family) ||
+          family.startsWith('system.descr') ||
+          family === 'sysDescr'
+        ) {
+          const v = (it.lastvalue ?? '').trim()
+          // a real sysDescr has spaces; ignore degenerate hostname echoes
+          if (v && /\s/.test(v)) {
+            const cur = sysDescrByHostId.get(it.hostid)
+            if (!cur || v.length > cur.length) sysDescrByHostId.set(it.hostid, v)
+          }
+          continue
+        }
         const ifName = it.name.match(ifSuffix)?.[1]
-        const family = it.key_.split('[')[0]
-        if (!ifName || !family) continue
+        if (!ifName) continue
         let ifMap = byHostIf.get(it.hostid)
         if (!ifMap) {
           ifMap = new Map()
@@ -643,9 +671,9 @@ export class ZabbixPlugin
           speedBps,
         })
       }
-      if (neighbors.length > 0) result.set(hostId, neighbors)
+      if (neighbors.length > 0) neighborsByHostId.set(hostId, neighbors)
     }
-    return result
+    return { neighborsByHostId, sysDescrByHostId }
   }
 
   // ============================================

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -9,6 +9,8 @@ import type {
   AlertQueryOptions,
   AlertSeverity,
   AlertsCapable,
+  ConfigOption,
+  ConfigOptionsCapable,
   ConnectionResult,
   DataSourceCapability,
   DataSourcePlugin,
@@ -23,11 +25,20 @@ import type {
   MetricsMapping,
   MetricsStatus,
   MonitoringHealth,
+  NetworkGraph,
   NodeMetrics,
+  TopologyCapable,
 } from '@shumoku/core'
 import { addHttpWarning, mapWithConcurrency } from '@shumoku/core'
 import { createHttpClient, type HttpClient } from '@shumoku/plugin-sdk'
-import type { ZabbixHost, ZabbixItem, ZabbixPluginConfig } from './types.js'
+import { convertSysmapToGraph } from './topology.js'
+import type {
+  ZabbixHost,
+  ZabbixItem,
+  ZabbixPluginConfig,
+  ZabbixSysmap,
+  ZabbixTopologyOptions,
+} from './types.js'
 
 /** Max in-flight Zabbix API calls during a metrics poll (was fully sequential). */
 const POLL_CONCURRENCY = 8
@@ -61,10 +72,23 @@ interface HostMeta {
   interfaces?: Array<{ available: string; error?: string }>
 }
 
-export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapable, AlertsCapable {
+export class ZabbixPlugin
+  implements
+    DataSourcePlugin,
+    MetricsCapable,
+    HostsCapable,
+    AlertsCapable,
+    TopologyCapable,
+    ConfigOptionsCapable
+{
   readonly type = 'zabbix'
   readonly displayName = 'Zabbix'
-  readonly capabilities: readonly DataSourceCapability[] = ['metrics', 'hosts', 'alerts']
+  readonly capabilities: readonly DataSourceCapability[] = [
+    'metrics',
+    'hosts',
+    'alerts',
+    'topology',
+  ]
 
   private config: ZabbixPluginConfig | null = null
   private requestId = 0
@@ -511,6 +535,91 @@ export class ZabbixPlugin implements DataSourcePlugin, MetricsCapable, HostsCapa
     'user.login',
     'user.checkauthentication',
   ])
+
+  // ============================================
+  // TopologyCapable Implementation
+  // ============================================
+
+  /**
+   * Import a Zabbix sysmap (network map) as a NetworkGraph. The map is chosen
+   * per attachment via `options.sysmapId` (from the topology source's
+   * `optionsJson`), so one Zabbix source can feed different maps into different
+   * topologies. Standard `map.get` only — no dependency on custom map modules.
+   */
+  async fetchTopology(options?: Record<string, unknown>): Promise<NetworkGraph> {
+    const opts = options as ZabbixTopologyOptions | undefined
+    const sysmapId = opts?.sysmapId
+    if (!sysmapId) {
+      throw new Error('Zabbix topology import requires a sysmapId — select a map to import.')
+    }
+
+    const maps = await this.apiRequest<ZabbixSysmap[]>('map.get', {
+      sysmapids: [sysmapId],
+      output: ['sysmapid', 'name', 'width', 'height'],
+      selectSelements: [
+        'selementid',
+        'elementtype',
+        'elementsubtype',
+        'label',
+        'x',
+        'y',
+        'iconid_off',
+        'elements',
+      ],
+      selectLinks: ['linkid', 'selementid1', 'selementid2', 'drawtype', 'color', 'label'],
+    })
+    const map = maps[0]
+    if (!map) throw new Error(`Zabbix map ${sysmapId} not found`)
+
+    // Resolve the host elements in one batched host.get.
+    const hostIds = [
+      ...new Set(
+        (map.selements ?? [])
+          .filter((se) => se.elementtype === '0')
+          .map((se) => se.elements?.[0]?.hostid)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ]
+    const hosts = hostIds.length
+      ? await this.apiRequest<ZabbixHost[]>('host.get', {
+          hostids: hostIds,
+          output: ['hostid', 'host', 'name', 'status'],
+          selectInterfaces: ['ip', 'dns', 'main', 'type', 'useip'],
+          selectInventory: ['hardware'],
+          selectHostGroups: ['groupid', 'name'],
+          selectParentTemplates: ['templateid', 'name'],
+        })
+      : []
+
+    const hostsById = new Map(hosts.map((h) => [h.hostid, h]))
+    // Group names come from the resolved hosts' memberships — no extra call.
+    const groupNamesById = new Map<string, string>()
+    for (const h of hosts) {
+      for (const g of h.hostgroups ?? []) groupNamesById.set(g.groupid, g.name)
+    }
+
+    const sourceId = this.config?.instanceId ?? 'zabbix'
+    return convertSysmapToGraph(map, hostsById, groupNamesById, {
+      sourceId,
+      observedAt: Date.now(),
+      groupBy: opts?.groupBy,
+      groupExclude: opts?.groupExclude,
+    })
+  }
+
+  // ============================================
+  // ConfigOptionsCapable Implementation
+  // ============================================
+
+  /** Dynamic candidates for `optionsSource` schema fields (the map picker). */
+  async getConfigOptions(key: string): Promise<ConfigOption[]> {
+    if (key !== 'map') return []
+    const maps = await this.apiRequest<ZabbixSysmap[]>('map.get', {
+      output: ['sysmapid', 'name'],
+      sortfield: 'name',
+    })
+    return maps.map((m) => ({ value: m.sysmapid, label: m.name }))
+  }
 
   private async apiRequest<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
     if (!this.config || !this.http) {

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -31,17 +31,20 @@ import type {
 } from '@shumoku/core'
 import { addHttpWarning, mapWithConcurrency } from '@shumoku/core'
 import { createHttpClient, type HttpClient } from '@shumoku/plugin-sdk'
-import { convertSysmapToGraph } from './topology.js'
+import { convertLldpToGraph } from './topology.js'
 import type {
   ZabbixHost,
   ZabbixItem,
+  ZabbixLldpNeighbor,
   ZabbixPluginConfig,
-  ZabbixSysmap,
   ZabbixTopologyOptions,
 } from './types.js'
 
 /** Max in-flight Zabbix API calls during a metrics poll (was fully sequential). */
 const POLL_CONCURRENCY = 8
+
+/** Host ids per `item.get` when fetching LLDP items (bounds payload + round-trips). */
+const LLDP_HOST_BATCH = 50
 
 /**
  * Per-request timeout. The shared HttpClient defaults to 10s, but Zabbix
@@ -541,84 +544,125 @@ export class ZabbixPlugin
   // ============================================
 
   /**
-   * Import a Zabbix sysmap (network map) as a NetworkGraph. The map is chosen
-   * per attachment via `options.sysmapId` (from the topology source's
-   * `optionsJson`), so one Zabbix source can feed different maps into different
-   * topologies. Standard `map.get` only — no dependency on custom map modules.
+   * Generate a NetworkGraph from Zabbix: nodes from hosts, links from per-host
+   * LLDP neighbor items. Standard data only — no maps / netmap module, and no
+   * direct SNMP reach (Zabbix is the collector). Scoped by `options.hostGroups`.
+   * See `apps/server/docs/design/zabbix-lldp-topology.md`.
    */
   async fetchTopology(options?: Record<string, unknown>): Promise<NetworkGraph> {
     const opts = options as ZabbixTopologyOptions | undefined
-    const sysmapId = opts?.sysmapId
-    if (!sysmapId) {
-      throw new Error('Zabbix topology import requires a sysmapId — select a map to import.')
-    }
+    const groupIds = opts?.hostGroups?.filter(Boolean)
 
-    const maps = await this.apiRequest<ZabbixSysmap[]>('map.get', {
-      sysmapids: [sysmapId],
-      output: ['sysmapid', 'name', 'width', 'height'],
-      selectSelements: [
-        'selementid',
-        'elementtype',
-        'elementsubtype',
-        'label',
-        'x',
-        'y',
-        'iconid_off',
-        'elements',
-      ],
-      selectLinks: ['linkid', 'selementid1', 'selementid2', 'drawtype', 'color', 'label'],
+    const hosts = await this.apiRequest<ZabbixHost[]>('host.get', {
+      ...(groupIds && groupIds.length > 0 ? { groupids: groupIds } : {}),
+      output: ['hostid', 'host', 'name', 'status'],
+      selectInterfaces: ['ip', 'dns', 'main', 'type', 'useip'],
+      selectInventory: ['hardware'],
+      selectHostGroups: ['groupid', 'name'],
     })
-    const map = maps[0]
-    if (!map) throw new Error(`Zabbix map ${sysmapId} not found`)
 
-    // Resolve the host elements in one batched host.get.
-    const hostIds = [
-      ...new Set(
-        (map.selements ?? [])
-          .filter((se) => se.elementtype === '0')
-          .map((se) => se.elements?.[0]?.hostid)
-          .filter((id): id is string => Boolean(id)),
-      ),
-    ]
-    const hosts = hostIds.length
-      ? await this.apiRequest<ZabbixHost[]>('host.get', {
-          hostids: hostIds,
-          output: ['hostid', 'host', 'name', 'status'],
-          selectInterfaces: ['ip', 'dns', 'main', 'type', 'useip'],
-          selectInventory: ['hardware'],
-          selectHostGroups: ['groupid', 'name'],
-          selectParentTemplates: ['templateid', 'name'],
-        })
-      : []
-
-    const hostsById = new Map(hosts.map((h) => [h.hostid, h]))
-    // Group names come from the resolved hosts' memberships — no extra call.
-    const groupNamesById = new Map<string, string>()
-    for (const h of hosts) {
-      for (const g of h.hostgroups ?? []) groupNamesById.set(g.groupid, g.name)
-    }
+    const neighborsByHostId = await this.fetchLldpNeighbors(hosts.map((h) => h.hostid))
 
     const sourceId = this.config?.instanceId ?? 'zabbix'
-    return convertSysmapToGraph(map, hostsById, groupNamesById, {
+    return convertLldpToGraph(hosts, neighborsByHostId, {
       sourceId,
       observedAt: Date.now(),
       groupBy: opts?.groupBy,
       groupExclude: opts?.groupExclude,
+      includeExternalNeighbors: opts?.includeExternalNeighbors,
     })
+  }
+
+  /**
+   * Assemble per-host LLDP adjacencies from the standard LLDP-MIB items
+   * (`lldp.rem.*` + `lldp.loc.if.ifSpeed`). Items are fetched in host-id batches
+   * and joined per interface by the `[ifName]` suffix in the item NAME (item keys
+   * are inconsistently shaped across families). Hosts without `lldp.rem.*` items
+   * yield no neighbors (→ nodes-only).
+   */
+  private async fetchLldpNeighbors(hostIds: string[]): Promise<Map<string, ZabbixLldpNeighbor[]>> {
+    const result = new Map<string, ZabbixLldpNeighbor[]>()
+    if (hostIds.length === 0) return result
+
+    const families = [
+      'lldp.rem.sysname',
+      'lldp.rem.port.id',
+      'lldp.rem.chassisid',
+      'lldp.loc.if.ifSpeed',
+      'lldp.loc.if.ifHighSpeed',
+    ]
+    const batches = Array.from({ length: Math.ceil(hostIds.length / LLDP_HOST_BATCH) }, (_, i) =>
+      hostIds.slice(i * LLDP_HOST_BATCH, (i + 1) * LLDP_HOST_BATCH),
+    )
+    const ifSuffix = /\[([^\]]+)\]\s*$/
+
+    const itemArrays = await mapWithConcurrency(batches, POLL_CONCURRENCY, (batch) =>
+      this.apiRequest<Array<{ hostid: string; name: string; key_: string; lastvalue: string }>>(
+        'item.get',
+        {
+          hostids: batch,
+          search: { key_: families },
+          searchByAny: true,
+          output: ['hostid', 'name', 'key_', 'lastvalue'],
+        },
+      ),
+    )
+
+    // group: hostid → ifName → { family: value }
+    const byHostIf = new Map<string, Map<string, Record<string, string>>>()
+    for (const items of itemArrays) {
+      for (const it of items) {
+        const ifName = it.name.match(ifSuffix)?.[1]
+        const family = it.key_.split('[')[0]
+        if (!ifName || !family) continue
+        let ifMap = byHostIf.get(it.hostid)
+        if (!ifMap) {
+          ifMap = new Map()
+          byHostIf.set(it.hostid, ifMap)
+        }
+        const fields = ifMap.get(ifName) ?? {}
+        fields[family] = it.lastvalue
+        ifMap.set(ifName, fields)
+      }
+    }
+
+    for (const [hostId, ifMap] of byHostIf) {
+      const neighbors: ZabbixLldpNeighbor[] = []
+      for (const [ifName, f] of ifMap) {
+        const remSysname = f['lldp.rem.sysname']
+        if (!remSysname) continue
+        const speedBps =
+          Number(f['lldp.loc.if.ifSpeed']) ||
+          Number(f['lldp.loc.if.ifHighSpeed']) * 1_000_000 ||
+          undefined
+        neighbors.push({
+          localIf: ifName,
+          remSysname,
+          remPortId: f['lldp.rem.port.id'],
+          remChassisId: f['lldp.rem.chassisid'],
+          speedBps,
+        })
+      }
+      if (neighbors.length > 0) result.set(hostId, neighbors)
+    }
+    return result
   }
 
   // ============================================
   // ConfigOptionsCapable Implementation
   // ============================================
 
-  /** Dynamic candidates for `optionsSource` schema fields (the map picker). */
+  /** Dynamic candidates for `optionsSource` schema fields (the host-group filter). */
   async getConfigOptions(key: string): Promise<ConfigOption[]> {
-    if (key !== 'map') return []
-    const maps = await this.apiRequest<ZabbixSysmap[]>('map.get', {
-      output: ['sysmapid', 'name'],
-      sortfield: 'name',
-    })
-    return maps.map((m) => ({ value: m.sysmapid, label: m.name }))
+    if (key !== 'hostgroup') return []
+    const groups = await this.apiRequest<Array<{ groupid: string; name: string }>>(
+      'hostgroup.get',
+      {
+        output: ['groupid', 'name'],
+        sortfield: 'name',
+      },
+    )
+    return groups.map((g) => ({ value: g.groupid, label: g.name }))
   }
 
   private async apiRequest<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {

--- a/libs/plugins/zabbix/src/topology.test.ts
+++ b/libs/plugins/zabbix/src/topology.test.ts
@@ -1,135 +1,175 @@
 import { describe, expect, it } from 'vitest'
-import { convertLldpToGraph } from './topology.js'
+import { convertZabbixToGraph } from './topology.js'
 import type { ZabbixHost, ZabbixLldpNeighbor } from './types.js'
 
 const OPTS = { sourceId: 'inst1', observedAt: 1_700_000_000_000 }
+const NO_NBR = new Map<string, ZabbixLldpNeighbor[]>()
+const NO_DESCR = new Map<string, string>()
 
-function hosts(): ZabbixHost[] {
-  return [
-    {
-      hostid: '1',
-      host: '172.16.0.2', // host.host is the IP here — must NOT be used as sysName
-      name: 'ptxA.noc',
-      status: '0',
-      interfaces: [{ ip: '172.16.0.2', main: '1', type: '2', useip: '1' }],
-      hostgroups: [{ groupid: '98', name: '016.000.seg' }],
-      inventory: { hardware: 'Juniper Networks, Inc. ptx10002-60mr , kernel JUNOS 26.2' },
-    },
-    {
-      hostid: '2',
-      host: '172.16.0.3',
-      name: 'ciscoB.noc',
-      status: '0',
-      interfaces: [{ ip: '172.16.0.3', main: '1', type: '2', useip: '1' }],
-      hostgroups: [{ groupid: '98', name: '016.000.seg' }],
-    },
-  ]
+function mkHost(over: Partial<ZabbixHost> & { hostid: string; name: string }): ZabbixHost {
+  return { host: '0.0.0.0', status: '0', ...over }
 }
 
-/** A↔B reported from both ends (bidirectional LLDP), plus A→external neighbor. */
-function neighbors(): Map<string, ZabbixLldpNeighbor[]> {
-  return new Map([
-    [
-      '1',
-      [
-        {
-          localIf: 'et-0/0/1',
-          remSysname: 'ciscoB.noc',
-          remPortId: 'et-0/0/9',
-          speedBps: 100_000_000_000,
-        },
-        { localIf: 'et-0/0/2', remSysname: 'extX.noc', remPortId: 'ge-1', speedBps: 1_000_000_000 },
-        { localIf: 'et-0/0/3', remSysname: '* No Info *' }, // no neighbor → ignored
-      ],
-    ],
-    // mirror of the A↔B link from B's side — must de-dup to a single link
-    [
-      '2',
-      [
-        {
-          localIf: 'et-0/0/9',
-          remSysname: 'ptxA.noc',
-          remPortId: 'et-0/0/1',
-          speedBps: 100_000_000_000,
-        },
-      ],
-    ],
-  ])
-}
-
-describe('convertLldpToGraph', () => {
-  it('builds host nodes with identity (sysName = host.name, not host.host)', () => {
-    const g = convertLldpToGraph(hosts(), new Map(), OPTS)
-    const a = g.nodes.find((n) => n.id === 'inst1:host:1')
-    expect(a?.label).toBe('ptxA.noc')
-    expect(a?.identity?.sysName).toBe('ptxA.noc') // NOT '172.16.0.2'
-    expect(a?.identity?.mgmtIp).toBe('172.16.0.2')
-    expect(a?.identity?.vendorIds?.['zabbix-hostid']).toBe('1')
-    expect(a?.spec).toMatchObject({ vendor: 'juniper', model: 'ptx10002-60mr' })
-    expect(a?.provenance).toEqual({ source: 'inst1', observedAt: OPTS.observedAt })
-    expect(a?.parent).toBe('inst1:sg:98')
-    // FQDN exposed for the compound layout (ghost detection + domain banding)
-    expect(a?.metadata?.['hostname']).toBe('ptxA.noc')
+describe('convertZabbixToGraph', () => {
+  it('builds host nodes: sysName=host.name, mgmtIp, hostname metadata, host-group parent', () => {
+    const hosts = [
+      mkHost({
+        hostid: '1',
+        host: '172.16.0.2', // host.host is the IP — must NOT be used as sysName
+        name: 'ptxA.noc',
+        interfaces: [{ ip: '172.16.0.2', main: '1', type: '2', useip: '1' }],
+        hostgroups: [{ groupid: '98', name: '016.000.seg' }],
+      }),
+    ]
+    const g = convertZabbixToGraph(hosts, NO_NBR, NO_DESCR, OPTS)
+    const n = g.nodes[0]
+    expect(n?.label).toBe('ptxA.noc')
+    expect(n?.identity?.sysName).toBe('ptxA.noc')
+    expect(n?.identity?.mgmtIp).toBe('172.16.0.2')
+    expect(n?.identity?.vendorIds?.['zabbix-hostid']).toBe('1')
+    expect(n?.metadata?.['hostname']).toBe('ptxA.noc')
+    expect(n?.parent).toBe('inst1:sg:016.000.seg')
+    expect(g.subgraphs?.[0]?.label).toBe('016.000.seg')
   })
 
-  it('builds links from LLDP neighbors with real ports + bandwidth, de-duping the mirror', () => {
-    const g = convertLldpToGraph(hosts(), neighbors(), OPTS)
-    // A↔B (deduped from both directions) + A↔extX = 2 links
-    expect(g.links).toHaveLength(2)
+  it('derives device type/vendor/model from SNMP sysDescr when inventory is empty', () => {
+    const hosts = [mkHost({ hostid: '1', name: 'ptxA.noc' })]
+    const descr = new Map([
+      ['1', 'Juniper Networks, Inc. ptx10002-60mr internet router, JUNOS 26.2'],
+    ])
+    const g = convertZabbixToGraph(hosts, NO_NBR, descr, OPTS)
+    expect(g.nodes[0]?.spec).toMatchObject({ kind: 'hardware', vendor: 'juniper', type: 'router' })
+    expect(g.nodes[0]?.spec?.model).toContain('ptx10002')
+  })
 
-    const ab = g.links.find(
-      (l) =>
-        (l.from.node === 'inst1:host:1' && l.to.node === 'inst1:host:2') ||
-        (l.from.node === 'inst1:host:2' && l.to.node === 'inst1:host:1'),
+  it('prefers structured inventory.{vendor,model,type} over parsing', () => {
+    const hosts = [
+      mkHost({
+        hostid: '1',
+        name: 'x',
+        inventory: { vendor: 'Cisco', model: 'C9300', type: 'switch' },
+      }),
+    ]
+    const g = convertZabbixToGraph(hosts, NO_NBR, NO_DESCR, OPTS)
+    expect(g.nodes[0]?.spec).toMatchObject({ vendor: 'cisco', model: 'C9300', type: 'l2-switch' })
+  })
+
+  it('honors Zabbix "/" nested host groups as nested subgraphs', () => {
+    const hosts = [
+      mkHost({ hostid: '1', name: 'x', hostgroups: [{ groupid: '5', name: 'DC/Rack1/Top' }] }),
+    ]
+    const g = convertZabbixToGraph(hosts, NO_NBR, NO_DESCR, OPTS)
+    expect(g.nodes[0]?.parent).toBe('inst1:sg:DC/Rack1/Top')
+    const byId = new Map((g.subgraphs ?? []).map((s) => [s.id, s]))
+    expect(byId.get('inst1:sg:DC')?.label).toBe('DC')
+    expect(byId.get('inst1:sg:DC')?.parent).toBeUndefined()
+    expect(byId.get('inst1:sg:DC/Rack1')?.parent).toBe('inst1:sg:DC')
+    expect(byId.get('inst1:sg:DC/Rack1/Top')?.parent).toBe('inst1:sg:DC/Rack1')
+    expect(byId.get('inst1:sg:DC/Rack1/Top')?.label).toBe('Top')
+  })
+
+  it('picks the most-specific group; a catch-all (largest) loses', () => {
+    const mk = (id: string, extra: boolean) =>
+      mkHost({
+        hostid: id,
+        name: `h${id}`,
+        hostgroups: [
+          { groupid: '9', name: 'all' },
+          ...(extra ? [{ groupid: '1', name: 'seg' }] : []),
+        ],
+      })
+    const g = convertZabbixToGraph(
+      [mk('1', true), mk('2', false), mk('3', false)],
+      NO_NBR,
+      NO_DESCR,
+      OPTS,
     )
-    expect(ab).toBeDefined()
-    expect(ab?.metadata?.['discoveredVia']).toBe('zabbix-lldp')
-    expect(ab?.metadata?.['speedBps']).toBe(100_000_000_000)
-
-    // real port labels on both ends
-    const a = g.nodes.find((n) => n.id === 'inst1:host:1')
-    expect(a?.ports?.map((p) => p.label).sort()).toEqual(['et-0/0/1', 'et-0/0/2'])
-    expect(a?.ports?.find((p) => p.label === 'et-0/0/1')?.speed).toBe('100g')
-    const b = g.nodes.find((n) => n.id === 'inst1:host:2')
-    expect(b?.ports?.map((p) => p.label)).toEqual(['et-0/0/9'])
-
-    // every link endpoint references a real port on its node
-    for (const l of g.links) {
-      const fn = g.nodes.find((n) => n.id === l.from.node)
-      const tn = g.nodes.find((n) => n.id === l.to.node)
-      expect(fn?.ports?.some((p) => p.id === l.from.port)).toBe(true)
-      expect(tn?.ports?.some((p) => p.id === l.to.port)).toBe(true)
-    }
+    expect(g.nodes.find((n) => n.id === 'inst1:host:1')?.parent).toBe('inst1:sg:seg')
+    expect(g.nodes.find((n) => n.id === 'inst1:host:2')?.parent).toBe('inst1:sg:all')
   })
 
-  it('synthesizes an external node for a neighbor that is not a Zabbix host', () => {
-    const g = convertLldpToGraph(hosts(), neighbors(), OPTS)
-    const ext = g.nodes.find((n) => n.id === 'inst1:ext:extX.noc')
-    expect(ext).toBeDefined()
-    expect(ext?.label).toBe('extX.noc')
-    expect(ext?.identity?.sysName).toBe('extX.noc')
-    expect(ext?.metadata?.['external']).toBe(true)
-    expect(ext?.parent).toBeUndefined()
-    expect(g.nodes).toHaveLength(3) // A, B, extX
+  it('builds LLDP links with real ports + bandwidth, de-duping the mirror', () => {
+    const hosts = [mkHost({ hostid: '1', name: 'A' }), mkHost({ hostid: '2', name: 'B' })]
+    const nbr = new Map<string, ZabbixLldpNeighbor[]>([
+      [
+        '1',
+        [
+          {
+            localIf: 'et-0/0/1',
+            remSysname: 'B',
+            remPortId: 'et-0/0/9',
+            speedBps: 100_000_000_000,
+          },
+        ],
+      ],
+      [
+        '2',
+        [
+          {
+            localIf: 'et-0/0/9',
+            remSysname: 'A',
+            remPortId: 'et-0/0/1',
+            speedBps: 100_000_000_000,
+          },
+        ],
+      ],
+    ])
+    const g = convertZabbixToGraph(hosts, nbr, NO_DESCR, OPTS)
+    expect(g.links).toHaveLength(1)
+    expect(g.links[0]?.metadata?.['discoveredVia']).toBe('zabbix-lldp')
+    expect(g.links[0]?.metadata?.['speedBps']).toBe(100_000_000_000)
+    expect(
+      g.nodes.find((n) => n.id === 'inst1:host:1')?.ports?.find((p) => p.label === 'et-0/0/1')
+        ?.speed,
+    ).toBe('100g')
   })
 
-  it('drops links to non-host neighbors when includeExternalNeighbors=false', () => {
-    const g = convertLldpToGraph(hosts(), neighbors(), { ...OPTS, includeExternalNeighbors: false })
-    expect(g.nodes.find((n) => n.id === 'inst1:ext:extX.noc')).toBeUndefined()
-    expect(g.nodes).toHaveLength(2)
-    expect(g.links).toHaveLength(1) // only A↔B
+  it('adds a PARENT-tag link where LLDP saw no neighbor', () => {
+    const hosts = [
+      mkHost({ hostid: '1', name: 'child.life', tags: [{ tag: 'PARENT', value: 'up.noc' }] }),
+      mkHost({ hostid: '2', name: 'up.noc' }),
+    ]
+    const g = convertZabbixToGraph(hosts, NO_NBR, NO_DESCR, OPTS)
+    expect(g.links).toHaveLength(1)
+    expect(g.links[0]?.metadata?.['discoveredVia']).toBe('zabbix-parent-tag')
+    expect([g.links[0]?.from.node, g.links[0]?.to.node].sort()).toEqual([
+      'inst1:host:1',
+      'inst1:host:2',
+    ])
   })
 
-  it("emits no subgraphs and no parents with groupBy:'none'", () => {
-    const g = convertLldpToGraph(hosts(), neighbors(), { ...OPTS, groupBy: 'none' })
+  it('does not duplicate an LLDP link with a PARENT-tag link', () => {
+    const hosts = [
+      mkHost({ hostid: '1', name: 'A', tags: [{ tag: 'PARENT', value: 'B' }] }),
+      mkHost({ hostid: '2', name: 'B' }),
+    ]
+    const nbr = new Map<string, ZabbixLldpNeighbor[]>([
+      ['1', [{ localIf: 'e1', remSysname: 'B', remPortId: 'e2' }]],
+    ])
+    const g = convertZabbixToGraph(hosts, nbr, NO_DESCR, OPTS)
+    expect(g.links).toHaveLength(1)
+    expect(g.links[0]?.metadata?.['discoveredVia']).toBe('zabbix-lldp')
+  })
+
+  it('synthesizes external nodes, or drops them when includeExternalNeighbors=false', () => {
+    const hosts = [mkHost({ hostid: '1', name: 'A' })]
+    const nbr = new Map<string, ZabbixLldpNeighbor[]>([
+      ['1', [{ localIf: 'e1', remSysname: 'ext.x', remPortId: 'p' }]],
+    ])
+    const g = convertZabbixToGraph(hosts, nbr, NO_DESCR, OPTS)
+    expect(g.nodes.find((n) => n.id === 'inst1:ext:ext.x')?.metadata?.['external']).toBe(true)
+    const g2 = convertZabbixToGraph(hosts, nbr, NO_DESCR, {
+      ...OPTS,
+      includeExternalNeighbors: false,
+    })
+    expect(g2.nodes).toHaveLength(1)
+    expect(g2.links).toHaveLength(0)
+  })
+
+  it("emits no subgraphs/parents with groupBy:'none'", () => {
+    const hosts = [mkHost({ hostid: '1', name: 'A', hostgroups: [{ groupid: '1', name: 'g' }] })]
+    const g = convertZabbixToGraph(hosts, NO_NBR, NO_DESCR, { ...OPTS, groupBy: 'none' })
     expect(g.subgraphs).toBeUndefined()
-    for (const n of g.nodes) expect(n.parent).toBeUndefined()
-  })
-
-  it('puts a host with no LLDP neighbors in the graph as a bare node', () => {
-    const g = convertLldpToGraph(hosts(), new Map(), OPTS)
-    expect(g.nodes).toHaveLength(2)
-    expect(g.links).toHaveLength(0)
-    expect(g.nodes.every((n) => !n.ports)).toBe(true)
+    expect(g.nodes[0]?.parent).toBeUndefined()
   })
 })

--- a/libs/plugins/zabbix/src/topology.test.ts
+++ b/libs/plugins/zabbix/src/topology.test.ts
@@ -1,224 +1,133 @@
 import { describe, expect, it } from 'vitest'
-import { convertSysmapToGraph } from './topology.js'
-import type { ZabbixHost, ZabbixSysmap } from './types.js'
+import { convertLldpToGraph } from './topology.js'
+import type { ZabbixHost, ZabbixLldpNeighbor } from './types.js'
 
 const OPTS = { sourceId: 'inst1', observedAt: 1_700_000_000_000 }
 
-/** A small but representative standard sysmap: a host-group area frame, two
- *  host elements both in that group, a decorative image element, a host↔host
- *  link, and a host↔image link (which must be dropped). */
-function fixtureMap(): ZabbixSysmap {
-  return {
-    sysmapid: '5',
-    name: 'Backbone',
-    width: '1920',
-    height: '1080',
-    selements: [
-      // host-group area frame (groupid 98)
-      {
-        selementid: '100',
-        elementtype: '3',
-        elementsubtype: '1',
-        label: '{HOST.NAME}',
-        elements: [{ groupid: '98' }],
-      },
-      // host-group tile with no member hosts on this map → subgraph dropped
-      { selementid: '101', elementtype: '3', label: 'empty', elements: [{ groupid: '999' }] },
-      // host elements
-      {
-        selementid: '200',
-        elementtype: '0',
-        label: '{HOST.NAME}',
-        elements: [{ hostid: '12758' }],
-      },
-      {
-        selementid: '201',
-        elementtype: '0',
-        label: '{HOST.NAME}',
-        elements: [{ hostid: '12759' }],
-      },
-      // decorative image element (no element ref)
-      { selementid: '300', elementtype: '4', label: '', elements: [] },
-    ],
-    links: [
-      // host ↔ host (kept)
-      {
-        linkid: '900',
-        selementid1: '200',
-        selementid2: '201',
-        drawtype: '2',
-        color: '0000FF',
-        label: '',
-      },
-      // host ↔ image (dropped — image isn't a resolved host node)
-      { linkid: '901', selementid1: '200', selementid2: '300', drawtype: '0', color: '000000' },
-    ],
-  }
-}
-
-function fixtureHosts(): Map<string, ZabbixHost> {
-  const hosts: ZabbixHost[] = [
+function hosts(): ZabbixHost[] {
+  return [
     {
-      hostid: '12758',
-      host: '172.16.0.2',
-      name: 'ptx10002-60mr.noc',
+      hostid: '1',
+      host: '172.16.0.2', // host.host is the IP here — must NOT be used as sysName
+      name: 'ptxA.noc',
       status: '0',
       interfaces: [{ ip: '172.16.0.2', main: '1', type: '2', useip: '1' }],
-      hostgroups: [{ groupid: '98', name: '016.000.Backbone Routers' }],
+      hostgroups: [{ groupid: '98', name: '016.000.seg' }],
       inventory: { hardware: 'Juniper Networks, Inc. ptx10002-60mr , kernel JUNOS 26.2' },
     },
     {
-      hostid: '12759',
+      hostid: '2',
       host: '172.16.0.3',
-      name: 'cisco8712.noc',
+      name: 'ciscoB.noc',
       status: '0',
       interfaces: [{ ip: '172.16.0.3', main: '1', type: '2', useip: '1' }],
-      hostgroups: [{ groupid: '98', name: '016.000.Backbone Routers' }],
+      hostgroups: [{ groupid: '98', name: '016.000.seg' }],
     },
   ]
-  return new Map(hosts.map((h) => [h.hostid, h]))
 }
 
-const GROUP_NAMES = new Map([['98', '016.000.Backbone Routers']])
-
-describe('convertSysmapToGraph', () => {
-  it('maps host elements to nodes with identity + provenance', () => {
-    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, OPTS)
-
-    expect(g.name).toBe('Backbone')
-    expect(g.nodes).toHaveLength(2)
-
-    const ptx = g.nodes.find((n) => n.id === 'inst1:se:200')
-    expect(ptx).toBeDefined()
-    expect(ptx?.label).toBe('ptx10002-60mr.noc') // host.name, not the macro label
-    expect(ptx?.identity?.mgmtIp).toBe('172.16.0.2')
-    expect(ptx?.identity?.sysName).toBe('172.16.0.2')
-    expect(ptx?.identity?.vendorIds?.['zabbix-hostid']).toBe('12758')
-    expect(ptx?.provenance).toEqual({ source: 'inst1', observedAt: OPTS.observedAt })
-    expect(ptx?.metadata?.['zabbixStatus']).toBe('monitored')
-  })
-
-  it('derives vendor/model from inventory.hardware (best-effort)', () => {
-    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, OPTS)
-    const ptx = g.nodes.find((n) => n.id === 'inst1:se:200')
-    expect(ptx?.spec?.kind).toBe('hardware')
-    expect(ptx?.spec).toMatchObject({ vendor: 'juniper', model: 'ptx10002-60mr' })
-
-    // host without inventory → bare hardware spec, no vendor/model
-    const cisco = g.nodes.find((n) => n.id === 'inst1:se:201')
-    expect(cisco?.spec).toEqual({ kind: 'hardware' })
-  })
-
-  it('groups by host-group membership and nests member nodes (default)', () => {
-    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, OPTS)
-    // both hosts are in group 98 → one subgraph, both parented; empty group 999
-    // (a type-3 tile with no member host) is irrelevant to membership grouping
-    expect(g.subgraphs).toHaveLength(1)
-    const sg = g.subgraphs?.[0]
-    expect(sg?.id).toBe('inst1:sg:98')
-    expect(sg?.label).toBe('016.000.Backbone Routers')
-    for (const n of g.nodes) expect(n.parent).toBe('inst1:sg:98')
-  })
-
-  it('picks the most-specific (fewest on-map members) host group, and honors groupExclude', () => {
-    // 3 hosts all in catch-all "all" (3 members); only host A is also in "seg-a" (1 member)
-    const mk = (id: string, groups: Array<[string, string]>): ZabbixHost => ({
-      hostid: id,
-      host: `h${id}`,
-      name: `h${id}`,
-      status: '0',
-      hostgroups: groups.map(([groupid, name]) => ({ groupid, name })),
-    })
-    const hosts = new Map([
+/** A↔B reported from both ends (bidirectional LLDP), plus A→external neighbor. */
+function neighbors(): Map<string, ZabbixLldpNeighbor[]> {
+  return new Map([
+    [
+      '1',
       [
-        '1',
-        mk('1', [
-          ['10', 'all'],
-          ['20', 'seg-a'],
-        ]),
+        {
+          localIf: 'et-0/0/1',
+          remSysname: 'ciscoB.noc',
+          remPortId: 'et-0/0/9',
+          speedBps: 100_000_000_000,
+        },
+        { localIf: 'et-0/0/2', remSysname: 'extX.noc', remPortId: 'ge-1', speedBps: 1_000_000_000 },
+        { localIf: 'et-0/0/3', remSysname: '* No Info *' }, // no neighbor → ignored
       ],
-      ['2', mk('2', [['10', 'all']])],
-      ['3', mk('3', [['10', 'all']])],
-    ])
-    const map: ZabbixSysmap = {
-      sysmapid: '9',
-      name: 'M',
-      selements: [
-        { selementid: 'a', elementtype: '0', elements: [{ hostid: '1' }] },
-        { selementid: 'b', elementtype: '0', elements: [{ hostid: '2' }] },
-        { selementid: 'c', elementtype: '0', elements: [{ hostid: '3' }] },
+    ],
+    // mirror of the A↔B link from B's side — must de-dup to a single link
+    [
+      '2',
+      [
+        {
+          localIf: 'et-0/0/9',
+          remSysname: 'ptxA.noc',
+          remPortId: 'et-0/0/1',
+          speedBps: 100_000_000_000,
+        },
       ],
-      links: [],
-    }
+    ],
+  ])
+}
 
-    const g = convertSysmapToGraph(map, hosts, new Map(), OPTS)
-    // host A → most-specific "seg-a" (1 < 3); B,C → "all"
-    expect(g.nodes.find((n) => n.id === 'inst1:se:a')?.parent).toBe('inst1:sg:20')
-    expect(g.nodes.find((n) => n.id === 'inst1:se:b')?.parent).toBe('inst1:sg:10')
-    expect(new Set((g.subgraphs ?? []).map((s) => s.id))).toEqual(
-      new Set(['inst1:sg:20', 'inst1:sg:10']),
+describe('convertLldpToGraph', () => {
+  it('builds host nodes with identity (sysName = host.name, not host.host)', () => {
+    const g = convertLldpToGraph(hosts(), new Map(), OPTS)
+    const a = g.nodes.find((n) => n.id === 'inst1:host:1')
+    expect(a?.label).toBe('ptxA.noc')
+    expect(a?.identity?.sysName).toBe('ptxA.noc') // NOT '172.16.0.2'
+    expect(a?.identity?.mgmtIp).toBe('172.16.0.2')
+    expect(a?.identity?.vendorIds?.['zabbix-hostid']).toBe('1')
+    expect(a?.spec).toMatchObject({ vendor: 'juniper', model: 'ptx10002-60mr' })
+    expect(a?.provenance).toEqual({ source: 'inst1', observedAt: OPTS.observedAt })
+    expect(a?.parent).toBe('inst1:sg:98')
+  })
+
+  it('builds links from LLDP neighbors with real ports + bandwidth, de-duping the mirror', () => {
+    const g = convertLldpToGraph(hosts(), neighbors(), OPTS)
+    // A↔B (deduped from both directions) + A↔extX = 2 links
+    expect(g.links).toHaveLength(2)
+
+    const ab = g.links.find(
+      (l) =>
+        (l.from.node === 'inst1:host:1' && l.to.node === 'inst1:host:2') ||
+        (l.from.node === 'inst1:host:2' && l.to.node === 'inst1:host:1'),
     )
+    expect(ab).toBeDefined()
+    expect(ab?.metadata?.['discoveredVia']).toBe('zabbix-lldp')
+    expect(ab?.metadata?.['speedBps']).toBe(100_000_000_000)
 
-    // excluding "all" leaves B,C ungrouped and only the seg-a subgraph
-    const g2 = convertSysmapToGraph(map, hosts, new Map(), { ...OPTS, groupExclude: ['all'] })
-    expect(g2.nodes.find((n) => n.id === 'inst1:se:a')?.parent).toBe('inst1:sg:20')
-    expect(g2.nodes.find((n) => n.id === 'inst1:se:b')?.parent).toBeUndefined()
-    expect(g2.subgraphs).toHaveLength(1)
-  })
+    // real port labels on both ends
+    const a = g.nodes.find((n) => n.id === 'inst1:host:1')
+    expect(a?.ports?.map((p) => p.label).sort()).toEqual(['et-0/0/1', 'et-0/0/2'])
+    expect(a?.ports?.find((p) => p.label === 'et-0/0/1')?.speed).toBe('100g')
+    const b = g.nodes.find((n) => n.id === 'inst1:host:2')
+    expect(b?.ports?.map((p) => p.label)).toEqual(['et-0/0/9'])
 
-  it("groupBy:'none' uses only standard host-group area elements", () => {
-    // fixtureMap has a type-3 area element for group 98 → subgraph from it
-    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, {
-      ...OPTS,
-      groupBy: 'none',
-    })
-    expect(g.subgraphs).toHaveLength(1)
-    expect(g.subgraphs?.[0]?.id).toBe('inst1:sg:98')
-    // label resolved from groupNamesById in the area path
-    expect(g.subgraphs?.[0]?.label).toBe('016.000.Backbone Routers')
-    for (const n of g.nodes) expect(n.parent).toBe('inst1:sg:98')
-  })
-
-  it('maps host↔host links and synthesizes a port per endpoint', () => {
-    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, OPTS)
-    // the host↔image link (901) is dropped
-    expect(g.links).toHaveLength(1)
-    const link = g.links[0]
-    expect(link.id).toBe('inst1:link:900')
-    expect(link.from.node).toBe('inst1:se:200')
-    expect(link.to.node).toBe('inst1:se:201')
-    expect(link.type).toBe('thick') // drawtype 2
-    expect(link.style?.stroke).toBe('#0000FF')
-
-    // endpoints reference real synthesized ports on their nodes
-    const fromNode = g.nodes.find((n) => n.id === link.from.node)
-    const toNode = g.nodes.find((n) => n.id === link.to.node)
-    expect(fromNode?.ports?.some((p) => p.id === link.from.port)).toBe(true)
-    expect(toNode?.ports?.some((p) => p.id === link.to.port)).toBe(true)
-  })
-
-  it('skips host elements whose host did not resolve', () => {
-    const hosts = fixtureHosts()
-    hosts.delete('12759') // host.get didn't return it
-    const g = convertSysmapToGraph(fixtureMap(), hosts, GROUP_NAMES, OPTS)
-    expect(g.nodes).toHaveLength(1)
-    expect(g.links).toHaveLength(0) // its only link now has an unresolved endpoint
-  })
-
-  it("emits no subgraphs for a map with no host-group area elements (groupBy:'none')", () => {
-    const map: ZabbixSysmap = {
-      sysmapid: '7',
-      name: 'Flat',
-      selements: [
-        { selementid: '1', elementtype: '0', elements: [{ hostid: '12758' }] },
-        { selementid: '2', elementtype: '0', elements: [{ hostid: '12759' }] },
-      ],
-      links: [],
+    // every link endpoint references a real port on its node
+    for (const l of g.links) {
+      const fn = g.nodes.find((n) => n.id === l.from.node)
+      const tn = g.nodes.find((n) => n.id === l.to.node)
+      expect(fn?.ports?.some((p) => p.id === l.from.port)).toBe(true)
+      expect(tn?.ports?.some((p) => p.id === l.to.port)).toBe(true)
     }
-    const g = convertSysmapToGraph(map, fixtureHosts(), GROUP_NAMES, { ...OPTS, groupBy: 'none' })
+  })
+
+  it('synthesizes an external node for a neighbor that is not a Zabbix host', () => {
+    const g = convertLldpToGraph(hosts(), neighbors(), OPTS)
+    const ext = g.nodes.find((n) => n.id === 'inst1:ext:extX.noc')
+    expect(ext).toBeDefined()
+    expect(ext?.label).toBe('extX.noc')
+    expect(ext?.identity?.sysName).toBe('extX.noc')
+    expect(ext?.metadata?.['external']).toBe(true)
+    expect(ext?.parent).toBeUndefined()
+    expect(g.nodes).toHaveLength(3) // A, B, extX
+  })
+
+  it('drops links to non-host neighbors when includeExternalNeighbors=false', () => {
+    const g = convertLldpToGraph(hosts(), neighbors(), { ...OPTS, includeExternalNeighbors: false })
+    expect(g.nodes.find((n) => n.id === 'inst1:ext:extX.noc')).toBeUndefined()
     expect(g.nodes).toHaveLength(2)
+    expect(g.links).toHaveLength(1) // only A↔B
+  })
+
+  it("emits no subgraphs and no parents with groupBy:'none'", () => {
+    const g = convertLldpToGraph(hosts(), neighbors(), { ...OPTS, groupBy: 'none' })
     expect(g.subgraphs).toBeUndefined()
-    expect(g.links).toHaveLength(0)
     for (const n of g.nodes) expect(n.parent).toBeUndefined()
+  })
+
+  it('puts a host with no LLDP neighbors in the graph as a bare node', () => {
+    const g = convertLldpToGraph(hosts(), new Map(), OPTS)
+    expect(g.nodes).toHaveLength(2)
+    expect(g.links).toHaveLength(0)
+    expect(g.nodes.every((n) => !n.ports)).toBe(true)
   })
 })

--- a/libs/plugins/zabbix/src/topology.test.ts
+++ b/libs/plugins/zabbix/src/topology.test.ts
@@ -68,6 +68,8 @@ describe('convertLldpToGraph', () => {
     expect(a?.spec).toMatchObject({ vendor: 'juniper', model: 'ptx10002-60mr' })
     expect(a?.provenance).toEqual({ source: 'inst1', observedAt: OPTS.observedAt })
     expect(a?.parent).toBe('inst1:sg:98')
+    // FQDN exposed for the compound layout (ghost detection + domain banding)
+    expect(a?.metadata?.['hostname']).toBe('ptxA.noc')
   })
 
   it('builds links from LLDP neighbors with real ports + bandwidth, de-duping the mirror', () => {

--- a/libs/plugins/zabbix/src/topology.test.ts
+++ b/libs/plugins/zabbix/src/topology.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest'
+import { convertSysmapToGraph } from './topology.js'
+import type { ZabbixHost, ZabbixSysmap } from './types.js'
+
+const OPTS = { sourceId: 'inst1', observedAt: 1_700_000_000_000 }
+
+/** A small but representative standard sysmap: a host-group area frame, two
+ *  host elements both in that group, a decorative image element, a host↔host
+ *  link, and a host↔image link (which must be dropped). */
+function fixtureMap(): ZabbixSysmap {
+  return {
+    sysmapid: '5',
+    name: 'Backbone',
+    width: '1920',
+    height: '1080',
+    selements: [
+      // host-group area frame (groupid 98)
+      {
+        selementid: '100',
+        elementtype: '3',
+        elementsubtype: '1',
+        label: '{HOST.NAME}',
+        elements: [{ groupid: '98' }],
+      },
+      // host-group tile with no member hosts on this map → subgraph dropped
+      { selementid: '101', elementtype: '3', label: 'empty', elements: [{ groupid: '999' }] },
+      // host elements
+      {
+        selementid: '200',
+        elementtype: '0',
+        label: '{HOST.NAME}',
+        elements: [{ hostid: '12758' }],
+      },
+      {
+        selementid: '201',
+        elementtype: '0',
+        label: '{HOST.NAME}',
+        elements: [{ hostid: '12759' }],
+      },
+      // decorative image element (no element ref)
+      { selementid: '300', elementtype: '4', label: '', elements: [] },
+    ],
+    links: [
+      // host ↔ host (kept)
+      {
+        linkid: '900',
+        selementid1: '200',
+        selementid2: '201',
+        drawtype: '2',
+        color: '0000FF',
+        label: '',
+      },
+      // host ↔ image (dropped — image isn't a resolved host node)
+      { linkid: '901', selementid1: '200', selementid2: '300', drawtype: '0', color: '000000' },
+    ],
+  }
+}
+
+function fixtureHosts(): Map<string, ZabbixHost> {
+  const hosts: ZabbixHost[] = [
+    {
+      hostid: '12758',
+      host: '172.16.0.2',
+      name: 'ptx10002-60mr.noc',
+      status: '0',
+      interfaces: [{ ip: '172.16.0.2', main: '1', type: '2', useip: '1' }],
+      hostgroups: [{ groupid: '98', name: '016.000.Backbone Routers' }],
+      inventory: { hardware: 'Juniper Networks, Inc. ptx10002-60mr , kernel JUNOS 26.2' },
+    },
+    {
+      hostid: '12759',
+      host: '172.16.0.3',
+      name: 'cisco8712.noc',
+      status: '0',
+      interfaces: [{ ip: '172.16.0.3', main: '1', type: '2', useip: '1' }],
+      hostgroups: [{ groupid: '98', name: '016.000.Backbone Routers' }],
+    },
+  ]
+  return new Map(hosts.map((h) => [h.hostid, h]))
+}
+
+const GROUP_NAMES = new Map([['98', '016.000.Backbone Routers']])
+
+describe('convertSysmapToGraph', () => {
+  it('maps host elements to nodes with identity + provenance', () => {
+    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, OPTS)
+
+    expect(g.name).toBe('Backbone')
+    expect(g.nodes).toHaveLength(2)
+
+    const ptx = g.nodes.find((n) => n.id === 'inst1:se:200')
+    expect(ptx).toBeDefined()
+    expect(ptx?.label).toBe('ptx10002-60mr.noc') // host.name, not the macro label
+    expect(ptx?.identity?.mgmtIp).toBe('172.16.0.2')
+    expect(ptx?.identity?.sysName).toBe('172.16.0.2')
+    expect(ptx?.identity?.vendorIds?.['zabbix-hostid']).toBe('12758')
+    expect(ptx?.provenance).toEqual({ source: 'inst1', observedAt: OPTS.observedAt })
+    expect(ptx?.metadata?.['zabbixStatus']).toBe('monitored')
+  })
+
+  it('derives vendor/model from inventory.hardware (best-effort)', () => {
+    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, OPTS)
+    const ptx = g.nodes.find((n) => n.id === 'inst1:se:200')
+    expect(ptx?.spec?.kind).toBe('hardware')
+    expect(ptx?.spec).toMatchObject({ vendor: 'juniper', model: 'ptx10002-60mr' })
+
+    // host without inventory → bare hardware spec, no vendor/model
+    const cisco = g.nodes.find((n) => n.id === 'inst1:se:201')
+    expect(cisco?.spec).toEqual({ kind: 'hardware' })
+  })
+
+  it('groups by host-group membership and nests member nodes (default)', () => {
+    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, OPTS)
+    // both hosts are in group 98 → one subgraph, both parented; empty group 999
+    // (a type-3 tile with no member host) is irrelevant to membership grouping
+    expect(g.subgraphs).toHaveLength(1)
+    const sg = g.subgraphs?.[0]
+    expect(sg?.id).toBe('inst1:sg:98')
+    expect(sg?.label).toBe('016.000.Backbone Routers')
+    for (const n of g.nodes) expect(n.parent).toBe('inst1:sg:98')
+  })
+
+  it('picks the most-specific (fewest on-map members) host group, and honors groupExclude', () => {
+    // 3 hosts all in catch-all "all" (3 members); only host A is also in "seg-a" (1 member)
+    const mk = (id: string, groups: Array<[string, string]>): ZabbixHost => ({
+      hostid: id,
+      host: `h${id}`,
+      name: `h${id}`,
+      status: '0',
+      hostgroups: groups.map(([groupid, name]) => ({ groupid, name })),
+    })
+    const hosts = new Map([
+      [
+        '1',
+        mk('1', [
+          ['10', 'all'],
+          ['20', 'seg-a'],
+        ]),
+      ],
+      ['2', mk('2', [['10', 'all']])],
+      ['3', mk('3', [['10', 'all']])],
+    ])
+    const map: ZabbixSysmap = {
+      sysmapid: '9',
+      name: 'M',
+      selements: [
+        { selementid: 'a', elementtype: '0', elements: [{ hostid: '1' }] },
+        { selementid: 'b', elementtype: '0', elements: [{ hostid: '2' }] },
+        { selementid: 'c', elementtype: '0', elements: [{ hostid: '3' }] },
+      ],
+      links: [],
+    }
+
+    const g = convertSysmapToGraph(map, hosts, new Map(), OPTS)
+    // host A → most-specific "seg-a" (1 < 3); B,C → "all"
+    expect(g.nodes.find((n) => n.id === 'inst1:se:a')?.parent).toBe('inst1:sg:20')
+    expect(g.nodes.find((n) => n.id === 'inst1:se:b')?.parent).toBe('inst1:sg:10')
+    expect(new Set((g.subgraphs ?? []).map((s) => s.id))).toEqual(
+      new Set(['inst1:sg:20', 'inst1:sg:10']),
+    )
+
+    // excluding "all" leaves B,C ungrouped and only the seg-a subgraph
+    const g2 = convertSysmapToGraph(map, hosts, new Map(), { ...OPTS, groupExclude: ['all'] })
+    expect(g2.nodes.find((n) => n.id === 'inst1:se:a')?.parent).toBe('inst1:sg:20')
+    expect(g2.nodes.find((n) => n.id === 'inst1:se:b')?.parent).toBeUndefined()
+    expect(g2.subgraphs).toHaveLength(1)
+  })
+
+  it("groupBy:'none' uses only standard host-group area elements", () => {
+    // fixtureMap has a type-3 area element for group 98 → subgraph from it
+    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, {
+      ...OPTS,
+      groupBy: 'none',
+    })
+    expect(g.subgraphs).toHaveLength(1)
+    expect(g.subgraphs?.[0]?.id).toBe('inst1:sg:98')
+    // label resolved from groupNamesById in the area path
+    expect(g.subgraphs?.[0]?.label).toBe('016.000.Backbone Routers')
+    for (const n of g.nodes) expect(n.parent).toBe('inst1:sg:98')
+  })
+
+  it('maps host↔host links and synthesizes a port per endpoint', () => {
+    const g = convertSysmapToGraph(fixtureMap(), fixtureHosts(), GROUP_NAMES, OPTS)
+    // the host↔image link (901) is dropped
+    expect(g.links).toHaveLength(1)
+    const link = g.links[0]
+    expect(link.id).toBe('inst1:link:900')
+    expect(link.from.node).toBe('inst1:se:200')
+    expect(link.to.node).toBe('inst1:se:201')
+    expect(link.type).toBe('thick') // drawtype 2
+    expect(link.style?.stroke).toBe('#0000FF')
+
+    // endpoints reference real synthesized ports on their nodes
+    const fromNode = g.nodes.find((n) => n.id === link.from.node)
+    const toNode = g.nodes.find((n) => n.id === link.to.node)
+    expect(fromNode?.ports?.some((p) => p.id === link.from.port)).toBe(true)
+    expect(toNode?.ports?.some((p) => p.id === link.to.port)).toBe(true)
+  })
+
+  it('skips host elements whose host did not resolve', () => {
+    const hosts = fixtureHosts()
+    hosts.delete('12759') // host.get didn't return it
+    const g = convertSysmapToGraph(fixtureMap(), hosts, GROUP_NAMES, OPTS)
+    expect(g.nodes).toHaveLength(1)
+    expect(g.links).toHaveLength(0) // its only link now has an unresolved endpoint
+  })
+
+  it("emits no subgraphs for a map with no host-group area elements (groupBy:'none')", () => {
+    const map: ZabbixSysmap = {
+      sysmapid: '7',
+      name: 'Flat',
+      selements: [
+        { selementid: '1', elementtype: '0', elements: [{ hostid: '12758' }] },
+        { selementid: '2', elementtype: '0', elements: [{ hostid: '12759' }] },
+      ],
+      links: [],
+    }
+    const g = convertSysmapToGraph(map, fixtureHosts(), GROUP_NAMES, { ...OPTS, groupBy: 'none' })
+    expect(g.nodes).toHaveLength(2)
+    expect(g.subgraphs).toBeUndefined()
+    expect(g.links).toHaveLength(0)
+    for (const n of g.nodes) expect(n.parent).toBeUndefined()
+  })
+})

--- a/libs/plugins/zabbix/src/topology.ts
+++ b/libs/plugins/zabbix/src/topology.ts
@@ -1,0 +1,332 @@
+/**
+ * Zabbix sysmap (network map) → shumoku NetworkGraph converter.
+ *
+ * Standard `map.get` shapes only — this does NOT depend on any custom Zabbix
+ * module's label/icon conventions (e.g. ShowNet's `/zabbix/netmap` generator).
+ * It reads what a vanilla sysmap exposes: host / host-group elements and the
+ * links between elements.
+ *
+ * What it maps (v1):
+ *   - selement elementtype '0' (host)       → Node (resolved via host.get)
+ *   - link (selementid1 ↔ selementid2)      → Link, with a synthesized port per
+ *                                             endpoint (the "1 port = 1 link
+ *                                             endpoint" model invariant)
+ *   - subgraphs via `groupBy`:
+ *       'hostgroup' (default) — each node nests under its most-specific host
+ *                               group (the membership group with the fewest
+ *                               on-map members), so an admin/catch-all group
+ *                               that contains everything loses to the real
+ *                               segment group. `groupExclude` drops named
+ *                               admin groups outright.
+ *       'none'                — only standard host-group *area* elements
+ *                               (elementtype '3') become subgraphs; members
+ *                               nest by membership. (Vanilla Zabbix maps draw
+ *                               groups this way; custom-generated maps don't.)
+ *
+ * Deliberately deferred (see #341 plan):
+ *   - positions: Zabbix x/y are NOT carried onto Node.position yet (pending a
+ *     spike on whether the layout engine preserves incoming coordinates).
+ *   - submap (type 1) / trigger (type 2) / image (type 4) elements are skipped.
+ *   - per-link port names / bandwidth / vlan: not present in standard map data.
+ */
+
+import type { Link, NetworkGraph, Node, NodePort, NodeSpec, Subgraph } from '@shumoku/core'
+import { buildIdentity, DeviceType } from '@shumoku/core'
+import type { ZabbixHost, ZabbixHostGroup, ZabbixMapLink, ZabbixSysmap } from './types.js'
+
+// selement.elementtype values (Zabbix map object model)
+const ELEM_HOST = '0'
+const ELEM_HOSTGROUP = '3'
+
+// link.drawtype → shumoku LinkType
+const DRAWTYPE_TO_LINKTYPE: Record<string, Link['type']> = {
+  '0': 'solid',
+  '2': 'thick',
+  '3': 'dashed',
+  '4': 'dashed',
+}
+
+export type GroupBy = 'none' | 'hostgroup'
+
+export interface ConvertSysmapOptions {
+  /** Source id stamped into `provenance.source` (the plugin instance id). */
+  sourceId: string
+  /** When the source observed this map (Unix ms). Stamped on every entity. */
+  observedAt: number
+  /** How to derive subgraphs. Default `'hostgroup'`. */
+  groupBy?: GroupBy
+  /** Host-group names to never use as a subgraph (admin / catch-all groups). */
+  groupExclude?: string[]
+}
+
+/** A host node staged before grouping (keeps its resolved host for membership). */
+interface StagedNode {
+  node: Node
+  host: ZabbixHost
+}
+
+/**
+ * Convert one resolved sysmap into a NetworkGraph.
+ *
+ * @param map            the sysmap (with `selements` + `links`)
+ * @param hostsById      hosts resolved via `host.get`, keyed by hostid
+ * @param groupNamesById host-group names keyed by groupid (for `groupBy:'none'`
+ *                       subgraph labels from host-group area elements)
+ */
+export function convertSysmapToGraph(
+  map: ZabbixSysmap,
+  hostsById: Map<string, ZabbixHost>,
+  groupNamesById: Map<string, string>,
+  options: ConvertSysmapOptions,
+): NetworkGraph {
+  const { sourceId, observedAt } = options
+  const groupBy: GroupBy = options.groupBy ?? 'hostgroup'
+  const selements = map.selements ?? []
+  const links = map.links ?? []
+
+  // --- Stage host nodes (parent assigned during grouping below). ----------
+  const staged: StagedNode[] = []
+  const selementToNode = new Map<string, string>()
+  for (const se of selements) {
+    if (se.elementtype !== ELEM_HOST) continue
+    const hostId = se.elements?.[0]?.hostid
+    if (!hostId) continue
+    const host = hostsById.get(hostId)
+    if (!host) continue // host.get didn't return it (e.g. permission) — skip
+
+    const nodeId = `${sourceId}:se:${se.selementid}`
+    selementToNode.set(se.selementid, nodeId)
+    staged.push({
+      host,
+      node: {
+        id: nodeId,
+        label: host.name || host.host || hostId,
+        spec: deriveSpec(host),
+        identity: buildIdentity({
+          mgmtIp: pickMgmtIp(host),
+          sysName: host.host || undefined,
+          vendorIds: { 'zabbix-hostid': hostId },
+        }),
+        provenance: { source: sourceId, observedAt },
+        metadata: {
+          zabbixHostId: hostId,
+          zabbixHost: host.host,
+          zabbixStatus: host.status === '0' ? 'monitored' : 'unmonitored',
+        },
+      },
+    })
+  }
+
+  // --- Grouping → subgraphs + node.parent. --------------------------------
+  const subgraphs =
+    groupBy === 'hostgroup'
+      ? groupByMembership(staged, sourceId, observedAt, options.groupExclude ?? [])
+      : groupByAreaElements(staged, selements, groupNamesById, sourceId, observedAt)
+
+  const nodes = staged.map((s) => s.node)
+
+  // --- Links between resolved host nodes; synthesize a port per endpoint. --
+  const portsByNode = new Map<string, NodePort[]>()
+  const graphLinks: Link[] = []
+  for (const ln of links) {
+    const fromNode = selementToNode.get(ln.selementid1)
+    const toNode = selementToNode.get(ln.selementid2)
+    if (!fromNode || !toNode) continue // endpoint not a resolved host — skip
+    if (fromNode === toNode) continue // self-link / decorative — skip
+
+    const link: Link = {
+      id: `${sourceId}:link:${ln.linkid}`,
+      from: { node: fromNode, port: synthPort(fromNode, ln, '1', portsByNode, sourceId) },
+      to: { node: toNode, port: synthPort(toNode, ln, '2', portsByNode, sourceId) },
+      provenance: { source: sourceId, observedAt },
+    }
+    const type = ln.drawtype ? DRAWTYPE_TO_LINKTYPE[ln.drawtype] : undefined
+    if (type) link.type = type
+    if (ln.color && /^[0-9a-fA-F]{6}$/.test(ln.color)) link.style = { stroke: `#${ln.color}` }
+    if (ln.label?.trim()) link.label = ln.label
+    graphLinks.push(link)
+  }
+
+  // attach synthesized ports to their nodes
+  for (const { node } of staged) {
+    const ports = portsByNode.get(node.id)
+    if (ports?.length) node.ports = ports
+  }
+
+  return {
+    version: '1',
+    name: map.name,
+    nodes,
+    links: graphLinks,
+    ...(subgraphs.length > 0 ? { subgraphs } : {}),
+  }
+}
+
+/**
+ * Group each node under its most-specific host group: among the host's
+ * memberships (minus `groupExclude`), the group with the fewest members
+ * *on this map* wins. This makes an admin / catch-all group that contains
+ * every host lose to the real segment group, with no vendor-specific naming
+ * assumptions. Mutates `staged[i].node.parent`; returns the used subgraphs.
+ */
+function groupByMembership(
+  staged: StagedNode[],
+  sourceId: string,
+  observedAt: number,
+  groupExclude: string[],
+): Subgraph[] {
+  const exclude = new Set(groupExclude)
+  // on-map member count per groupid
+  const memberCount = new Map<string, number>()
+  for (const { host } of staged) {
+    for (const g of host.hostgroups ?? []) {
+      if (exclude.has(g.name)) continue
+      memberCount.set(g.groupid, (memberCount.get(g.groupid) ?? 0) + 1)
+    }
+  }
+
+  const usedGroups = new Map<string, ZabbixHostGroup>()
+  for (const { node, host } of staged) {
+    const candidates = (host.hostgroups ?? []).filter((g) => memberCount.has(g.groupid))
+    if (candidates.length === 0) continue
+    candidates.sort(
+      (a, b) =>
+        (memberCount.get(a.groupid) ?? 0) - (memberCount.get(b.groupid) ?? 0) ||
+        a.name.localeCompare(b.name) ||
+        a.groupid.localeCompare(b.groupid),
+    )
+    const primary = candidates[0]
+    if (!primary) continue
+    node.parent = subgraphId(sourceId, primary.groupid)
+    usedGroups.set(primary.groupid, primary)
+  }
+
+  return [...usedGroups.values()].map((g) => ({
+    id: subgraphId(sourceId, g.groupid),
+    label: g.name,
+    provenance: { source: sourceId, observedAt },
+  }))
+}
+
+/**
+ * Group by standard host-group *area* elements (elementtype '3'): each becomes
+ * a subgraph and member host nodes nest into it. This is how vanilla Zabbix
+ * maps express grouping; custom-generated maps usually omit it (so this path
+ * yields a flat graph for them — by design). Mutates `node.parent`.
+ */
+function groupByAreaElements(
+  staged: StagedNode[],
+  selements: ZabbixSysmap['selements'],
+  groupNamesById: Map<string, string>,
+  sourceId: string,
+  observedAt: number,
+): Subgraph[] {
+  const groupIds = new Set<string>()
+  for (const se of selements ?? []) {
+    if (se.elementtype !== ELEM_HOSTGROUP) continue
+    const groupId = se.elements?.[0]?.groupid
+    if (groupId) groupIds.add(groupId)
+  }
+  if (groupIds.size === 0) return []
+
+  const usedGroups = new Map<string, string>() // groupid -> label
+  for (const { node, host } of staged) {
+    for (const g of host.hostgroups ?? []) {
+      if (!groupIds.has(g.groupid)) continue
+      node.parent = subgraphId(sourceId, g.groupid)
+      usedGroups.set(g.groupid, groupNamesById.get(g.groupid) ?? g.name)
+      break
+    }
+  }
+
+  return [...usedGroups.entries()].map(([groupid, label]) => ({
+    id: subgraphId(sourceId, groupid),
+    label,
+    provenance: { source: sourceId, observedAt },
+  }))
+}
+
+function subgraphId(sourceId: string, groupId: string): string {
+  return `${sourceId}:sg:${groupId}`
+}
+
+/**
+ * Synthesize a port on `nodeId` for one end of link `ln`. A Zabbix map link is
+ * node-level (no interface), so we mint one port per link endpoint to satisfy
+ * the "1 port = 1 link endpoint" invariant and return its id.
+ */
+function synthPort(
+  nodeId: string,
+  ln: ZabbixMapLink,
+  end: '1' | '2',
+  portsByNode: Map<string, NodePort[]>,
+  sourceId: string,
+): string {
+  const portId = `${nodeId}:port:link:${ln.linkid}:${end}`
+  const list = portsByNode.get(nodeId) ?? []
+  list.push({ id: portId, label: '', connectors: [], provenance: { source: sourceId } })
+  portsByNode.set(nodeId, list)
+  return portId
+}
+
+/** Management IP: default (`main==='1'`) interface with an IP, else first with an IP. */
+function pickMgmtIp(host: ZabbixHost): string | undefined {
+  const withIp = (host.interfaces ?? []).filter((i) => i.ip && i.ip.trim() !== '')
+  if (withIp.length === 0) return undefined
+  return (withIp.find((i) => i.main === '1') ?? withIp[0])?.ip
+}
+
+// --- best-effort device facts from inventory.hardware (Phase-3-lite) -------
+// Standard Zabbix exposes no structured vendor/model/type, so we parse the
+// free-text `inventory.hardware` (an SNMP sysDescr-style string). Best-effort:
+// unknown fields are left undefined and the renderer falls back to a generic
+// device icon.
+
+const VENDOR_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/juniper/i, 'juniper'],
+  [/cisco/i, 'cisco'],
+  [/arista/i, 'arista'],
+  [/palo\s*alto/i, 'paloalto'],
+  [/forti/i, 'fortinet'],
+  [/huawei/i, 'huawei'],
+  [/nokia|alcatel/i, 'nokia'],
+  [/mellanox|nvidia/i, 'nvidia'],
+  [/dell/i, 'dell'],
+  [/hewlett|hpe|aruba/i, 'hpe'],
+  [/linux/i, 'linux'],
+]
+
+const COMPANY_PREFIX =
+  /^(juniper networks,?\s*inc\.?|cisco systems,?\s*inc\.?|arista networks,?\s*inc\.?|palo alto networks,?\s*inc\.?|fortinet,?\s*inc\.?|huawei technologies co\.?,?\s*ltd\.?|dell\s*inc\.?|hewlett[\w- ]*|nvidia|mellanox technologies)\s*/i
+
+function deriveSpec(host: ZabbixHost): NodeSpec {
+  const spec: NodeSpec = { kind: 'hardware' }
+  const hw = host.inventory?.hardware?.trim()
+  if (!hw) return spec
+
+  for (const [re, vendor] of VENDOR_PATTERNS) {
+    if (re.test(hw)) {
+      spec.vendor = vendor
+      break
+    }
+  }
+  const model = hw
+    .replace(COMPANY_PREFIX, '')
+    .match(/[A-Za-z]*\d[\w./-]*/)?.[0]
+    ?.replace(/[,.]+$/, '')
+  if (model) spec.model = model
+  const type = detectDeviceType(hw)
+  if (type) spec.type = type
+  return spec
+}
+
+function detectDeviceType(hw: string): DeviceType | undefined {
+  const s = hw.toLowerCase()
+  if (/firewall|fortigate|\bpa-\d|\bsrx/.test(s)) return DeviceType.Firewall
+  if (/access point|\bap\b|wireless/.test(s)) return DeviceType.AccessPoint
+  if (/load\s*balancer/.test(s)) return DeviceType.LoadBalancer
+  if (/switch|switching/.test(s)) return DeviceType.L2Switch
+  if (/router|\bios xr\b/.test(s)) return DeviceType.Router
+  if (/linux|\bserver\b/.test(s)) return DeviceType.Server
+  return undefined
+}

--- a/libs/plugins/zabbix/src/topology.ts
+++ b/libs/plugins/zabbix/src/topology.ts
@@ -1,62 +1,33 @@
 /**
- * Zabbix sysmap (network map) → shumoku NetworkGraph converter.
+ * Zabbix → shumoku NetworkGraph converter.
  *
- * Standard `map.get` shapes only — this does NOT depend on any custom Zabbix
- * module's label/icon conventions (e.g. ShowNet's `/zabbix/netmap` generator).
- * It reads what a vanilla sysmap exposes: host / host-group elements and the
- * links between elements.
+ * Generates topology from **standard Zabbix data**, with no dependency on Zabbix
+ * maps or the custom netmap/L2DM map-generation module, and no direct SNMP reach
+ * (Zabbix is the collector):
+ *   - nodes ← hosts (`host.get`)
+ *   - links ← per-host LLDP neighbor adjacencies (assembled by the plugin from the
+ *     standard LLDP-MIB `lldp.rem.*` / `lldp.loc.if.*` items)
  *
- * What it maps (v1):
- *   - selement elementtype '0' (host)       → Node (resolved via host.get)
- *   - link (selementid1 ↔ selementid2)      → Link, with a synthesized port per
- *                                             endpoint (the "1 port = 1 link
- *                                             endpoint" model invariant)
- *   - subgraphs via `groupBy`:
- *       'hostgroup' (default) — each node nests under its most-specific host
- *                               group (the membership group with the fewest
- *                               on-map members), so an admin/catch-all group
- *                               that contains everything loses to the real
- *                               segment group. `groupExclude` drops named
- *                               admin groups outright.
- *       'none'                — only standard host-group *area* elements
- *                               (elementtype '3') become subgraphs; members
- *                               nest by membership. (Vanilla Zabbix maps draw
- *                               groups this way; custom-generated maps don't.)
- *
- * Deliberately deferred (see #341 plan):
- *   - positions: Zabbix x/y are NOT carried onto Node.position yet (pending a
- *     spike on whether the layout engine preserves incoming coordinates).
- *   - submap (type 1) / trigger (type 2) / image (type 4) elements are skipped.
- *   - per-link port names / bandwidth / vlan: not present in standard map data.
+ * See `apps/server/docs/design/zabbix-lldp-topology.md` for the full design.
  */
 
 import type { Link, NetworkGraph, Node, NodePort, NodeSpec, Subgraph } from '@shumoku/core'
 import { buildIdentity, DeviceType } from '@shumoku/core'
-import type { ZabbixHost, ZabbixHostGroup, ZabbixMapLink, ZabbixSysmap } from './types.js'
-
-// selement.elementtype values (Zabbix map object model)
-const ELEM_HOST = '0'
-const ELEM_HOSTGROUP = '3'
-
-// link.drawtype → shumoku LinkType
-const DRAWTYPE_TO_LINKTYPE: Record<string, Link['type']> = {
-  '0': 'solid',
-  '2': 'thick',
-  '3': 'dashed',
-  '4': 'dashed',
-}
+import type { ZabbixHost, ZabbixLldpNeighbor } from './types.js'
 
 export type GroupBy = 'none' | 'hostgroup'
 
-export interface ConvertSysmapOptions {
+export interface ConvertOptions {
   /** Source id stamped into `provenance.source` (the plugin instance id). */
   sourceId: string
-  /** When the source observed this map (Unix ms). Stamped on every entity. */
+  /** When the source observed this (Unix ms). Stamped on every entity. */
   observedAt: number
   /** How to derive subgraphs. Default `'hostgroup'`. */
   groupBy?: GroupBy
   /** Host-group names to never use as a subgraph (admin / catch-all groups). */
   groupExclude?: string[]
+  /** Synthesize nodes for LLDP neighbors that aren't Zabbix hosts. Default true. */
+  includeExternalNeighbors?: boolean
 }
 
 /** A host node staged before grouping (keeps its resolved host for membership). */
@@ -65,109 +36,158 @@ interface StagedNode {
   host: ZabbixHost
 }
 
+/** Placeholder values the L2DM template uses when LLDP returned no neighbor. */
+const NO_NEIGHBOR = /^\s*(\*\s*no info\s*\*|-|unknown|)\s*$/i
+
 /**
- * Convert one resolved sysmap into a NetworkGraph.
+ * Convert hosts + their LLDP adjacencies into a NetworkGraph.
  *
- * @param map            the sysmap (with `selements` + `links`)
- * @param hostsById      hosts resolved via `host.get`, keyed by hostid
- * @param groupNamesById host-group names keyed by groupid (for `groupBy:'none'`
- *                       subgraph labels from host-group area elements)
+ * @param hosts             hosts resolved via `host.get`
+ * @param neighborsByHostId LLDP adjacencies per hostid (assembled by the plugin)
  */
-export function convertSysmapToGraph(
-  map: ZabbixSysmap,
-  hostsById: Map<string, ZabbixHost>,
-  groupNamesById: Map<string, string>,
-  options: ConvertSysmapOptions,
+export function convertLldpToGraph(
+  hosts: ZabbixHost[],
+  neighborsByHostId: Map<string, ZabbixLldpNeighbor[]>,
+  options: ConvertOptions,
 ): NetworkGraph {
   const { sourceId, observedAt } = options
   const groupBy: GroupBy = options.groupBy ?? 'hostgroup'
-  const selements = map.selements ?? []
-  const links = map.links ?? []
+  const includeExternal = options.includeExternalNeighbors ?? true
 
-  // --- Stage host nodes (parent assigned during grouping below). ----------
+  // --- 1. Host nodes (parent assigned during grouping). -------------------
   const staged: StagedNode[] = []
-  const selementToNode = new Map<string, string>()
-  for (const se of selements) {
-    if (se.elementtype !== ELEM_HOST) continue
-    const hostId = se.elements?.[0]?.hostid
-    if (!hostId) continue
-    const host = hostsById.get(hostId)
-    if (!host) continue // host.get didn't return it (e.g. permission) — skip
-
-    const nodeId = `${sourceId}:se:${se.selementid}`
-    selementToNode.set(se.selementid, nodeId)
-    staged.push({
-      host,
-      node: {
-        id: nodeId,
-        label: host.name || host.host || hostId,
-        spec: deriveSpec(host),
-        identity: buildIdentity({
-          mgmtIp: pickMgmtIp(host),
-          sysName: host.host || undefined,
-          vendorIds: { 'zabbix-hostid': hostId },
-        }),
-        provenance: { source: sourceId, observedAt },
-        metadata: {
-          zabbixHostId: hostId,
-          zabbixHost: host.host,
-          zabbixStatus: host.status === '0' ? 'monitored' : 'unmonitored',
-        },
+  const nodeByHostId = new Map<string, Node>()
+  const nodeBySysName = new Map<string, Node>() // host.name → node, for neighbor resolution
+  for (const host of hosts) {
+    const node: Node = {
+      id: `${sourceId}:host:${host.hostid}`,
+      label: host.name || host.host || host.hostid,
+      spec: deriveSpec(host),
+      identity: buildIdentity({
+        mgmtIp: pickMgmtIp(host),
+        // sysName = host.name (the real hostname). NOT host.host, which is often
+        // the management IP here — using it would break neighbor resolution and
+        // cross-source clustering.
+        sysName: host.name || undefined,
+        vendorIds: { 'zabbix-hostid': host.hostid },
+      }),
+      provenance: { source: sourceId, observedAt },
+      metadata: {
+        zabbixHostId: host.hostid,
+        zabbixHost: host.host,
+        zabbixStatus: host.status === '0' ? 'monitored' : 'unmonitored',
       },
-    })
+    }
+    staged.push({ node, host })
+    nodeByHostId.set(host.hostid, node)
+    if (host.name) nodeBySysName.set(host.name, node)
   }
 
-  // --- Grouping → subgraphs + node.parent. --------------------------------
+  // --- 2. Grouping → subgraphs + node.parent (host nodes only). -----------
   const subgraphs =
     groupBy === 'hostgroup'
       ? groupByMembership(staged, sourceId, observedAt, options.groupExclude ?? [])
-      : groupByAreaElements(staged, selements, groupNamesById, sourceId, observedAt)
+      : []
 
-  const nodes = staged.map((s) => s.node)
+  // --- 3. Links from LLDP adjacencies; real ports; de-dup. ----------------
+  const externalNodes = new Map<string, Node>() // sysname → synthesized node
+  const portsByNode = new Map<string, Map<string, NodePort>>()
+  const links: Link[] = []
+  const seenLinks = new Set<string>()
 
-  // --- Links between resolved host nodes; synthesize a port per endpoint. --
-  const portsByNode = new Map<string, NodePort[]>()
-  const graphLinks: Link[] = []
-  for (const ln of links) {
-    const fromNode = selementToNode.get(ln.selementid1)
-    const toNode = selementToNode.get(ln.selementid2)
-    if (!fromNode || !toNode) continue // endpoint not a resolved host — skip
-    if (fromNode === toNode) continue // self-link / decorative — skip
-
-    const link: Link = {
-      id: `${sourceId}:link:${ln.linkid}`,
-      from: { node: fromNode, port: synthPort(fromNode, ln, '1', portsByNode, sourceId) },
-      to: { node: toNode, port: synthPort(toNode, ln, '2', portsByNode, sourceId) },
-      provenance: { source: sourceId, observedAt },
+  const ensurePort = (node: Node, label: string, speedBps?: number): NodePort => {
+    let ports = portsByNode.get(node.id)
+    if (!ports) {
+      ports = new Map()
+      portsByNode.set(node.id, ports)
     }
-    const type = ln.drawtype ? DRAWTYPE_TO_LINKTYPE[ln.drawtype] : undefined
-    if (type) link.type = type
-    if (ln.color && /^[0-9a-fA-F]{6}$/.test(ln.color)) link.style = { stroke: `#${ln.color}` }
-    if (ln.label?.trim()) link.label = ln.label
-    graphLinks.push(link)
+    const id = `${node.id}:port:${label}`
+    const existing = ports.get(id)
+    if (existing) return existing
+    const port: NodePort = {
+      id,
+      label,
+      connectors: [],
+      provenance: { source: sourceId },
+    }
+    const speed = speedLabel(speedBps)
+    if (speed) port.speed = speed
+    ports.set(id, port)
+    return port
   }
 
-  // attach synthesized ports to their nodes
-  for (const { node } of staged) {
+  for (const host of hosts) {
+    const localNode = nodeByHostId.get(host.hostid)
+    if (!localNode) continue
+    for (const nbr of neighborsByHostId.get(host.hostid) ?? []) {
+      if (!nbr.localIf || NO_NEIGHBOR.test(nbr.remSysname)) continue
+
+      // resolve the remote end to a host node, else synthesize an external one
+      let remoteNode = nodeBySysName.get(nbr.remSysname)
+      if (!remoteNode) {
+        if (!includeExternal) continue
+        remoteNode = externalNodes.get(nbr.remSysname)
+        if (!remoteNode) {
+          remoteNode = {
+            id: `${sourceId}:ext:${nbr.remSysname}`,
+            label: nbr.remSysname,
+            spec: { kind: 'hardware' },
+            identity: buildIdentity({ sysName: nbr.remSysname, chassisId: nbr.remChassisId }),
+            provenance: { source: sourceId, observedAt },
+            metadata: { external: true },
+          }
+          externalNodes.set(nbr.remSysname, remoteNode)
+        }
+      }
+
+      const localPort = ensurePort(localNode, nbr.localIf, nbr.speedBps)
+      // Remote port label: the peer's port-id when it looks like a port name.
+      // (When it's a MAC, this is still a stable per-link label; see de-dup note.)
+      const remoteLabel = nbr.remPortId?.trim() || `to-${host.hostid}-${nbr.localIf}`
+      const remotePort = ensurePort(remoteNode, remoteLabel)
+
+      // De-dup the bidirectional LLDP report. Canonical key = the sorted pair of
+      // endpoint port-ids; the mirror collapses when remPortId == the peer's
+      // ifName (real port names). MAC-typed port-ids may not collapse — accepted.
+      const key = [`${localNode.id}|${localPort.id}`, `${remoteNode.id}|${remotePort.id}`]
+        .sort()
+        .join('::')
+      if (seenLinks.has(key)) continue
+      seenLinks.add(key)
+
+      const link: Link = {
+        id: `${sourceId}:link:${links.length}`,
+        from: { node: localNode.id, port: localPort.id },
+        to: { node: remoteNode.id, port: remotePort.id },
+        provenance: { source: sourceId, observedAt },
+        metadata: { discoveredVia: 'zabbix-lldp' },
+      }
+      if (nbr.speedBps) link.metadata = { ...link.metadata, speedBps: nbr.speedBps }
+      links.push(link)
+    }
+  }
+
+  // attach ports to their nodes
+  const allNodes = [...staged.map((s) => s.node), ...externalNodes.values()]
+  for (const node of allNodes) {
     const ports = portsByNode.get(node.id)
-    if (ports?.length) node.ports = ports
+    if (ports?.size) node.ports = [...ports.values()]
   }
 
   return {
     version: '1',
-    name: map.name,
-    nodes,
-    links: graphLinks,
+    name: 'Zabbix',
+    nodes: allNodes,
+    links,
     ...(subgraphs.length > 0 ? { subgraphs } : {}),
   }
 }
 
 /**
  * Group each node under its most-specific host group: among the host's
- * memberships (minus `groupExclude`), the group with the fewest members
- * *on this map* wins. This makes an admin / catch-all group that contains
- * every host lose to the real segment group, with no vendor-specific naming
- * assumptions. Mutates `staged[i].node.parent`; returns the used subgraphs.
+ * memberships (minus `groupExclude`), the group with the fewest members in this
+ * import wins, so an admin / catch-all group that contains everything loses to
+ * the real segment group. Mutates `staged[i].node.parent`; returns the subgraphs.
  */
 function groupByMembership(
   staged: StagedNode[],
@@ -176,7 +196,6 @@ function groupByMembership(
   groupExclude: string[],
 ): Subgraph[] {
   const exclude = new Set(groupExclude)
-  // on-map member count per groupid
   const memberCount = new Map<string, number>()
   for (const { host } of staged) {
     for (const g of host.hostgroups ?? []) {
@@ -185,7 +204,7 @@ function groupByMembership(
     }
   }
 
-  const usedGroups = new Map<string, ZabbixHostGroup>()
+  const usedGroups = new Map<string, string>() // groupid → name
   for (const { node, host } of staged) {
     const candidates = (host.hostgroups ?? []).filter((g) => memberCount.has(g.groupid))
     if (candidates.length === 0) continue
@@ -197,76 +216,15 @@ function groupByMembership(
     )
     const primary = candidates[0]
     if (!primary) continue
-    node.parent = subgraphId(sourceId, primary.groupid)
-    usedGroups.set(primary.groupid, primary)
-  }
-
-  return [...usedGroups.values()].map((g) => ({
-    id: subgraphId(sourceId, g.groupid),
-    label: g.name,
-    provenance: { source: sourceId, observedAt },
-  }))
-}
-
-/**
- * Group by standard host-group *area* elements (elementtype '3'): each becomes
- * a subgraph and member host nodes nest into it. This is how vanilla Zabbix
- * maps express grouping; custom-generated maps usually omit it (so this path
- * yields a flat graph for them — by design). Mutates `node.parent`.
- */
-function groupByAreaElements(
-  staged: StagedNode[],
-  selements: ZabbixSysmap['selements'],
-  groupNamesById: Map<string, string>,
-  sourceId: string,
-  observedAt: number,
-): Subgraph[] {
-  const groupIds = new Set<string>()
-  for (const se of selements ?? []) {
-    if (se.elementtype !== ELEM_HOSTGROUP) continue
-    const groupId = se.elements?.[0]?.groupid
-    if (groupId) groupIds.add(groupId)
-  }
-  if (groupIds.size === 0) return []
-
-  const usedGroups = new Map<string, string>() // groupid -> label
-  for (const { node, host } of staged) {
-    for (const g of host.hostgroups ?? []) {
-      if (!groupIds.has(g.groupid)) continue
-      node.parent = subgraphId(sourceId, g.groupid)
-      usedGroups.set(g.groupid, groupNamesById.get(g.groupid) ?? g.name)
-      break
-    }
+    node.parent = `${sourceId}:sg:${primary.groupid}`
+    usedGroups.set(primary.groupid, primary.name)
   }
 
   return [...usedGroups.entries()].map(([groupid, label]) => ({
-    id: subgraphId(sourceId, groupid),
+    id: `${sourceId}:sg:${groupid}`,
     label,
     provenance: { source: sourceId, observedAt },
   }))
-}
-
-function subgraphId(sourceId: string, groupId: string): string {
-  return `${sourceId}:sg:${groupId}`
-}
-
-/**
- * Synthesize a port on `nodeId` for one end of link `ln`. A Zabbix map link is
- * node-level (no interface), so we mint one port per link endpoint to satisfy
- * the "1 port = 1 link endpoint" invariant and return its id.
- */
-function synthPort(
-  nodeId: string,
-  ln: ZabbixMapLink,
-  end: '1' | '2',
-  portsByNode: Map<string, NodePort[]>,
-  sourceId: string,
-): string {
-  const portId = `${nodeId}:port:link:${ln.linkid}:${end}`
-  const list = portsByNode.get(nodeId) ?? []
-  list.push({ id: portId, label: '', connectors: [], provenance: { source: sourceId } })
-  portsByNode.set(nodeId, list)
-  return portId
 }
 
 /** Management IP: default (`main==='1'`) interface with an IP, else first with an IP. */
@@ -276,11 +234,18 @@ function pickMgmtIp(host: ZabbixHost): string | undefined {
   return (withIp.find((i) => i.main === '1') ?? withIp[0])?.ip
 }
 
+/** Humanize a bits/sec speed to a port label (e.g. 100000000000 → "100g"). */
+function speedLabel(bps?: number): string | undefined {
+  if (!bps || bps <= 0) return undefined
+  if (bps % 1_000_000_000 === 0) return `${bps / 1_000_000_000}g`
+  if (bps % 1_000_000 === 0) return `${bps / 1_000_000}m`
+  return undefined
+}
+
 // --- best-effort device facts from inventory.hardware (Phase-3-lite) -------
 // Standard Zabbix exposes no structured vendor/model/type, so we parse the
 // free-text `inventory.hardware` (an SNMP sysDescr-style string). Best-effort:
-// unknown fields are left undefined and the renderer falls back to a generic
-// device icon.
+// unknown fields are left undefined and the renderer falls back to a generic icon.
 
 const VENDOR_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   [/juniper/i, 'juniper'],

--- a/libs/plugins/zabbix/src/topology.ts
+++ b/libs/plugins/zabbix/src/topology.ts
@@ -73,6 +73,11 @@ export function convertLldpToGraph(
       }),
       provenance: { source: sourceId, observedAt },
       metadata: {
+        // `hostname` (FQDN) is what the compound layout reads to (a) tell a
+        // real device from an information-less ghost and (b) band link-less
+        // members by domain (`.noc` / `.sec` / …). Without it every link-less
+        // host is treated as a ghost and dumped into the "未マップ" grid.
+        hostname: host.name || host.host,
         zabbixHostId: host.hostid,
         zabbixHost: host.host,
         zabbixStatus: host.status === '0' ? 'monitored' : 'unmonitored',
@@ -134,7 +139,7 @@ export function convertLldpToGraph(
             spec: { kind: 'hardware' },
             identity: buildIdentity({ sysName: nbr.remSysname, chassisId: nbr.remChassisId }),
             provenance: { source: sourceId, observedAt },
-            metadata: { external: true },
+            metadata: { external: true, hostname: nbr.remSysname },
           }
           externalNodes.set(nbr.remSysname, remoteNode)
         }

--- a/libs/plugins/zabbix/src/topology.ts
+++ b/libs/plugins/zabbix/src/topology.ts
@@ -1,14 +1,16 @@
 /**
  * Zabbix → shumoku NetworkGraph converter.
  *
- * Generates topology from **standard Zabbix data**, with no dependency on Zabbix
- * maps or the custom netmap/L2DM map-generation module, and no direct SNMP reach
- * (Zabbix is the collector):
- *   - nodes ← hosts (`host.get`)
- *   - links ← per-host LLDP neighbor adjacencies (assembled by the plugin from the
- *     standard LLDP-MIB `lldp.rem.*` / `lldp.loc.if.*` items)
+ * Generates topology from standard Zabbix data (no maps / netmap module, no
+ * direct SNMP reach — Zabbix is the collector). Grounded in the Zabbix 7.0 API
+ * spec cross-referenced with the live ShowNet data and the human-built sysmaps;
+ * see `apps/server/docs/design/zabbix-lldp-topology.md`.
  *
- * See `apps/server/docs/design/zabbix-lldp-topology.md` for the full design.
+ *   - nodes    ← hosts (`host.get`); keyed on `name` (host.host is the mgmt IP)
+ *   - links    ← LLDP neighbor items (`lldp.rem.*` / `lldp.loc.if.*`), plus a
+ *                `PARENT` host-tag fallback where LLDP saw no neighbor
+ *   - groups   ← host groups, honoring the Zabbix `/` nesting convention
+ *   - device   ← parsed from inventory.{type,vendor,model,hardware} + SNMP sysDescr
  */
 
 import type { Link, NetworkGraph, Node, NodePort, NodeSpec, Subgraph } from '@shumoku/core'
@@ -26,8 +28,10 @@ export interface ConvertOptions {
   groupBy?: GroupBy
   /** Host-group names to never use as a subgraph (admin / catch-all groups). */
   groupExclude?: string[]
-  /** Synthesize nodes for LLDP neighbors that aren't Zabbix hosts. Default true. */
+  /** Synthesize nodes for LLDP/tag neighbors that aren't Zabbix hosts. Default true. */
   includeExternalNeighbors?: boolean
+  /** Host-tag name naming an upstream device (fallback link). Default `'PARENT'`. */
+  parentTag?: string
 }
 
 /** A host node staged before grouping (keeps its resolved host for membership). */
@@ -36,23 +40,26 @@ interface StagedNode {
   host: ZabbixHost
 }
 
-/** Placeholder values the L2DM template uses when LLDP returned no neighbor. */
+/** Placeholder values the LLDP template uses when no neighbor was seen. */
 const NO_NEIGHBOR = /^\s*(\*\s*no info\s*\*|-|unknown|)\s*$/i
 
 /**
- * Convert hosts + their LLDP adjacencies into a NetworkGraph.
+ * Convert hosts + their LLDP adjacencies (and SNMP sysDescr) into a NetworkGraph.
  *
- * @param hosts             hosts resolved via `host.get`
+ * @param hosts             hosts resolved via `host.get` (with tags + inventory)
  * @param neighborsByHostId LLDP adjacencies per hostid (assembled by the plugin)
+ * @param sysDescrByHostId  per-host SNMP sysDescr (for device-type derivation)
  */
-export function convertLldpToGraph(
+export function convertZabbixToGraph(
   hosts: ZabbixHost[],
   neighborsByHostId: Map<string, ZabbixLldpNeighbor[]>,
+  sysDescrByHostId: Map<string, string>,
   options: ConvertOptions,
 ): NetworkGraph {
   const { sourceId, observedAt } = options
   const groupBy: GroupBy = options.groupBy ?? 'hostgroup'
   const includeExternal = options.includeExternalNeighbors ?? true
+  const parentTag = options.parentTag ?? 'PARENT'
 
   // --- 1. Host nodes (parent assigned during grouping). -------------------
   const staged: StagedNode[] = []
@@ -62,21 +69,17 @@ export function convertLldpToGraph(
     const node: Node = {
       id: `${sourceId}:host:${host.hostid}`,
       label: host.name || host.host || host.hostid,
-      spec: deriveSpec(host),
+      spec: deriveSpec(host, sysDescrByHostId.get(host.hostid)),
       identity: buildIdentity({
         mgmtIp: pickMgmtIp(host),
-        // sysName = host.name (the real hostname). NOT host.host, which is often
-        // the management IP here — using it would break neighbor resolution and
-        // cross-source clustering.
+        // sysName = host.name (the real hostname). NOT host.host, which is the
+        // management IP here — using it breaks neighbor resolution + clustering.
         sysName: host.name || undefined,
         vendorIds: { 'zabbix-hostid': host.hostid },
       }),
       provenance: { source: sourceId, observedAt },
       metadata: {
-        // `hostname` (FQDN) is what the compound layout reads to (a) tell a
-        // real device from an information-less ghost and (b) band link-less
-        // members by domain (`.noc` / `.sec` / …). Without it every link-less
-        // host is treated as a ghost and dumped into the "未マップ" grid.
+        // FQDN for the compound layout (ghost detection + domain fallback band).
         hostname: host.name || host.host,
         zabbixHostId: host.hostid,
         zabbixHost: host.host,
@@ -88,17 +91,18 @@ export function convertLldpToGraph(
     if (host.name) nodeBySysName.set(host.name, node)
   }
 
-  // --- 2. Grouping → subgraphs + node.parent (host nodes only). -----------
+  // --- 2. Grouping → nested subgraphs (Zabbix '/' hierarchy) + node.parent. -
   const subgraphs =
     groupBy === 'hostgroup'
-      ? groupByMembership(staged, sourceId, observedAt, options.groupExclude ?? [])
+      ? groupByHostGroup(staged, sourceId, observedAt, options.groupExclude ?? [])
       : []
 
-  // --- 3. Links from LLDP adjacencies; real ports; de-dup. ----------------
+  // --- 3. Links: LLDP neighbors, then PARENT-tag fallback. -----------------
   const externalNodes = new Map<string, Node>() // sysname → synthesized node
   const portsByNode = new Map<string, Map<string, NodePort>>()
   const links: Link[] = []
-  const seenLinks = new Set<string>()
+  const seenLinks = new Set<string>() // canonical endpoint-port pairs
+  const linkedNodePairs = new Set<string>() // canonical node pairs (for tag de-dup)
 
   const ensurePort = (node: Node, label: string, speedBps?: number): NodePort => {
     let ports = portsByNode.get(node.id)
@@ -109,56 +113,54 @@ export function convertLldpToGraph(
     const id = `${node.id}:port:${label}`
     const existing = ports.get(id)
     if (existing) return existing
-    const port: NodePort = {
-      id,
-      label,
-      connectors: [],
-      provenance: { source: sourceId },
-    }
+    const port: NodePort = { id, label, connectors: [], provenance: { source: sourceId } }
     const speed = speedLabel(speedBps)
     if (speed) port.speed = speed
     ports.set(id, port)
     return port
   }
 
+  const resolveRemote = (sysName: string, chassisId?: string): Node | undefined => {
+    const host = nodeBySysName.get(sysName)
+    if (host) return host
+    if (!includeExternal) return undefined
+    let ext = externalNodes.get(sysName)
+    if (!ext) {
+      ext = {
+        id: `${sourceId}:ext:${sysName}`,
+        label: sysName,
+        spec: { kind: 'hardware' },
+        identity: buildIdentity({ sysName, chassisId }),
+        provenance: { source: sourceId, observedAt },
+        metadata: { external: true, hostname: sysName },
+      }
+      externalNodes.set(sysName, ext)
+    }
+    return ext
+  }
+
+  const nodePairKey = (a: string, b: string): string => [a, b].sort().join('::')
+
+  // 3a. LLDP links (the authoritative neighbor data).
   for (const host of hosts) {
     const localNode = nodeByHostId.get(host.hostid)
     if (!localNode) continue
     for (const nbr of neighborsByHostId.get(host.hostid) ?? []) {
       if (!nbr.localIf || NO_NEIGHBOR.test(nbr.remSysname)) continue
-
-      // resolve the remote end to a host node, else synthesize an external one
-      let remoteNode = nodeBySysName.get(nbr.remSysname)
-      if (!remoteNode) {
-        if (!includeExternal) continue
-        remoteNode = externalNodes.get(nbr.remSysname)
-        if (!remoteNode) {
-          remoteNode = {
-            id: `${sourceId}:ext:${nbr.remSysname}`,
-            label: nbr.remSysname,
-            spec: { kind: 'hardware' },
-            identity: buildIdentity({ sysName: nbr.remSysname, chassisId: nbr.remChassisId }),
-            provenance: { source: sourceId, observedAt },
-            metadata: { external: true, hostname: nbr.remSysname },
-          }
-          externalNodes.set(nbr.remSysname, remoteNode)
-        }
-      }
+      const remoteNode = resolveRemote(nbr.remSysname, nbr.remChassisId)
+      if (!remoteNode || remoteNode.id === localNode.id) continue
 
       const localPort = ensurePort(localNode, nbr.localIf, nbr.speedBps)
-      // Remote port label: the peer's port-id when it looks like a port name.
-      // (When it's a MAC, this is still a stable per-link label; see de-dup note.)
       const remoteLabel = nbr.remPortId?.trim() || `to-${host.hostid}-${nbr.localIf}`
       const remotePort = ensurePort(remoteNode, remoteLabel)
 
-      // De-dup the bidirectional LLDP report. Canonical key = the sorted pair of
-      // endpoint port-ids; the mirror collapses when remPortId == the peer's
-      // ifName (real port names). MAC-typed port-ids may not collapse — accepted.
-      const key = [`${localNode.id}|${localPort.id}`, `${remoteNode.id}|${remotePort.id}`]
-        .sort()
-        .join('::')
+      const key = nodePairKey(
+        `${localNode.id}|${localPort.id}`,
+        `${remoteNode.id}|${remotePort.id}`,
+      )
       if (seenLinks.has(key)) continue
       seenLinks.add(key)
+      linkedNodePairs.add(nodePairKey(localNode.id, remoteNode.id))
 
       const link: Link = {
         id: `${sourceId}:link:${links.length}`,
@@ -169,6 +171,28 @@ export function convertLldpToGraph(
       }
       if (nbr.speedBps) link.metadata = { ...link.metadata, speedBps: nbr.speedBps }
       links.push(link)
+    }
+  }
+
+  // 3b. PARENT-tag fallback links — only where LLDP saw nothing between the pair.
+  if (parentTag) {
+    for (const { node, host } of staged) {
+      const up = host.tags?.find((t) => t.tag === parentTag)?.value?.trim()
+      if (!up) continue
+      const upstream = resolveRemote(up)
+      if (!upstream || upstream.id === node.id) continue
+      if (linkedNodePairs.has(nodePairKey(node.id, upstream.id))) continue
+      linkedNodePairs.add(nodePairKey(node.id, upstream.id))
+
+      const fromPort = ensurePort(node, `parent:${up}`)
+      const toPort = ensurePort(upstream, `child:${host.name || host.hostid}`)
+      links.push({
+        id: `${sourceId}:link:${links.length}`,
+        from: { node: node.id, port: fromPort.id },
+        to: { node: upstream.id, port: toPort.id },
+        provenance: { source: sourceId, observedAt },
+        metadata: { discoveredVia: 'zabbix-parent-tag' },
+      })
     }
   }
 
@@ -189,12 +213,13 @@ export function convertLldpToGraph(
 }
 
 /**
- * Group each node under its most-specific host group: among the host's
- * memberships (minus `groupExclude`), the group with the fewest members in this
- * import wins, so an admin / catch-all group that contains everything loses to
- * the real segment group. Mutates `staged[i].node.parent`; returns the subgraphs.
+ * Group nodes by their host group, honoring Zabbix's `/` nesting convention
+ * ("A/B/C" → nested subgraphs A ⊃ A/B ⊃ A/B/C). Each node lands in its
+ * most-specific group: deepest `/` path, then fewest members (so an admin /
+ * catch-all group that contains everything loses), then name. `groupExclude`
+ * drops named admin groups outright. Mutates `node.parent`; returns subgraphs.
  */
-function groupByMembership(
+function groupByHostGroup(
   staged: StagedNode[],
   sourceId: string,
   observedAt: number,
@@ -205,31 +230,43 @@ function groupByMembership(
   for (const { host } of staged) {
     for (const g of host.hostgroups ?? []) {
       if (exclude.has(g.name)) continue
-      memberCount.set(g.groupid, (memberCount.get(g.groupid) ?? 0) + 1)
+      memberCount.set(g.name, (memberCount.get(g.name) ?? 0) + 1)
     }
   }
+  const sgId = (path: string): string => `${sourceId}:sg:${path}`
+  const depth = (name: string): number => name.split('/').length
 
-  const usedGroups = new Map<string, string>() // groupid → name
+  const usedLeaves = new Set<string>()
   for (const { node, host } of staged) {
-    const candidates = (host.hostgroups ?? []).filter((g) => memberCount.has(g.groupid))
-    if (candidates.length === 0) continue
-    candidates.sort(
+    const cands = (host.hostgroups ?? []).filter((g) => memberCount.has(g.name))
+    if (cands.length === 0) continue
+    cands.sort(
       (a, b) =>
-        (memberCount.get(a.groupid) ?? 0) - (memberCount.get(b.groupid) ?? 0) ||
-        a.name.localeCompare(b.name) ||
-        a.groupid.localeCompare(b.groupid),
+        depth(b.name) - depth(a.name) ||
+        (memberCount.get(a.name) ?? 0) - (memberCount.get(b.name) ?? 0) ||
+        a.name.localeCompare(b.name),
     )
-    const primary = candidates[0]
-    if (!primary) continue
-    node.parent = `${sourceId}:sg:${primary.groupid}`
-    usedGroups.set(primary.groupid, primary.name)
+    const leaf = cands[0]
+    if (!leaf) continue
+    node.parent = sgId(leaf.name)
+    usedLeaves.add(leaf.name)
   }
 
-  return [...usedGroups.entries()].map(([groupid, label]) => ({
-    id: `${sourceId}:sg:${groupid}`,
-    label,
-    provenance: { source: sourceId, observedAt },
-  }))
+  // Emit a subgraph for each used leaf AND every '/' ancestor (Zabbix does not
+  // create parent groups automatically, so synthesize the intermediate levels).
+  const subById = new Map<string, Subgraph>()
+  for (const leaf of usedLeaves) {
+    const segs = leaf.split('/')
+    for (const [i, seg] of segs.entries()) {
+      const path = segs.slice(0, i + 1).join('/')
+      const id = sgId(path)
+      if (subById.has(id)) continue
+      const sg: Subgraph = { id, label: seg, provenance: { source: sourceId, observedAt } }
+      if (i > 0) sg.parent = sgId(segs.slice(0, i).join('/'))
+      subById.set(id, sg)
+    }
+  }
+  return [...subById.values()]
 }
 
 /** Management IP: default (`main==='1'`) interface with an IP, else first with an IP. */
@@ -247,10 +284,10 @@ function speedLabel(bps?: number): string | undefined {
   return undefined
 }
 
-// --- best-effort device facts from inventory.hardware (Phase-3-lite) -------
-// Standard Zabbix exposes no structured vendor/model/type, so we parse the
-// free-text `inventory.hardware` (an SNMP sysDescr-style string). Best-effort:
-// unknown fields are left undefined and the renderer falls back to a generic icon.
+// --- device facts: inventory (structured) → inventory.hardware / sysDescr ----
+// Zabbix has no native device-role enum; structured inventory.{type,vendor,model}
+// is spec-faithful but usually empty, so we fall back to parsing the free-text
+// inventory.hardware / SNMP sysDescr (both vendor/model/OS strings).
 
 const VENDOR_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   [/juniper/i, 'juniper'],
@@ -263,40 +300,68 @@ const VENDOR_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
   [/mellanox|nvidia/i, 'nvidia'],
   [/dell/i, 'dell'],
   [/hewlett|hpe|aruba/i, 'hpe'],
-  [/linux/i, 'linux'],
+  [/\bnec\b/i, 'nec'],
+  [/linux|ubuntu|debian|centos|red\s*hat/i, 'linux'],
 ]
 
 const COMPANY_PREFIX =
-  /^(juniper networks,?\s*inc\.?|cisco systems,?\s*inc\.?|arista networks,?\s*inc\.?|palo alto networks,?\s*inc\.?|fortinet,?\s*inc\.?|huawei technologies co\.?,?\s*ltd\.?|dell\s*inc\.?|hewlett[\w- ]*|nvidia|mellanox technologies)\s*/i
+  /^(juniper networks,?\s*inc\.?|cisco systems,?\s*inc\.?|cisco\b|arista networks,?\s*inc\.?|palo alto networks\b|fortinet,?\s*inc\.?|huawei technologies co\.?,?\s*ltd\.?|dell\s*inc\.?|hewlett[\w- ]*|nvidia|mellanox technologies)[ ,]*/i
 
-function deriveSpec(host: ZabbixHost): NodeSpec {
+function deriveSpec(host: ZabbixHost, sysDescr?: string): NodeSpec {
   const spec: NodeSpec = { kind: 'hardware' }
-  const hw = host.inventory?.hardware?.trim()
-  if (!hw) return spec
+  const inv = host.inventory
 
-  for (const [re, vendor] of VENDOR_PATTERNS) {
-    if (re.test(hw)) {
-      spec.vendor = vendor
-      break
+  // 1. structured inventory (spec-faithful; rarely populated)
+  if (inv?.vendor?.trim()) spec.vendor = inv.vendor.trim().toLowerCase()
+  if (inv?.model?.trim()) spec.model = inv.model.trim()
+  let type = inv?.type?.trim() ? detectType(inv.type) : undefined
+
+  // 2. free-text facts: the most informative of inventory.hardware / sysDescr,
+  //    skipping a degenerate value that just echoes the host name/ip.
+  const text = bestFactsText(host, inv?.hardware, sysDescr)
+  if (text) {
+    if (!spec.vendor) {
+      for (const [re, vendor] of VENDOR_PATTERNS) {
+        if (re.test(text)) {
+          spec.vendor = vendor
+          break
+        }
+      }
     }
+    if (!spec.model) {
+      const model = text
+        .replace(COMPANY_PREFIX, '')
+        .match(/[A-Za-z]*\d[\w./-]*/)?.[0]
+        ?.replace(/[,.]+$/, '')
+      if (model) spec.model = model
+    }
+    if (!type) type = detectType(text)
   }
-  const model = hw
-    .replace(COMPANY_PREFIX, '')
-    .match(/[A-Za-z]*\d[\w./-]*/)?.[0]
-    ?.replace(/[,.]+$/, '')
-  if (model) spec.model = model
-  const type = detectDeviceType(hw)
   if (type) spec.type = type
   return spec
 }
 
-function detectDeviceType(hw: string): DeviceType | undefined {
-  const s = hw.toLowerCase()
-  if (/firewall|fortigate|\bpa-\d|\bsrx/.test(s)) return DeviceType.Firewall
-  if (/access point|\bap\b|wireless/.test(s)) return DeviceType.AccessPoint
+/** Pick the most informative facts string; drop one that just echoes name/ip. */
+function bestFactsText(host: ZabbixHost, hardware?: string, sysDescr?: string): string | undefined {
+  const echo = new Set([host.name, host.host].filter(Boolean))
+  const cands = [sysDescr, hardware]
+    .map((s) => s?.trim())
+    // a real descr has whitespace; drop empties and bare name/ip echoes
+    .filter((s): s is string => typeof s === 'string' && !echo.has(s) && /\s/.test(s))
+  // longest = most detail
+  cands.sort((a, b) => b.length - a.length)
+  return cands[0]
+}
+
+function detectType(text: string): DeviceType | undefined {
+  const s = text.toLowerCase()
+  if (/firewall|fortigate|fortindr|\bsrx\d|\bpa-\d|palo\s*alto/.test(s)) return DeviceType.Firewall
+  if (/access point|wireless|\bwlc\b/.test(s)) return DeviceType.AccessPoint
   if (/load\s*balancer/.test(s)) return DeviceType.LoadBalancer
-  if (/switch|switching/.test(s)) return DeviceType.L2Switch
-  if (/router|\bios xr\b/.test(s)) return DeviceType.Router
-  if (/linux|\bserver\b/.test(s)) return DeviceType.Server
+  if (/nexus|nx-os|\bqfx\d|arista|\beos\b|\bs9\d{3}/.test(s)) return DeviceType.L3Switch
+  if (/switch|switching|\bex\d{3,}|catalyst|\bc9\d{3}/.test(s)) return DeviceType.L2Switch
+  if (/router|ios xr|\bptx\d|\bmx\d|\bne\d{3,}|\basr\d|crpd|\bxrd\b/.test(s))
+    return DeviceType.Router
+  if (/linux|\bserver\b|ubuntu|centos|windows/.test(s)) return DeviceType.Server
   return undefined
 }

--- a/libs/plugins/zabbix/src/types.ts
+++ b/libs/plugins/zabbix/src/types.ts
@@ -33,11 +33,17 @@ export interface ZabbixTopologyOptions {
   /** Host-group names to never use as a subgraph (admin / catch-all groups). */
   groupExclude?: string[]
   /**
-   * Synthesize a node for an LLDP neighbor that isn't a Zabbix host (default
-   * true) so the link still renders and a later discovery of that device
-   * clusters with it. When false, links to non-host neighbors are dropped.
+   * Synthesize a node for an LLDP neighbor / tag upstream that isn't a Zabbix
+   * host (default true) so the link still renders and a later discovery of that
+   * device clusters with it. When false, links to non-host devices are dropped.
    */
   includeExternalNeighbors?: boolean
+  /**
+   * Host-tag name whose value names an upstream device (e.g. `PARENT=core.noc`).
+   * Used to draw a "tag-derived" link where LLDP has no neighbor — the green
+   * links in the ShowNet maps. Default `'PARENT'`; empty disables tag links.
+   */
+  parentTag?: string
 }
 
 /**
@@ -81,12 +87,20 @@ export interface ZabbixParentTemplate {
   name: string
 }
 
+/** A `{tag, value}` from `host.get` `selectTags`. */
+export interface ZabbixTag {
+  tag: string
+  value?: string
+}
+
 /**
  * Host inventory (`host.get` `selectInventory`). Free-text fields, mostly empty
- * under auto inventory mode; `hardware` is the most reliable device-facts source
- * (vendor/model/OS as an SNMP sysDescr-style string).
+ * under auto inventory mode. The structured `type`/`vendor`/`model` are the
+ * spec-faithful device facts; `hardware` is an SNMP sysDescr-style fallback.
  */
 export interface ZabbixInventory {
+  /** Free-text device type/role, e.g. "Router". Spec field; often empty. */
+  type?: string
   hardware?: string
   vendor?: string
   model?: string
@@ -109,6 +123,8 @@ export interface ZabbixHost {
   parentTemplates?: ZabbixParentTemplate[]
   /** Present when `host.get` is called with `selectInventory`. */
   inventory?: ZabbixInventory
+  /** Present when `host.get` is called with `selectTags`. */
+  tags?: ZabbixTag[]
 }
 
 export interface ZabbixItem {

--- a/libs/plugins/zabbix/src/types.ts
+++ b/libs/plugins/zabbix/src/types.ts
@@ -14,18 +14,47 @@ export interface ZabbixPluginConfig {
   instanceId?: string
 }
 
-/** Per-attachment topology options passed to `fetchTopology` (from `optionsJson`). */
+/**
+ * Per-attachment topology options passed to `fetchTopology` (from `optionsJson`).
+ * Topology is generated from hosts (nodes) + LLDP neighbor items (links) — see
+ * `apps/server/docs/design/zabbix-lldp-topology.md`.
+ */
 export interface ZabbixTopologyOptions {
-  /** sysmapid of the Zabbix map (sysmap) to import. Required. */
-  sysmapId?: string
+  /**
+   * Host-group ids to scope the import to. Strongly recommended — a Zabbix
+   * instance can hold thousands of hosts. Empty / absent = all hosts.
+   */
+  hostGroups?: string[]
   /**
    * How to derive subgraphs. `'hostgroup'` (default) nests each node under its
-   * most-specific host group; `'none'` uses only standard host-group area
-   * elements on the map. See the converter for details.
+   * most-specific host group; `'none'` emits a flat graph.
    */
   groupBy?: 'none' | 'hostgroup'
   /** Host-group names to never use as a subgraph (admin / catch-all groups). */
   groupExclude?: string[]
+  /**
+   * Synthesize a node for an LLDP neighbor that isn't a Zabbix host (default
+   * true) so the link still renders and a later discovery of that device
+   * clusters with it. When false, links to non-host neighbors are dropped.
+   */
+  includeExternalNeighbors?: boolean
+}
+
+/**
+ * One LLDP adjacency discovered on a host, assembled by the plugin from the
+ * per-interface `lldp.rem.*` / `lldp.loc.if.*` items and handed to the converter.
+ */
+export interface ZabbixLldpNeighbor {
+  /** Local interface name (e.g. `et-0/0/5`). */
+  localIf: string
+  /** Remote system name reported by LLDP (resolved against `host.name`). */
+  remSysname: string
+  /** Remote port id (a port name, or a MAC when port-id is MAC-typed). */
+  remPortId?: string
+  /** Remote chassis id (identity key for a synthesized external node). */
+  remChassisId?: string
+  /** Local interface speed in bits/sec, when known. */
+  speedBps?: number
 }
 
 // Zabbix API types
@@ -80,57 +109,6 @@ export interface ZabbixHost {
   parentTemplates?: ZabbixParentTemplate[]
   /** Present when `host.get` is called with `selectInventory`. */
   inventory?: ZabbixInventory
-}
-
-// ============================================
-// Sysmap (network map) API types — standard `map.get` shapes only.
-// https://www.zabbix.com/documentation/7.0/en/manual/api/reference/map/object
-// ============================================
-
-/** Element reference inside a `selement.elements` array (varies by elementtype). */
-export interface ZabbixSelementRef {
-  hostid?: string
-  groupid?: string
-  triggerid?: string
-  sysmapid?: string
-}
-
-/**
- * A map element (`selement`). `elementtype`: '0' host, '1' map (submap),
- * '2' trigger, '3' host group, '4' image. `elementsubtype` '1' on a host-group
- * element means "separate hosts" (the group is drawn as an area of its hosts).
- */
-export interface ZabbixSelement {
-  selementid: string
-  elementtype: string
-  elementsubtype?: string
-  label?: string
-  x?: string
-  y?: string
-  iconid_off?: string
-  elements?: ZabbixSelementRef[]
-}
-
-/** A map link between two selements. */
-export interface ZabbixMapLink {
-  linkid: string
-  selementid1: string
-  selementid2: string
-  /** '0' line, '2' bold, '3' dotted, '4' dashed. */
-  drawtype?: string
-  /** Hex color without '#', e.g. '0000FF'. */
-  color?: string
-  label?: string
-}
-
-/** A Zabbix sysmap (network map) from `map.get`. */
-export interface ZabbixSysmap {
-  sysmapid: string
-  name: string
-  width?: string
-  height?: string
-  selements?: ZabbixSelement[]
-  links?: ZabbixMapLink[]
 }
 
 export interface ZabbixItem {

--- a/libs/plugins/zabbix/src/types.ts
+++ b/libs/plugins/zabbix/src/types.ts
@@ -5,6 +5,27 @@ export interface ZabbixPluginConfig {
   pollInterval?: number
   /** Skip TLS certificate verification (self-signed / private-CA upstreams). */
   insecure?: boolean
+  /**
+   * Data-source instance id, injected by the host at construction (NOT a form
+   * field). Stamped into `provenance.source` on every topology entity so the
+   * resolver can attribute / the human can override. Falls back to the plugin
+   * type when absent — see the #339 instance-id plumbing direction.
+   */
+  instanceId?: string
+}
+
+/** Per-attachment topology options passed to `fetchTopology` (from `optionsJson`). */
+export interface ZabbixTopologyOptions {
+  /** sysmapid of the Zabbix map (sysmap) to import. Required. */
+  sysmapId?: string
+  /**
+   * How to derive subgraphs. `'hostgroup'` (default) nests each node under its
+   * most-specific host group; `'none'` uses only standard host-group area
+   * elements on the map. See the converter for details.
+   */
+  groupBy?: 'none' | 'hostgroup'
+  /** Host-group names to never use as a subgraph (admin / catch-all groups). */
+  groupExclude?: string[]
 }
 
 // Zabbix API types
@@ -19,12 +40,97 @@ export interface ZabbixHostInterface {
   useip?: string
 }
 
+/** A `{groupid, name}` from `host.get` `selectHostGroups` / `hostgroup.get`. */
+export interface ZabbixHostGroup {
+  groupid: string
+  name: string
+}
+
+/** A `{name}` from `host.get` `selectParentTemplates`. */
+export interface ZabbixParentTemplate {
+  templateid?: string
+  name: string
+}
+
+/**
+ * Host inventory (`host.get` `selectInventory`). Free-text fields, mostly empty
+ * under auto inventory mode; `hardware` is the most reliable device-facts source
+ * (vendor/model/OS as an SNMP sysDescr-style string).
+ */
+export interface ZabbixInventory {
+  hardware?: string
+  vendor?: string
+  model?: string
+  os?: string
+  serialno_a?: string
+  location?: string
+  [key: string]: string | undefined
+}
+
 export interface ZabbixHost {
   hostid: string
   host: string
   name: string
+  /** '0' = monitored, '1' = unmonitored. */
   status: string
   interfaces?: ZabbixHostInterface[]
+  /** Present when `host.get` is called with `selectHostGroups`. */
+  hostgroups?: ZabbixHostGroup[]
+  /** Present when `host.get` is called with `selectParentTemplates`. */
+  parentTemplates?: ZabbixParentTemplate[]
+  /** Present when `host.get` is called with `selectInventory`. */
+  inventory?: ZabbixInventory
+}
+
+// ============================================
+// Sysmap (network map) API types — standard `map.get` shapes only.
+// https://www.zabbix.com/documentation/7.0/en/manual/api/reference/map/object
+// ============================================
+
+/** Element reference inside a `selement.elements` array (varies by elementtype). */
+export interface ZabbixSelementRef {
+  hostid?: string
+  groupid?: string
+  triggerid?: string
+  sysmapid?: string
+}
+
+/**
+ * A map element (`selement`). `elementtype`: '0' host, '1' map (submap),
+ * '2' trigger, '3' host group, '4' image. `elementsubtype` '1' on a host-group
+ * element means "separate hosts" (the group is drawn as an area of its hosts).
+ */
+export interface ZabbixSelement {
+  selementid: string
+  elementtype: string
+  elementsubtype?: string
+  label?: string
+  x?: string
+  y?: string
+  iconid_off?: string
+  elements?: ZabbixSelementRef[]
+}
+
+/** A map link between two selements. */
+export interface ZabbixMapLink {
+  linkid: string
+  selementid1: string
+  selementid2: string
+  /** '0' line, '2' bold, '3' dotted, '4' dashed. */
+  drawtype?: string
+  /** Hex color without '#', e.g. '0000FF'. */
+  color?: string
+  label?: string
+}
+
+/** A Zabbix sysmap (network map) from `map.get`. */
+export interface ZabbixSysmap {
+  sysmapid: string
+  name: string
+  width?: string
+  height?: string
+  selements?: ZabbixSelement[]
+  links?: ZabbixMapLink[]
 }
 
 export interface ZabbixItem {


### PR DESCRIPTION
Closes #341.

Makes the Zabbix plugin a **topology source that generates nodes + links from
standard Zabbix data** — no dependency on Zabbix maps or the custom netmap/L2DM
module, and no direct SNMP reach from shumoku (Zabbix stays the collector).

> Supersedes the initial map-import approach (the first commit on this branch).
> Rebuilt by cross-referencing the Zabbix 7.0 API spec, the live `zabbix-test`
> instance, and the human-built ShowNet sysmaps (used only as a rendering reference).

## What it does

| source | → |
|--------|---|
| `host.get` (scoped by host group) | **nodes** — keyed on `name` (the real hostname; `host.host` is the mgmt IP in this data) |
| per-host **LLDP-MIB** neighbor items (`lldp.rem.*` / `lldp.loc.*`) | **links** |
| `PARENT` host-tag (fallback where LLDP saw no neighbor) | **links** |
| host groups (honoring the `/` nesting convention) | **subgraphs** |
| `inventory.{type,vendor,model}` → parse `inventory.hardware` / SNMP `sysDescr` | **device type / vendor / model** |

Per-attachment `optionsSchema` → `optionsJson`: `hostGroups` (scope, `optionsSource:'hostgroup'`),
`groupBy`, `groupExclude`, `includeExternalNeighbors`, `parentTag`.

## Verified end-to-end against zabbix-test (Zabbix 7.0.23)

- Full instance: 1386 nodes → **43 host-group subgraphs** with correct membership
  (Backbone Routers 63 / Service 78 / Data Center 71 / …).
- Scoped to one host group (`hostGroups:["98"]`): clean **63 nodes / 67 links**,
  device-type icons resolved from sysDescr, rendered in the web compound view.

## Core change (note for review)

`layout/auto-placement/flat-tree/compound.ts` now **honors a source's explicit
subgraphs** (`node.parent`) instead of always banding by hostname domain. Principle:
*grouping — including nesting — is each plugin's responsibility; the layout faithfully
renders the plugin's subgraphs.* The hostname-domain banding remains as the fallback
when a node has no `parent`.

> **TTDB impact:** topologies that set explicit subgraphs now render those instead
> of domain bands. 290 core layout tests pass; worth a visual sanity-check on TTDB
> before/after merge.

Also required setting `metadata.hostname` on host nodes so the compound layout
doesn't treat link-less hosts (the majority — only backbone gear has LLDP) as
information-less *ghosts* and dump them into the "未マップ" grid.

## Tests

- `libs/plugins/zabbix/src/topology.test.ts` — 10 converter unit tests (identity,
  sysDescr type, structured inventory, `/`-nesting, most-specific group, LLDP
  links + mirror de-dup, PARENT links + dedup, external nodes, `groupBy:'none'`).
- biome clean · zabbix typecheck clean · core 290/290 · server-web svelte-check 0/0.

## Deferred follow-ups (to file as issues)

- [ ] Catalog-based device icons + plugin `sysObjectID` (option B) — type/icon best done downstream via catalog.
- [ ] Configurable LLDP key prefix / OID for non-L2DM templates (v1 auto-detects the common one).
- [ ] Mapping page scale — virtualize the node list + lazy host picker (freezes at ~1386 hosts).
- [ ] Host-group filter UX — searchable combobox (names → ids), fix freeSolo/id mismatch.
- [ ] Un-scoped "import everything" handling — junk groups (dummy_hosts, contributor demo, 監視対象外, catch-all auto-register).

## Design doc

`apps/server/docs/design/zabbix-lldp-topology.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
