### PR TITLE
feat(mapping): SNMP interface keys + sysName & cross-vocab interface matching

### DIFF
--- a/apps/server/web/src/lib/auto-mapping.test.ts
+++ b/apps/server/web/src/lib/auto-mapping.test.ts
@@ -398,4 +398,56 @@ describe('matchNodeToHost', () => {
     const hosts = [{ id: 'h1', name: 'core-rtr-01', identity: { mgmtIp: '10.0.0.11' } }]
     expect(matchNodeToHost(node, hosts)).toBeNull()
   })
+
+  it('matches via sysName when the display label does not match', () => {
+    // node label is a human name; sysName is the real hostname Zabbix knows
+    const node = { label: 'DL380 Gen12-1', identity: { sysName: 'dl380-1.dc' } }
+    const hosts = [{ id: 'h1', name: '172.16.0.5', displayName: 'dl380-1.dc' }]
+    const m = matchNodeToHost(node, hosts)
+    expect(m?.host.id).toBe('h1')
+    expect(m?.via).toBe('name')
+  })
+})
+
+// ============================================
+// TTDB speed-prefix normalization + cross-vocabulary interface matching
+// ============================================
+
+describe('speed-prefix normalization', () => {
+  it('normalizes TTDB 100G (hg) to the hundred-gig group', () => {
+    const r = normalizeInterfaceName('hg-1/0/49')
+    expect(r.prefix).toBe('hundredge')
+    expect(r.numbers).toEqual([1, 0, 49])
+  })
+
+  it('normalizes TTDB 10G (xg) to the ten-gig group', () => {
+    expect(normalizeInterfaceName('xg-1/1/1').prefix).toBe('te')
+  })
+
+  it('normalizes truncated/spaced Zabbix SNMP names', () => {
+    const r = normalizeInterfaceName('HundredGigabitEther 1/0/49')
+    expect(r.prefix).toBe('hundredge')
+    expect(r.numbers).toEqual([1, 0, 49])
+  })
+
+  it('matches hg-1/0/49 to "HundredGigabitEther 1/0/49"', () => {
+    const m = findBestInterfaceMatch('hg-1/0/49', [
+      'HundredGigabitEther 1/0/49',
+      'HundredGigabitEther 1/0/50',
+    ])
+    expect(m).toBe('HundredGigabitEther 1/0/49')
+  })
+})
+
+describe('findBestInterfaceMatch cross-vocabulary number fallback', () => {
+  it('matches a speed-prefixed port to a type-named one by unique port number', () => {
+    // hg-1/5 (TTDB 100G) ↔ Ethernet1/5 (Nexus): no shared prefix, unique number
+    const m = findBestInterfaceMatch('hg-1/5', ['Ethernet1/3', 'Ethernet1/5', 'Ethernet1/6'])
+    expect(m).toBe('Ethernet1/5')
+  })
+
+  it('refuses the number fallback when the port number is ambiguous', () => {
+    // ge-0/1 and xe-0/1 are different physical ports sharing a number → skip
+    expect(findBestInterfaceMatch('hg-0/1', ['ge-0/1', 'xe-0/1'])).toBeNull()
+  })
 })

--- a/apps/server/web/src/lib/auto-mapping.ts
+++ b/apps/server/web/src/lib/auto-mapping.ts
@@ -22,10 +22,25 @@ import { type Identity, nodeIdentityKeys } from '@shumoku/core'
 // ============================================
 
 const PREFIX_GROUPS: [string[], string][] = [
-  [['hundredgigabitethernet', 'hundredgige', 'hu'], 'hundredge'],
-  [['fortygigabitethernet', 'fortygige', 'fo'], 'fortyge'],
+  // Speed prefixes carry vendor full names, common abbreviations, and TTDB's
+  // speed-coded forms (eg = 1G, xg = 10G, fg = 40G, hg = 100G, fhg = 400G,
+  // ehg = 800G). Zabbix SNMP sometimes truncates the vendor word
+  // ("HundredGigabitEther"), so the truncated spelling is listed too.
+  [
+    ['eighthundredgigabitethernet', 'eighthundredgigabitether', 'eighthundredgige', 'ehg'],
+    'eighthundredge',
+  ],
+  [
+    ['fourhundredgigabitethernet', 'fourhundredgigabitether', 'fourhundredgige', 'fhg'],
+    'fourhundredge',
+  ],
+  [['hundredgigabitethernet', 'hundredgigabitether', 'hundredgige', 'hu', 'hg'], 'hundredge'],
+  [['fortygigabitethernet', 'fortygigabitether', 'fortygige', 'fo', 'fg'], 'fortyge'],
   [['twentyfivegigabitethernet', 'twentyfivegige'], 'twentyfivege'],
-  [['tengigabitethernet', 'tengigaethernet', 'tenge', 'te', 'xge', 'xe'], 'te'],
+  [
+    ['tengigabitethernet', 'tengigabitether', 'tengigaethernet', 'tenge', 'te', 'xge', 'xe', 'xg'],
+    'te',
+  ],
   [['gigabitethernet', 'gigaethernet', 'gi', 'ge'], 'ge'],
   [['fastethernet', 'fa', 'fe'], 'fe'],
   [['ethernet', 'ens', 'enp', 'eno', 'eth', 'en'], 'eth'],
@@ -191,6 +206,18 @@ export function findBestInterfaceMatch(
 
   if (bestScore >= threshold) return bestCandidate
 
+  // Cross-vocabulary fallback: a port named by speed class (TTDB's hg/xg/fhg…)
+  // and one named by media/type (`Ethernet1/5`, `et-0/0/0`, `swp0`) share no
+  // canonical prefix, so the score above is 0 even for the same physical port —
+  // but the port NUMBER aligns. Match on the number sequence, and only when
+  // exactly one candidate carries it, so genuinely ambiguous cases (a chassis
+  // exposing `ge-0/1` and `xe-0/1`) fall through instead of mis-binding.
+  if (norm.numbers.length > 0) {
+    const want = norm.numbers.join('/')
+    const numHits = candidates.filter((c) => normalizeInterfaceName(c).numbers.join('/') === want)
+    if (numHits.length === 1) return numHits[0] ?? null
+  }
+
   // Fallback: single candidate → assume it's the same physical port
   if (opts.singleCandidateFallback && candidates.length === 1) {
     return candidates[0] ?? null
@@ -335,12 +362,19 @@ export function matchNodeToHost<H extends MatchableHost>(
   hosts: readonly H[],
 ): NodeHostMatch<H> | null {
   const nodeLabel = Array.isArray(node.label) ? node.label[0] : node.label
+  // Try both the display label and the discovered sysName as the node's name:
+  // a device's sysName ("dl380-1.dc") often matches a monitoring host's visible
+  // name even when the human label ("DL380 Gen12-1") doesn't.
+  const nodeNames = [nodeLabel, node.identity?.sysName].filter((s): s is string => !!s)
 
   let best: { host: H; total: number; identity: number; name: number } | null = null
   let topCount = 0
   for (const host of hosts) {
     const identity = identityMatchScore(node, host)
-    const name = nodeLabel ? nodeNameMatchScore(nodeLabel, host.name, host.displayName) : 0
+    const name = nodeNames.reduce(
+      (max, n) => Math.max(max, nodeNameMatchScore(n, host.name, host.displayName)),
+      0,
+    )
     const total = identity + name * NAME_TIEBREAK_WEIGHT
     if (!best || total > best.total) {
       best = { host, total, identity, name }

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -312,30 +312,71 @@ export class ZabbixPlugin
     return (main ?? withIp[0])?.ip
   }
 
+  /**
+   * Item-key prefixes that carry per-interface traffic counters, paired with
+   * the direction they represent. Covers Zabbix Agent (`net.if.in/out`) and the
+   * standard SNMP templates network gear actually uses — `ifHCInOctets` /
+   * `ifHCOutOctets` (64-bit) and `ifInOctets` / `ifOutOctets` (32-bit). Without
+   * the SNMP keys, interface lookup returns nothing for SNMP-monitored
+   * switches/routers and link mapping can never resolve.
+   */
+  private static readonly TRAFFIC_KEY_DIRECTIONS: ReadonlyArray<readonly [string, 'in' | 'out']> = [
+    ['net.if.in', 'in'],
+    ['net.if.out', 'out'],
+    ['ifHCInOctets', 'in'],
+    ['ifHCOutOctets', 'out'],
+    ['ifInOctets', 'in'],
+    ['ifOutOctets', 'out'],
+  ]
+
+  /** Substrings passed to `item.get` search to pull every traffic item. */
+  private static readonly TRAFFIC_KEY_SEARCH = ZabbixPlugin.TRAFFIC_KEY_DIRECTIONS.map(([k]) => k)
+
+  /** Traffic direction a counter key represents, or null if it isn't one. */
+  private static trafficDirection(key: string): 'in' | 'out' | null {
+    for (const [prefix, dir] of ZabbixPlugin.TRAFFIC_KEY_DIRECTIONS) {
+      if (key.startsWith(prefix)) return dir
+    }
+    return null
+  }
+
+  /**
+   * Resolve the interface a traffic item belongs to. Both Agent and SNMP
+   * templates put the interface name in the key bracket
+   * (`net.if.in[eth0]`, `ifHCInOctets[GigabitEthernet1/0/1]`), sometimes with a
+   * trailing " (alias)" — strip that. Fall back to parsing the item name.
+   */
+  private static interfaceNameOf(key: string, name: string): string {
+    const bracket = key.match(/\[(.+)\]/)?.[1]
+    if (bracket) return bracket.replace(/\s*\([^)]*\)\s*$/, '').trim()
+    return ZabbixPlugin.extractInterfaceName(name)
+  }
+
   async getHostItems(hostId: string): Promise<HostItem[]> {
     // Fetch only network interface traffic items (net.if.in / net.if.out)
     const items = await this.apiRequest<ZabbixItem[]>('item.get', {
       output: ['itemid', 'hostid', 'name', 'key_', 'lastvalue', 'units'],
       hostids: [hostId],
-      search: { key_: ['net.if.in', 'net.if.out'] },
+      search: { key_: ZabbixPlugin.TRAFFIC_KEY_SEARCH },
       searchByAny: true,
       filter: { status: '0', state: '0' },
     })
 
-    return items.map((item) => {
-      const ifName = ZabbixPlugin.extractInterfaceName(item.name)
-      const isIn = item.key_.startsWith('net.if.in')
-
-      return {
-        id: item.itemid,
-        hostId: item.hostid,
-        name: item.name,
-        key: item.key_,
-        lastValue: item.lastvalue,
-        unit: (item as ZabbixItem & { units?: string }).units,
-        interfaceName: ifName,
-        direction: isIn ? 'in' : 'out',
-      } satisfies HostItem
+    return items.flatMap((item) => {
+      const direction = ZabbixPlugin.trafficDirection(item.key_)
+      if (!direction) return [] // search is a substring match — drop incidental hits
+      return [
+        {
+          id: item.itemid,
+          hostId: item.hostid,
+          name: item.name,
+          key: item.key_,
+          lastValue: item.lastvalue,
+          unit: (item as ZabbixItem & { units?: string }).units,
+          interfaceName: ZabbixPlugin.interfaceNameOf(item.key_, item.name),
+          direction,
+        } satisfies HostItem,
+      ]
     })
   }
 
@@ -903,18 +944,18 @@ export class ZabbixPlugin
 
   /**
    * Get interface traffic items for a host.
-   * Searches by both key pattern and item name to support
-   * agent-based (net.if.in[eth0]) and SNMP-based (net.if.in[ifHCInOctets.N]) items.
+   * Searches Agent (`net.if.in[eth0]`) and SNMP
+   * (`ifHCInOctets[GigabitEthernet1/0/1]`) counter keys and matches the
+   * requested interface by the name resolved from each item's key bracket.
    */
   async getInterfaceItems(
     hostId: string,
     interfaceName?: string,
   ): Promise<{ in: HostItem | null; out: HostItem | null }> {
-    // Fetch all net.if.in / net.if.out items for this host
     const items = await this.apiRequest<ZabbixItem[]>('item.get', {
       output: ['itemid', 'hostid', 'name', 'key_', 'lastvalue'],
       hostids: [hostId],
-      search: { key_: ['net.if.in', 'net.if.out'] },
+      search: { key_: ZabbixPlugin.TRAFFIC_KEY_SEARCH },
       searchByAny: true,
       filter: { status: '0', state: '0' },
     })
@@ -923,12 +964,12 @@ export class ZabbixPlugin
     let outItem: HostItem | null = null
 
     for (const item of items) {
-      // Match by interface name extracted from item name (works for both agent and SNMP)
-      if (interfaceName) {
-        const extractedName = ZabbixPlugin.extractInterfaceName(item.name)
-        if (extractedName !== interfaceName) {
-          continue
-        }
+      const direction = ZabbixPlugin.trafficDirection(item.key_)
+      if (!direction) continue
+
+      // Match by interface name resolved from the key (works for Agent + SNMP)
+      if (interfaceName && ZabbixPlugin.interfaceNameOf(item.key_, item.name) !== interfaceName) {
+        continue
       }
 
       const hostItem: HostItem = {
@@ -939,11 +980,8 @@ export class ZabbixPlugin
         lastValue: item.lastvalue,
       }
 
-      if (item.key_.startsWith('net.if.in')) {
-        inItem = hostItem
-      } else if (item.key_.startsWith('net.if.out')) {
-        outItem = hostItem
-      }
+      if (direction === 'in') inItem = hostItem
+      else outItem = hostItem
     }
 
     return { in: inItem, out: outItem }


### PR DESCRIPTION
## What

TTDBトポロジ × SNMP監視Zabbix のマッピングが **ノード120/166・リンク0/140** だった件を調査し、3つのギャップを修正。実データ（ShowNet）で同じ画面が **ノード~127・リンク~37** まで解決するようになった。

## 調査で判明した3ギャップ → 修正

### 1. Zabbix: SNMPのインターフェースキー未対応（リンク0の直接原因）
`getHostItems`/`getInterfaceItems` が `net.if.in/out`（Agent流）しか検索しておらず、SNMP監視のネットワーク機器（トラフィックは `ifHCInOctets[<ifName>]`/`ifHCOutOctets`、32bitは `ifInOctets`/`ifOutOctets`）でインターフェース0件 → リンク紐付け不能だった。
- SNMPキーも検索対象に追加、方向はキー接頭辞から判定
- インターフェース名は**キーの`[...]`から抽出**（末尾の` (alias)`除去）。SNMP項目名は `Interface X:` 形式でないため

### 2. ノード: sysName を名前照合に使用（+~11ノード）
`matchNodeToHost` が `node.identity.sysName` も名前候補に（host名＋表示名と照合）。mgmtIpを持たないがホスト名で監視されているサーバー/アプライアンスを回収。

### 3. インターフェース名の語彙差（リンク 20→37）
- `normalizeInterfaceName` に TTDBの速度接頭辞（xg=10G/fg=40G/hg=100G/fhg=400G/ehg=800G）とZabbixの省略形（`HundredGigabitEther`）を追加
- `findBestInterfaceMatch` に**異語彙フォールバック**: 速度名(`hg-1/5`)と型名(`Ethernet1/5`)は正規接頭辞が違うが**ポート番号で一致** → 番号一致が**一意な時だけ**採用（`ge-0/1`vs`xe-0/1`の曖昧は自動スキップ）

## テスト
auto-mapping に7ケース追加（sysName照合 / 速度接頭辞正規化 / 異語彙番号フォールバックの一意・曖昧）。計60 green。typecheck・lint・build 通過。

## 残る未マップ（ツールの限界ではなくデータ起因）
- Zabbixがそのホストのインターフェースを監視していない（traffic項目なし）
- ポート番号体系が機器側と食い違う / 該当ポートが未監視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
