### PR TITLE
feat(mapping): LLDP neighbour-based link interface resolution (T1)

### DIFF
--- a/apps/server/api/src/api/datasources.ts
+++ b/apps/server/api/src/api/datasources.ts
@@ -307,6 +307,19 @@ export function createDataSourcesApi(): Hono {
     }
   })
 
+  // Get interface neighbours (LLDP/CDP) for a specific host
+  app.get('/:id/hosts/:hostId/neighbors', async (c) => {
+    const id = c.req.param('id')
+    const hostId = c.req.param('hostId')
+    try {
+      const neighbors = await service.getInterfaceNeighbors(id, hostId)
+      return c.json(neighbors)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
+  })
+
   // Discover all metrics for a specific host
   app.get('/:id/hosts/:hostId/metrics', async (c) => {
     const id = c.req.param('id')

--- a/apps/server/api/src/plugins/types.ts
+++ b/apps/server/api/src/plugins/types.ts
@@ -29,6 +29,7 @@ export {
   hasMetricsCapability,
   hasNativeApi,
   hasTopologyCapability,
+  type InterfaceNeighbor,
   type LinkMetrics,
   type LinkMetricsMapping,
   type MetricsCapable,

--- a/apps/server/api/src/services/datasource.ts
+++ b/apps/server/api/src/services/datasource.ts
@@ -19,6 +19,7 @@ import type {
   DiscoveredMetric,
   Host,
   HostItem,
+  InterfaceNeighbor,
 } from '../plugins/types.js'
 import type { DataSource, DataSourceInput, DataSourceStatus, DataSourceType } from '../types.js'
 
@@ -309,6 +310,19 @@ export class DataSourceService {
     }
 
     return plugin.getHostItems?.(hostId) || []
+  }
+
+  /**
+   * Get interface neighbours (LLDP/CDP) for a host from a data source
+   * (if supported). Used by link mapping to resolve a link's interface.
+   */
+  async getInterfaceNeighbors(id: string, hostId: string): Promise<InterfaceNeighbor[]> {
+    const plugin = this.getPlugin(id)
+    if (!plugin || !hasHostsCapability(plugin)) {
+      return []
+    }
+
+    return plugin.getInterfaceNeighbors?.(hostId) || []
   }
 
   /**

--- a/apps/server/docs/design/link-interface-resolution.md
+++ b/apps/server/docs/design/link-interface-resolution.md
@@ -88,8 +88,9 @@ LLDP also reports the remote port (`Ethernet 25`, `FourHundredGigE0/0/0/12`),
 which feeds T1's parallel-link disambiguation. The same device's `ifAlias`
 independently encodes the peer (`hg-25.thunder7465-1.noc`) — a secondary signal
 where LLDP is absent. Fuzzy T3 alone resolved 37/140 links on this topology
-(see `feat(mapping): SNMP interface keys …`, PR #351); T1 is expected to lift
-the LLDP-covered subset to near-complete.
+(PR #351); adding T1 (PR #353) lifts a Zabbix-sourced topology (test4) to 54/66
+— 52 via LLDP neighbour, 2 via name — where the remaining gap is data (hosts
+Zabbix doesn't monitor for interface traffic).
 
 ## Failure modes / contract (must address before relying on link metrics)
 
@@ -106,10 +107,23 @@ the LLDP-covered subset to near-complete.
 ## Status / next
 
 - T3 (fuzzy + speed-prefix + number fallback) — **shipped** (PR #351).
-- T1 (LLDP) — **validated** on live data (above); not yet implemented. Highest
-  value next step; the Zabbix plugin already parses LLDP for topology
-  (`zabbix-lldp-topology.md`), so the neighbour table is in reach.
+- T1 (LLDP neighbour, with remote-port disambiguation) — **shipped** (PR #353):
+  a `getInterfaceNeighbors` capability (Zabbix reuses its LLDP parse),
+  `matchInterfaceByNeighbor`, and link auto-map tries it before T3. The mapping
+  UI loads interfaces + neighbours for mapped hosts before matching.
 - T0 (port identity) — needs sources to stamp `NodePort.identity`; blocked on
   TTDB (and any abstract-port source) emitting ifName/ifIndex.
+
+### Open follow-ups
+
+- **Metrics-poll performance** (not yet addressed): the server polls *all* DB
+  topologies every cycle, and `pollMetrics` issues per-node (`item.get` +
+  `host.get`) and per-link (`getInterfaceItems` + `getItemsByIds`) calls, so a
+  poll fans out to hundreds–thousands of Zabbix requests and can overrun the
+  interval (`Skipping metrics poll — previous poll still running`). Candidate
+  fixes: poll only subscribed topologies; batch node health by `hostids`; cache
+  interface resolution per host within a poll.
 - Before wiring link metrics broadly, fix the **polarity (B1)** and
   **counter/rate (B2)** contract.
+- Derive `NAME_TIEBREAK_WEIGHT` from the weakest identity weight instead of the
+  hardcoded `0.9` (the "name never outranks identity" invariant is comment-only).

--- a/apps/server/docs/design/link-interface-resolution.md
+++ b/apps/server/docs/design/link-interface-resolution.md
@@ -1,0 +1,115 @@
+# Link → interface resolution
+
+How a topology **link** binds to the **interface counter** a metrics source
+exposes, so the weathermap can colour the link by utilization.
+
+This is the link-level analogue of node→host identity matching
+(`matchNodeToHost`). It exists because mapping by interface *name* alone is
+brittle: every system names the same physical port differently (TTDB speed
+codes `hg-1/0/49`, Cisco `GigabitEthernet1/0/49`, Juniper `et-0/0/0`, AlaxalA
+`port1.26`, Zabbix SNMP truncations `HundredGigabitEther 1/0/49`). Chasing that
+with a synonym table is endless.
+
+## The problem decomposes into two joins
+
+A topology link is `A:portX ↔ B:portY`. With nodes already mapped to hosts
+(`A → hostA`, `B → hostB`, by identity — see `topology-foundation-identity.md`):
+
+1. **Node join** — topology node → metrics host. Solved by identity
+   (mgmtIp / chassisId / sysName).
+2. **Port join** — topology port → metrics interface, *on that device*. This doc.
+
+The port join is the hard part: it is a correspondence between two naming /
+identity systems for the **same device's** interfaces.
+
+## Key insight: a link already knows its peer
+
+The current fuzzy matcher scores `portX`'s *name* against hostA's interface
+names in isolation — and throws away the fact that we know the link goes to **B**.
+The peer is the strongest disambiguator we have. Two mechanisms exploit it:
+
+- **LLDP neighbour table** — the device itself reports, per local interface, the
+  neighbour it sees (`lldp.rem.sysname[<localIf>]`, `lldp.rem.port.id[...]`).
+  For link `A↔B` we look up the local interface on A whose neighbour is B. No
+  port-name matching at all.
+- **Port identity** — if the topology port carries `ifName` / `ifIndex` / `mac`,
+  it joins to the metrics interface deterministically (both sides speak SNMP).
+
+## Tiered resolution algorithm
+
+For a link `A:portX ↔ B:portY`, try each endpoint (A first, then B); within an
+endpoint, take the highest tier that resolves:
+
+```
+T0  Port identity      portX.identity.ifIndex|ifName|mac == an interface on hostA  (exact)
+T1  LLDP + remote port hostA LLDP: neighbour ≈ B AND remotePortId ≈ portY → localIf
+T2  LLDP single        exactly one hostA interface faces B → that one
+T3  Name fuzzy         normalizeInterfaceName(portX) vs hostA interface names,
+                       with the cross-vocabulary number fallback (last resort)
+```
+
+- **T1 before T2** so parallel links / LAGs (A and B joined by N cables) are
+  disambiguated by the *remote* port, not left ambiguous.
+- **T3** is the current `findBestInterfaceMatch` (speed-prefix synonyms +
+  unique-number fallback). It stays as the floor for sources with no identity
+  and no LLDP.
+- Resolution yields `(host, ifName)`; persist that, plus the **orientation**
+  (see Failure modes B1).
+
+### Why this generalises across metrics sources
+
+| Source | Port identity | LLDP | Counter |
+| --- | --- | --- | --- |
+| Zabbix (SNMP) | ifName (key bracket), ifIndex | `lldp.rem.*[localIf]` | bps **or raw octets** (template-dependent) |
+| Prometheus (snmp_exporter) | `ifName` / `ifIndex` / `ifDescr` labels | lldp module | raw counter → `rate()` |
+| Aruba Instant On | port number only | usually none | API value |
+| NetBox (topology source) | explicit interface-level **cables** | — | n/a |
+
+The unifying move: **stamp port identity (ifName/ifIndex/mac) onto the topology
+link's endpoints at discovery time**, the way nodes carry `Identity`. Core
+already has `NodePort.identity` and `portIdentityKeys`. Then T0 resolves on every
+metrics source by the same key and fuzzy name matching becomes a degenerate
+fallback. NetBox cables and SNMP/LLDP discovery already know connectivity at the
+interface level; TTDB is the outlier that emits abstract port names only.
+
+## Evidence (ShowNet, live Zabbix)
+
+`mx301.noc` (Juniper) — 4 topology links, all resolved by T1 with **zero** name
+matching, despite the TTDB ↔ Juniper vocabulary gap:
+
+```
+fhg-0-0-22  peer cisco8711-32fh.noc   → et-0/0/22   (LLDP neighbour)
+hg-0-0-1    peer thunder7465-1.noc    → et-0/0/1
+fhg-0-0-12  peer ptx10002-36qdd.noc   → et-0/0/12
+xg-0-0-14   peer thunder7465-2.noc    → xe-0/0/14
+```
+
+LLDP also reports the remote port (`Ethernet 25`, `FourHundredGigE0/0/0/12`),
+which feeds T1's parallel-link disambiguation. The same device's `ifAlias`
+independently encodes the peer (`hg-25.thunder7465-1.noc`) — a secondary signal
+where LLDP is absent. Fuzzy T3 alone resolved 37/140 links on this topology
+(see `feat(mapping): SNMP interface keys …`, PR #351); T1 is expected to lift
+the LLDP-covered subset to near-complete.
+
+## Failure modes / contract (must address before relying on link metrics)
+
+| # | Issue | Severity | Mitigation |
+| --- | --- | --- | --- |
+| B1 | **Direction polarity** — picking A's interface vs B's flips in/out; the weathermap arrow can point the wrong way | High | Orient by `link.from`; store the chosen side + an inversion flag, or always emit in/out relative to link direction |
+| B2 | **Counter vs rate** — `ifHCInOctets` is sometimes a raw octet counter, not bps; reading `lastvalue` as bps then explodes utilization. (Verified bps on this Zabbix, but template/Prometheus-dependent) | High | Inspect units; accept only rate items, else convert counter→rate. Metrics contract: **links return directional bps** |
+| B3 | **Sub-interfaces / logical units** (`et-0/0/0.211`, `bme0.0`) inflate the candidate set, defeating the unique-number fallback and risking a logical-IF match | Medium | Prefer physical interfaces; drop `.`/`:` logical units or fold by base port |
+| B4 | **LAG / parallel links** — logical (`ae`/`Po`) vs member double-counting; T2 ambiguity | Medium | Use T1 remote-port; prefer the logical aggregate when the link is the aggregate |
+| B5 | **ifIndex instability** across reboots (see identity doc) | Medium | ifIndex for same-scan joins; ifName for cross-time / cross-rescan |
+| B6 | **LLDP remote id formats** — chassisId as MAC vs string, sysName FQDN vs short | Low | Reuse node identity matching to normalise the remote id |
+| B7 | **No LLDP on the peer** (servers/appliances) | Low | Fall through to T3 |
+
+## Status / next
+
+- T3 (fuzzy + speed-prefix + number fallback) — **shipped** (PR #351).
+- T1 (LLDP) — **validated** on live data (above); not yet implemented. Highest
+  value next step; the Zabbix plugin already parses LLDP for topology
+  (`zabbix-lldp-topology.md`), so the neighbour table is in reach.
+- T0 (port identity) — needs sources to stamp `NodePort.identity`; blocked on
+  TTDB (and any abstract-port source) emitting ifName/ifIndex.
+- Before wiring link metrics broadly, fix the **polarity (B1)** and
+  **counter/rate (B2)** contract.

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -101,6 +101,7 @@ import type {
   DiscoveredMetric,
   Host,
   HostItem,
+  InterfaceNeighbor,
 } from './types'
 
 // Data Sources API
@@ -156,6 +157,9 @@ export const dataSources = {
 
   getHostItems: (id: string, hostId: string) =>
     request<HostItem[]>(`/datasources/${id}/hosts/${hostId}/items`),
+
+  getInterfaceNeighbors: (id: string, hostId: string) =>
+    request<InterfaceNeighbor[]>(`/datasources/${id}/hosts/${hostId}/neighbors`),
 
   discoverMetrics: (id: string, hostId: string) =>
     request<DiscoveredMetric[]>(`/datasources/${id}/hosts/${hostId}/metrics`),

--- a/apps/server/web/src/lib/auto-mapping.test.ts
+++ b/apps/server/web/src/lib/auto-mapping.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   findBestInterfaceMatch,
   interfaceMatchScore,
+  matchInterfaceByNeighbor,
   matchNodeToHost,
   nodeNameMatchScore,
   normalizeInterfaceName,
@@ -449,5 +450,47 @@ describe('findBestInterfaceMatch cross-vocabulary number fallback', () => {
   it('refuses the number fallback when the port number is ambiguous', () => {
     // ge-0/1 and xe-0/1 are different physical ports sharing a number → skip
     expect(findBestInterfaceMatch('hg-0/1', ['ge-0/1', 'xe-0/1'])).toBeNull()
+  })
+})
+
+describe('matchInterfaceByNeighbor', () => {
+  const peer = {
+    label: 'Switch B',
+    identity: { sysName: 'sw-b.dc', chassisId: 'AA:BB:CC:00:11:22' },
+  }
+
+  it('resolves the local interface facing the peer by sysName', () => {
+    const neighbors = [
+      { localInterface: 'et-0/0/1', remoteSysName: 'other.dc' },
+      { localInterface: 'et-0/0/9', remoteSysName: 'sw-b.dc' },
+    ]
+    expect(matchInterfaceByNeighbor(peer, 'hg-3', neighbors)).toBe('et-0/0/9')
+  })
+
+  it('matches by chassisId when the sysName differs', () => {
+    const neighbors = [{ localInterface: 'et-0/0/5', remoteChassisId: 'aa:bb:cc:00:11:22' }]
+    expect(matchInterfaceByNeighbor(peer, undefined, neighbors)).toBe('et-0/0/5')
+  })
+
+  it('returns null when no neighbour is the peer', () => {
+    const neighbors = [{ localInterface: 'et-0/0/1', remoteSysName: 'somewhere-else' }]
+    expect(matchInterfaceByNeighbor(peer, 'hg-3', neighbors)).toBeNull()
+  })
+
+  it('disambiguates parallel links to the same peer by the remote port', () => {
+    const neighbors = [
+      { localInterface: 'et-0/0/1', remoteSysName: 'sw-b.dc', remotePortId: 'Ethernet1/1' },
+      { localInterface: 'et-0/0/2', remoteSysName: 'sw-b.dc', remotePortId: 'Ethernet1/2' },
+    ]
+    // peer port hg-1/2 → Ethernet1/2 (number-aligned) → et-0/0/2
+    expect(matchInterfaceByNeighbor(peer, 'hg-1/2', neighbors)).toBe('et-0/0/2')
+  })
+
+  it('stays ambiguous (null) for parallel links with no distinguishing remote port', () => {
+    const neighbors = [
+      { localInterface: 'et-0/0/1', remoteSysName: 'sw-b.dc' },
+      { localInterface: 'et-0/0/2', remoteSysName: 'sw-b.dc' },
+    ]
+    expect(matchInterfaceByNeighbor(peer, undefined, neighbors)).toBeNull()
   })
 })

--- a/apps/server/web/src/lib/auto-mapping.ts
+++ b/apps/server/web/src/lib/auto-mapping.ts
@@ -15,7 +15,7 @@
  *   NetBox "GE0/0"  ↔  Zabbix "GigaEthernet0"  (UNIVERGE IX)
  */
 
-import { type Identity, nodeIdentityKeys } from '@shumoku/core'
+import { type Identity, type InterfaceNeighbor, nodeIdentityKeys } from '@shumoku/core'
 
 // ============================================
 // Interface name prefix synonyms
@@ -396,4 +396,69 @@ export function matchNodeToHost<H extends MatchableHost>(
   // host at the top score (source-priority order via the strict `>` above).
   if (best.name < NODE_MATCH_THRESHOLD) return null
   return { host: best.host, via: 'name' }
+}
+
+// ============================================
+// Link → interface resolution via neighbour discovery (LLDP/CDP)
+// ============================================
+
+/** The far-end node of a link, as the matcher needs to recognise it. */
+export interface MatchablePeer {
+  identity?: Identity
+  label?: string | string[]
+}
+
+/** True if two device names refer to the same host (exact or domain-stripped). */
+function sameDeviceName(a: string | undefined, b: string | undefined): boolean {
+  return !!a && !!b && nodeNameMatchScore(a, b) >= 0.9
+}
+
+/**
+ * Resolve which local interface faces `peer` using a host's neighbour table —
+ * the deterministic, naming-agnostic alternative to interface-name matching.
+ *
+ * A link `A↔B` asks A's neighbours for the one whose remote end is B (matched
+ * by sysName / chassisId / mgmtIp, or the peer's label). When several local
+ * interfaces face B (a LAG or parallel links), `peerPort` disambiguates via the
+ * neighbour's `remotePortId`. Returns null if no neighbour matches or the
+ * choice stays ambiguous — callers fall back to name matching.
+ */
+export function matchInterfaceByNeighbor(
+  peer: MatchablePeer,
+  peerPort: string | undefined,
+  neighbors: readonly InterfaceNeighbor[],
+): string | null {
+  if (neighbors.length === 0) return null
+
+  const peerLabel = Array.isArray(peer.label) ? peer.label[0] : peer.label
+  const peerSys = peer.identity?.sysName
+  const peerChassis = peer.identity?.chassisId?.toLowerCase()
+  const peerMgmt = peer.identity?.mgmtIp
+
+  const facesPeer = (n: InterfaceNeighbor): boolean => {
+    if (n.remoteChassisId && peerChassis && n.remoteChassisId.toLowerCase() === peerChassis) {
+      return true
+    }
+    const rs = n.remoteSysName
+    if (rs && (sameDeviceName(rs, peerSys) || sameDeviceName(rs, peerLabel) || rs === peerMgmt)) {
+      return true
+    }
+    return false
+  }
+
+  const hits = neighbors.filter(facesPeer)
+  if (hits.length === 0) return null
+  if (hits.length === 1) return hits[0]?.localInterface ?? null
+
+  // Parallel links / LAG: disambiguate by the peer's own port id.
+  if (peerPort) {
+    const remotePorts = hits.map((n) => n.remotePortId).filter((p): p is string => !!p)
+    const bestRemote = findBestInterfaceMatch(peerPort, remotePorts)
+    if (bestRemote) {
+      const picked = hits.filter((n) => n.remotePortId === bestRemote)
+      if (picked.length === 1) return picked[0]?.localInterface ?? null
+    }
+  }
+
+  return null // ambiguous → fall back to name matching
 }

--- a/apps/server/web/src/lib/stores/index.ts
+++ b/apps/server/web/src/lib/stores/index.ts
@@ -19,6 +19,7 @@ export {
 export {
   hostInterfaces,
   hostInterfacesLoading,
+  hostNeighbors,
   linkMapping,
   type MappingHost,
   mappingError,

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -21,7 +21,14 @@ import { derived, get, writable } from 'svelte/store'
 import { api } from '$lib/api'
 import { matchNodeToHost } from '$lib/auto-mapping'
 import { topologies } from '$lib/stores/topologies'
-import type { Host, HostItem, MetricsMapping, Topology, TopologyDataSource } from '$lib/types'
+import type {
+  Host,
+  HostItem,
+  InterfaceNeighbor,
+  MetricsMapping,
+  Topology,
+  TopologyDataSource,
+} from '$lib/types'
 
 /**
  * A `Host` annotated with its origin data source. Web-local — does not
@@ -51,6 +58,8 @@ interface MappingState {
   // Interfaces per host (hostId -> interfaces)
   hostInterfaces: Record<string, HostItem[]>
   hostInterfacesLoading: Record<string, boolean>
+  // LLDP/CDP neighbours per host (hostId -> neighbours), for link auto-map
+  hostNeighbors: Record<string, InterfaceNeighbor[]>
   loading: boolean
   hostsLoading: boolean
   error: string | null
@@ -63,6 +72,7 @@ const initialState: MappingState = {
   metricsSources: [],
   hostInterfaces: {},
   hostInterfacesLoading: {},
+  hostNeighbors: {},
   loading: false,
   hostsLoading: false,
   error: null,
@@ -290,6 +300,16 @@ function createMappingStore() {
         hostInterfacesLoading: { ...s.hostInterfacesLoading, [hostId]: true },
       }))
 
+      // Fetch neighbours alongside interfaces — link auto-map prefers the LLDP
+      // neighbour (which local interface faces the peer) over name matching.
+      // A neighbour fetch failure must not block interface loading.
+      api.dataSources
+        .getInterfaceNeighbors(sourceId, hostId)
+        .then((neighbors) =>
+          update((s) => ({ ...s, hostNeighbors: { ...s.hostNeighbors, [hostId]: neighbors } })),
+        )
+        .catch(() => {})
+
       try {
         const items = await api.dataSources.getHostItems(sourceId, hostId)
         // Filter to unique interface names (remove :in/:out suffix)
@@ -415,3 +435,4 @@ export const mappingHosts = derived(mappingStore, ($s) => $s.hosts)
 export const metricsSources = derived(mappingStore, ($s) => $s.metricsSources)
 export const hostInterfaces = derived(mappingStore, ($s) => $s.hostInterfaces)
 export const hostInterfacesLoading = derived(mappingStore, ($s) => $s.hostInterfacesLoading)
+export const hostNeighbors = derived(mappingStore, ($s) => $s.hostNeighbors)

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -300,18 +300,15 @@ function createMappingStore() {
         hostInterfacesLoading: { ...s.hostInterfacesLoading, [hostId]: true },
       }))
 
-      // Fetch neighbours alongside interfaces — link auto-map prefers the LLDP
-      // neighbour (which local interface faces the peer) over name matching.
-      // A neighbour fetch failure must not block interface loading.
-      api.dataSources
-        .getInterfaceNeighbors(sourceId, hostId)
-        .then((neighbors) =>
-          update((s) => ({ ...s, hostNeighbors: { ...s.hostNeighbors, [hostId]: neighbors } })),
-        )
-        .catch(() => {})
-
       try {
-        const items = await api.dataSources.getHostItems(sourceId, hostId)
+        // Fetch interfaces and LLDP/CDP neighbours together so both are ready
+        // when this resolves — link auto-map prefers the neighbour (which local
+        // interface faces the peer) and falls back to name matching. A neighbour
+        // fetch failure must not fail interface loading.
+        const [items, neighbors] = await Promise.all([
+          api.dataSources.getHostItems(sourceId, hostId),
+          api.dataSources.getInterfaceNeighbors(sourceId, hostId).catch(() => []),
+        ])
         // Filter to unique interface names (remove :in/:out suffix)
         const interfaceNames = new Set<string>()
         const interfaces: HostItem[] = []
@@ -336,6 +333,7 @@ function createMappingStore() {
         update((s) => ({
           ...s,
           hostInterfaces: { ...s.hostInterfaces, [hostId]: interfaces },
+          hostNeighbors: { ...s.hostNeighbors, [hostId]: neighbors },
           hostInterfacesLoading: { ...s.hostInterfacesLoading, [hostId]: false },
         }))
       } catch {

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -31,6 +31,7 @@ export type {
   Host,
   HostItem,
   Identity,
+  InterfaceNeighbor,
   LinkMetricsMapping,
   MetricsMapping,
   NodeMetricsMapping,

--- a/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
@@ -177,7 +177,7 @@
     return [info.interfaceName, info.label, ...(info.aliases ?? [])].filter((n): n is string => !!n)
   }
 
-  function loadInterfacesForMappedNodes() {
+  async function loadInterfacesForMappedNodes() {
     const hostIds = new Set<string>()
     for (const edge of edges) {
       const fromHostId = $nodeMapping[edge.from.nodeId]?.hostId
@@ -185,7 +185,7 @@
       if (fromHostId) hostIds.add(fromHostId)
       if (toHostId) hostIds.add(toHostId)
     }
-    for (const hostId of hostIds) mappingStore.loadHostInterfaces(hostId)
+    await Promise.all([...hostIds].map((hostId) => mappingStore.loadHostInterfaces(hostId)))
   }
 
   function handleNodeMappingChange(nodeId: string, hostId: string) {
@@ -203,6 +203,10 @@
       ...mappingStore.autoMapNodes(parsedTopology.graph.nodes, { overwrite: false }),
       kind: 'nodes',
     }
+    // Load interfaces + neighbours for the freshly mapped hosts so a following
+    // link auto-map has data to match against (bulk node mapping doesn't load
+    // them the way the per-node dropdown does).
+    void loadInterfacesForMappedNodes()
     scheduleClearAutoMapResult()
   }
 
@@ -535,7 +539,11 @@
             <Button
               variant="outline"
               size="sm"
-              onclick={() => {
+              onclick={async () => {
+                // Make sure interfaces + neighbours are loaded for the mapped
+                // hosts before matching, so link auto-map works even right after
+                // a bulk node auto-map (interfaces load lazily).
+                await loadInterfacesForMappedNodes()
                 const matched = handleAutoMapLinks()
                 if (matched > 0) {
                   autoMapResult = { matched, total: edges.length, kind: 'links' }

--- a/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
@@ -22,9 +22,16 @@
   } from 'phosphor-svelte'
   import { onMount } from 'svelte'
   import { api } from '$lib/api'
-  import { findBestInterfaceMatch } from '$lib/auto-mapping'
+  import { findBestInterfaceMatch, matchInterfaceByNeighbor } from '$lib/auto-mapping'
   import { Button } from '$lib/components/ui/button'
-  import { hostInterfaces, linkMapping, mappingHosts, mappingStore, nodeMapping } from '$lib/stores'
+  import {
+    hostInterfaces,
+    hostNeighbors,
+    linkMapping,
+    mappingHosts,
+    mappingStore,
+    nodeMapping,
+  } from '$lib/stores'
   import type { MetricsData } from '$lib/stores/metrics'
   import type { EdgeEndpoint, Identity, MetricsMapping } from '$lib/types'
   import { nodeLabelById, nodeLabel as resolveNodeLabel } from '$lib/utils/node-label'
@@ -268,6 +275,38 @@
     }
   }
 
+  function nodeForMapping(nodeId: string): { identity?: Identity; label?: string | string[] } {
+    return parsedTopology?.graph.nodes.find((n) => n.id === nodeId) ?? {}
+  }
+
+  /**
+   * Resolve one endpoint's interface: LLDP neighbour first (which local
+   * interface faces the peer), then fuzzy port-name matching. A neighbour hit
+   * is only accepted when it maps to a monitored interface so the link polls.
+   */
+  function resolveLinkInterface(
+    hostId: string | undefined,
+    side: EdgeEndpoint,
+    peerNodeId: string,
+    peerPort: string | undefined,
+    interfaces: Array<{ name: string }>,
+  ): string | null {
+    if (!hostId || interfaces.length === 0) return null
+    const names = interfaces.map((i) => i.name)
+    const neighborIf = matchInterfaceByNeighbor(
+      nodeForMapping(peerNodeId),
+      peerPort,
+      $hostNeighbors[hostId] ?? [],
+    )
+    if (neighborIf) {
+      const resolved = names.includes(neighborIf)
+        ? neighborIf
+        : findBestInterfaceMatch(neighborIf, names, { singleCandidateFallback: false })
+      if (resolved) return resolved
+    }
+    return findMatchingInterface(portMatchCandidates(side), interfaces)
+  }
+
   function handleAutoMapLinks() {
     let matched = 0
     for (const edge of edges) {
@@ -279,21 +318,24 @@
       if (currentMapping.interface) continue
 
       let monitoredNodeId: string | null = null
-      let matchedInterface: string | null = null
-
-      if (fromHostId && fromInterfaces.length > 0) {
-        const match = findMatchingInterface(portMatchCandidates(edge.from), fromInterfaces)
-        if (match) {
-          monitoredNodeId = edge.from.nodeId
-          matchedInterface = match
-        }
-      }
-      if (!matchedInterface && toHostId && toInterfaces.length > 0) {
-        const match = findMatchingInterface(portMatchCandidates(edge.to), toInterfaces)
-        if (match) {
-          monitoredNodeId = edge.to.nodeId
-          matchedInterface = match
-        }
+      let matchedInterface = resolveLinkInterface(
+        fromHostId,
+        edge.from,
+        edge.to.nodeId,
+        edge.to.port,
+        fromInterfaces,
+      )
+      if (matchedInterface) {
+        monitoredNodeId = edge.from.nodeId
+      } else {
+        matchedInterface = resolveLinkInterface(
+          toHostId,
+          edge.to,
+          edge.from.nodeId,
+          edge.from.port,
+          toInterfaces,
+        )
+        if (matchedInterface) monitoredNodeId = edge.to.nodeId
       }
       if (!matchedInterface) {
         if (fromHostId && fromInterfaces.length > 0) monitoredNodeId = edge.from.nodeId

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -88,7 +88,7 @@ accordingly.
 | Mixin              | Purpose                                                | Methods                              |
 |--------------------|--------------------------------------------------------|--------------------------------------|
 | `TopologyCapable`  | Provide a `NetworkGraph` (nodes, links, subgraphs)     | `fetchTopology`, `watchTopology?`    |
-| `HostsCapable`     | List the monitored hosts so the mapping UI can choose  | `getHosts`, `getHostItems?`, `searchHosts?`, `discoverMetrics?` |
+| `HostsCapable`     | List the monitored hosts so the mapping UI can choose  | `getHosts`, `getHostItems?`, `getInterfaceNeighbors?`, `searchHosts?`, `discoverMetrics?` |
 | `MetricsCapable`   | Poll current metrics for mapped nodes/links            | `pollMetrics`, `subscribeMetrics?`   |
 | `AlertsCapable`    | Surface active/resolved alerts                         | `getAlerts`                          |
 | `NativeApiCapable` | Dev-only raw API passthrough for debugging             | `nativeApi(method, params)`          |

--- a/libs/@shumoku/core/src/plugin-types.ts
+++ b/libs/@shumoku/core/src/plugin-types.ts
@@ -78,6 +78,24 @@ export interface HostItem {
 }
 
 /**
+ * A device's view of what sits on the far end of one of its interfaces,
+ * derived from neighbour discovery (LLDP/CDP). Lets link mapping bind a
+ * topology link `A↔B` to the exact interface on A that faces B — by the peer's
+ * identity, not by fuzzy interface-name matching. Plugins translate their
+ * upstream's neighbour data into this neutral shape.
+ */
+export interface InterfaceNeighbor {
+  /** Local interface the neighbour is seen on (matches `HostItem.interfaceName`). */
+  localInterface: string
+  /** Neighbour's system name (e.g. LLDP remote sysName), if reported. */
+  remoteSysName?: string
+  /** Neighbour's chassis id (e.g. LLDP remote chassisId), if reported. */
+  remoteChassisId?: string
+  /** Neighbour's own port id/name, for disambiguating parallel links. */
+  remotePortId?: string
+}
+
+/**
  * A metric discovered from a data source for a specific host.
  *
  * The "All metrics" tab in the mapping UI dumps these for browsing —
@@ -301,6 +319,13 @@ export interface HostsCapable {
    * Get items for a specific host
    */
   getHostItems?(hostId: string): Promise<HostItem[]>
+
+  /**
+   * Get neighbour discovery (LLDP/CDP) for a host's interfaces, so link
+   * mapping can resolve which local interface faces a given peer. Optional —
+   * plugins implement it only when the upstream exposes neighbour data.
+   */
+  getInterfaceNeighbors?(hostId: string): Promise<InterfaceNeighbor[]>
 
   /**
    * Search hosts by name

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -19,6 +19,7 @@ import type {
   HostItem,
   HostsCapable,
   Identity,
+  InterfaceNeighbor,
   LinkMetricsMapping,
   MetricsCapable,
   MetricsData,
@@ -378,6 +379,21 @@ export class ZabbixPlugin
         } satisfies HostItem,
       ]
     })
+  }
+
+  /**
+   * Neighbour discovery for a host's interfaces, from Zabbix's LLDP items
+   * (reuses the same `lldp.rem.*` parse as topology import). Lets link mapping
+   * resolve the local interface facing a peer without interface-name fuzzing.
+   */
+  async getInterfaceNeighbors(hostId: string): Promise<InterfaceNeighbor[]> {
+    const { neighborsByHostId } = await this.fetchLldpData([hostId])
+    return (neighborsByHostId.get(hostId) ?? []).map((n) => ({
+      localInterface: n.localIf,
+      ...(n.remSysname ? { remoteSysName: n.remSysname } : {}),
+      ...(n.remChassisId ? { remoteChassisId: n.remChassisId } : {}),
+      ...(n.remPortId ? { remotePortId: n.remPortId } : {}),
+    }))
   }
 
   async searchHosts(query: string): Promise<Host[]> {


### PR DESCRIPTION
## What

設計doc の **T1（LLDP近傍ベースのリンク→インターフェース解決）を実装**。リンク `A↔B` を、A の近傍テーブルから「B に向くローカルインターフェース」で特定する。ポート名のfuzzy照合を介さないので、命名語彙の差（TTDB `fhg-0-0-22` ↔ Juniper `et-0/0/22`）を**完全に回避**。

設計doc（#352から取り込み、本PRに統合）も含む。**#352 はクローズ可**。

## Changes（層ごと）

- **core**: `HostsCapable.getInterfaceNeighbors?(hostId)` + neutral型 `InterfaceNeighbor`（localInterface + remote sysName/chassisId/portId）
- **zabbix**: 既存のトポロジ生成と同じ `lldp.rem.*` パース（`fetchLldpData`）を再利用して実装
- **api**: service メソッド + `/datasources/:id/hosts/:hostId/neighbors`
- **web**: mappingストアが近傍をインターフェースと一緒にロード。`matchInterfaceByNeighbor` が remote==peer（sysName/chassisId/mgmtIp）でローカルIFを特定、**並列リンク/LAGは remotePortId で絞り込み**。`handleAutoMapLinks` は近傍を先に試し、**監視対象IFに解決できた時だけ採用**、ダメなら従来のfuzzyへフォールバック

## 解決階層（設計通り）
```
T1 LLDP近傍(+remPort)  ← 本PRで実装、決定的・語彙非依存
T3 名前fuzzy           ← #351で実装済み、フォールバック
（T0 ポートidentity は将来：ソースが ifName/ifIndex を出せば）
```

## 検証（実機 ShowNet）
140リンク中 **46解決（近傍28・fuzzy18）**。近傍28は fuzzy では取れない語彙差ケースを決定的に解決、並列リンクにも強い。未解決は端点未マップ/IF未監視/LLDP無しのデータ起因。

テスト: `matchInterfaceByNeighbor` に5ケース追加（sysName/chassisId一致・非一致・並列のremPort絞り込み・曖昧null）。計65 green。typecheck/lint/build 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
