### PR TITLE
docs(server): bring DB docs to as-built after composition-store

### DIFF
--- a/apps/server/docs/database.md
+++ b/apps/server/docs/database.md
@@ -5,39 +5,44 @@ Shumoku Server uses SQLite (via `bun:sqlite`) for persistent storage. The databa
 ## Overview
 
 ```
-┌─────────────────┐     ┌─────────────────────────┐     ┌─────────────────┐
-│  data_sources   │     │  topology_data_sources  │     │   topologies    │
-│─────────────────│     │─────────────────────────│     │─────────────────│
-│ id (PK)         │◄────│ data_source_id (FK)     │     │ id (PK)         │
-│ name            │     │ topology_id (FK)        │────►│ name            │
-│ type            │     │ purpose                 │     │ content_json    │
-│ config_json     │     │ sync_mode               │     │ mapping_json    │
-│ status          │     │ ...                     │     │ ...             │
-│ ...             │     └─────────────────────────┘     └─────────────────┘
-└─────────────────┘
-                                                        ┌─────────────────┐
-                                                        │   dashboards    │
-                                                        │─────────────────│
-                                                        │ id (PK)         │
-                                                        │ name            │
-                                                        │ layout_json     │
-                                                        └─────────────────┘
+┌─────────────────┐     ┌─────────────────────────┐     ┌──────────────────────┐
+│  data_sources   │     │  topology_data_sources  │     │      topologies      │
+│─────────────────│     │─────────────────────────│     │──────────────────────│
+│ id (PK)         │◄────│ data_source_id (FK)     │     │ id (PK)              │
+│ name            │     │ topology_id (FK)        │────►│ name                 │
+│ type            │     │ purpose (topology|      │     │ share_token          │
+│ config_json     │     │          metrics)       │     │ composition_revision │
+│ status …        │     │ sync_mode, priority …   │     │ created_at, updated… │
+└─────────────────┘     └─────────────────────────┘     └──────────────────────┘
+   ▲  type='manual' rows hold the authored graph at config_json.graph
+   │
+   │   ┌──────────────────────────┐     ┌──────────────────────────┐
+   └───│  topology_observations   │     │  topology_resolved_graph │
+       │──────────────────────────│     │──────────────────────────│
+       │ id (PK)                  │     │ topology_id (PK, FK)     │
+       │ topology_id (FK)         │     │ graph_json               │
+       │ source_id (FK)           │     │ layout_json              │
+       │ captured_at, status      │     │ icon_dimensions_json     │
+       │ graph_json (snapshot)    │     │ built_revision           │
+       │ node/link/port_count     │     │ resolver_version         │
+       └──────────────────────────┘     │ computed_at              │
+        one per source-scan (history)   └──────────────────────────┘
+                                          derived artifact, 1 per topology
 
-                                                        ┌─────────────────┐
-                                                        │    settings     │
-                                                        │─────────────────│
-                                                        │ key (PK)        │
-                                                        │ value           │
-                                                        └─────────────────┘
-
-                                                        ┌─────────────────┐
-                                                        │   migrations    │
-                                                        │─────────────────│
-                                                        │ id (PK)         │
-                                                        │ name (UNIQUE)   │
-                                                        │ applied_at      │
-                                                        └─────────────────┘
+┌─────────────┐  ┌────────────┐  ┌──────────────────────────────┐
+│ dashboards  │  │  settings  │  │ migrations (id, name, applied)│
+└─────────────┘  └────────────┘  └──────────────────────────────┘
+(+ auth / share-token / grafana-alert tables — see migrations 005-007)
 ```
+
+**Composition model (since the composition-store refactor):** a topology is a
+shell; its sources live in `topology_data_sources` (m2m, by purpose); each
+source's scans are appended to `topology_observations`; the human-authored graph
+lives on the Manual source's `config_json.graph`; `resolve()` folds these into
+the displayed graph, which is materialized in `topology_resolved_graph` and
+invalidated by `composition_revision`. The **metrics mapping** is no longer a
+column — it is `metrics-binding` attachments on the resolved graph (see
+`docs/design/topology-composition-store.md`).
 
 ## Tables
 
@@ -86,47 +91,55 @@ External data source connections (Zabbix, NetBox, Prometheus, etc.)
 
 ### topologies
 
-Network topology definitions with optional metrics mapping.
+Topology **shell** only. Graph content lives in observations / the Manual
+source; the metrics mapping lives as `metrics-binding` attachments on the
+resolved graph (no column). Legacy columns `content_json` (dropped m010),
+`topology_source_id` / `metrics_source_id` / `mapping_json` (dropped in the
+composition-store refactor) are gone.
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | TEXT (PK) | Unique identifier (nanoid) |
 | `name` | TEXT | Topology name |
-| `content_json` | TEXT | Multi-file YAML content (see below) |
-| `topology_source_id` | TEXT (FK) | Data source for topology sync (optional) |
-| `metrics_source_id` | TEXT (FK) | Data source for metrics (optional) |
-| `mapping_json` | TEXT | Node/Link to monitoring host mapping (JSON) |
+| `share_token` | TEXT | Public-share token (NULL when not shared) |
+| `composition_revision` | INTEGER | Bumped on any composition input change; invalidates the materialized resolved graph (O(1)) |
 | `created_at` | INTEGER | Creation timestamp (ms) |
 | `updated_at` | INTEGER | Last update timestamp (ms) |
 
-**content_json format:**
+### topology_observations
 
-```json
-{
-  "files": [
-    { "name": "main.yaml", "content": "name: My Network\nnodes:\n  - id: router1\n..." },
-    { "name": "campus.yaml", "content": "name: Campus\nnodes:\n..." }
-  ]
-}
-```
+One row per source-scan snapshot (append-only history; retention enforced on
+write). `resolve()` folds the latest non-failed snapshot per source plus the
+authored graph into the displayed graph.
 
-**mapping_json format (ZabbixMapping):**
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | TEXT (PK) | Unique identifier (nanoid) |
+| `topology_id` | TEXT (FK) | Reference to topologies.id |
+| `source_id` | TEXT (FK) | Reference to data_sources.id |
+| `captured_at` | INTEGER | Scan/capture timestamp (ms) |
+| `status` | TEXT | `ok` \| `partial` \| `failed` \| `empty` |
+| `status_message` | TEXT | Optional message for status != ok |
+| `graph_json` | TEXT | Serialized NetworkGraph (NULL when failed) |
+| `node_count` / `link_count` / `port_count` | INTEGER | Cheap counters for list/debug |
+| `created_at` | INTEGER | Row creation timestamp (ms) |
 
-```json
-{
-  "nodes": {
-    "router1": { "hostId": "prometheus-hostname-or-zabbix-hostid" },
-    "switch1": { "hostId": "switch1.example.com" }
-  },
-  "links": {
-    "link-0": {
-      "monitoredNodeId": "router1",
-      "interface": "ge-0/0/1",
-      "bandwidth": 1000000000
-    }
-  }
-}
-```
+### topology_resolved_graph
+
+Materialized resolver output (1 per topology) so reads/polls skip
+re-resolve + re-layout. Served only when `built_revision` equals the topology's
+current `composition_revision` and `resolver_version` matches the code constant;
+otherwise recomputed.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `topology_id` | TEXT (PK, FK) | Reference to topologies.id |
+| `graph_json` | TEXT | Resolved NetworkGraph |
+| `layout_json` | TEXT | `computeNetworkLayout()` output `{layout, resolved}` (Map-aware encoded) |
+| `icon_dimensions_json` | TEXT | Resolved icon dimensions (entries) |
+| `built_revision` | INTEGER | `composition_revision` this was built from |
+| `resolver_version` | INTEGER | Resolve/layout algorithm version |
+| `computed_at` | INTEGER | Build timestamp (ms) |
 
 ### topology_data_sources
 
@@ -141,7 +154,9 @@ Junction table for topology-datasource relationships (many-to-many).
 | `sync_mode` | TEXT | `manual`, `on_view`, or `webhook` |
 | `webhook_secret` | TEXT | Secret for webhook validation (optional) |
 | `last_synced_at` | INTEGER | Last sync timestamp (ms) |
-| `priority` | INTEGER | Priority order (higher = preferred) |
+| `priority` | INTEGER | Priority order (lower number = higher precedence in the resolver field-merge) |
+| `consecutive_failures` | INTEGER | Retraction hysteresis counter |
+| `last_ok_captured_at` | INTEGER | Last successful capture timestamp (ms) |
 | `created_at` | INTEGER | Creation timestamp (ms) |
 | `updated_at` | INTEGER | Last update timestamp (ms) |
 
@@ -182,13 +197,16 @@ Tracks applied database migrations.
 
 | Index | Table | Columns |
 |-------|-------|---------|
-| `idx_topologies_topology_source` | topologies | topology_source_id |
-| `idx_topologies_metrics_source` | topologies | metrics_source_id |
 | `idx_topologies_name` | topologies | name |
 | `idx_data_sources_name` | data_sources | name |
 | `idx_data_sources_type` | data_sources | type |
 | `idx_topology_data_sources_topology` | topology_data_sources | topology_id |
 | `idx_topology_data_sources_source` | topology_data_sources | data_source_id |
+| `idx_topology_observations_topology_source` | topology_observations | topology_id, source_id, captured_at DESC |
+| `idx_topology_observations_captured_at` | topology_observations | captured_at |
+
+(`idx_topologies_topology_source` / `idx_topologies_metrics_source` were dropped
+with their columns in the composition-store refactor.)
 
 ## Migrations
 
@@ -199,6 +217,16 @@ Schema migrations use numbered SQL files in `src/db/migrations/`. On startup, th
 | `001_initial.sql` | Initial schema (tables, indexes) |
 | `002_health_check.sql` | Health check status fields for data_sources |
 | `003_topology_data_sources.sql` | Junction table for many-to-many relationships |
+| `004_topology_source_options.sql` | Per-attachment options |
+| `005_auth.sql` / `006_share_tokens.sql` / `007_grafana_alerts.sql` | Auth, share tokens, alerts |
+| `008_topology_observations.sql` | Observation snapshots + hysteresis columns |
+| `010_manual_as_source.sql` / `011_manual_graph_to_config.sql` | Authored content → Manual source (content_json dropped) |
+| `012_resolved_graph_cache.sql` | `composition_revision` + `topology_resolved_graph` |
+| `013_drop_legacy_source_columns.sql` | Backfill legacy source pointers → m2m, then drop the columns |
+
+(`009` is intentionally skipped. `mapping_json` is dropped imperatively by the
+startup backfill after migrating it to bindings — not by a SQL migration — since
+the data move needs the resolver.)
 
 **Adding a new migration:**
 
@@ -213,10 +241,12 @@ Schema migrations use numbered SQL files in `src/db/migrations/`. On startup, th
 See `apps/server/src/types.ts` for corresponding TypeScript interfaces:
 
 - `DataSource` - data_sources table
-- `Topology` - topologies table
+- `Topology` - topologies table (shell)
 - `TopologyDataSource` - topology_data_sources table
+- `TopologyObservation` - topology_observations table
 - `Dashboard` - dashboards table
-- `ZabbixMapping` - mapping_json structure
+- `MetricsMapping` (core `plugin-types.ts`) - the mapping shape derived from
+  `metrics-binding` attachments at read/poll time (no longer a stored column)
 
 ## Database Configuration
 

--- a/apps/server/docs/design/topology-foundation-metrics.md
+++ b/apps/server/docs/design/topology-foundation-metrics.md
@@ -2,6 +2,10 @@
 
 > ステータス: ドラフト。`topology-foundation.md` の付属。
 > ユーザの感覚「更新情報やメトリクス情報はログとして残る」を実装するための方針。
+>
+> **更新あり**: 本文の `topologies.mapping_json` は廃止済み。マッピングは
+> 解決済みグラフ上の `metrics-binding` attachment から導出する（保存カラムなし）。
+> as-built は `topology-composition-store.md` / `../database.md` を参照。
 
 ## 0. 現状の穴
 

--- a/apps/server/docs/design/topology-foundation-schema.md
+++ b/apps/server/docs/design/topology-foundation-schema.md
@@ -2,6 +2,12 @@
 
 > ステータス: ドラフト。`topology-foundation.md` の付属。
 > core 型拡張 + DB スキーマの具体形。後方互換は考慮しない。
+>
+> **一部実装済み・更新あり**: ここで計画した `topology_source_id` /
+> `metrics_source_id` の廃止と `mapping_json` の置き換えは composition-store
+> リファクタで実施済み（マッピング = `metrics-binding` attachment、ソース = m2m
+> 一本化、解決済みグラフ = `topology_resolved_graph` にマテリアライズ）。
+> **as-built は `topology-composition-store.md` と `../database.md` を参照。**
 
 ## 1. core 型の拡張
 


### PR DESCRIPTION
Follow-up to #360. The canonical `apps/server/docs/database.md` was stale (predated migration 008) — still listed `content_json` / `mapping_json` / `topology_source_id` / `metrics_source_id` and stopped at migration 003. Updated to as-built: shell `topologies` (share_token + composition_revision), `topology_observations`, `topology_resolved_graph`, corrected indexes + migration list, and the mapping-is-attachments note. Added supersession pointers to the two foundation drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)