### PR TITLE
feat(server): move authored graph to its own store (manual_source_graph)

### DIFF
--- a/apps/server/api/src/api/datasources.ts
+++ b/apps/server/api/src/api/datasources.ts
@@ -249,8 +249,8 @@ export function createDataSourcesApi(): Hono {
       if (!dataSource) {
         return c.json({ error: 'Data source not found' }, 404)
       }
-      // A config edit can change resolve inputs (a Manual source's authored
-      // graph lives in config_json.graph) → invalidate attached topologies.
+      // A config edit can change what a source contributes → defensively
+      // invalidate attached topologies' resolved artifacts.
       getTopologyService().clearCacheForDataSource(id)
       return c.json({
         ...dataSource,

--- a/apps/server/api/src/db/migrations/014_authored_graph_store.sql
+++ b/apps/server/api/src/db/migrations/014_authored_graph_store.sql
@@ -1,0 +1,23 @@
+-- Move the Manual source's authored graph out of `data_sources.config_json.graph`
+-- into its own table. The authored graph is *content*, not connection *config*;
+-- migration 011 stashed it in config_json as an interim home. Give it a real
+-- store keyed by the Manual source id (so it can be shared across topologies).
+--
+-- See issue #361 / apps/server/docs/design/topology-composition-store.md § Phase 4.
+
+CREATE TABLE IF NOT EXISTS manual_source_graph (
+  source_id  TEXT PRIMARY KEY REFERENCES data_sources(id) ON DELETE CASCADE,
+  graph_json TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- Backfill: copy config_json.graph → the table for every Manual source that has one.
+INSERT OR IGNORE INTO manual_source_graph (source_id, graph_json, updated_at)
+SELECT id, json_extract(config_json, '$.graph'), updated_at
+FROM data_sources
+WHERE type = 'manual' AND json_extract(config_json, '$.graph') IS NOT NULL;
+
+-- Strip the graph key from config_json — content no longer lives in config.
+UPDATE data_sources
+SET config_json = json_remove(config_json, '$.graph')
+WHERE type = 'manual' AND json_extract(config_json, '$.graph') IS NOT NULL;

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -19,6 +19,7 @@ import migration010 from './migrations/010_manual_as_source.sql'
 import migration011 from './migrations/011_manual_graph_to_config.sql'
 import migration012 from './migrations/012_resolved_graph_cache.sql'
 import migration013 from './migrations/013_drop_legacy_source_columns.sql'
+import migration014 from './migrations/014_authored_graph_store.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -34,6 +35,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '011_manual_graph_to_config.sql', sql: migration011 },
   { name: '012_resolved_graph_cache.sql', sql: migration012 },
   { name: '013_drop_legacy_source_columns.sql', sql: migration013 },
+  { name: '014_authored_graph_store.sql', sql: migration014 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -5,8 +5,8 @@
  * Storage model: the `topologies` table holds only the topology shell
  * (name, share_token, composition_revision). Sources live in
  * `topology_data_sources` (m2m); per-source graph snapshots in
- * `topology_observations`; the human-authored graph on the Manual source's
- * `config_json.graph`; the metrics mapping as `metrics-binding` attachments on
+ * `topology_observations`; the human-authored graph in `manual_source_graph`
+ * (keyed by the Manual source id); the metrics mapping as `metrics-binding` attachments on
  * the resolved graph (no `mapping_json`); the resolved graph + layout are
  * materialized in `topology_resolved_graph`.
  *
@@ -338,18 +338,16 @@ export class TopologyService {
   ): Promise<{ dataSourceId: string }> {
     const now = timestamp()
     const dsId = await generateId()
-    // Seed config_json with an empty graph so the editor opens on a
-    // blank canvas. Manual content lives here, not in observations
-    // (see migration 011).
-    const emptyConfig = JSON.stringify({
-      graph: { version: '1', nodes: [], links: [] },
-    })
+    // No graph in config_json — the authored graph lives in
+    // `manual_source_graph` (migration 014). An absent row reads as null and
+    // resolve() treats that as an empty authored graph, so the editor still
+    // opens on a blank canvas without seeding anything.
     this.db
       .prepare(
         `INSERT INTO data_sources (id, name, type, config_json, status, fail_count, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(dsId, 'Manual', 'manual', emptyConfig, 'connected', 0, now, now)
+      .run(dsId, 'Manual', 'manual', '{}', 'connected', 0, now, now)
     await this.topologySources.add(topologyId, {
       dataSourceId: dsId,
       purpose,
@@ -1149,50 +1147,49 @@ export class TopologyService {
   // at the API boundary (api/observations.ts) and at resolve() time.
 
   /**
-   * Read the graph stored on a Manual data source 's config_json.
-   * Returns null when the source doesn 't exist, isn 't Manual, or has
-   * no graph (e.g. freshly attached then config cleared by hand).
+   * Read the authored graph for a Manual data source from `manual_source_graph`
+   * (its own store — content, not config; see migration 014). Returns null when
+   * the source doesn't exist, isn't Manual, or has no authored graph yet.
    *
    * Public so the discovery-policy API can compute / mutate the authored
-   * layer without poking the data_sources table directly.
+   * layer without poking the storage directly.
    */
   readManualGraph(sourceId: string): NetworkGraph | null {
+    const src = this.db.query('SELECT type FROM data_sources WHERE id = ?').get(sourceId) as
+      | { type: string }
+      | undefined
+    if (!src || src.type !== 'manual') return null
     const row = this.db
-      .query('SELECT type, config_json FROM data_sources WHERE id = ?')
-      .get(sourceId) as { type: string; config_json: string } | undefined
-    if (!row || row.type !== 'manual') return null
+      .query('SELECT graph_json FROM manual_source_graph WHERE source_id = ?')
+      .get(sourceId) as { graph_json: string } | undefined
+    if (!row) return null
     try {
-      const config = JSON.parse(row.config_json) as { graph?: NetworkGraph }
-      return config.graph ?? null
+      return JSON.parse(row.graph_json) as NetworkGraph
     } catch {
       return null
     }
   }
 
   /**
-   * Persist a new authored graph onto a Manual data source 's config_json.
-   * Preserves any sibling keys we don 't own. Invalidates EVERY topology attached
-   * to this Manual source (the authored graph is source-level content and can be
-   * shared across topologies) so none serves a stale resolved artifact — callers
-   * don't need a separate clearCacheEntry.
+   * Persist a Manual source's authored graph into `manual_source_graph` (upsert).
+   * Invalidates EVERY topology attached to this Manual source (the authored graph
+   * is source-level content and can be shared across topologies) so none serves a
+   * stale resolved artifact — callers don't need a separate clearCacheEntry.
    */
   writeManualGraph(sourceId: string, graph: NetworkGraph): void {
-    const row = this.db
-      .query('SELECT type, config_json FROM data_sources WHERE id = ?')
-      .get(sourceId) as { type: string; config_json: string } | undefined
-    if (!row || row.type !== 'manual') {
+    const src = this.db.query('SELECT type FROM data_sources WHERE id = ?').get(sourceId) as
+      | { type: string }
+      | undefined
+    if (!src || src.type !== 'manual') {
       throw new Error(`Data source ${sourceId} is not a Manual source`)
     }
-    let config: Record<string, unknown> = {}
-    try {
-      config = JSON.parse(row.config_json) as Record<string, unknown>
-    } catch {
-      // Corrupted config — start fresh.
-    }
-    config['graph'] = graph
     this.db
-      .query('UPDATE data_sources SET config_json = ?, updated_at = ? WHERE id = ?')
-      .run(JSON.stringify(config), timestamp(), sourceId)
+      .query(
+        `INSERT INTO manual_source_graph (source_id, graph_json, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(source_id) DO UPDATE SET graph_json = excluded.graph_json, updated_at = excluded.updated_at`,
+      )
+      .run(sourceId, JSON.stringify(graph), timestamp())
     // Fan-out invalidation: this Manual source may be attached to several
     // topologies; all of them must re-resolve.
     this.clearCacheForDataSource(sourceId)

--- a/apps/server/docs/database.md
+++ b/apps/server/docs/database.md
@@ -14,7 +14,7 @@ Shumoku Server uses SQLite (via `bun:sqlite`) for persistent storage. The databa
 │ config_json     │     │          metrics)       │     │ composition_revision │
 │ status …        │     │ sync_mode, priority …   │     │ created_at, updated… │
 └─────────────────┘     └─────────────────────────┘     └──────────────────────┘
-   ▲  type='manual' rows hold the authored graph at config_json.graph
+   ▲  type='manual' rows: authored graph in `manual_source_graph` (by source id)
    │
    │   ┌──────────────────────────┐     ┌──────────────────────────┐
    └───│  topology_observations   │     │  topology_resolved_graph │
@@ -38,7 +38,7 @@ Shumoku Server uses SQLite (via `bun:sqlite`) for persistent storage. The databa
 **Composition model (since the composition-store refactor):** a topology is a
 shell; its sources live in `topology_data_sources` (m2m, by purpose); each
 source's scans are appended to `topology_observations`; the human-authored graph
-lives on the Manual source's `config_json.graph`; `resolve()` folds these into
+lives in `manual_source_graph` (keyed by the Manual source id); `resolve()` folds these into
 the displayed graph, which is materialized in `topology_resolved_graph` and
 invalidated by `composition_revision`. The **metrics mapping** is no longer a
 column — it is `metrics-binding` attachments on the resolved graph (see
@@ -88,6 +88,19 @@ External data source connections (Zabbix, NetBox, Prometheus, etc.)
   "groupBy": "site"
 }
 ```
+
+### manual_source_graph
+
+The authored graph for a Manual data source (content, not config — migration
+014 moved it out of `config_json.graph`). Keyed by the Manual source id so it can
+be shared across topologies. `resolve()` reads it as the top-priority authored
+contribution.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `source_id` | TEXT (PK, FK→data_sources) | The Manual data source |
+| `graph_json` | TEXT | Serialized authored NetworkGraph |
+| `updated_at` | INTEGER | Last edit timestamp (ms) |
 
 ### topologies
 
@@ -223,6 +236,7 @@ Schema migrations use numbered SQL files in `src/db/migrations/`. On startup, th
 | `010_manual_as_source.sql` / `011_manual_graph_to_config.sql` | Authored content → Manual source (content_json dropped) |
 | `012_resolved_graph_cache.sql` | `composition_revision` + `topology_resolved_graph` |
 | `013_drop_legacy_source_columns.sql` | Backfill legacy source pointers → m2m, then drop the columns |
+| `014_authored_graph_store.sql` | Move Manual authored graph `config_json.graph` → `manual_source_graph` table |
 
 (`009` is intentionally skipped. `mapping_json` is dropped imperatively by the
 startup backfill after migrating it to bindings — not by a SQL migration — since


### PR DESCRIPTION
Closes #361. Moves the Manual source's authored graph out of `data_sources.config_json.graph` into a dedicated `manual_source_graph` table (content, not config).

- migration 014: create table + backfill (`json_extract`) + strip (`json_remove`), idempotent (validated vs bun:sqlite).
- readManualGraph/writeManualGraph use the table (the only 2 accessors).
- attachManualSource seeds `config_json '{}'`; fresh Manual reads null → empty authored graph (blank canvas preserved).
- database.md + comments updated.

Validated via bun smokes (migration backfill incl. sibling-key preservation + idempotency; service round-trip; fresh-manual resolve). api 16 + web 0-error green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)