### PR TITLE
feat(server): Manual = uniform data source (authored graph as observations)

### DIFF
--- a/apps/server/api/src/api/discovery-policy.ts
+++ b/apps/server/api/src/api/discovery-policy.ts
@@ -255,7 +255,7 @@ export function createDiscoveryPolicyApi(): Hono {
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
 
     const manualId = await service.ensureManualSource(topologyId)
-    const authored = service.readManualGraph(manualId) ?? {
+    const authored = service.readManualGraph(topologyId, manualId) ?? {
       version: '1' as const,
       name: topology.name,
       nodes: [],
@@ -386,7 +386,7 @@ export function createDiscoveryPolicyApi(): Hono {
       }
     }
 
-    service.writeManualGraph(manualId, next)
+    await service.writeManualGraph(topologyId, manualId, next)
     service.clearCacheEntry(topologyId)
 
     // Recompute the affected effective policy for the response.
@@ -453,7 +453,7 @@ export function createDiscoveryPolicyApi(): Hono {
     const topology = service.get(topologyId)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
     const manualId = await service.ensureManualSource(topologyId)
-    const authored = service.readManualGraph(manualId) ?? {
+    const authored = service.readManualGraph(topologyId, manualId) ?? {
       version: '1' as const,
       name: topology.name,
       nodes: [],
@@ -461,7 +461,7 @@ export function createDiscoveryPolicyApi(): Hono {
     }
     const exclusions = [...(authored.exclusions ?? [])]
     if (!exclusions.some((e) => exclusionKey(e) === exclusionKey(ex))) exclusions.push(ex)
-    service.writeManualGraph(manualId, { ...authored, exclusions })
+    await service.writeManualGraph(topologyId, manualId, { ...authored, exclusions })
     service.clearCacheEntry(topologyId)
     return c.json({ exclusions })
   })
@@ -474,12 +474,12 @@ export function createDiscoveryPolicyApi(): Hono {
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
     const manualId = service.findManualSourceId(topologyId)
     if (!manualId) return c.json({ exclusions: [] })
-    const authored = service.readManualGraph(manualId)
+    const authored = service.readManualGraph(topologyId, manualId)
     if (!authored) return c.json({ exclusions: [] })
     const exclusions = (authored.exclusions ?? []).filter(
       (e) => exclusionKey(e) !== exclusionKey(ex),
     )
-    service.writeManualGraph(manualId, { ...authored, exclusions })
+    await service.writeManualGraph(topologyId, manualId, { ...authored, exclusions })
     service.clearCacheEntry(topologyId)
     return c.json({ exclusions })
   })
@@ -494,7 +494,7 @@ export function createDiscoveryPolicyApi(): Hono {
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
     const manualId = service.findManualSourceId(topologyId)
     if (!manualId) return c.json({ cleared: false, reason: 'no authored layer' })
-    const authored = service.readManualGraph(manualId)
+    const authored = service.readManualGraph(topologyId, manualId)
     if (!authored) return c.json({ cleared: false, reason: 'no authored graph' })
     // Strip overlay: drop attachments from every node/subgraph, the topology
     // default, and all exclusions. Keep the nodes themselves out entirely —
@@ -507,7 +507,7 @@ export function createDiscoveryPolicyApi(): Hono {
       attachments: undefined,
       exclusions: undefined,
     }
-    service.writeManualGraph(manualId, cleared)
+    await service.writeManualGraph(topologyId, manualId, cleared)
     service.clearCacheEntry(topologyId)
     return c.json({ cleared: true })
   })

--- a/apps/server/api/src/api/topology-sources.ts
+++ b/apps/server/api/src/api/topology-sources.ts
@@ -221,6 +221,22 @@ topologySourcesApi.put('/:topologyId/sources', async (c) => {
     if (!ds) {
       return c.json({ error: `Data source ${source.dataSourceId} not found` }, 404)
     }
+    // Manual is per-topology — its authored graph lives in THIS topology's
+    // observations. Reject a Manual that belongs to another topology (sharing it
+    // would make its editor ambiguous); same invariant as the POST attach path.
+    if (ds.type === 'manual') {
+      const attachedElsewhere = getTopologySourcesService()
+        .listByDataSource(source.dataSourceId)
+        .some((t) => t.topologyId !== topologyId)
+      if (attachedElsewhere) {
+        return c.json(
+          {
+            error: 'Manual sources are per-topology; cannot attach one owned by another topology.',
+          },
+          409,
+        )
+      }
+    }
   }
 
   try {

--- a/apps/server/api/src/api/topology-sources.ts
+++ b/apps/server/api/src/api/topology-sources.ts
@@ -105,6 +105,17 @@ topologySourcesApi.post('/:topologyId/sources', async (c) => {
     return c.json({ error: 'Data source not found' }, 404)
   }
 
+  // Manual content is per-topology (its authored graph lives in this topology's
+  // observations). Sharing one Manual across topologies would be ambiguous to
+  // edit, so a Manual is one-per-topology and created fresh (the `type:'manual'`
+  // inline path), never attached as an existing source.
+  if (dataSource.type === 'manual') {
+    return c.json(
+      { error: 'Manual sources are per-topology; create a new one instead of attaching.' },
+      409,
+    )
+  }
+
   // Check if already exists
   const existing = getTopologySourcesService().find(topologyId, body.dataSourceId, body.purpose)
   if (existing) {

--- a/apps/server/api/src/db/migrations/014_manual_graph_to_observations.sql
+++ b/apps/server/api/src/db/migrations/014_manual_graph_to_observations.sql
@@ -9,13 +9,14 @@
 
 -- 1. Move each Manual source's config_json.graph → a fresh observation per
 --    attached topology. `json_valid` guards against malformed config (the
---    migration runner is not transactional). INSERT OR IGNORE = idempotent
---    (derived id is unique per topology; 011 already deleted old manual obs).
+--    migration runner is not transactional). The id is unique per
+--    (topology, source) so multiple Manuals on one topology each survive.
+--    INSERT OR IGNORE = idempotent (011 already deleted old manual obs).
 INSERT OR IGNORE INTO topology_observations
   (id, topology_id, source_id, captured_at, status, graph_json,
    node_count, link_count, port_count, created_at)
 SELECT
-  'obs_man_' || tds.topology_id,
+  'obs_man_' || tds.topology_id || '_' || ds.id,
   tds.topology_id,
   ds.id,
   ds.updated_at,
@@ -32,9 +33,12 @@ WHERE ds.type = 'manual'
   AND json_valid(ds.config_json)
   AND json_extract(ds.config_json, '$.graph') IS NOT NULL;
 
--- 2. Strip the graph from config — content no longer lives in config.
+-- 2. Strip the graph from config — but ONLY for sources whose graph actually
+--    landed in an observation above. A Manual with no topology attachment (or
+--    malformed config) keeps its config.graph rather than losing it silently.
 UPDATE data_sources
 SET config_json = json_remove(config_json, '$.graph')
 WHERE type = 'manual'
   AND json_valid(config_json)
-  AND json_extract(config_json, '$.graph') IS NOT NULL;
+  AND json_extract(config_json, '$.graph') IS NOT NULL
+  AND EXISTS (SELECT 1 FROM topology_observations o WHERE o.source_id = data_sources.id);

--- a/apps/server/api/src/db/migrations/014_manual_graph_to_observations.sql
+++ b/apps/server/api/src/db/migrations/014_manual_graph_to_observations.sql
@@ -1,0 +1,40 @@
+-- Make Manual a uniform data source: its authored graph becomes a per-topology
+-- `topology_observations` snapshot, like every other source — reversing
+-- migration 011 (which parked it in `config_json.graph`) and restoring the shape
+-- of migration 010. The editor's save then records observations like a sync.
+--
+-- See apps/server/docs/design/manual-source-unification.md (#368). No-backcompat:
+-- the source-level content-mirror sharing 011 added is dropped (it was unused —
+-- each topology already owns its Manual source).
+
+-- 1. Move each Manual source's config_json.graph → a fresh observation per
+--    attached topology. `json_valid` guards against malformed config (the
+--    migration runner is not transactional). INSERT OR IGNORE = idempotent
+--    (derived id is unique per topology; 011 already deleted old manual obs).
+INSERT OR IGNORE INTO topology_observations
+  (id, topology_id, source_id, captured_at, status, graph_json,
+   node_count, link_count, port_count, created_at)
+SELECT
+  'obs_man_' || tds.topology_id,
+  tds.topology_id,
+  ds.id,
+  ds.updated_at,
+  'ok',
+  json_extract(ds.config_json, '$.graph'),
+  COALESCE(json_array_length(ds.config_json, '$.graph.nodes'), 0),
+  COALESCE(json_array_length(ds.config_json, '$.graph.links'), 0),
+  0,
+  ds.updated_at
+FROM data_sources ds
+JOIN topology_data_sources tds
+  ON tds.data_source_id = ds.id AND tds.purpose = 'topology'
+WHERE ds.type = 'manual'
+  AND json_valid(ds.config_json)
+  AND json_extract(ds.config_json, '$.graph') IS NOT NULL;
+
+-- 2. Strip the graph from config — content no longer lives in config.
+UPDATE data_sources
+SET config_json = json_remove(config_json, '$.graph')
+WHERE type = 'manual'
+  AND json_valid(config_json)
+  AND json_extract(config_json, '$.graph') IS NOT NULL;

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -19,6 +19,7 @@ import migration010 from './migrations/010_manual_as_source.sql'
 import migration011 from './migrations/011_manual_graph_to_config.sql'
 import migration012 from './migrations/012_resolved_graph_cache.sql'
 import migration013 from './migrations/013_drop_legacy_source_columns.sql'
+import migration014 from './migrations/014_manual_graph_to_observations.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -34,6 +35,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '011_manual_graph_to_config.sql', sql: migration011 },
   { name: '012_resolved_graph_cache.sql', sql: migration012 },
   { name: '013_drop_legacy_source_columns.sql', sql: migration013 },
+  { name: '014_manual_graph_to_observations.sql', sql: migration014 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/discovery-scheduler.ts
+++ b/apps/server/api/src/services/discovery-scheduler.ts
@@ -164,7 +164,7 @@ export function resolveCredentialsForAutoscan(
 ): Record<string, string> {
   const topology = topologyService.get(topologyId)
   if (!topology?.manualSourceId) return {}
-  const graph = topologyService.readManualGraph(topology.manualSourceId)
+  const graph = topologyService.readManualGraph(topologyId, topology.manualSourceId)
   if (!graph) return {}
 
   const subgraphLookup = new Map(
@@ -317,7 +317,7 @@ export class DiscoveryScheduler {
   ): Promise<import('@shumoku/core').Attachment[] | undefined> {
     const topology = this.topologyService.get(topologyId)
     if (!topology?.manualSourceId) return undefined
-    const graph = this.topologyService.readManualGraph(topology.manualSourceId)
+    const graph = this.topologyService.readManualGraph(topologyId, topology.manualSourceId)
     return graph?.attachments
   }
 

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -160,19 +160,22 @@ export class ObservationsService {
    * transient failed scan doesn't drop a source's last-good nodes.
    */
   latestPerSource(topologyId: string): TopologyObservation[] {
+    // ROW_NUMBER (not MAX+join) so a same-millisecond capture_at tie resolves
+    // deterministically to ONE row per source (latest captured, then highest
+    // rowid = insert order) instead of returning both.
     const rows = this.db
       .query(
-        `SELECT t.* FROM topology_observations t
-         INNER JOIN (
-           SELECT source_id, MAX(captured_at) AS latest
-           FROM topology_observations
+        `SELECT * FROM (
+           SELECT t.*,
+                  ROW_NUMBER() OVER (
+                    PARTITION BY source_id ORDER BY captured_at DESC, rowid DESC
+                  ) AS rn
+           FROM topology_observations t
            WHERE topology_id = ?
-           GROUP BY source_id
-         ) m ON m.source_id = t.source_id AND m.latest = t.captured_at
-         WHERE t.topology_id = ?
-         ORDER BY t.captured_at DESC`,
+         ) WHERE rn = 1
+         ORDER BY captured_at DESC`,
       )
-      .all(topologyId, topologyId) as ObservationRow[]
+      .all(topologyId) as ObservationRow[]
     return rows.map(rowToObservation)
   }
 
@@ -187,19 +190,21 @@ export class ObservationsService {
    * is real evidence.
    */
   latestSuccessfulPerSource(topologyId: string): TopologyObservation[] {
+    // ROW_NUMBER tiebreak (see latestPerSource) so same-ms captures resolve to a
+    // single deterministic latest per source.
     const rows = this.db
       .query(
-        `SELECT t.* FROM topology_observations t
-         INNER JOIN (
-           SELECT source_id, MAX(captured_at) AS latest
-           FROM topology_observations
+        `SELECT * FROM (
+           SELECT t.*,
+                  ROW_NUMBER() OVER (
+                    PARTITION BY source_id ORDER BY captured_at DESC, rowid DESC
+                  ) AS rn
+           FROM topology_observations t
            WHERE topology_id = ? AND status != 'failed'
-           GROUP BY source_id
-         ) m ON m.source_id = t.source_id AND m.latest = t.captured_at
-         WHERE t.topology_id = ? AND t.status != 'failed'
-         ORDER BY t.captured_at DESC`,
+         ) WHERE rn = 1
+         ORDER BY captured_at DESC`,
       )
-      .all(topologyId, topologyId) as ObservationRow[]
+      .all(topologyId) as ObservationRow[]
     return rows.map(rowToObservation)
   }
 
@@ -253,7 +258,7 @@ export class ObservationsService {
              SELECT id,
                     ROW_NUMBER() OVER (
                       PARTITION BY topology_id, source_id
-                      ORDER BY captured_at DESC
+                      ORDER BY captured_at DESC, rowid DESC
                     ) AS rn
              FROM topology_observations
              WHERE status != 'failed'
@@ -272,7 +277,7 @@ export class ObservationsService {
              SELECT id,
                     ROW_NUMBER() OVER (
                       PARTITION BY topology_id, source_id
-                      ORDER BY captured_at DESC
+                      ORDER BY captured_at DESC, rowid DESC
                     ) AS rn
              FROM topology_observations
              WHERE status = 'failed'

--- a/apps/server/api/src/services/topology-sources.ts
+++ b/apps/server/api/src/services/topology-sources.ts
@@ -102,6 +102,31 @@ export class TopologySourcesService {
   }
 
   /**
+   * List the attachments of a given data source across ALL topologies. Used to
+   * enforce Manual's one-per-topology invariant (reject sharing a Manual).
+   */
+  listByDataSource(dataSourceId: string): TopologyDataSource[] {
+    const rows = this.db
+      .query(
+        `SELECT
+          tds.*,
+          ds.id as ds_id,
+          ds.name as ds_name,
+          ds.type as ds_type,
+          ds.config_json as ds_config_json,
+          ds.status as ds_status,
+          ds.fail_count as ds_fail_count,
+          ds.created_at as ds_created_at,
+          ds.updated_at as ds_updated_at
+        FROM topology_data_sources tds
+        JOIN data_sources ds ON ds.id = tds.data_source_id
+        WHERE tds.data_source_id = ?`,
+      )
+      .all(dataSourceId) as TopologyDataSourceRow[]
+    return rows.map(rowToTopologyDataSource)
+  }
+
+  /**
    * List data sources by purpose (topology or metrics)
    */
   listByPurpose(topologyId: string, purpose: DataSourcePurpose): TopologyDataSource[] {

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -4,11 +4,11 @@
  *
  * Storage model: the `topologies` table holds only the topology shell
  * (name, share_token, composition_revision). Sources live in
- * `topology_data_sources` (m2m); per-source graph snapshots in
- * `topology_observations`; the human-authored graph on the Manual source's
- * `config_json.graph`; the metrics mapping as `metrics-binding` attachments on
- * the resolved graph (no `mapping_json`); the resolved graph + layout are
- * materialized in `topology_resolved_graph`.
+ * `topology_data_sources` (m2m); per-source graph snapshots — INCLUDING the
+ * Manual source's human-authored graph (the editor's save records one) — in
+ * `topology_observations`; the metrics mapping as `metrics-binding` attachments
+ * on the resolved graph (no `mapping_json`); the resolved graph + layout are
+ * materialized in `topology_resolved_graph`. Manual is a uniform data source.
  *
  * The editor 's "save" routes through this service 's `create()` /
  * `update()` `contentJson` input. Internally that translates to:
@@ -338,18 +338,16 @@ export class TopologyService {
   ): Promise<{ dataSourceId: string }> {
     const now = timestamp()
     const dsId = await generateId()
-    // Seed config_json with an empty graph so the editor opens on a
-    // blank canvas. Manual content lives here, not in observations
-    // (see migration 011).
-    const emptyConfig = JSON.stringify({
-      graph: { version: '1', nodes: [], links: [] },
-    })
+    // Manual has no connection config and no seeded content: its authored graph
+    // is a topology_observations snapshot recorded by the editor's first save.
+    // Until then there's no observation → resolve treats authored as empty (blank
+    // canvas). Config is `{}` like any source with nothing to configure.
     this.db
       .prepare(
         `INSERT INTO data_sources (id, name, type, config_json, status, fail_count, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(dsId, 'Manual', 'manual', emptyConfig, 'connected', 0, now, now)
+      .run(dsId, 'Manual', 'manual', '{}', 'connected', 0, now, now)
     await this.topologySources.add(topologyId, {
       dataSourceId: dsId,
       purpose,
@@ -610,7 +608,7 @@ export class TopologyService {
   ): Promise<void> {
     const manualId = await this.ensureManualSource(topologyId)
     const topology = this.get(topologyId)
-    const authored = this.readManualGraph(manualId) ?? {
+    const authored = this.readManualGraph(topologyId, manualId) ?? {
       version: '1' as const,
       name: topology?.name ?? 'Manual',
       nodes: [],
@@ -715,8 +713,8 @@ export class TopologyService {
     })
     nodes = nodes.filter((n) => !isPureEmptyOverlay(n))
 
-    // writeManualGraph fans out invalidation to every attached topology.
-    this.writeManualGraph(manualId, { ...authored, nodes })
+    // Records a new authored observation for this topology + invalidates it.
+    await this.writeManualGraph(topologyId, manualId, { ...authored, nodes })
   }
 
   /**
@@ -975,19 +973,16 @@ export class TopologyService {
     // drop a source's last-good nodes (C7 — failed never retracts).
     const latest = this.observations.latestSuccessfulPerSource(topology.id)
     const manualId = topology.manualSourceId
-    const authored: NetworkGraph = manualId
-      ? (this.readManualGraph(manualId) ?? {
-          version: '1',
-          name: topology.name,
-          nodes: [],
-          links: [],
-        })
-      : {
-          version: '1',
-          name: topology.name,
-          nodes: [],
-          links: [],
-        }
+    // The authored graph is the Manual source's latest observation — it's just
+    // another snapshot in `latest`, fed to resolve() as the top-priority
+    // contribution. Absent (fresh Manual / no Manual) → empty.
+    const manualGraph = manualId ? latest.find((o) => o.sourceId === manualId)?.graph : undefined
+    const authored: NetworkGraph = manualGraph ?? {
+      version: '1',
+      name: topology.name,
+      nodes: [],
+      links: [],
+    }
     // Source priority feeds the resolver's field merge: when two sources
     // observe the same device, the higher-priority source wins each field it
     // holds. Mirrors `topology_data_sources.priority`. The Manual/authored
@@ -1149,53 +1144,50 @@ export class TopologyService {
   // at the API boundary (api/observations.ts) and at resolve() time.
 
   /**
-   * Read the graph stored on a Manual data source 's config_json.
-   * Returns null when the source doesn 't exist, isn 't Manual, or has
-   * no graph (e.g. freshly attached then config cleared by hand).
+   * Read a Manual source's authored graph for a topology — the latest
+   * observation it recorded against that topology (Manual is a uniform source;
+   * its content is a per-topology observation, not config). Returns null when
+   * there's no observation yet (fresh Manual = blank canvas).
    *
-   * Public so the discovery-policy API can compute / mutate the authored
-   * layer without poking the data_sources table directly.
+   * Public so the discovery-policy API can compute / mutate the authored layer.
    */
-  readManualGraph(sourceId: string): NetworkGraph | null {
+  readManualGraph(topologyId: string, sourceId: string): NetworkGraph | null {
     const row = this.db
-      .query('SELECT type, config_json FROM data_sources WHERE id = ?')
-      .get(sourceId) as { type: string; config_json: string } | undefined
-    if (!row || row.type !== 'manual') return null
+      .query(
+        `SELECT graph_json FROM topology_observations
+         WHERE topology_id = ? AND source_id = ? AND graph_json IS NOT NULL
+         ORDER BY captured_at DESC LIMIT 1`,
+      )
+      .get(topologyId, sourceId) as { graph_json: string } | undefined
+    if (!row) return null
     try {
-      const config = JSON.parse(row.config_json) as { graph?: NetworkGraph }
-      return config.graph ?? null
+      return JSON.parse(row.graph_json) as NetworkGraph
     } catch {
       return null
     }
   }
 
   /**
-   * Persist a new authored graph onto a Manual data source 's config_json.
-   * Preserves any sibling keys we don 't own. Invalidates EVERY topology attached
-   * to this Manual source (the authored graph is source-level content and can be
-   * shared across topologies) so none serves a stale resolved artifact — callers
-   * don't need a separate clearCacheEntry.
+   * Persist a Manual source's authored graph by recording a new observation
+   * against the topology (the human is the "scanner"). resolve() folds the
+   * latest one as the top-priority authored contribution. Per-topology: an edit
+   * to topology X's authored graph only invalidates X.
    */
-  writeManualGraph(sourceId: string, graph: NetworkGraph): void {
-    const row = this.db
-      .query('SELECT type, config_json FROM data_sources WHERE id = ?')
-      .get(sourceId) as { type: string; config_json: string } | undefined
-    if (!row || row.type !== 'manual') {
+  async writeManualGraph(topologyId: string, sourceId: string, graph: NetworkGraph): Promise<void> {
+    const src = this.db.query('SELECT type FROM data_sources WHERE id = ?').get(sourceId) as
+      | { type: string }
+      | undefined
+    if (!src || src.type !== 'manual') {
       throw new Error(`Data source ${sourceId} is not a Manual source`)
     }
-    let config: Record<string, unknown> = {}
-    try {
-      config = JSON.parse(row.config_json) as Record<string, unknown>
-    } catch {
-      // Corrupted config — start fresh.
-    }
-    config['graph'] = graph
-    this.db
-      .query('UPDATE data_sources SET config_json = ?, updated_at = ? WHERE id = ?')
-      .run(JSON.stringify(config), timestamp(), sourceId)
-    // Fan-out invalidation: this Manual source may be attached to several
-    // topologies; all of them must re-resolve.
-    this.clearCacheForDataSource(sourceId)
+    await this.observations.record({
+      topologyId,
+      sourceId,
+      capturedAt: timestamp(),
+      status: 'ok',
+      graph,
+    })
+    this.clearCacheEntry(topologyId)
   }
 
   /**

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -1156,7 +1156,7 @@ export class TopologyService {
       .query(
         `SELECT graph_json FROM topology_observations
          WHERE topology_id = ? AND source_id = ? AND graph_json IS NOT NULL
-         ORDER BY captured_at DESC LIMIT 1`,
+         ORDER BY captured_at DESC, rowid DESC LIMIT 1`,
       )
       .get(topologyId, sourceId) as { graph_json: string } | undefined
     if (!row) return null

--- a/apps/server/docs/database.md
+++ b/apps/server/docs/database.md
@@ -14,7 +14,7 @@ Shumoku Server uses SQLite (via `bun:sqlite`) for persistent storage. The databa
 │ config_json     │     │          metrics)       │     │ composition_revision │
 │ status …        │     │ sync_mode, priority …   │     │ created_at, updated… │
 └─────────────────┘     └─────────────────────────┘     └──────────────────────┘
-   ▲  type='manual' rows hold the authored graph at config_json.graph
+   ▲  type='manual': authored graph = a topology_observations snapshot (uniform source)
    │
    │   ┌──────────────────────────┐     ┌──────────────────────────┐
    └───│  topology_observations   │     │  topology_resolved_graph │
@@ -37,8 +37,9 @@ Shumoku Server uses SQLite (via `bun:sqlite`) for persistent storage. The databa
 
 **Composition model (since the composition-store refactor):** a topology is a
 shell; its sources live in `topology_data_sources` (m2m, by purpose); each
-source's scans are appended to `topology_observations`; the human-authored graph
-lives on the Manual source's `config_json.graph`; `resolve()` folds these into
+source's scans are appended to `topology_observations` — including the Manual
+source's human-authored graph (the editor's save records one; Manual is a uniform
+source, see `docs/design/manual-source-unification.md`); `resolve()` folds these into
 the displayed graph, which is materialized in `topology_resolved_graph` and
 invalidated by `composition_revision`. The **metrics mapping** is no longer a
 column — it is `metrics-binding` attachments on the resolved graph (see
@@ -223,6 +224,7 @@ Schema migrations use numbered SQL files in `src/db/migrations/`. On startup, th
 | `010_manual_as_source.sql` / `011_manual_graph_to_config.sql` | Authored content → Manual source (content_json dropped) |
 | `012_resolved_graph_cache.sql` | `composition_revision` + `topology_resolved_graph` |
 | `013_drop_legacy_source_columns.sql` | Backfill legacy source pointers → m2m, then drop the columns |
+| `014_manual_graph_to_observations.sql` | Manual authored graph `config_json.graph` → per-topology observation (reverses 011); Manual becomes a uniform source |
 
 (`009` is intentionally skipped. `mapping_json` is dropped imperatively by the
 startup backfill after migrating it to bindings — not by a SQL migration — since

--- a/apps/server/docs/design/manual-source-unification.md
+++ b/apps/server/docs/design/manual-source-unification.md
@@ -91,7 +91,7 @@ scan, no capability flags).
 
 ## Migration
 
-`015_manual_graph_to_observations.sql` (reverse of 011, restore 010's shape):
+`014_manual_graph_to_observations.sql` (reverse of 011, restore 010's shape):
 
 ```sql
 -- Move each Manual source's config_json.graph back into a fresh observation.

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -172,18 +172,17 @@
   }
 
   function getConfigFromForm(type: string): string {
-    // Manual stores its graph in config_json. Parse whichever editor pane is
-    // active, then serialise. Everything else serialises the schema-driven
-    // `config` (empty password fields are pruned → the server preserves the
-    // stored secret).
-    if (type === 'manual') {
-      const graph =
-        editorMode === 'yaml'
-          ? new YamlParser().parse(yamlContent).graph
-          : (JSON.parse(jsonContent) as NetworkGraph)
-      return JSON.stringify({ graph })
-    }
+    // Manual has no connection config — its graph is recorded as an observation
+    // (see manualGraphFromEditor / handleSave), not stored in config_json.
+    if (type === 'manual') return '{}'
     return JSON.stringify(pruneEmpty(config))
+  }
+
+  /** Parse the active editor pane (YAML or JSON) into a NetworkGraph. */
+  function manualGraphFromEditor(): NetworkGraph {
+    return editorMode === 'yaml'
+      ? new YamlParser().parse(yamlContent).graph
+      : (JSON.parse(jsonContent) as NetworkGraph)
   }
 
   function pruneEmpty(obj: Record<string, unknown>): Record<string, unknown> {
@@ -258,12 +257,19 @@
           } catch (err) {
             console.warn('[Manual] Failed to list attached topologies:', err)
           }
-          // Seed the editor with the source 's stored graph.
-          const graph = (parsed as { graph?: Record<string, unknown> }).graph ?? {
-            version: '1',
-            nodes: [],
-            links: [],
+          // Manual content is a per-topology observation now (not config_json).
+          // Seed the editor from this source's latest snapshot for its topology.
+          let graph: Record<string, unknown> = { version: '1', nodes: [], links: [] }
+          const topoId = attachedTopologies[0]?.topologyId
+          if (topoId) {
+            try {
+              const snap = await api.topologies.sources.latestSnapshot(topoId, currentId)
+              if (snap?.graph) graph = snap.graph as unknown as Record<string, unknown>
+            } catch (err) {
+              console.warn('[Manual] Failed to load latest snapshot:', err)
+            }
           }
+          if (cancelled) return
           jsonContent = JSON.stringify(graph, null, 2)
           yamlContent = graphToYaml(graph)
         }
@@ -311,6 +317,15 @@
       const updates = {
         name: formName.trim(),
         configJson: getConfigFromForm(dataSource.type),
+      }
+
+      // Manual: persist the drawn graph as an observation against its topology
+      // (the human is the "scanner"); config_json holds no graph.
+      if (dataSource.type === 'manual') {
+        const topoId = attachedTopologies[0]?.topologyId
+        if (topoId) {
+          await api.topologies.sources.recordObservation(topoId, id, manualGraphFromEditor(), 'ok')
+        }
       }
 
       dataSource = await dataSources.update(id, updates)

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -321,16 +321,24 @@
 
       // Manual: persist the drawn graph as an observation against its topology
       // (the human is the "scanner"); config_json holds no graph. The authored
-      // graph is per-topology, so a Manual must be attached to exactly one
-      // topology to be editable here — refuse rather than silently lose the edit.
+      // graph is per-topology, so this editor requires EXACTLY one attached
+      // topology — refuse on none (would silently lose the edit) or many (would
+      // edit an arbitrary one). New sharing is blocked server-side; this guards
+      // any pre-existing shared Manual until the editor moves into the topology
+      // context (#362).
       if (dataSource.type === 'manual') {
-        const topoId = attachedTopologies[0]?.topologyId
-        if (!topoId) {
-          error = 'Attach this Manual source to a topology before editing its content.'
+        if (attachedTopologies.length !== 1) {
+          error =
+            attachedTopologies.length === 0
+              ? 'Attach this Manual source to a topology before editing its content.'
+              : 'This Manual is attached to multiple topologies; edit its content from a topology.'
           saving = false
           return
         }
-        await api.topologies.sources.recordObservation(topoId, id, manualGraphFromEditor(), 'ok')
+        const topoId = attachedTopologies[0]?.topologyId
+        if (topoId) {
+          await api.topologies.sources.recordObservation(topoId, id, manualGraphFromEditor(), 'ok')
+        }
       }
 
       dataSource = await dataSources.update(id, updates)

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -320,12 +320,17 @@
       }
 
       // Manual: persist the drawn graph as an observation against its topology
-      // (the human is the "scanner"); config_json holds no graph.
+      // (the human is the "scanner"); config_json holds no graph. The authored
+      // graph is per-topology, so a Manual must be attached to exactly one
+      // topology to be editable here — refuse rather than silently lose the edit.
       if (dataSource.type === 'manual') {
         const topoId = attachedTopologies[0]?.topologyId
-        if (topoId) {
-          await api.topologies.sources.recordObservation(topoId, id, manualGraphFromEditor(), 'ok')
+        if (!topoId) {
+          error = 'Attach this Manual source to a topology before editing its content.'
+          saving = false
+          return
         }
+        await api.topologies.sources.recordObservation(topoId, id, manualGraphFromEditor(), 'ok')
       }
 
       dataSource = await dataSources.update(id, updates)

--- a/apps/server/web/src/routes/(app)/topologies/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/+page.svelte
@@ -2,7 +2,6 @@
   import { GearSixIcon, PlusIcon, TreeStructureIcon } from 'phosphor-svelte'
   import { onMount } from 'svelte'
   import { goto } from '$app/navigation'
-  import { api } from '$lib/api'
   import { Button } from '$lib/components/ui/button'
   import * as Dialog from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
@@ -35,14 +34,12 @@
     formError = ''
 
     try {
-      // Two-step: create the topology shell, then attach a Manual
-      // source. Manual owns the graph content; the topology row
-      // just owns name / mapping / share state.
+      // A topology is a composition of sources. Create the shell and land on its
+      // Sources tab to add sources (Manual is just one option — no longer
+      // auto-attached; it's created lazily on first edit).
       const topology = await topologies.create({ name })
-      const { dataSourceId } = await api.topologies.sources.attachManual(topology.id)
       showCreateModal = false
-      // Manual content lives on the source itself — edit on /datasources/<id>.
-      await goto(`/datasources/${dataSourceId}`)
+      await goto(`/topologies/${topology.id}/sources`)
     } catch (e) {
       formError = e instanceof Error ? e.message : 'Failed to create topology'
     } finally {
@@ -107,16 +104,8 @@
                 href="/topologies/{topo.id}"
                 class="btn btn-primary py-1 px-3 text-xs flex-1 text-center"
               >
-                View
+                Open
               </a>
-              {#if topo.manualSourceId}
-                <a
-                  href="/datasources/{topo.manualSourceId}"
-                  class="btn btn-secondary py-1 px-3 text-xs flex-1 text-center"
-                >
-                  Edit
-                </a>
-              {/if}
             </div>
           </div>
         </div>
@@ -130,7 +119,7 @@
     <Dialog.Header>
       <Dialog.Title>Add Topology</Dialog.Title>
       <Dialog.Description>
-        Give your topology a name. You can edit its content on the next screen.
+        Give your topology a name, then add data sources to compose it.
       </Dialog.Description>
     </Dialog.Header>
 

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -20,7 +20,6 @@
   import { api } from '$lib/api'
   import { Button } from '$lib/components/ui/button'
   import {
-    dataSources,
     displaySettings,
     liveUpdatesEnabled,
     metricsConnected,
@@ -47,18 +46,20 @@
   })
 
   /**
-   * edgeStyle / splineMode live on `NetworkGraph.settings` inside the
-   * Manual source's stored graph (config_json.graph). Read/write goes
-   * through the data source config, not through observations.
+   * edgeStyle / splineMode live on `NetworkGraph.settings` inside the Manual
+   * source's authored graph, which is now a per-topology observation. Read the
+   * latest snapshot; write by recording a new observation.
    */
   async function parseGraphSettings() {
     if (!ctx.topology?.manualSourceId) return
     try {
-      const ds = await api.dataSources.get(ctx.topology.manualSourceId)
-      const config = JSON.parse(ds.configJson || '{}') as {
-        graph?: { settings?: { edgeStyle?: string; splineMode?: string } }
-      }
-      const settings = config.graph?.settings
+      const snap = await api.topologies.sources.latestSnapshot(
+        ctx.topology.id,
+        ctx.topology.manualSourceId,
+      )
+      const settings = (
+        snap?.graph as { settings?: { edgeStyle?: string; splineMode?: string } } | null
+      )?.settings
       edgeStyle = settings?.edgeStyle || 'orthogonal'
       splineMode = settings?.splineMode || 'sloppy'
     } catch {
@@ -70,12 +71,11 @@
     if (!ctx.topology?.manualSourceId) return
     savingEdgeStyle = true
     try {
-      const ds = await api.dataSources.get(ctx.topology.manualSourceId)
-      const config = JSON.parse(ds.configJson || '{}') as {
-        graph?: { settings?: Record<string, unknown>; [k: string]: unknown }
-        [k: string]: unknown
-      }
-      const graph = (config.graph ?? { version: '1', nodes: [], links: [] }) as {
+      const snap = await api.topologies.sources.latestSnapshot(
+        ctx.topology.id,
+        ctx.topology.manualSourceId,
+      )
+      const graph = (snap?.graph ?? { version: '1', nodes: [], links: [] }) as unknown as {
         settings?: Record<string, unknown>
         [k: string]: unknown
       }
@@ -83,10 +83,12 @@
       graph.settings['edgeStyle'] = edgeStyle
       if (edgeStyle === 'splines') graph.settings['splineMode'] = splineMode
       else delete graph.settings['splineMode']
-      config.graph = graph
-      await dataSources.update(ctx.topology.manualSourceId, {
-        configJson: JSON.stringify(config),
-      })
+      await api.topologies.sources.recordObservation(
+        ctx.topology.id,
+        ctx.topology.manualSourceId,
+        graph as unknown as Parameters<typeof api.topologies.sources.recordObservation>[2],
+        'ok',
+      )
     } catch (e) {
       console.error('Failed to update edge style:', e)
     } finally {


### PR DESCRIPTION
Closes #368. Makes Manual behave like every other data source: authored graph = per-topology `topology_observations` snapshot (editor save records one), not `config_json.graph`. Reverses migration 011's unused content-mirror. Plus manual-centric UX remnant cleanup (no auto-attach on create; card Edit button removed).

Design: `apps/server/docs/design/manual-source-unification.md`. Supersedes #361.
Editor relocation + 5→3 tab IA remain #362.

Validated via bun smokes (migration 014 incl. malformed-guard/idempotency; full attach→write→observation→read→resolve flow) + api 16/web 0-error/typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)