### PR TITLE
docs: mark manual unification implemented; supersede config_json.graph notes

### DIFF
--- a/apps/server/docs/design/manual-source-unification.md
+++ b/apps/server/docs/design/manual-source-unification.md
@@ -1,6 +1,6 @@
 # Manual source unification — make Manual a uniform data source
 
-> Status: design (signed off). Issue: #368. Supersedes #361. Builds on the composition-store
+> Status: IMPLEMENTED — merged in PR #370. Issue: #368. Supersedes #361. Builds on the composition-store
 > refactor (`topology-composition-store.md`). No backward compatibility.
 
 ## The problem
@@ -181,7 +181,7 @@ working (now writing observations) until #362 moves it.
 ## Phasing
 
 **This PR (Manual unification + remnant cleanup, backend-led):**
-1. Migration 015 (config_json.graph → observation; strip config).
+1. Migration 014 (config_json.graph → observation; strip config).
 2. Service: `readManualGraph`/`writeManualGraph` → observation read/record;
    `parseTopology` authored = latest manual observation; `attachManualSource`
    seeds nothing; **`create()`/create-flow no longer auto-attach Manual** (lazy

--- a/apps/server/docs/design/topology-composition-store.md
+++ b/apps/server/docs/design/topology-composition-store.md
@@ -35,9 +35,17 @@ below is the reasoning of record; the deltas from it, all deliberate:
 - **resolve gained link-endpoint port-id remap** so a port binding folds onto the
   link's endpoint port.
 
-Follow-ups (own PRs): #361 authored-graph store, #362 5→3 tab IA, #363 plugin
-port identity, #364 DB integration-test harness. Non-data-model perf
-(orchestration / render) stays in `performance-scaling.md` (#354).
+Follow-ups (own PRs): #362 5→3 tab IA, #363 plugin port identity, #364 DB
+integration-test harness. Non-data-model perf (orchestration / render) stays in
+`performance-scaling.md` (#354).
+
+> **Superseded below — authored-graph storage:** every mention in this doc of the
+> Manual/authored graph living in `data_sources.config_json.graph` (the survey
+> table, §3, Phase-4 "move to its own store", #361) is **out of date**. PR #370
+> (#368, `manual-source-unification.md`) made Manual a uniform data source: its
+> authored graph is now a **per-topology `topology_observations` snapshot**, and
+> `config_json.graph` is gone. #361 (move to a dedicated table) was superseded by
+> that — the graph lives in observations like every other source's content.
 
 ## Mental model: two axes on one hub
 


### PR DESCRIPTION
Doc accuracy after #370.