### PR TITLE
test(server-api): bun:sqlite DB test harness for the composition store

### DIFF
--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -9,7 +9,9 @@
     "build": "tsc && bun -e \"import{cpSync}from'fs';cpSync('src/db/migrations','dist/api/src/db/migrations',{recursive:true})\"",
     "dev": "NODE_ENV=development bun --watch src/index.ts",
     "start": "bun dist/api/src/index.js",
-    "test": "vitest --passWithNoTests",
+    "test": "vitest run && bun test ./test",
+    "test:unit": "vitest run",
+    "test:db": "bun test ./test",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "format": "biome check --write ."

--- a/apps/server/api/test/db/helper.ts
+++ b/apps/server/api/test/db/helper.ts
@@ -1,0 +1,74 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Shared setup for DB-backed tests (run under `bun test`, not vitest — they need
+ * `bun:sqlite`). Each test file inits a fresh temp database in `beforeAll` and
+ * tears it down in `afterAll`; the DB connection is a process singleton, so
+ * files run sequentially and each closes before the next inits.
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  closeDatabase,
+  generateId,
+  getDatabase,
+  initDatabase,
+  timestamp,
+} from '../../src/db/index.ts'
+
+export interface TempDb {
+  dir: string
+  teardown: () => void
+}
+
+export function setupTempDb(): TempDb {
+  const dir = mkdtempSync(join(tmpdir(), 'shumoku-db-test-'))
+  initDatabase(dir)
+  return {
+    dir,
+    teardown: () => {
+      closeDatabase()
+      try {
+        rmSync(dir, { recursive: true, force: true })
+      } catch {
+        // Windows may hold the file briefly; the temp dir is reaped by the OS.
+      }
+    },
+  }
+}
+
+export { generateId, getDatabase, timestamp }
+
+/** Insert a data source row directly (bypassing the plugin layer). */
+export function insertDataSource(type: string, id?: string): string {
+  const db = getDatabase()
+  const sid = id ?? `ds_${Math.abs(hash(type + Math.random().toString()))}`
+  const now = timestamp()
+  db.query(
+    `INSERT INTO data_sources (id, name, type, config_json, status, fail_count, created_at, updated_at)
+     VALUES (?, ?, ?, '{}', 'connected', 0, ?, ?)`,
+  ).run(sid, type, type, now, now)
+  return sid
+}
+
+/** Attach a data source to a topology via the m2m table. */
+export function attachSource(
+  topologyId: string,
+  dataSourceId: string,
+  purpose: 'topology' | 'metrics',
+): void {
+  const db = getDatabase()
+  const now = timestamp()
+  db.query(
+    `INSERT INTO topology_data_sources (id, topology_id, data_source_id, purpose, sync_mode, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'manual', ?, ?)`,
+  ).run(`tds_${topologyId}_${dataSourceId}_${purpose}`, topologyId, dataSourceId, purpose, now, now)
+}
+
+function hash(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0
+  return h
+}

--- a/apps/server/api/test/db/manual-source.test.ts
+++ b/apps/server/api/test/db/manual-source.test.ts
@@ -1,0 +1,62 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { NetworkGraph } from '@shumoku/core'
+import { TopologyService } from '../../src/services/topology.ts'
+import { getDatabase, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+let svc: TopologyService
+beforeAll(() => {
+  db_ = setupTempDb()
+  svc = new TopologyService()
+})
+afterAll(() => db_.teardown())
+
+const g = (nodeId: string): NetworkGraph =>
+  ({
+    version: '1',
+    name: 'manual',
+    nodes: [{ id: nodeId, label: nodeId, shape: 'rect', identity: { mgmtIp: '10.0.0.1' } }],
+    links: [],
+  }) as NetworkGraph
+
+describe('Manual = uniform data source (authored graph as observation)', () => {
+  test('attachManualSource seeds config {} (no graph) and reads null until saved', async () => {
+    const topo = await svc.create({ name: 'm1' })
+    const manualId = await svc.ensureManualSource(topo.id)
+    const cfg = getDatabase()
+      .query('SELECT config_json FROM data_sources WHERE id = ?')
+      .get(manualId) as { config_json: string }
+    expect(JSON.parse(cfg.config_json).graph).toBeUndefined()
+    expect(svc.readManualGraph(topo.id, manualId)).toBeNull()
+  })
+
+  test('writeManualGraph records an observation; readManualGraph + resolve see it', async () => {
+    const topo = await svc.create({ name: 'm2' })
+    const manualId = await svc.ensureManualSource(topo.id)
+    await svc.writeManualGraph(topo.id, manualId, g('a'))
+
+    // Stored as an observation, not in config_json.
+    const obs = getDatabase()
+      .query(
+        'SELECT graph_json, status FROM topology_observations WHERE topology_id = ? AND source_id = ?',
+      )
+      .get(topo.id, manualId) as { graph_json: string; status: string } | undefined
+    expect(obs?.status).toBe('ok')
+    expect(JSON.parse(obs?.graph_json ?? '{}').nodes).toHaveLength(1)
+
+    expect(svc.readManualGraph(topo.id, manualId)?.nodes?.[0]?.id).toBe('a')
+    const parsed = await svc.getParsed(topo.id)
+    expect(parsed?.graph.nodes.some((n) => n.identity?.mgmtIp === '10.0.0.1')).toBe(true)
+  })
+
+  test('latest observation wins on re-save', async () => {
+    const topo = await svc.create({ name: 'm3' })
+    const manualId = await svc.ensureManualSource(topo.id)
+    await svc.writeManualGraph(topo.id, manualId, g('first'))
+    await svc.writeManualGraph(topo.id, manualId, g('second'))
+    expect(svc.readManualGraph(topo.id, manualId)?.nodes?.[0]?.id).toBe('second')
+  })
+})

--- a/apps/server/api/test/db/mapping-backfill.test.ts
+++ b/apps/server/api/test/db/mapping-backfill.test.ts
@@ -1,0 +1,57 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { NetworkGraph } from '@shumoku/core'
+import { TopologyService } from '../../src/services/topology.ts'
+import { attachSource, getDatabase, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+let svc: TopologyService
+beforeAll(() => {
+  db_ = setupTempDb()
+  svc = new TopologyService()
+})
+afterAll(() => db_.teardown())
+
+const columnExists = (table: string, col: string): boolean =>
+  (getDatabase().query(`PRAGMA table_info(${table})`).all() as { name: string }[]).some(
+    (c) => c.name === col,
+  )
+
+describe('mapping_json backfill (Phase 2 → bindings, then drop column)', () => {
+  test('migrates a legacy mapping_json node entry to a binding, then drops the column', async () => {
+    // The column is created by migration 001 and only dropped by the backfill.
+    expect(columnExists('topologies', 'mapping_json')).toBe(true)
+
+    const topo = await svc.create({ name: 'bf' })
+    const manualId = await svc.ensureManualSource(topo.id)
+    const graph: NetworkGraph = {
+      version: '1',
+      name: 'bf',
+      nodes: [{ id: 'a', label: 'A', shape: 'rect', identity: { mgmtIp: '10.0.0.1' } }],
+      links: [],
+    } as NetworkGraph
+    await svc.writeManualGraph(topo.id, manualId, graph)
+    attachSource(topo.id, insertDataSource('zabbix', 'zbx_bf'), 'metrics')
+
+    const nodeAId = (await svc.getParsed(topo.id))?.graph.nodes.find(
+      (n) => n.identity?.mgmtIp === '10.0.0.1',
+    )?.id
+    expect(nodeAId).toBeTruthy()
+
+    // Seed a legacy mapping_json keyed by the resolved node id.
+    getDatabase()
+      .query('UPDATE topologies SET mapping_json = ? WHERE id = ?')
+      .run(JSON.stringify({ nodes: { [nodeAId as string]: { hostId: '99' } }, links: {} }), topo.id)
+
+    await svc.backfillMetricsBindings()
+
+    expect(columnExists('topologies', 'mapping_json')).toBe(false)
+    const mapping = (await svc.getParsed(topo.id))?.mapping
+    expect(mapping?.nodes?.[nodeAId as string]?.hostId).toBe('99')
+    // create() still works after the column is gone (no mapping_json in INSERT).
+    const after = await svc.create({ name: 'after-drop' })
+    expect(after.id).toBeTruthy()
+  })
+})

--- a/apps/server/api/test/db/metrics-binding.test.ts
+++ b/apps/server/api/test/db/metrics-binding.test.ts
@@ -1,0 +1,83 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { NetworkGraph } from '@shumoku/core'
+import { TopologyService } from '../../src/services/topology.ts'
+import { attachSource, getDatabase, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+let svc: TopologyService
+beforeAll(() => {
+  db_ = setupTempDb()
+  svc = new TopologyService()
+})
+afterAll(() => db_.teardown())
+
+/** Topology with a Manual graph (2 nodes + a link, port identities) and a metrics source. */
+async function fixture(
+  name: string,
+): Promise<{ topoId: string; nodeAId: string; metricsId: string }> {
+  const topo = await svc.create({ name })
+  const manualId = await svc.ensureManualSource(topo.id)
+  const graph: NetworkGraph = {
+    version: '1',
+    name,
+    nodes: [
+      {
+        id: 'a',
+        label: 'A',
+        shape: 'rect',
+        identity: { mgmtIp: '10.0.0.1' },
+        ports: [{ id: 'pa', label: 'Gi0/1', connectors: ['rj45'], identity: { ifName: 'Gi0/1' } }],
+      },
+      {
+        id: 'b',
+        label: 'B',
+        shape: 'rect',
+        identity: { mgmtIp: '10.0.0.2' },
+        ports: [{ id: 'pb', label: 'Gi0/2', connectors: ['rj45'], identity: { ifName: 'Gi0/2' } }],
+      },
+    ],
+    links: [{ id: 'L1', from: { node: 'a', port: 'pa' }, to: { node: 'b', port: 'pb' } }],
+  } as NetworkGraph
+  await svc.writeManualGraph(topo.id, manualId, graph)
+  const metricsId = insertDataSource('zabbix', `zbx_${name}`)
+  attachSource(topo.id, metricsId, 'metrics')
+  const parsed = await svc.getParsed(topo.id)
+  const nodeAId = parsed?.graph.nodes.find((n) => n.identity?.mgmtIp === '10.0.0.1')?.id ?? ''
+  return { topoId: topo.id, nodeAId, metricsId }
+}
+
+describe('metrics binding write path (identity-keyed attachments)', () => {
+  test('node + link bindings derive back; clearing removes them', async () => {
+    const { topoId, nodeAId } = await fixture('mb1')
+    await svc.updateMapping(topoId, {
+      nodes: { [nodeAId]: { hostId: '42', hostName: 'hostA' } },
+      links: { L1: { monitoredNodeId: nodeAId, interface: 'Gi0/1', bandwidth: 1000 } },
+    })
+    let m = (await svc.getParsed(topoId))?.mapping
+    expect(m?.nodes?.[nodeAId]).toEqual({ hostId: '42', hostName: 'hostA' })
+    expect(m?.links?.['L1']?.monitoredNodeId).toBe(nodeAId)
+    expect(m?.links?.['L1']?.interface).toBe('Gi0/1')
+    expect(m?.links?.['L1']?.bandwidth).toBe(1000)
+
+    await svc.updateMapping(topoId, { nodes: {}, links: {} })
+    m = (await svc.getParsed(topoId))?.mapping
+    expect(m?.nodes?.[nodeAId]).toBeUndefined()
+    expect(m?.links?.['L1']).toBeUndefined()
+  })
+
+  test('a binding from a detached metrics source stops driving the mapping', async () => {
+    const { topoId, nodeAId, metricsId } = await fixture('mb2')
+    await svc.updateMapping(topoId, { nodes: { [nodeAId]: { hostId: '7' } }, links: {} })
+    expect((await svc.getParsed(topoId))?.mapping?.nodes?.[nodeAId]?.hostId).toBe('7')
+
+    // Detach the metrics source → its binding must no longer surface.
+    getDatabase()
+      .query("DELETE FROM topology_data_sources WHERE data_source_id = ? AND purpose = 'metrics'")
+      .run(metricsId)
+    svc.clearCacheEntry(topoId)
+    expect((await svc.getParsed(topoId))?.mapping?.nodes?.[nodeAId]).toBeUndefined()
+  })
+})

--- a/apps/server/api/test/db/resolved-cache.test.ts
+++ b/apps/server/api/test/db/resolved-cache.test.ts
@@ -1,0 +1,61 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { TopologyService } from '../../src/services/topology.ts'
+import { getDatabase, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+let svc: TopologyService
+beforeAll(() => {
+  db_ = setupTempDb()
+  svc = new TopologyService()
+})
+afterAll(() => db_.teardown())
+
+const revision = (id: string): number =>
+  (
+    getDatabase()
+      .query('SELECT composition_revision AS r FROM topologies WHERE id = ?')
+      .get(id) as {
+      r: number
+    }
+  ).r
+
+const artifactRevision = (id: string): number | null =>
+  (
+    getDatabase()
+      .query('SELECT built_revision AS r FROM topology_resolved_graph WHERE topology_id = ?')
+      .get(id) as { r: number } | undefined
+  )?.r ?? null
+
+describe('Phase 3 materialized resolved graph (composition_revision)', () => {
+  test('first getParsed persists an artifact stamped at the current revision', async () => {
+    const topo = await svc.create({ name: 'rc1' })
+    expect(await svc.getParsed(topo.id)).not.toBeNull()
+    expect(artifactRevision(topo.id)).toBe(revision(topo.id))
+  })
+
+  test('clearCache() bumps every revision (invalidates persisted artifacts) and rebuilds', async () => {
+    const topo = await svc.create({ name: 'rc2' })
+    await svc.getParsed(topo.id)
+    const rev = revision(topo.id)
+    // clearCache() is a bulk reset: it must invalidate persisted artifacts too,
+    // so it bumps the revision. The next read recomputes at the new revision.
+    svc.clearCache()
+    expect(revision(topo.id)).toBe(rev + 1)
+    expect(await svc.getParsed(topo.id)).not.toBeNull()
+    expect(artifactRevision(topo.id)).toBe(rev + 1)
+  })
+
+  test('clearCacheEntry bumps the revision; the artifact rebuilds at the new one', async () => {
+    const topo = await svc.create({ name: 'rc3' })
+    await svc.getParsed(topo.id)
+    const rev = revision(topo.id)
+    svc.clearCacheEntry(topo.id)
+    expect(revision(topo.id)).toBe(rev + 1)
+    expect(artifactRevision(topo.id)).toBe(rev) // stale until next read
+    await svc.getParsed(topo.id)
+    expect(artifactRevision(topo.id)).toBe(rev + 1)
+  })
+})

--- a/apps/server/api/test/db/schema.test.ts
+++ b/apps/server/api/test/db/schema.test.ts
@@ -1,0 +1,59 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { getDatabase, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+beforeAll(() => {
+  db_ = setupTempDb()
+})
+afterAll(() => db_.teardown())
+
+const tableNames = (): string[] =>
+  (
+    getDatabase().query("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+      name: string
+    }[]
+  ).map((t) => t.name)
+
+const columns = (table: string): string[] =>
+  (getDatabase().query(`PRAGMA table_info(${table})`).all() as { name: string }[]).map(
+    (c) => c.name,
+  )
+
+describe('migration chain (001-014)', () => {
+  test('all composition-store tables exist', () => {
+    const t = tableNames()
+    for (const name of [
+      'data_sources',
+      'topologies',
+      'topology_data_sources',
+      'topology_observations',
+      'topology_resolved_graph',
+    ]) {
+      expect(t).toContain(name)
+    }
+  })
+
+  test('topologies is a shell — legacy columns dropped, composition_revision added', () => {
+    const cols = columns('topologies')
+    expect(cols).toContain('composition_revision')
+    expect(cols).toContain('share_token')
+    // Dropped by migrations: content_json (010), source pointers (013).
+    expect(cols).not.toContain('topology_source_id')
+    expect(cols).not.toContain('metrics_source_id')
+    expect(cols).not.toContain('content_json')
+    // NOTE: mapping_json is created by 001 and dropped by the imperative
+    // backfill (not a migration), so it's still present right after migrations.
+    // Its removal is covered in mapping-backfill.test.ts.
+    expect(cols).toContain('mapping_json')
+  })
+
+  test('topology_resolved_graph has the artifact columns', () => {
+    const cols = columns('topology_resolved_graph')
+    for (const c of ['graph_json', 'layout_json', 'built_revision', 'resolver_version']) {
+      expect(cols).toContain(c)
+    }
+  })
+})

--- a/apps/server/api/vitest.config.ts
+++ b/apps/server/api/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+// Vitest runs the pure unit tests under `src/`. DB-backed tests live in `test/`
+// and run under `bun test` instead, because they import `bun:sqlite` (via the
+// migration runner / services) which the Node-based vitest runtime can't load.
+// See the `test` script (`vitest run && bun test ./test`).
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+})


### PR DESCRIPTION
Closes #364. Adds committed regression coverage for the DB refactor (composition store + manual unification) that was only smoke-validated. vitest (Node) can't load bun:sqlite, so DB tests run under `bun test` (test/db/) alongside the vitest unit tests (src/).

12 DB tests: migration/schema sanity, manual-as-observation round-trip, metrics-binding write path (+ detached-source filter), Phase-3 resolved-cache invalidation, mapping_json backfill→bindings+drop. All green + existing 16 vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)