### PR TITLE
feat(zabbix): stamp port & interface identity for link metric bindings (#363)

### DIFF
--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -30,7 +30,7 @@ import type {
   NodeMetrics,
   TopologyCapable,
 } from '@shumoku/core'
-import { addHttpWarning, mapWithConcurrency } from '@shumoku/core'
+import { addHttpWarning, buildIdentity, mapWithConcurrency } from '@shumoku/core'
 import { createHttpClient, type HttpClient } from '@shumoku/plugin-sdk'
 import { convertZabbixToGraph } from './topology.js'
 import type {
@@ -366,6 +366,7 @@ export class ZabbixPlugin
     return items.flatMap((item) => {
       const direction = ZabbixPlugin.trafficDirection(item.key_)
       if (!direction) return [] // search is a substring match — drop incidental hits
+      const interfaceName = ZabbixPlugin.interfaceNameOf(item.key_, item.name)
       return [
         {
           id: item.itemid,
@@ -374,7 +375,10 @@ export class ZabbixPlugin
           key: item.key_,
           lastValue: item.lastvalue,
           unit: (item as ZabbixItem & { units?: string }).units,
-          interfaceName: ZabbixPlugin.interfaceNameOf(item.key_, item.name),
+          interfaceName,
+          // Durable interface key for link-metric binding (Zabbix LLDP exposes
+          // only ifName — no ifIndex/mac through the API).
+          ...(interfaceName ? { interfaceIdentity: buildIdentity({ ifName: interfaceName }) } : {}),
           direction,
         } satisfies HostItem,
       ]
@@ -390,6 +394,7 @@ export class ZabbixPlugin
     const { neighborsByHostId } = await this.fetchLldpData([hostId])
     return (neighborsByHostId.get(hostId) ?? []).map((n) => ({
       localInterface: n.localIf,
+      ...(n.localIf ? { localInterfaceIdentity: buildIdentity({ ifName: n.localIf }) } : {}),
       ...(n.remSysname ? { remoteSysName: n.remSysname } : {}),
       ...(n.remChassisId ? { remoteChassisId: n.remChassisId } : {}),
       ...(n.remPortId ? { remotePortId: n.remPortId } : {}),

--- a/libs/plugins/zabbix/src/topology.test.ts
+++ b/libs/plugins/zabbix/src/topology.test.ts
@@ -122,26 +122,14 @@ describe('convertZabbixToGraph', () => {
       .find((n) => n.id === 'inst1:host:1')
       ?.ports?.find((p) => p.label === 'et-0/0/1')
     expect(localPort?.speed).toBe('100g')
-    // Port identity is stamped from the local ifName so link metric bindings
-    // survive re-scans (the #363 contract).
+    // The local ifName is the authoritative port key, stamped as identity so
+    // link metric bindings resolve across re-scans (the #363 contract). Both
+    // hosts stamp their own ports from their local LLDP side.
     expect(localPort?.identity).toEqual({ ifName: 'et-0/0/1' })
-    // The remote port-id is a port name → ifName identity (not a MAC).
-    const remotePort = g.nodes
+    const peerLocalPort = g.nodes
       .find((n) => n.id === 'inst1:host:2')
       ?.ports?.find((p) => p.label === 'et-0/0/9')
-    expect(remotePort?.identity).toEqual({ ifName: 'et-0/0/9' })
-  })
-
-  it('stamps a MAC-typed remote port-id as a mac identity', () => {
-    const hosts = [mkHost({ hostid: '1', name: 'A' })]
-    const nbr = new Map<string, ZabbixLldpNeighbor[]>([
-      ['1', [{ localIf: 'e1', remSysname: 'ext.x', remPortId: '00:11:22:33:44:55' }]],
-    ])
-    const g = convertZabbixToGraph(hosts, nbr, NO_DESCR, OPTS)
-    const remotePort = g.nodes
-      .find((n) => n.id === 'inst1:ext:ext.x')
-      ?.ports?.find((p) => p.label === '00:11:22:33:44:55')
-    expect(remotePort?.identity).toEqual({ mac: '00:11:22:33:44:55' })
+    expect(peerLocalPort?.identity).toEqual({ ifName: 'et-0/0/9' })
   })
 
   it('adds a PARENT-tag link where LLDP saw no neighbor', () => {

--- a/libs/plugins/zabbix/src/topology.test.ts
+++ b/libs/plugins/zabbix/src/topology.test.ts
@@ -118,10 +118,30 @@ describe('convertZabbixToGraph', () => {
     expect(g.links).toHaveLength(1)
     expect(g.links[0]?.metadata?.['discoveredVia']).toBe('zabbix-lldp')
     expect(g.links[0]?.metadata?.['speedBps']).toBe(100_000_000_000)
-    expect(
-      g.nodes.find((n) => n.id === 'inst1:host:1')?.ports?.find((p) => p.label === 'et-0/0/1')
-        ?.speed,
-    ).toBe('100g')
+    const localPort = g.nodes
+      .find((n) => n.id === 'inst1:host:1')
+      ?.ports?.find((p) => p.label === 'et-0/0/1')
+    expect(localPort?.speed).toBe('100g')
+    // Port identity is stamped from the local ifName so link metric bindings
+    // survive re-scans (the #363 contract).
+    expect(localPort?.identity).toEqual({ ifName: 'et-0/0/1' })
+    // The remote port-id is a port name → ifName identity (not a MAC).
+    const remotePort = g.nodes
+      .find((n) => n.id === 'inst1:host:2')
+      ?.ports?.find((p) => p.label === 'et-0/0/9')
+    expect(remotePort?.identity).toEqual({ ifName: 'et-0/0/9' })
+  })
+
+  it('stamps a MAC-typed remote port-id as a mac identity', () => {
+    const hosts = [mkHost({ hostid: '1', name: 'A' })]
+    const nbr = new Map<string, ZabbixLldpNeighbor[]>([
+      ['1', [{ localIf: 'e1', remSysname: 'ext.x', remPortId: '00:11:22:33:44:55' }]],
+    ])
+    const g = convertZabbixToGraph(hosts, nbr, NO_DESCR, OPTS)
+    const remotePort = g.nodes
+      .find((n) => n.id === 'inst1:ext:ext.x')
+      ?.ports?.find((p) => p.label === '00:11:22:33:44:55')
+    expect(remotePort?.identity).toEqual({ mac: '00:11:22:33:44:55' })
   })
 
   it('adds a PARENT-tag link where LLDP saw no neighbor', () => {

--- a/libs/plugins/zabbix/src/topology.ts
+++ b/libs/plugins/zabbix/src/topology.ts
@@ -13,7 +13,15 @@
  *   - device   ← parsed from inventory.{type,vendor,model,hardware} + SNMP sysDescr
  */
 
-import type { Link, NetworkGraph, Node, NodePort, NodeSpec, Subgraph } from '@shumoku/core'
+import type {
+  Identity,
+  Link,
+  NetworkGraph,
+  Node,
+  NodePort,
+  NodeSpec,
+  Subgraph,
+} from '@shumoku/core'
 import { buildIdentity, DeviceType } from '@shumoku/core'
 import type { ZabbixHost, ZabbixLldpNeighbor } from './types.js'
 
@@ -42,6 +50,8 @@ interface StagedNode {
 
 /** Placeholder values the LLDP template uses when no neighbor was seen. */
 const NO_NEIGHBOR = /^\s*(\*\s*no info\s*\*|-|unknown|)\s*$/i
+// MAC address forms: colon/hyphen-separated octets, or Cisco dotted-quad.
+const MAC_LIKE = /^(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}$|^(?:[0-9a-f]{4}\.){2}[0-9a-f]{4}$/i
 
 /**
  * Convert hosts + their LLDP adjacencies (and SNMP sysDescr) into a NetworkGraph.
@@ -104,7 +114,12 @@ export function convertZabbixToGraph(
   const seenLinks = new Set<string>() // canonical endpoint-port pairs
   const linkedNodePairs = new Set<string>() // canonical node pairs (for tag de-dup)
 
-  const ensurePort = (node: Node, label: string, speedBps?: number): NodePort => {
+  const ensurePort = (
+    node: Node,
+    label: string,
+    speedBps?: number,
+    identity?: Identity,
+  ): NodePort => {
     let ports = portsByNode.get(node.id)
     if (!ports) {
       ports = new Map()
@@ -112,12 +127,25 @@ export function convertZabbixToGraph(
     }
     const id = `${node.id}:port:${label}`
     const existing = ports.get(id)
-    if (existing) return existing
+    if (existing) {
+      // Backfill identity if a later assertion (LLDP > tag fallback) supplies one.
+      if (identity && !existing.identity) existing.identity = identity
+      return existing
+    }
     const port: NodePort = { id, label, connectors: [], provenance: { source: sourceId } }
+    if (identity) port.identity = identity
     const speed = speedLabel(speedBps)
     if (speed) port.speed = speed
     ports.set(id, port)
     return port
+  }
+
+  // LLDP remote port-id is a port name, or a MAC when port-id is MAC-typed —
+  // stamp the matching identity key so link bindings resolve across re-scans.
+  const lldpPortIdentity = (portId: string | undefined): Identity | undefined => {
+    const v = portId?.trim()
+    if (!v) return undefined
+    return MAC_LIKE.test(v) ? buildIdentity({ mac: v }) : buildIdentity({ ifName: v })
   }
 
   const resolveRemote = (sysName: string, chassisId?: string): Node | undefined => {
@@ -150,9 +178,19 @@ export function convertZabbixToGraph(
       const remoteNode = resolveRemote(nbr.remSysname, nbr.remChassisId)
       if (!remoteNode || remoteNode.id === localNode.id) continue
 
-      const localPort = ensurePort(localNode, nbr.localIf, nbr.speedBps)
+      const localPort = ensurePort(
+        localNode,
+        nbr.localIf,
+        nbr.speedBps,
+        buildIdentity({ ifName: nbr.localIf }),
+      )
       const remoteLabel = nbr.remPortId?.trim() || `to-${host.hostid}-${nbr.localIf}`
-      const remotePort = ensurePort(remoteNode, remoteLabel)
+      const remotePort = ensurePort(
+        remoteNode,
+        remoteLabel,
+        undefined,
+        lldpPortIdentity(nbr.remPortId),
+      )
 
       const key = nodePairKey(
         `${localNode.id}|${localPort.id}`,

--- a/libs/plugins/zabbix/src/topology.ts
+++ b/libs/plugins/zabbix/src/topology.ts
@@ -50,8 +50,6 @@ interface StagedNode {
 
 /** Placeholder values the LLDP template uses when no neighbor was seen. */
 const NO_NEIGHBOR = /^\s*(\*\s*no info\s*\*|-|unknown|)\s*$/i
-// MAC address forms: colon/hyphen-separated octets, or Cisco dotted-quad.
-const MAC_LIKE = /^(?:[0-9a-f]{2}[:-]){5}[0-9a-f]{2}$|^(?:[0-9a-f]{4}\.){2}[0-9a-f]{4}$/i
 
 /**
  * Convert hosts + their LLDP adjacencies (and SNMP sysDescr) into a NetworkGraph.
@@ -128,8 +126,9 @@ export function convertZabbixToGraph(
     const id = `${node.id}:port:${label}`
     const existing = ports.get(id)
     if (existing) {
-      // Backfill identity if a later assertion (LLDP > tag fallback) supplies one.
-      if (identity && !existing.identity) existing.identity = identity
+      // Union identity keys across assertions (a port can be observed from more
+      // than one host); existing keys win on conflict so the result is stable.
+      if (identity) existing.identity = { ...identity, ...existing.identity }
       return existing
     }
     const port: NodePort = { id, label, connectors: [], provenance: { source: sourceId } }
@@ -138,14 +137,6 @@ export function convertZabbixToGraph(
     if (speed) port.speed = speed
     ports.set(id, port)
     return port
-  }
-
-  // LLDP remote port-id is a port name, or a MAC when port-id is MAC-typed —
-  // stamp the matching identity key so link bindings resolve across re-scans.
-  const lldpPortIdentity = (portId: string | undefined): Identity | undefined => {
-    const v = portId?.trim()
-    if (!v) return undefined
-    return MAC_LIKE.test(v) ? buildIdentity({ mac: v }) : buildIdentity({ ifName: v })
   }
 
   const resolveRemote = (sysName: string, chassisId?: string): Node | undefined => {
@@ -178,6 +169,11 @@ export function convertZabbixToGraph(
       const remoteNode = resolveRemote(nbr.remSysname, nbr.remChassisId)
       if (!remoteNode || remoteNode.id === localNode.id) continue
 
+      // Only the local interface name is an authoritative port key (from the
+      // host's own `lldp.loc.if` data). The remote port-id alone can't be
+      // classified (ifName vs MAC needs the LLDP port-id subtype, which the
+      // template doesn't expose), so we don't stamp the remote port — that
+      // peer's own scan stamps its ports from its local side anyway.
       const localPort = ensurePort(
         localNode,
         nbr.localIf,
@@ -185,12 +181,7 @@ export function convertZabbixToGraph(
         buildIdentity({ ifName: nbr.localIf }),
       )
       const remoteLabel = nbr.remPortId?.trim() || `to-${host.hostid}-${nbr.localIf}`
-      const remotePort = ensurePort(
-        remoteNode,
-        remoteLabel,
-        undefined,
-        lldpPortIdentity(nbr.remPortId),
-      )
+      const remotePort = ensurePort(remoteNode, remoteLabel)
 
       const key = nodePairKey(
         `${localNode.id}|${localPort.id}`,


### PR DESCRIPTION
Closes #363.

Zabbix LLDP topology ports and host/interface items now carry a durable interface identity key (`ifName`), so link-metric bindings resolve by identity across re-scans instead of breaking on positional ids. This fills the `portIdentity` the server's binding write path already reads (`topology.ts:669`) for the Zabbix/SNMP/TTDB path.

## Changes
- **`topology.ts`** — `ensurePort` stamps `NodePort.identity` with the authoritative local `{ ifName }` (from the host's own `lldp.loc.if` data). Identity keys are *unioned* across assertions (a port observed from multiple hosts merges keys; existing keys win on conflict → order-stable).
- **`plugin.ts`** — `getHostItems` stamps `interfaceIdentity`; `getInterfaceNeighbors` stamps `localInterfaceIdentity` — both from the unambiguous interface name.
- Tests for the local-identity stamping on both peers of an LLDP mirror.

## Design note
The remote port-id is **not** stamped as identity. An LLDP remote port-id can't be classified `ifName`-vs-`mac` from syntax alone (that needs the LLDP port-id subtype, which the standard templates don't expose). Since a metrics binding always lives on the monitored (local) side, and every host stamps its own ports from its local LLDP data, peer ports still get correct identity without guessing.

Reviewed via Codex (read-only): no BLOCKER/MAJOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)