### PR TITLE
docs(server): design DB-native persistence — document + relations hybrid

### DIFF
--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -5,14 +5,20 @@
 
 ## ⚠️ Canonical model — read first
 
-> **The human is fully just a top-priority source. There is no authored layer and no
-> human-vs-machine special-casing.** A topology is **N source contributions**; each is
-> tagged by a `source` (a `data_sources.id`, or `'human'`). The human differs only by:
-> - **priority** — a *value* (`'human'` = the maximum). "Human wins" = higher number,
->   never `if (human)`.
-> - **write mode** — `'human'` is *edited-in-place* (persists); external sources are
->   *re-fetched* (a re-sync can drop a node → retraction). This is "edited vs synced",
->   orthogonal to human-ness (a static import would also be "edited").
+> **The human is fully just a top-priority source. No authored layer, no human-vs-machine
+> special-casing, and NO reserved magic literal** (neither `'authored'` nor `'human'`).
+> A topology is **N source contributions**, each a `contribution_source` row. The human's
+> contribution is an *ordinary row* with a normal id; it is distinguished only by **typed
+> column values**, never by a branched string:
+> - **priority** — a *value* (the human's row holds the maximum). "Human wins" = higher
+>   number, never `if (human)`.
+> - **`write_mode = 'edited'`** — edited-in-place (persists); external sources are
+>   `'synced'` (re-fetched; a re-sync can drop a node → retraction). A typed kind, the
+>   only basis for retraction, **orthogonal to human-ness** (a static import is also `'edited'`).
+> - **`origin = 'human'`** — a typed discriminator used only to *route* a human edit to
+>   its row; the merge branches on **nothing** human-specific (only `priority`).
+>
+> The old `'authored'` literal (~15 `=== 'authored'` sites in `resolve.ts`) is **removed**.
 >
 > **Presence (scoop) and hide are the same bucket**: every contribution asserts
 > elements with a **sign** — a normal element row = "this node is here" (scoop); an
@@ -65,8 +71,10 @@ attachments, the binding target, the assertion sign) as real FK-enforced columns
 
 ## Schema (END STATE)
 
-`source_id` is `data_sources.id` or the literal `'human'`. `payload_json` is the document
-column (promote a scalar to a generated column only when a query needs it).
+`source_id` is `data_sources.id` for an external source, or an ordinary per-topology id
+for the human contribution (`origin='human'`) — **no code branches on its value**;
+`origin`/`write_mode`/`priority` columns carry the only differences. `payload_json` is the
+document column (promote a scalar to a generated column only when a query needs it).
 
 ```
 -- Existing, unchanged
@@ -77,8 +85,9 @@ topology_resolved_graph topology_id, graph_json, layout_json, …, built_revisio
 -- topology_observations: RETIRED (its content becomes contribution_* rows; keep only as a raw audit log if desired)
 
 -- ② Internal per-topology source registry (NOT data_sources; NOT in the Sources UI).
---    The 'human' row is internal bookkeeping — it never appears as an attachable source,
---    so the "phantom Manual" UX problem does not return. Resolves priority + FK + retraction.
+--    The human contribution is an ordinary row here (origin='human', normal id) — internal
+--    bookkeeping, never an attachable source, so the "phantom Manual" UX problem does not
+--    return. Resolves priority + FK + retraction. Nothing branches on the id value.
 contribution_source
   topology_id TEXT REFERENCES topologies(id) ON DELETE CASCADE,
   source_id   TEXT,                              -- data_sources.id | 'human'

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -1,255 +1,252 @@
-# DB-native persistence — uniform contributions, document + relations
+# DB-native persistence — uniform contributions, one assertion bucket
 
-> Status: DRAFT (2026-06-07, **rewritten to the uniform-contribution model** after
-> review found the previous draft was re-introducing a dissolved "authored layer").
-> Design of record for the follow-up to PR #375 (#362). No backward compatibility.
+> Status: DRAFT (2026-06-07, converged after multiple adversarial reviews + user
+> steer). Design of record for the follow-up to PR #375 (#362). No backward compat.
 
-## ⚠️ Canonical model — read this first (the root-cause fix)
+## ⚠️ Canonical model — read first
 
-This single statement is the source of truth. Every past round of confusion came from
-re-deriving a privileged "authored / Manual layer" that **does not exist**:
-
-> **There is NO authored layer. There is NO human-vs-machine branch.**
-> A topology is **N source contributions**, each tagged by a `source`
-> (`data_sources.id` *or the literal* `'human'`). The human edit is **just one
-> source** — it differs only by *values*, never by code path:
-> - **priority** — the human contribution has the highest priority (it wins per-field).
->   "Human wins" = "highest priority number", not an `if (human)`.
-> - **negation** — a *negative assertion* (suppression / exclusion) is a tombstone
->   contribution; today only `'human'` emits them, but that's usage, not a special case.
-> - **provenance** — `source` is a label the UI reads to mark a value editable; it is
->   not a layer.
+> **The human is fully just a top-priority source. There is no authored layer and no
+> human-vs-machine special-casing.** A topology is **N source contributions**; each is
+> tagged by a `source` (a `data_sources.id`, or `'human'`). The human differs only by:
+> - **priority** — a *value* (`'human'` = the maximum). "Human wins" = higher number,
+>   never `if (human)`.
+> - **write mode** — `'human'` is *edited-in-place* (persists); external sources are
+>   *re-fetched* (a re-sync can drop a node → retraction). This is "edited vs synced",
+>   orthogonal to human-ness (a static import would also be "edited").
 >
-> `resolve()` clusters all contributions by identity and merges by priority. Storage,
-> merge, and API treat `'human'` **identically** to any data source. **Do not add a
-> special table, code path, or vocabulary for "authored" / "Manual".** This was
-> settled by #335 (Git-like priority merge) and #370 (Manual is a uniform source);
-> this document finishes the job in storage.
-
-If a future change tempts you to special-case the human/Manual contribution — stop.
-That is the recurring bug.
+> **Presence (scoop) and hide are the same bucket**: every contribution asserts
+> elements with a **sign** — a normal element row = "this node is here" (scoop); an
+> identity-only element row with `negate=1` = "hide this node". Same for attachments:
+> `negate=0` asserts, `negate=1` suppresses. `resolve()` clusters by identity and, per
+> identity/key, the **highest-priority assertion's sign** decides presence/value. Any
+> source can hide in principle; today only `'human'` does — usage, not a rule.
+>
+> The literal `'authored'` special-cases in `resolve.ts` (~15 sites) are **residue to
+> remove**, replaced by priority + the signed-assertion model. Do NOT re-introduce a
+> special table, code path, or vocabulary for "authored"/"Manual". (Settled by #335 +
+> #370; this doc finishes it in storage.)
 
 ## Thesis
 
-Two "types" were conflated:
+Two "types" were conflated: (1) `@shumoku/core`'s `NetworkGraph` — the interchange/
+serialization format (parser/renderer/export), JSON-shaped, **stays**; (2) the server's
+*persistence* model — which was just (1) pickled as a blob, moved three times
+(`content_json` → `config_json.graph` → `topology_observations.graph_json`) without
+cutting the "core type == storage model" coupling.
 
-1. **`@shumoku/core`'s `NetworkGraph`** — the library's interchange/serialization format
-   (parser output, renderer input, every export). JSON-shaped, correctly so. **Stays.**
-2. **The server's persistence model** — it was just (1) pickled as a blob; three
-   refactors only *moved* the blob (`content_json` → `config_json.graph` →
-   `topology_observations.graph_json`), never cutting the **"core type == storage
-   model"** coupling. Worse, each move kept the *Manual = special* framing alive, so the
-   metrics mapping stayed un-queryable and the "authored layer" kept being re-derived.
+> **North star.** The **DB is canonical**; `NetworkGraph` (JSON) is a lossless
+> projection (export = project; import = decompose). **We go DB-native precisely to
+> unlock the scaling/tuning a JSON blob structurally cannot do** — index into it,
+> partially update it, query it — rather than parsing the whole blob every time. The
+> write cost of normalizing scans is *managed by DB design* (indexes, per-source
+> incremental replace, generated columns), not avoided by retreating to JSON.
 
-> **North star.** The **DB is canonical**. `NetworkGraph` (JSON) is a **lossless
-> projection**: export = project the DB to a graph; import = decompose a graph into
-> contribution rows. The human contribution round-trips like any source's.
-
-## Architecture: uniform per-source contributions (document + relations)
+## Architecture: uniform contributions + one signed-assertion bucket
 
 Every source — external *and* `'human'` — stores the **same shape**:
+- a **`contribution_source`** registry row (priority, write-mode, graph-level payload);
+- **`contribution_element`** rows (node|port|subgraph|termination + `payload_json`),
+  each with a **`negate`** sign (0 = present/scoop, 1 = hide; a hide row is identity-only);
+- **`contribution_identity`** rows — the match keys resolve clusters on;
+- **`contribution_link`** rows;
+- **`contribution_attachment`** rows (access|policy|metrics-binding) with **`negate`**
+  (0 = assert, 1 = suppress) and the binding's dependency target as an FK column.
 
-- **`contribution_element`** rows (node / port / subgraph / **termination**), each with a
-  `payload_json` document column for the un-queried payload (label, spec/equipment,
-  icon, style, position, intra-source structural detail like pins/direction/via/bends).
-- **`contribution_identity`** rows — the multi-key match keys resolve clusters on.
-- **`contribution_link`** rows — edges (endpoints reference the source's own elements).
-- **`contribution_attachment`** rows — **the mapping/policy/access** (metrics-binding's
-  dependency target is an FK column, not buried in JSON).
-- **negations** (suppression / exclusion) — tombstone rows, source-tagged.
+`resolve()` reads all contribution rows, **assembles one input per source**, clusters by
+identity, and for each cluster/key takes the **highest-priority assertion's sign** to
+decide presence and per-field values; then materializes ③ `topology_resolved_graph`.
+**Merged entities are never persisted** — clustering stays in-memory at read time, so the
+composition-store "entity merge/split" YAGNI is respected (we persist *per-source*
+contributions, never merged ones).
 
-`resolve()` reads all contribution rows for a topology, **assembles one input entry per
-source** (the same `SnapshotEntry[]` it already consumes), clusters by identity, merges
-by priority, and materializes ③ `topology_resolved_graph`. **Merged entities are never
-persisted** — clustering stays in-memory at read time, exactly as today, so the
-"entity merge/split" problem the composition-store doc deferred (YAGNI) **does not
-arise** (that objection was about persisting *merged* entities; we persist *per-source*
-contributions).
-
-**This is the document+relations hybrid applied uniformly:** rows + a payload document
-column (not over-normalized — spec/style/position stay JSON), with the queryable axes
-(identity, attachments, links, the binding's target) as real FK-enforced columns.
-
-### Why uniform (not "human = rows, observed = JSON")
-
-An earlier draft stored the human contribution as relational rows and observed
-contributions as JSON snapshots. That re-introduced exactly the human-vs-machine split
-#335 dissolved (see Canonical model). The trilemma — *uniformity* vs *queryable O(1)
-mapping* vs *don't-normalize-observed* — is resolved by choosing **uniformity +
-queryability**: normalize **all** contributions to the rows-plus-payload shape. The cost
-is that an external sync writes per-source rows (a transactional replace) instead of one
-JSON blob; in return the mapping is queryable, edits are O(1), and there is one code
-path for everyone.
+This is the document+relations hybrid applied uniformly: rows + a payload document column
+(not over-normalized — spec/style/position stay JSON), with the queryable axes (identity,
+attachments, the binding target, the assertion sign) as real FK-enforced columns.
 
 ## Schema (END STATE)
 
-`source` is `data_sources.id` or the literal `'human'` everywhere. `payload_json` is the
-document column (promote a scalar to a generated column only when a query needs it).
+`source_id` is `data_sources.id` or the literal `'human'`. `payload_json` is the document
+column (promote a scalar to a generated column only when a query needs it).
 
 ```
 -- Existing, unchanged
 topologies              id, name, share_token, composition_revision, …
-data_sources            id, name, type, config_json, status…
-topology_data_sources   id, topology_id, data_source_id, purpose, sync_mode, priority,
-                        last_synced_at, status, consecutive_failures, last_ok_captured_at…
-topology_resolved_graph topology_id, graph_json, layout_json, …, built_revision, resolver_version
-                                                            -- ③ materialized stitch (output)
--- NOTE: topology_observations (the per-source JSON snapshot) is RETIRED — its content
--- becomes contribution_* rows. (Or kept only as a raw audit log, decided at migration.)
+data_sources            id, name, type, config_json, status…           -- USER-FACING source catalog
+topology_data_sources   id, topology_id, data_source_id, purpose, sync_mode, priority, …  -- user-facing attach config
+topology_resolved_graph topology_id, graph_json, layout_json, …, built_revision, resolver_version  -- ③ output
+-- topology_observations: RETIRED (its content becomes contribution_* rows; keep only as a raw audit log if desired)
 
--- ② Uniform contributions (rows + payload document column)
+-- ② Internal per-topology source registry (NOT data_sources; NOT in the Sources UI).
+--    The 'human' row is internal bookkeeping — it never appears as an attachable source,
+--    so the "phantom Manual" UX problem does not return. Resolves priority + FK + retraction.
+contribution_source
+  topology_id TEXT REFERENCES topologies(id) ON DELETE CASCADE,
+  source_id   TEXT,                              -- data_sources.id | 'human'
+  origin      TEXT,                              -- 'data-source' | 'human'
+  priority    INTEGER,                           -- merge precedence; 'human' = MAX
+  write_mode  TEXT,                              -- 'synced' (re-fetched, retractable) | 'edited' (in place, persists)
+  graph_payload_json TEXT,                       -- THIS contribution's graph-level fields: settings, pins, version, name
+  PRIMARY KEY (topology_id, source_id)
+
+-- ② Contributions (rows + payload doc column), uniform for every source incl. 'human'
 contribution_element
-  id            INTEGER PRIMARY KEY,
-  topology_id   TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
-  source        TEXT NOT NULL,                 -- data_source_id | 'human'
-  local_id      TEXT NOT NULL,                 -- element id within this source's assertion (round-trips)
-  kind          TEXT NOT NULL,                 -- 'node'|'port'|'subgraph'|'termination'
-  parent_local_id TEXT,                        -- within the same source
-  payload_json  TEXT,                          -- label, spec/equipment, icon, style, position, intra-source detail
-  UNIQUE (topology_id, source, local_id)
+  id INTEGER PRIMARY KEY,
+  topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
+  local_id    TEXT NOT NULL,                     -- element id WITHIN this source (round-trips); never the cross-source key
+  kind        TEXT NOT NULL,                     -- 'node'|'port'|'subgraph'|'termination'
+  parent_local_id TEXT,
+  negate      INTEGER NOT NULL DEFAULT 0,        -- 0 = present (scoop), 1 = hide (identity-only row)
+  payload_json TEXT,
+  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE,
+  UNIQUE (topology_id, source_id, local_id)
 
 contribution_identity
-  element_id  INTEGER REFERENCES contribution_element(id) ON DELETE CASCADE,
-  topology_id TEXT NOT NULL,                   -- denormalized for the cross-source cluster index
-  key_type    TEXT, key_value TEXT,
+  element_id INTEGER REFERENCES contribution_element(id) ON DELETE CASCADE,
+  topology_id TEXT NOT NULL,                     -- denormalized for the cross-source cluster index
+  key_type TEXT, key_value TEXT,
   PRIMARY KEY (element_id, key_type, key_value)  WITHOUT ROWID
 
 contribution_link
   id INTEGER PRIMARY KEY,
-  topology_id TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
-  source TEXT NOT NULL,
-  from_local_id TEXT, to_local_id TEXT,        -- within source (node or port)
-  payload_json TEXT                            -- type, arrow, label, via, bends, cable, per-endpoint plug/ip/pin
+  topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
+  from_local_id TEXT, to_local_id TEXT,
+  negate INTEGER NOT NULL DEFAULT 0,
+  payload_json TEXT,
+  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE
 
 contribution_attachment
   id INTEGER PRIMARY KEY,
-  topology_id TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
-  source TEXT NOT NULL,
+  topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
   element_id INTEGER REFERENCES contribution_element(id) ON DELETE CASCADE,  -- NULL ⇔ scope='topology-default'
-  scope TEXT, kind TEXT,                        -- 'access'|'policy'|'metrics-binding'
-  attachment_key TEXT,                         -- attachmentKey(): 'access:snmp'|'policy'|'metrics-binding:<sourceId>'
-  target_source_id TEXT REFERENCES data_sources(id) ON DELETE SET NULL,  -- metrics-binding dependency target (non-destructive)
-  negate INTEGER NOT NULL DEFAULT 0,           -- 1 = suppression (tombstone for this key)
-  payload_json TEXT                            -- {community,version}|{mode,intervalMs}|{hostId,interfaceIdentity,interfaceName,bandwidth}
-
-contribution_exclusion                          -- identity-keyed negative assertion (hide a node)
-  topology_id TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
-  source TEXT NOT NULL, key_type TEXT, key_value TEXT,
-  PRIMARY KEY (topology_id, source, key_type, key_value)  WITHOUT ROWID
+  scope TEXT, kind TEXT,                         -- 'access'|'policy'|'metrics-binding'
+  attachment_key TEXT,                           -- attachmentKey(): 'access:snmp'|'policy'|'metrics-binding:<sourceId>'
+  target_source_id TEXT REFERENCES data_sources(id) ON DELETE SET NULL,  -- metrics-binding target (non-destructive)
+  negate INTEGER NOT NULL DEFAULT 0,             -- 0 = assert, 1 = suppress
+  payload_json TEXT,
+  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE
 ```
+Notes:
+- **One assertion bucket**: scoop/hide are `contribution_element.negate`; assert/suppress
+  are `contribution_attachment.negate`. No separate `exclusion`/`suppressedAttachments`
+  side-channel, no authored-only privilege. (Replaces the old `authored.exclusions`
+  array + `suppressedAttachments`.)
+- **Identity-anchored** (settles the composition-store invariant-6 contradiction):
+  `local_id` is only the intra-source handle; cross-source matching is `contribution_identity`.
+- **`contribution_source` resolves three prior blockers at once**: `'human'` priority lives
+  here (= MAX, the one legitimate human-specific *value*); FK integrity (every contribution
+  FKs a real registry row, incl. `'human'`); retraction = `write_mode` (`'edited'` rows
+  persist, `'synced'` rows are replaced per sync). Graph-level `settings`/`pins` live in
+  `graph_payload_json` (closes that round-trip gap).
+- **Terminations** = `kind='termination'`; `link.via` references the source's own terminations.
+- **Topology-default** = `attachment.element_id NULL`; partial unique index
+  `(topology_id, source_id, attachment_key) WHERE element_id IS NULL` + the symmetric
+  `WHERE element_id IS NOT NULL` for one-slot-per-key.
 
-Design notes (resolving the review findings):
-- **No human/machine split** — `source` is the only axis; `'human'` is a value. Priority
-  comes from `topology_data_sources.priority` (and `'human'` = top); never an `if`.
-- **Identity-anchored, not id-anchored** — the binding/policy on a node is a
-  `contribution_attachment` whose `contribution_element` carries the node's `identity`
-  rows; resolve clusters it with observed contributions by identity. This honors the
-  composition-store invariant "overrides are identity-keyed" — `local_id` is only the
-  intra-source handle, never the cross-source key.
-- **Terminations have a home** (`kind='termination'`); `link.via` references the source's
-  own termination elements.
-- **Topology-default** = `element_id NULL`; uniqueness via a partial unique index
-  `(topology_id, source, attachment_key) WHERE element_id IS NULL`.
-- **Suppression = `negate=1`** attachment row; **exclusion** = `contribution_exclusion`.
-  Both are ordinary source-tagged contributions (today emitted by `'human'`).
-- **`target_source_id` is non-destructive** — `ON DELETE SET NULL` (and resolve already
-  filters bindings to currently-attached sources), matching today's "detach keeps the
-  binding dormant, doesn't delete it" semantics. No surprise cascade.
-- **Round-trip** — referenceable structure (terminations, pins) are elements/edges;
-  opaque routing/presentation (bends, style, position) is `payload_json`. Enumerate the
-  exact `NetworkGraph` field → column / `payload_json` / resolve-only mapping in the
-  stage-1 PR; the golden test asserts a *normalized* equivalence (canonical key order),
-  not byte-identity.
-
-## Projection / ingestion + resolve
+## Resolve / projection / ingestion
 
 ```
-buildContributions(topologyId): SnapshotEntry[]   -- one entry per source (incl. 'human'),
-                                                  -- assembled from contribution_* rows (indexed scans)
-resolve(buildContributions(topologyId)) → resolved graph → materialize ③   -- merge UNCHANGED
-
-buildGraph(topologyId): NetworkGraph    -- project the 'human' contribution (export) or the resolved graph
-ingestGraph(topologyId, source, graph)  -- decompose a NetworkGraph into that source's contribution rows
-                                        -- (one transaction; replace that source's rows; PRAGMA defer_foreign_keys
-                                        --  for intra-import forward refs)
+buildContributions(topologyId): per-source inputs   -- assembled from contribution_* rows (indexed scans)
+resolve(buildContributions(topologyId)) → resolved graph → materialize ③
+  · cluster elements by identity
+  · presence: per cluster, the highest-priority element's `negate` decides (0 present / 1 hidden)
+  · fields & attachments: per key, the highest-priority assertion's sign + payload wins
+buildGraph(topologyId, source_id): NetworkGraph     -- project ONE source's contribution (export/edit; raw ids)
+exportResolved(topologyId): NetworkGraph            -- project the materialized resolved graph (final picture)
+ingestGraph(topologyId, source_id, graph)           -- decompose a graph into that source's rows; ONE txn;
+                                                    --   PRAGMA defer_foreign_keys for intra-import forward refs
 ```
-- **resolve()'s merge is genuinely unchanged** — its *feed* changes from `(authored
-  object + observation JSON)` to `buildContributions()` rows. The golden test asserts
-  `resolve(buildContributions(x)) ≡ resolve(old readManualGraph+snapshots)`, not just a
-  build round-trip. Complexity moves into `buildContributions`/`ingestGraph`.
+- **resolve's clustering + priority field-merge stay; its presence/suppression unify into
+  the signed-assertion model and the `'authored'` literal special-cases are removed.** So
+  it is *not* "unchanged" — be honest — but the change is a simplification (one rule:
+  top-priority-sign), not a new merge. Golden test: `resolve(buildContributions(x))`
+  matches the old `resolve(readManual + snapshots)` for representative graphs.
 - **A sync** = `ingestGraph(topology, <data_source_id>, scannedGraph)` (replace that
-  source's rows; on a failed scan, leave them — status lives on `topology_data_sources`).
-- **A human edit** = write `'human'` contribution rows directly (O(1) per binding).
-- **No more phantom Manual** — the human contribution is rows tagged `'human'`, owned by
-  the topology; nothing auto-creates a "Manual source".
+  source's rows transactionally; on a failed scan, leave them — status on `topology_data_sources`).
+- **A human edit** = write `'human'` rows incrementally (one attachment/element row =
+  O(1)); never a full-replace, so a crash can't wipe the human contribution. Import
+  (`ingestGraph` of the whole human graph) is the only full-replace and is one transaction.
+- **No phantom Manual** — the human contribution is rows under an internal
+  `contribution_source('human')`, never a user-facing data source.
 
-## Staged migration
+## Scaling (why DB-native, not a blob)
 
-1. **`contribution_element`/`identity`/`link` + `buildContributions` for the `'human'`
-   source** + `ingestGraph`/`buildGraph` + golden round-trip test. Backfill the Manual
-   observation's graph into `'human'` rows; drop Manual-as-authored.
-2. **`contribution_attachment`** — metrics-binding first (`target_source_id` FK), then
-   policy/access; `contribution_exclusion` + `negate` suppression. `reconcileBindings`
-   writes `'human'` attachment rows.
-3. **Observed sources → contributions.** `syncSource` writes `<data_source_id>`
-   contribution rows (replace per source) instead of a `topology_observations` snapshot;
-   resolve feeds from rows; retire `topology_observations` (or keep as a raw audit log).
-4. **Retire** `manual_source_id`/`findManualSourceId`/`ensureManualSource`; on-demand
-   generated columns; optional `product` table. **#375 gap closed; no authored layer left.**
-0. **Cleanup (any time):** `DROP TABLE IF EXISTS manual_source_graph, snmp_credentials`
-   (dead tables from deleted migrations; present only in long-lived dev DBs).
-
-Backfill is **imperative TS, not SQL** (it needs `resolve()`/`attachmentKey` slotting,
-identity keys, audit-don't-drop — like the existing `backfillMetricsBindings`).
+Normalizing scans is the *point*, not a cost to dodge — it unlocks what a JSON blob
+cannot:
+- **Partial update** — edit one binding = one row (O(1)), vs rewrite the whole blob.
+- **Query** — "bindings for source X", "what depends on host H", "disabled nodes" = indexed
+  SQL, vs parse-and-walk every blob.
+- **Incremental / scoped reads** — resolve reads only the rows it needs; future per-subgraph
+  or per-source partial resolve becomes possible.
+The per-source row-replace on sync (e.g. ~tens of thousands of rows for a 1475-node scan)
+is a transactional write at the 5-minute cadence — measure it, then tune with the index
+plan below, WAL, and batched transactions. It is bounded and infrequent, not a wall.
 
 ## Performance & indexing
 
-- **Read (hot path)** — served from materialized ③ (~19ms / 1475 nodes); ② touched only
-  on rebuild. Add a per-topology `authored_revision` (bump on any ② write) stored in ③
-  as `built_from_revision` so staleness is a single integer compare.
-- **Write** — a binding edit = one `contribution_attachment` UPSERT/DELETE (O(1)).
-- **Sync** — per-source transactional row replace; more rows than one blob, but bounded
-  and infrequent, and resolve reads rows instead of parsing N blobs.
-- **Index every FK column** (SQLite does NOT auto-index FKs; cascade deletes full-scan
-  otherwise): `contribution_element(topology_id, source)`, `(parent_local_id)`;
+- **Read (hot path)** — served from materialized ③ (~19ms/1475 nodes); ② touched only on
+  rebuild. Add per-topology `authored_revision` (bump on any ② write) stored in ③ as
+  `built_from_revision` → staleness is one integer compare (also the optimistic-concurrency hook).
+- **Index every FK** (SQLite does NOT auto-index FKs; cascades full-scan otherwise):
+  `contribution_element(topology_id, source_id)`, `(parent_local_id)`;
   `contribution_identity(topology_id, key_type, key_value)` (cross-source cluster);
-  `contribution_attachment(topology_id, source, element_id)`, `(topology_id, kind)`,
-  `(target_source_id)`; `contribution_link(topology_id, source)`, endpoints.
-  No redundant prefixes; never index `payload_json`.
+  `contribution_attachment(topology_id, source_id, element_id)`, `(topology_id, kind)`,
+  `(target_source_id)`; `contribution_link(topology_id, source_id)`, endpoints. No
+  redundant prefixes; never index `payload_json`.
 - **Avoid N+1** — `buildContributions` fetches each table once per topology.
-- **PK strategy** — `INTEGER PRIMARY KEY` for the high-volume contribution tables;
-  `WITHOUT ROWID` for the small composite-key ones (`contribution_identity`,
-  `contribution_exclusion`) if rows stay <~200 B (verify with `sqlite3_analyzer`);
+- **PK strategy** — `INTEGER PRIMARY KEY` for high-volume tables; `WITHOUT ROWID` for the
+  small composite-key `contribution_identity` if rows stay <~200 B (verify with
+  `sqlite3_analyzer`; long `key_value` like a full chassis string can blow the threshold);
   TEXT nanoid only for externally-referenced entities (topologies, data_sources).
 - **PRAGMAs** shipped in PR #377 (WAL, synchronous=NORMAL, foreign_keys=ON,
   busy_timeout=5000, cache_size=-65536, temp_store=MEMORY, mmap_size=256MiB; optimize on
-  close). `defer_foreign_keys` within `ingestGraph` for forward refs.
+  close). `defer_foreign_keys` inside `ingestGraph`.
 - **`payload_json`** TEXT by default (SQLite 3.51.1 has JSONB; reserve it + generated
-  columns for filtered scalars). Verify hot queries with `EXPLAIN QUERY PLAN`.
+  columns for filtered scalars). Verify hot queries with `EXPLAIN QUERY PLAN` (no `SCAN TABLE`).
+
+## Staged migration
+
+1. **`contribution_source` + `contribution_element`/`identity`/`link` + `buildContributions`
+   for `'human'`** + `ingestGraph`/`buildGraph` + golden round-trip test. Backfill the
+   Manual observation graph into `'human'` rows.
+2. **`contribution_attachment` (with `negate`)** — metrics-binding first
+   (`target_source_id` FK), then policy/access; unify hide via `contribution_element.negate`.
+   Remove the `'authored'` literal special-cases + the `exclusions`/`suppressedAttachments`
+   side-channels in `resolve.ts`.
+3. **Observed sources → contributions.** `syncSource` writes `<data_source_id>` rows
+   (per-source replace) instead of a `topology_observations` snapshot; resolve feeds from
+   rows; retire `topology_observations` (or keep as raw audit log).
+4. **Retire** `manual_source_id`/`findManualSourceId`/`ensureManualSource`; on-demand
+   generated columns; optional `product` table. **#375 gap closed; no authored layer left.**
+0. **Cleanup (any time):** `DROP TABLE IF EXISTS manual_source_graph, snmp_credentials`.
+
+Backfill is **imperative TS, not SQL** (needs `resolve()`/`attachmentKey` slotting,
+identity keys, audit-don't-drop — like the existing `backfillMetricsBindings`).
 
 ## Risks / open questions
 
-- **Sync cost** — observed scans become row-replaces; measure vs the old single-blob
-  write before committing stage 3 (the only stage that touches the observed path).
-- **`buildContributions` fidelity** — golden test gates it (must equal the old resolve
-  feed), since the merge depends on exact contribution shape.
-- **No authored history** — replace/upsert keeps current state only; today's append-only
-  Manual observations gave latent undo. Acceptable (no UI uses it); the per-source-row
-  shape lets an append-only `contribution_event` log be added later without schema change.
+- **Sync write cost** — quantify the per-source row-replace at 1475-node scale before
+  committing stage 3 (the only stage touching the observed path); tune via indexes/batching.
+- **`resolve.ts` rewrite** — removing the `'authored'` literal + unifying negative
+  assertions is a real change; the golden test (parity with old resolve output) gates it.
+- **`buildContributions` fidelity** — it must reproduce the exact contribution shape the
+  merge expects; gated by the golden test.
+- **No authored history** — replace/upsert keeps current state only (today's append-only
+  Manual observations gave latent undo). Acceptable; an append-only `contribution_event`
+  log can be added later without schema change.
 - **Editor (apps/editor, IndexedDB) convergence** — standing strategic risk; intended
   end-state: server canonical, editor a `NetworkGraph` round-trip client. Not solved here.
 - **Terminology purge** — residual "authored layer" wording in `manual-source-unification.md`,
-  `topology-composition-store.md`, and core type comments is the root cause of repeated
-  confusion; align them to the Canonical model above as a follow-up.
+  `topology-composition-store.md`, and core comments (`resolve.ts`, `observations.ts`,
+  `types.ts`) is the root cause of repeated confusion; align to the Canonical model.
 
 ## References (verified 2026-06)
-- Backstage entity-document + relations table + stitching (relations are a regenerated cache; we choose FK-enforced — a deliberate divergence): <https://backstage.io/docs/features/software-catalog/life-of-an-entity/>
+- Backstage entity-document + relations table + stitching (their relations are a regenerated cache; we choose FK-enforced — a deliberate divergence): <https://backstage.io/docs/features/software-catalog/life-of-an-entity/>
 - Grafana App Platform — K8s-style resources over SQL unified storage: <https://deepwiki.com/grafana/grafana/3.3-folder-management>
-- SQLite JSON/JSONB + generated columns: <https://sqlite.org/json1.html>; FK not auto-indexed: <https://www.sqlite.org/foreignkeys.html>; WITHOUT ROWID: <https://www.sqlite.org/withoutrowid.html>; query planner: <https://www.sqlite.org/queryplanner.html>
-- Production PRAGMAs: <https://databaseschool.com/articles/sqlite-recommended-pragmas>; bun:sqlite: <https://bun.com/docs/runtime/sqlite>
+- SQLite: JSON/JSONB + generated columns <https://sqlite.org/json1.html>; FK not auto-indexed <https://www.sqlite.org/foreignkeys.html>; WITHOUT ROWID <https://www.sqlite.org/withoutrowid.html>; query planner <https://www.sqlite.org/queryplanner.html>
+- Production PRAGMAs <https://databaseschool.com/articles/sqlite-recommended-pragmas>; bun:sqlite <https://bun.com/docs/runtime/sqlite>
 
 ## Relationship to existing docs
-- `topology-source-priority-merge.md` / #335 — the Canonical model is its storage-side completion.
-- `topology-composition-store.md` — its identity-keyed-store intent realized; its observed-normalization YAGNI is respected (we persist per-source contributions, never merged entities).
-- `manual-source-unification.md` — #375 known-gap closed; its residual "authored" wording to be purged.
+- `topology-source-priority-merge.md` / #335 — the Canonical model is its storage-side completion (signed assertions = the symmetric add/override/delete it specified).
+- `topology-composition-store.md` — identity-keyed-store intent realized; observed-normalization YAGNI respected (per-source contributions, never merged entities).
+- `manual-source-unification.md` — #375 known-gap closed; residual "authored" wording to be purged.
 - `topology-ui-ia.md` — unaffected (UI reads the projected graph).

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -200,6 +200,22 @@ cheaper. The wins must be earned with index design and N+1 avoidance.
 **Avoid N+1 (the main pitfall):** `buildGraph` must fetch each relations table **once
 per topology** (single indexed scan) and assemble in memory — never per-element queries.
 
+**Primary-key strategy (Shumoku-specific — we use nanoid TEXT PKs everywhere).** TEXT
+PKs are a real cost on the high-row-count internal tables: a TEXT PK leaves the hidden
+`rowid` AND stores the string in every index, vs an `INTEGER PRIMARY KEY` which *is* the
+rowid (one fast B-tree, less storage — Android's guidance). So:
+- Keep **TEXT nanoid** for externally-referenced entities (topologies, data_sources —
+  they appear in URLs / the API).
+- For internal, never-URL-exposed, high-volume relations tables (`identity`,
+  `attachment`), prefer **`INTEGER PRIMARY KEY`**, or **`WITHOUT ROWID` with the natural
+  composite key** for `suppression` / `exclusion` (composite PKs, no surrogate id needed).
+
+**Push work into SQL, don't re-walk JSON in app code.** Filtering / aggregation /
+existence checks belong in queries (SQLite's engine ≫ JS loops), which is the whole
+point of relationalizing ② — e.g. "bindings for source X" is an indexed `WHERE`, not a
+`graph.nodes.flatMap(...)` over a parsed blob. (`COUNT(*)`/`EXISTS`/`LIMIT`, select only
+needed columns.)
+
 **SQLite levers:**
 - `doc_json` as **TEXT is the safe default** (we read the whole doc and parse in JS);
   reserve **JSONB + generated columns** for scalars we actually filter on (promote on
@@ -209,9 +225,11 @@ per topology** (single indexed scan) and assemble in memory — never per-elemen
 - Batch in **one transaction**: `reconcileBindings`' N-row replace, and `ingestGraph`.
 - Keep using bun:sqlite prepared statements (`.query()` cache).
 
-**Measure before tuning:** add phase timing (DB read / merge / layout / ③ write) around
-resolve so the bottleneck is data, not a guess. Today only the cache-hit path (~19ms)
-is measured; the rebuild path is what to instrument.
+**Measure with `EXPLAIN QUERY PLAN` (+ SQLite's `.expert`)**, not by guessing — confirm
+every hot query hits an index (no `SCAN TABLE`). Add phase timing (DB read / merge /
+layout / ③ write) around resolve; today only the cache-hit path (~19ms) is measured, the
+rebuild path is what to instrument. (Prior art: Bencher cut response time ~1200× with
+exactly this — targeted compound indexes + a materialized view, found via EXPLAIN.)
 
 ## Risks / open questions
 
@@ -232,6 +250,8 @@ is measured; the rebuild path is what to instrument.
 - SQLite JSON / JSONB + virtual generated columns: <https://sqlite.org/json1.html>, <https://www.dbpro.app/blog/sqlite-json-virtual-columns-indexing>
 - Grafana App Platform — K8s-style resources over SQL unified storage: <https://deepwiki.com/grafana/grafana/3.3-folder-management>
 - Backstage — entity document + relations table + stitching: <https://backstage.io/docs/features/software-catalog/life-of-an-entity/>, <https://backstage.io/docs/features/software-catalog/creating-the-catalog-graph/>
+- SQLite performance best practices (Android) — INTEGER PK, compound indexes, WAL+synchronous, transactions, EXPLAIN QUERY PLAN, push work into SQL: <https://developer.android.com/topic/performance/sqlite-performance-best-practices>
+- SQLite performance tuning (Bencher) — compound indexes + materialized view + EXPLAIN/`.expert`, ~1200× win: <https://bencher.dev/learn/engineering/sqlite-performance-tuning/>
 
 ## Relationship to existing docs
 - `topology-composition-store.md` — predecessor; its identity-keyed-store intent is realized here; `metrics-binding`-as-attachment = stage-1 input.

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -1,8 +1,19 @@
 # DB-native persistence — uniform contributions, one assertion bucket
 
-> Status: DRAFT (2026-06-07, converged after multiple adversarial reviews incl. a Codex
-> macro data-structure review, + user steer). Design of record for the follow-up to PR
+> Status: ADOPTED (2026-06-07, converged after multiple adversarial reviews incl. Codex
+> macro + per-stage reviews, + user steer). Design of record for the follow-up to PR
 > #375 (#362). No backward compat.
+>
+> **Shipped:** stage 0 (drop dead tables, #379) · stage 1 (contribution store + codec +
+> DB-native authored/intrinsic layer, #378) · the no-phantom-Manual edit paths (#380) ·
+> **stage 3 (observed sources read DB-native from the contribution store, #381)**. Stage 3
+> kept `topology_observations` as the append-only audit/history log (the "or keep as raw
+> audit log" option sanctioned below) — the resolver reads the `contribution_*` rows;
+> `ObservationsService.record()` materializes each observed graph into a contribution in
+> one transaction. **Remaining:** stage 2b (drop the `resolve.ts` `'authored'` lib-internal
+> literal — low value; storage is already clean) and stage 4 (retire
+> `manual_source_id`/`ensureManualSource` — blocked on the editor relocation into the
+> topology context, #362).
 
 ## ⚠️ Canonical model — read first
 

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -189,13 +189,23 @@ cheaper. The wins must be earned with index design and N+1 avoidance.
   cost is `computeNetworkLayout` (CPU) and the ③ Map-aware JSON serialize — both
   unchanged by this design and addressed separately (`performance-scaling.md`).
 
-**Indexes (design up front):**
-- every ②-relations table: `topology_id`
-- `attachment(topology_id, element_kind, element_ref)` — per-element fold
+**Index every foreign-key column (SQLite does NOT auto-index FKs).** With
+`foreign_keys = ON` and `ON DELETE CASCADE` from `topologies`, deleting a topology runs
+`SELECT … WHERE <child_fk> = ?` per child table — a **full table scan without an index**
+(sqlite.org/foreignkeys.html). So every FK column in the new tables needs an explicit
+index. The compound indexes below already cover the `topology_id` FK by prefix.
+
+**Indexes (design up front; equality → range/order → output; no redundant prefixes):**
+- `attachment(topology_id, element_kind, element_ref)` — per-element fold (also covers
+  `topology_id`-only by prefix → no separate `topology_id` index)
 - `attachment(topology_id, kind, source)` — "bindings by source" queries
-- `identity` UNIQUE `(topology_id, element_kind, element_ref, key_type, key_value)`
-  + reverse `(topology_id, key_type, key_value)` for the merge's identity match
+- `identity` PK `(topology_id, element_kind, element_ref, key_type, key_value)`
+  + reverse index `(topology_id, key_type, key_value)` for the merge's identity match
+- `suppression` / `exclusion` — their composite PK IS the index
 - observation prune already supported by `(topology_id, source_id, captured_at DESC)`
+- **Covering** only where the output is small (key/existence checks); do NOT add
+  `payload_json` to an index (large value defeats the point). `COUNT(*)`/`EXISTS` over
+  these indexes stay index-only.
 
 **Avoid N+1 (the main pitfall):** `buildGraph` must fetch each relations table **once
 per topology** (single indexed scan) and assemble in memory — never per-element queries.
@@ -206,9 +216,15 @@ PKs are a real cost on the high-row-count internal tables: a TEXT PK leaves the 
 rowid (one fast B-tree, less storage — Android's guidance). So:
 - Keep **TEXT nanoid** for externally-referenced entities (topologies, data_sources —
   they appear in URLs / the API).
-- For internal, never-URL-exposed, high-volume relations tables (`identity`,
-  `attachment`), prefer **`INTEGER PRIMARY KEY`**, or **`WITHOUT ROWID` with the natural
-  composite key** for `suppression` / `exclusion` (composite PKs, no surrogate id needed).
+- **`WITHOUT ROWID` with the natural composite key** for `identity` / `suppression` /
+  `exclusion` — they have composite keys, **small rows**, and no surrogate id is needed.
+  WITHOUT ROWID fits exactly here (~2× faster, ~50% less space) *provided* the row stays
+  **under ~1/20 of a page (~200 B at the 4 KiB page size)** — the sqlite.org rule of
+  thumb; verify with `sqlite3_analyzer`.
+- **Keep a rowid (`INTEGER PRIMARY KEY`)** for `attachment` — `payload_json` can push
+  rows over that ~200 B threshold, and WITHOUT ROWID *hurts* large-row tables (content in
+  interior B-tree nodes lowers fan-out). Index it as above.
+- Decide WITHOUT-ROWID-vs-rowid by **measuring actual row size**, not by guessing.
 
 **Push work into SQL, don't re-walk JSON in app code.** Filtering / aggregation /
 existence checks belong in queries (SQLite's engine ≫ JS loops), which is the whole
@@ -216,12 +232,32 @@ point of relationalizing ② — e.g. "bindings for source X" is an indexed `WHE
 `graph.nodes.flatMap(...)` over a parsed blob. (`COUNT(*)`/`EXISTS`/`LIMIT`, select only
 needed columns.)
 
-**SQLite levers:**
-- `doc_json` as **TEXT is the safe default** (we read the whole doc and parse in JS);
-  reserve **JSONB + generated columns** for scalars we actually filter on (promote on
-  demand, STORED+index for hot filters / expression index for rare ones).
-- WAL is on (concurrent read during scheduler writes); set `synchronous=NORMAL`,
-  `busy_timeout`, and a sensible `cache_size`/`mmap_size`.
+**Connection PRAGMAs — current gap (fix independently, applies now).** `db/index.ts`
+today sets only `journal_mode=WAL` + `foreign_keys=ON`. Missing the rest of the standard
+production set — most importantly **`busy_timeout`**: it's `0` today, so the moment the
+discovery scheduler writes while the UI reads, a reader/writer collision throws
+`SQLITE_BUSY` instead of waiting. Recommended set on every connection (well-sourced
+2024-2026 values):
+```
+PRAGMA journal_mode = WAL;       -- ✓ already
+PRAGMA foreign_keys = ON;        -- ✓ already
+PRAGMA synchronous = NORMAL;     -- safe + faster with WAL (currently FULL)
+PRAGMA busy_timeout = 5000;      -- ★ currently 0 → SQLITE_BUSY under scheduler+UI contention
+PRAGMA cache_size = -65536;      -- 64 MiB page cache (currently ~2 MiB)
+PRAGMA temp_store = MEMORY;      -- temp B-trees in RAM
+PRAGMA mmap_size = 268435456;    -- 256 MiB mmap → fewer read syscalls
+-- page_size = 4096 already set in the file
+```
+Run **`PRAGMA optimize`** on connection close (and periodically) so the planner has
+up-to-date stats; run **`ANALYZE`** after large backfills.
+
+**Storage of `doc_json`.** bun:sqlite here bundles **SQLite 3.51.1**, so the **JSONB type
+(3.45+) is available.** Still, **TEXT is the safe default** (we read the whole doc and
+parse in JS — JSONB's win is for in-DB `json_extract`, which we only do for promoted
+generated columns). Reserve **JSONB + generated columns** for scalars we actually filter
+on (STORED + index for hot filters / expression index for rare ones).
+
+**Other levers:**
 - Batch in **one transaction**: `reconcileBindings`' N-row replace, and `ingestGraph`.
 - Keep using bun:sqlite prepared statements (`.query()` cache).
 
@@ -239,9 +275,12 @@ exactly this — targeted compound indexes + a materialized view, found via EXPL
 - **`element_ref` identity model** — confirm identity-anchored refs handle the
   "authored attachment on an observed-only node" case (the empty-overlay-node the
   current code already prunes post-merge).
-- **`doc_json` as JSONB vs TEXT** — SQLite JSONB needs 3.45+ and bun:sqlite's bundled
-  SQLite version; verify before relying on the JSONB type (TEXT + `json_extract`
-  generated columns works regardless and is the safe default).
+- **`doc_json` as JSONB vs TEXT** — confirmed available (bun 1.3.4 → SQLite 3.51.1), but
+  TEXT + `json_extract` generated columns is the safe default; adopt JSONB deliberately
+  as a parse/storage optimization, not by default.
+- **WITHOUT ROWID row-size threshold** — `identity`/`suppression`/`exclusion` must stay
+  under ~200 B/row (4 KiB page) to benefit; verify with `sqlite3_analyzer` before
+  committing to it, else fall back to a rowid table.
 - **Editor convergence / `product` table** — deliberately deferred.
 
 ## References (prior art, verified 2026-06)
@@ -252,6 +291,11 @@ exactly this — targeted compound indexes + a materialized view, found via EXPL
 - Backstage — entity document + relations table + stitching: <https://backstage.io/docs/features/software-catalog/life-of-an-entity/>, <https://backstage.io/docs/features/software-catalog/creating-the-catalog-graph/>
 - SQLite performance best practices (Android) — INTEGER PK, compound indexes, WAL+synchronous, transactions, EXPLAIN QUERY PLAN, push work into SQL: <https://developer.android.com/topic/performance/sqlite-performance-best-practices>
 - SQLite performance tuning (Bencher) — compound indexes + materialized view + EXPLAIN/`.expert`, ~1200× win: <https://bencher.dev/learn/engineering/sqlite-performance-tuning/>
+- SQLite foreign keys — FK columns are NOT auto-indexed; index child keys: <https://www.sqlite.org/foreignkeys.html>
+- SQLite WITHOUT ROWID — when it helps (composite PK, <~1/20 page row) vs hurts: <https://www.sqlite.org/withoutrowid.html>
+- SQLite query planner — covering indexes, compound order, redundant-prefix, ANALYZE: <https://www.sqlite.org/queryplanner.html>
+- Production PRAGMA values (synchronous/busy_timeout/cache_size/mmap_size/temp_store): <https://databaseschool.com/articles/sqlite-recommended-pragmas>, <https://cj.rs/blog/sqlite-pragma-cheatsheet-for-performance-and-consistency/>
+- bun:sqlite (journal default DELETE → set WAL; safeIntegers): <https://bun.com/docs/runtime/sqlite>
 
 ## Relationship to existing docs
 - `topology-composition-store.md` — predecessor; its identity-keyed-store intent is realized here; `metrics-binding`-as-attachment = stage-1 input.

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -95,15 +95,19 @@ topology_resolved_graph topology_id, graph_json, layout_json, …, built_revisio
 contribution_source
   topology_id   TEXT REFERENCES topologies(id) ON DELETE CASCADE,
   source_id     TEXT,                            -- this contribution's id (ordinary id)
-  attachment_id TEXT REFERENCES topology_data_sources(id) ON DELETE CASCADE,  -- the (topology, source, purpose='topology') attach row; NULL ⇔ intrinsic
+  attachment_id TEXT,                            -- the attach row; NULL ⇔ intrinsic
   last_status   TEXT,                            -- 'ok'|'partial'|'empty'|'failed' (external; drives the replace strategy)
   last_ok_at    INTEGER,
   graph_payload_json TEXT,                       -- graph-level fields: version, name, description, settings, pins
-  PRIMARY KEY (topology_id, source_id)
-  -- priority is NOT stored here — it has ONE source of truth: external = the attach row's
-  --   topology_data_sources.priority; intrinsic (attachment_id IS NULL) = MAX. Detach (delete
-  --   of the attach row) cascades the contribution. One intrinsic per topology:
-  -- CREATE UNIQUE INDEX one_intrinsic ON contribution_source(topology_id) WHERE attachment_id IS NULL;
+  PRIMARY KEY (topology_id, source_id),
+  -- Composite FK ties the attach row to THIS topology (can't reference another topology's attach):
+  FOREIGN KEY (attachment_id, topology_id) REFERENCES topology_data_sources(id, topology_id) ON DELETE CASCADE
+  -- + attach row must be purpose='topology' (ingest/CHECK); one contribution per attach:
+  --   CREATE UNIQUE INDEX one_per_attach ON contribution_source(attachment_id) WHERE attachment_id IS NOT NULL;
+  --   CREATE UNIQUE INDEX one_intrinsic  ON contribution_source(topology_id)   WHERE attachment_id IS NULL;
+  -- priority has ONE source of truth: external = the attach row's topology_data_sources.priority;
+  --   intrinsic (attachment_id IS NULL) = MAX. Detach (delete of the attach row) cascades the contribution.
+  -- (requires a UNIQUE(id, topology_id) candidate key on topology_data_sources for the composite FK)
 
 -- ② Contributions (rows + payload doc column), uniform for every contribution (external + intrinsic)
 contribution_element
@@ -128,32 +132,44 @@ contribution_identity
 contribution_link
   id INTEGER PRIMARY KEY,
   topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
-  from_node_local_id TEXT, from_port_local_id TEXT,   -- endpoint = node (+ optional port); all same-source elements (FK each)
-  to_node_local_id   TEXT, to_port_local_id   TEXT,
-  presence    TEXT CHECK (presence IN ('present','hide')),
-  payload_json TEXT,                             -- type, arrow, label, bends, cable, style, per-endpoint plug/ip/pin (presentation)
-  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE
-  -- + composite FK each of the four endpoints → contribution_element(local_id, topology_id, source_id)
+  local_id    TEXT NOT NULL,                      -- the source-local Link.id (round-trips)
+  from_node_local_id TEXT NOT NULL, from_port_local_id TEXT,   -- endpoint = node (+ optional port), same-source elements
+  to_node_local_id   TEXT NOT NULL, to_port_local_id   TEXT,
+  presence    TEXT CHECK (presence IN ('present','hide')),     -- RESERVED — see "link scope" note (links are pass-through today)
+  payload_json TEXT,                             -- everything else (type/arrow/label/bends/cable/style/rateBps/vlan/redundancy/metadata/per-endpoint plug/ip/pin)
+  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE,
+  FOREIGN KEY (from_node_local_id, topology_id, source_id) REFERENCES contribution_element(local_id, topology_id, source_id),
+  FOREIGN KEY (to_node_local_id,   topology_id, source_id) REFERENCES contribution_element(local_id, topology_id, source_id),
+  FOREIGN KEY (from_port_local_id, topology_id, source_id) REFERENCES contribution_element(local_id, topology_id, source_id),
+  FOREIGN KEY (to_port_local_id,   topology_id, source_id) REFERENCES contribution_element(local_id, topology_id, source_id),
+  UNIQUE (topology_id, source_id, local_id)
+  -- (an endpoint port must belong to its endpoint node, and *_node/*_port must reference
+  --  kind='node'/'port' rows — enforced at ingest; see "kind/scope integrity")
 
 contribution_link_via                            -- ordered termination transits (Link.via), NORMALIZED (not JSON)
   link_id INTEGER REFERENCES contribution_link(id) ON DELETE CASCADE,
-  seq     INTEGER, termination_local_id TEXT,    -- a kind='termination' element in the same source
-  PRIMARY KEY (link_id, seq)  WITHOUT ROWID
+  topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
+  seq     INTEGER, termination_local_id TEXT NOT NULL,   -- a kind='termination' element in the same source
+  PRIMARY KEY (link_id, seq)  WITHOUT ROWID,
+  FOREIGN KEY (termination_local_id, topology_id, source_id) REFERENCES contribution_element(local_id, topology_id, source_id)
 
 contribution_attachment
   id INTEGER PRIMARY KEY,
   topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
-  element_id  INTEGER,                           -- NULL ⇔ scope='topology-default'
-  scope TEXT CHECK (scope IN ('node','subgraph','topology-default')),
-  kind  TEXT CHECK (kind IN ('access','policy','metrics-binding')),
-  attachment_key TEXT,                           -- generated CENTRALLY by attachmentKey() at ingest (canonical, derived from kind+payload)
+  element_id  INTEGER,                           -- NULL iff scope='topology-default' (CHECK below)
+  scope TEXT NOT NULL CHECK (scope IN ('node','port','subgraph','topology-default')),  -- 'port' added: link metrics bind to a port
+  kind  TEXT NOT NULL CHECK (kind IN ('access','policy','metrics-binding')),
+  attachment_key TEXT NOT NULL,                  -- generated CENTRALLY by attachmentKey() at ingest (canonical, derived from kind+payload)
   target_source_id TEXT REFERENCES data_sources(id) ON DELETE CASCADE,  -- metrics-binding dependency target (see note)
   negate INTEGER NOT NULL DEFAULT 0,             -- 0 = assert, 1 = suppress
   payload_json TEXT,
+  CHECK ((scope = 'topology-default') = (element_id IS NULL)),   -- default ⇔ no element; otherwise element required
+  CHECK ((kind = 'metrics-binding' AND negate = 0) <= (target_source_id IS NOT NULL)),  -- a real binding needs a target
   FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE,
   FOREIGN KEY (element_id, topology_id, source_id) REFERENCES contribution_element(id, topology_id, source_id) ON DELETE CASCADE,
   UNIQUE (topology_id, source_id, element_id, attachment_key)   -- one slot per (source, element, key)
   -- topology-default one-slot: CREATE UNIQUE INDEX ON contribution_attachment(topology_id, source_id, attachment_key) WHERE element_id IS NULL;
+  -- (scope must match the referenced element's kind: node→node, port→port, subgraph→subgraph — enforced at ingest)
 ```
 Notes (incorporating the Codex macro review):
 - **Tri-state presence (the neutral-anchor fix).** `presence` is NULL / `'present'` / `'hide'`.
@@ -213,11 +229,21 @@ while `'hide'` removes by priority. An attachment-on-an-observed-node is exactly
 impossible now, not just discouraged).
 
 **Kind scope.** Identity-clustering + signed presence apply to **nodes and their ports
-only**. `subgraph`/`termination` are **pass-through per source** (resolve has no identity
-key for them today; ids are namespaced per source). So `negate` on a subgraph/termination
-is **reserved, not yet resolved** — do NOT implement subgraph/termination hide until
-resolve gains an identity for them. The "uniform negate" claim is for the kinds the
-merge actually clusters.
+only**. `subgraph`, `termination`, **and links** are **pass-through per source** today
+(resolve has no cross-source identity for them — subgraph ids are namespaced per source,
+links are passed through by endpoint remap, `resolve.ts:814`). So `presence` on a
+subgraph / termination / **link** is **reserved, not yet resolved** — do NOT implement
+their hide until resolve gains an identity for them (for links: a key derived from
+resolved endpoint identities, tracked as a separate clustering PR). The "signed presence"
+claim is for the kinds the merge actually clusters (nodes/ports).
+
+**Design vs implementation boundary.** This doc fixes the *model* + the *invariants*
+(presence tri-state, ownership-via-attach, composite-FK same-source rule, scope↔kind
+match, no-cycle hierarchy, lossless-by-construction codec, priority direction + tie-break).
+The *executable* form — exact `CHECK`/`FOREIGN KEY`/trigger DDL, cycle-rejection, pin-ref
+validation, and the interface-generated round-trip fixtures — is the **stage-1
+implementation deliverable**, where it is actually *tested* (golden round-trip + DB tests).
+A design doc is not a full DDL; the constraints are proven in code, not prose.
 
 - **resolve's clustering + priority field-merge stay; its presence/suppression unify into
   the signed-assertion model and the `'authored'` literal special-cases are removed.** So
@@ -257,11 +283,18 @@ home — a **column**, a **payload_json** key, or **derived/resolve-only** (neve
 | `Subgraph` | `id,parent` | `label,direction,style,spec,file,pins` | `children[]` (derived from parent edges) |
 | `Attachment` | `kind,scope,attachment_key,target_source_id,negate` | kind leaves (`community/version`,`mode/intervalMs`,`hostId/interfaceIdentity/…`) | `provenance` (resolve) |
 
+**Lossless by construction.** `payload_json` is the **catch-all for every field not promoted
+to a column** — store `(node minus the promoted columns)` and, on read, overlay columns
+back onto payload. So nothing can be silently dropped (Node.size/termination, the full
+NodePort surface, Link.rateBps/vlan/redundancy/metadata, every Termination field, etc. ride
+in payload automatically); the column list is an *optimization* for query, not the
+completeness boundary. The codec table above just records which fields are *promoted*.
+
 Rules: **empty vs absent is preserved** (a stored `''`/`[]` is distinct from a missing
-key); `description` and every optional field has an explicit home (Codex caught
-`description` missing). Golden fixtures must cover every optional field, empty-vs-absent,
-and a full real graph. The test asserts a **normalized equality** (canonical key order),
-and additionally `resolve(buildContributions(x)) ≡ resolve(old readManual + snapshots)`.
+key). Golden fixtures are **generated from the core interfaces** (not hand-listed) so a new
+field is covered by construction; cover empty-vs-absent and a full real graph. The test
+asserts a **normalized equality** (canonical key order), and additionally
+`resolve(buildContributions(x)) ≡ resolve(old readManual + snapshots)`.
 
 ## Priority (one direction, derived, deterministic)
 
@@ -271,8 +304,9 @@ and additionally `resolve(buildContributions(x)) ≡ resolve(old readManual + sn
   to the higher-wins convention explicitly.
 - **Single source of truth**: external priority = the attach row's `topology_data_sources.priority`
   (not duplicated on `contribution_source`); the intrinsic contribution = MAX.
-- **Deterministic tie-break** for equal priority: contribution revision (newer wins) then
-  `source_id` — never rely on row order.
+- **Deterministic tie-break** for equal priority: `source_id` ascending — stable, unique
+  per contribution, no stored revision needed; never rely on row insertion order. (Today
+  `resolve()` ties on `capturedAt` then nothing — make the final key `source_id`.)
 
 ## Scaling (why DB-native, not a blob)
 

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -5,27 +5,28 @@
 
 ## ⚠️ Canonical model — read first
 
-> **The human is fully just a top-priority source. No authored layer, no human-vs-machine
-> special-casing, and NO reserved magic literal** (neither `'authored'` nor `'human'`).
-> A topology is **N source contributions**, each a `contribution_source` row. The human's
-> contribution is an *ordinary row* with a normal id; it is distinguished only by **typed
-> column values**, never by a branched string:
-> - **priority** — a *value* (the human's row holds the maximum). "Human wins" = higher
->   number, never `if (human)`.
-> - **`write_mode = 'edited'`** — edited-in-place (persists); external sources are
->   `'synced'` (re-fetched; a re-sync can drop a node → retraction). A typed kind, the
->   only basis for retraction, **orthogonal to human-ness** (a static import is also `'edited'`).
-> - **`origin = 'human'`** — a typed discriminator used only to *route* a human edit to
->   its row; the merge branches on **nothing** human-specific (only `priority`).
+> **There is no "human" or "authored" concept at all — not a layer, not a label, not an
+> `origin` flag.** A topology is **N contributions**, each a `contribution_source` row with
+> a `priority`. The ONLY structural distinction is **external vs the project's own**:
+> - a contribution **backed by a `data_source`** (`data_source_id` set) is an *external
+>   feed* — re-fetched on sync, so a re-sync that omits a node retracts it;
+> - a contribution with **`data_source_id IS NULL`** is the **project's own assertions** —
+>   written by the editor, never re-fetched, so it persists.
 >
-> The old `'authored'` literal (~15 `=== 'authored'` sites in `resolve.ts`) is **removed**.
+> This is **ownership / lifecycle (intrinsic vs external), NOT human-vs-machine** — a
+> future automated writer of project-owned data is also `data_source_id NULL`. "The
+> project's edits win" = its row holds the top `priority` (a *value*), never `if`. **The
+> merge branches on nothing but `priority`.** Editing writes the project's own
+> contribution (the topology's intrinsic layer, always available) — **it never spawns a
+> source**. Both the `'authored'` literal (~15 `=== 'authored'` sites in `resolve.ts`) and
+> any `'human'` tag are **removed**; retraction is derivable from `data_source_id IS NULL`.
 >
 > **Presence (scoop) and hide are the same bucket**: every contribution asserts
 > elements with a **sign** — a normal element row = "this node is here" (scoop); an
 > identity-only element row with `negate=1` = "hide this node". Same for attachments:
 > `negate=0` asserts, `negate=1` suppresses. `resolve()` clusters by identity and, per
 > identity/key, the **highest-priority assertion's sign** decides presence/value. Any
-> source can hide in principle; today only `'human'` does — usage, not a rule.
+> source can hide in principle; today only the project's own (intrinsic) contribution does — usage, not a rule.
 >
 > The literal `'authored'` special-cases in `resolve.ts` (~15 sites) are **residue to
 > remove**, replaced by priority + the signed-assertion model. Do NOT re-introduce a
@@ -49,7 +50,7 @@ cutting the "core type == storage model" coupling.
 
 ## Architecture: uniform contributions + one signed-assertion bucket
 
-Every source — external *and* `'human'` — stores the **same shape**:
+Every contribution — external feeds *and* the project's own — stores the **same shape**:
 - a **`contribution_source`** registry row (priority, write-mode, graph-level payload);
 - **`contribution_element`** rows (node|port|subgraph|termination + `payload_json`),
   each with a **`negate`** sign (0 = present/scoop, 1 = hide; a hide row is identity-only);
@@ -71,10 +72,11 @@ attachments, the binding target, the assertion sign) as real FK-enforced columns
 
 ## Schema (END STATE)
 
-`source_id` is `data_sources.id` for an external source, or an ordinary per-topology id
-for the human contribution (`origin='human'`) — **no code branches on its value**;
-`origin`/`write_mode`/`priority` columns carry the only differences. `payload_json` is the
-document column (promote a scalar to a generated column only when a query needs it).
+A contribution is identified by `contribution_source.id` (an ordinary id). It is an
+external feed when its `data_source_id` is set, or the project's own when
+`data_source_id IS NULL` — that NULL is the only discriminator, and **no code branches on
+any source string literal**. `payload_json` is the document column (promote a scalar to a
+generated column only when a query needs it).
 
 ```
 -- Existing, unchanged
@@ -84,20 +86,19 @@ topology_data_sources   id, topology_id, data_source_id, purpose, sync_mode, pri
 topology_resolved_graph topology_id, graph_json, layout_json, …, built_revision, resolver_version  -- ③ output
 -- topology_observations: RETIRED (its content becomes contribution_* rows; keep only as a raw audit log if desired)
 
--- ② Internal per-topology source registry (NOT data_sources; NOT in the Sources UI).
---    The human contribution is an ordinary row here (origin='human', normal id) — internal
---    bookkeeping, never an attachable source, so the "phantom Manual" UX problem does not
---    return. Resolves priority + FK + retraction. Nothing branches on the id value.
+-- ② Per-topology contribution registry. One row per contribution. data_source_id set =
+--    external feed; data_source_id NULL = the project's own (intrinsic) contribution
+--    (written by the editor, never re-fetched). The intrinsic row is NOT a data_source and
+--    NOT in the Sources UI, so "phantom Manual" does not return. No 'human'/'authored' tag.
 contribution_source
-  topology_id TEXT REFERENCES topologies(id) ON DELETE CASCADE,
-  source_id   TEXT,                              -- data_sources.id | 'human'
-  origin      TEXT,                              -- 'data-source' | 'human'
-  priority    INTEGER,                           -- merge precedence; 'human' = MAX
-  write_mode  TEXT,                              -- 'synced' (re-fetched, retractable) | 'edited' (in place, persists)
-  graph_payload_json TEXT,                       -- THIS contribution's graph-level fields: settings, pins, version, name
+  topology_id    TEXT REFERENCES topologies(id) ON DELETE CASCADE,
+  source_id      TEXT,                           -- this contribution's id (ordinary id)
+  data_source_id TEXT REFERENCES data_sources(id) ON DELETE CASCADE,  -- NULL ⇔ the project's own contribution
+  priority       INTEGER,                        -- merge precedence; the intrinsic contribution = MAX
+  graph_payload_json TEXT,                       -- this contribution's graph-level fields: settings, pins, version, name
   PRIMARY KEY (topology_id, source_id)
 
--- ② Contributions (rows + payload doc column), uniform for every source incl. 'human'
+-- ② Contributions (rows + payload doc column), uniform for every contribution (external + intrinsic)
 contribution_element
   id INTEGER PRIMARY KEY,
   topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
@@ -141,11 +142,11 @@ Notes:
   array + `suppressedAttachments`.)
 - **Identity-anchored** (settles the composition-store invariant-6 contradiction):
   `local_id` is only the intra-source handle; cross-source matching is `contribution_identity`.
-- **`contribution_source` resolves three prior blockers at once**: `'human'` priority lives
-  here (= MAX, the one legitimate human-specific *value*); FK integrity (every contribution
-  FKs a real registry row, incl. `'human'`); retraction = `write_mode` (`'edited'` rows
-  persist, `'synced'` rows are replaced per sync). Graph-level `settings`/`pins` live in
-  `graph_payload_json` (closes that round-trip gap).
+- **`contribution_source` resolves three prior blockers at once**: priority lives here (a
+  value; the intrinsic `data_source_id IS NULL` row = MAX); FK integrity (every contribution
+  FKs a real registry row); retraction is derivable (`data_source_id IS NULL` → never
+  re-fetched → persists; otherwise replaced per sync). Graph-level `settings`/`pins` live in
+  `graph_payload_json` (closes that round-trip gap). No `'human'`/`'authored'` literal anywhere.
 - **Terminations** = `kind='termination'`; `link.via` references the source's own terminations.
 - **Topology-default** = `attachment.element_id NULL`; partial unique index
   `(topology_id, source_id, attachment_key) WHERE element_id IS NULL` + the symmetric
@@ -171,11 +172,12 @@ ingestGraph(topologyId, source_id, graph)           -- decompose a graph into th
   matches the old `resolve(readManual + snapshots)` for representative graphs.
 - **A sync** = `ingestGraph(topology, <data_source_id>, scannedGraph)` (replace that
   source's rows transactionally; on a failed scan, leave them — status on `topology_data_sources`).
-- **A human edit** = write `'human'` rows incrementally (one attachment/element row =
-  O(1)); never a full-replace, so a crash can't wipe the human contribution. Import
-  (`ingestGraph` of the whole human graph) is the only full-replace and is one transaction.
-- **No phantom Manual** — the human contribution is rows under an internal
-  `contribution_source('human')`, never a user-facing data source.
+- **An editor edit** = write the project's-own contribution (the `data_source_id IS NULL`
+  row) incrementally (one attachment/element row = O(1)); never a full-replace, so a crash
+  can't wipe it. Import (`ingestGraph` of the whole project graph) is the only full-replace
+  and is one transaction.
+- **No phantom Manual** — the project's own data is rows under the intrinsic
+  `contribution_source` row (`data_source_id IS NULL`), never a user-facing data source.
 
 ## Scaling (why DB-native, not a blob)
 
@@ -215,8 +217,8 @@ plan below, WAL, and batched transactions. It is bounded and infrequent, not a w
 ## Staged migration
 
 1. **`contribution_source` + `contribution_element`/`identity`/`link` + `buildContributions`
-   for `'human'`** + `ingestGraph`/`buildGraph` + golden round-trip test. Backfill the
-   Manual observation graph into `'human'` rows.
+   for the intrinsic contribution** + `ingestGraph`/`buildGraph` + golden round-trip test.
+   Backfill the Manual observation graph into the intrinsic (`data_source_id IS NULL`) rows.
 2. **`contribution_attachment` (with `negate`)** — metrics-binding first
    (`target_source_id` FK), then policy/access; unify hide via `contribution_element.negate`.
    Remove the `'authored'` literal special-cases + the `exclusions`/`suppressedAttachments`

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -1,8 +1,9 @@
 # DB-native persistence — document + relations, the modern hybrid
 
-> Status: DRAFT (2026-06-07). Design of record for the follow-up to PR #375 (#362).
-> Supersedes the storage framing in `topology-composition-store.md` and the
-> known-gap in `manual-source-unification.md`. No backward compatibility.
+> Status: DRAFT (2026-06-07, **revised after an adversarial macro review** — see
+> § "Why elements are rows"). Design of record for the follow-up to PR #375 (#362).
+> Supersedes the storage framing in `topology-composition-store.md` and the known-gap
+> in `manual-source-unification.md`. No backward compatibility.
 
 ## Thesis
 
@@ -11,12 +12,12 @@ The server conflated two "types":
 1. **`@shumoku/core`'s `NetworkGraph`** — the library's interchange / serialization
    format (parser output, renderer input, every export). JSON-shaped, correctly so.
    **Stays untouched.**
-2. **The server's persistence model** — what the *application* stores and queries.
-   It was just (1) pickled as a blob; three refactors (`content_json` →
+2. **The server's persistence model** — what the *application* stores and queries. It
+   was just (1) pickled as a blob; three refactors (`content_json` →
    `config_json.graph` → `topology_observations.graph_json`) only *moved* the blob,
    never cutting the **"core type == storage model"** coupling. That debt surfaces as:
-   editing the composed graph spawns a phantom Manual source; "Manual is uniform"
-   is skin-deep; the metrics mapping can't be queried, indexed, or partially updated.
+   editing the composed graph spawns a phantom Manual source; "Manual is uniform" is
+   skin-deep; the metrics mapping can't be queried, indexed, or partially updated.
 
 > **North star.** The **DB is canonical**. `NetworkGraph` (JSON) is a **lossless,
 > bidirectional operation surface**: read/export *projects* the DB to a graph;
@@ -25,47 +26,65 @@ The server conflated two "types":
 
 ## Chosen architecture: document + relations (the modern hybrid)
 
-Researching how "DB-backed but JSON-operable" tools are actually built (2024–2025)
-shows a clear convergence — **not** "fully normalize everything," and **not** "one
-big blob," but a hybrid:
+How "DB-backed but JSON-operable" tools are actually built (2024–2026) converges on a
+hybrid — **not** "fully normalize everything," **not** "one big blob":
 
-- **Storage = document + generated-column indexes.** Store the resource as JSON(B);
-  *promote only the queried fields* to generated columns + indexes. Postgres
-  (JSONB + generated columns/expression indexes) and **SQLite ≥ 3.45 (2024): JSONB
-  type + virtual generated columns over `json_extract` + indexes** both do this
-  natively. You keep the document AND get B-tree query speed — no false choice.
-- **Relations = a normalized edge/dependency table.** Backstage stores entities as
-  documents but emits a dedicated **`relations` table** for the graph edges (used for
-  traversal, orphan detection, cascade delete). Edges/keys are normalized; payload
-  is document.
-- **Resource model + declarative apply + reconcile.** Grafana's App Platform now
-  models dashboards as **K8s-style resources (metadata/spec/status, apiVersion)** over
-  a **SQL unified storage** backend, with a declarative API. Processing = `spec ⊕
-  observed → reconcile/stitch → materialized status`.
+- **Storage = rows + a document column.** Backstage stores each catalog *entity* as a
+  row with a JSON document, **plus a normalized `relations` table** for the graph edges
+  (used for traversal, orphan detection, cascade delete). Edges/keys/identity are
+  columns; the rest of the payload is the document.
+- **Promote only what you query.** SQLite ≥ 3.45 / Postgres: keep the payload as
+  JSON(B), lift queried scalars to **generated columns + indexes** on demand.
+- **Resource model + declarative apply + reconcile.** Grafana's App Platform models
+  dashboards as K8s-style resources (metadata/spec/status) over SQL storage; processing
+  is `spec ⊕ observed → reconcile/stitch → materialized status`.
 
-**The split-canonical rule** (this is the key line):
+**The split-canonical rule** (the key line):
 
-> **Edges, dependencies, and identity keys = normalized relational tables (truth).**
-> **Element payload (label, equipment/spec, icon, style, position) = JSON document
-> (truth) + generated columns for the scalars you query.**
+> **Skeleton + edges + dependencies + identity = normalized columns (truth, FK-enforced).**
+> **The rest of an element's payload (spec/equipment, icon, style, position) = a JSON
+> document column on that element's row (truth) + generated columns when queried.**
 > Neither "all tables" nor "all blob."
 
-This solves the user's stated concerns exactly: the **mapping / dependency** data
-becomes relational rows (queryable, partial-updatable, merge-by-identity), while
-equipment/icons/style stay in the document (promote to generated columns only if a
-query needs them — no over-normalization).
+Mapping / dependency data becomes real, FK-enforced rows (queryable, partially
+updatable, integrity-checked); equipment/icons/style stay in the per-element document.
+
+## Why elements are rows (not one authored-graph blob) — the load-bearing decision
+
+An earlier draft kept all authored structure in a single `authored_graph.doc_json`
+blob and hung the relations off it "by identity." An adversarial review killed that:
+
+- **No referential integrity.** An `attachment`/`identity` row would reference a node
+  *inside a JSON blob* — no FK possible, so orphan rows are structural and need a manual
+  sweep. The old nested-in-blob model got node↔attachment atomicity for free; a blob +
+  side tables *loses* it.
+- **No stable anchor.** Identity is multi-key, mutable, and absent on hand-drawn nodes
+  (the current code falls back to node-id). "Anchor by identity" can't address an
+  identity-less node, and `topology-default` scope has no element at all.
+- **Dependency edge buried in JSON.** A metrics-binding's *target* (`sourceId`, host)
+  in `payload_json` is unqueryable and can't FK-cascade when its data source is deleted
+  — i.e. the "dependency table" wouldn't model the dependency.
+
+**Resolution:** promote the authored skeleton to **per-element rows** (`element`,
+`link`) with a **`payload_json` column** for the un-queried payload. Now identity /
+attachment / suppression are **FK children of `element` with `ON DELETE CASCADE`** (B1
++ atomicity solved structurally), `element.id` is the stable anchor (B2), and the
+binding's target is an FK column (B3). Payload stays JSON → not over-normalized. This
+is the Backstage shape applied at element granularity.
 
 ## Three layers
 
 | Layer | Contents | Storage |
 | --- | --- | --- |
-| **① External input** | per-source raw scans | **JSON snapshot (keep)** — `topology_observations.graph_json` |
-| **② Internal — document** | authored *structure*: nodes/links/subgraphs/terminations + payload (label, equipment/spec, **icon**, style, position) | **JSONB document (canonical)** + generated columns as needed |
-| **② Internal — relations** | identity keys, **metrics-binding (the mapping)**, policy, access, exclusions, suppressions | **normalized tables (canonical)** |
-| **③ Output** | resolved graph, exports | **materialized JSON (keep)** — `topology_resolved_graph` (= the "stitched/final entity") |
+| **① External input** | per-source raw scans (incl. their inline observed attachments) | **JSON snapshot (keep)** — `topology_observations.graph_json` |
+| **② Internal** | authored elements/links (skeleton columns + payload doc column); identity; **metrics-binding/policy/access** attachments; suppressions; exclusions | **rows + document column (canonical, FK-enforced)** |
+| **③ Output** | resolved graph, exports | **materialized JSON (keep)** — `topology_resolved_graph` (the "stitched/final entity") |
 
-Each fact has exactly one home: structure → ②-document or ① (observed); dependency /
-intent / identity → ②-relations. No double truth.
+Each *fact* has one home. Note the honest scoping of **②'s `attachment` table = the
+authored layer only**; *observed* attachments stay inline in their observation snapshot
+(① JSON) and are merged at resolve. So "query the mapping" means the authored bindings
+(today the mapping is authored-only by design); if binding-discovery ever emits observed
+bindings, they enter via ① and resolve — revisit promoting them then.
 
 ## Schema (END STATE)
 
@@ -79,225 +98,197 @@ topology_resolved_graph topology_id, graph_json, layout_json, … built_revision
                                                             -- ③ OUTPUT (materialized stitch)
 ```
 
-### ②-document — authored structure (replaces "the Manual source's graph")
+### ② Authored elements (rows + payload document column)
 ```
-authored_graph
-  topology_id   TEXT PK FK
-  doc_json      TEXT (JSONB)   -- authored NetworkGraph STRUCTURE: nodes/links/subgraphs/
-                               -- terminations/pins + payload (label, spec/equipment, icon,
-                               -- style, position). MINUS dependency/intent attachments
-                               -- (those are relations rows).
-  version       INTEGER        -- bump per save (cheap history; cf. Grafana dashboard_version)
-  updated_at    INTEGER
-  -- Promote queried scalars as generated columns + indexes WHEN a query needs them, e.g.:
-  --   node_count INT GENERATED ALWAYS AS (json_array_length(doc_json,'$.nodes')) VIRTUAL
-  -- Don't pre-normalize; add on demand.
-```
-Topology-owned. **Not a Manual source.** This kills "editing spawns a Manual."
+element
+  id            TEXT PK            -- the graph node/port/subgraph id (round-trips)
+  topology_id   TEXT NOT NULL  REFERENCES topologies(id) ON DELETE CASCADE
+  kind          TEXT NOT NULL      -- 'node' | 'port' | 'subgraph'
+  parent_id     TEXT  REFERENCES element(id) ON DELETE CASCADE   -- port→node, node→subgraph, subgraph→subgraph
+  payload_json  TEXT               -- un-queried payload: label, spec/equipment, icon, style,
+                                   -- position, metadata. Promote a scalar to a generated
+                                   -- column only when a query needs it.
 
-### ②-relations — identity, dependency, intent (the "mapping/dependency tables")
+link
+  id              TEXT PK
+  topology_id     TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE
+  from_element_id TEXT REFERENCES element(id) ON DELETE CASCADE   -- node or port
+  to_element_id   TEXT REFERENCES element(id) ON DELETE CASCADE
+  payload_json    TEXT             -- type, arrow, label, via, bends, cable, style (routing/presentation)
 ```
-identity     id, topology_id, element_kind('node'|'port'|'subgraph'), element_ref,
-             key_type('mgmtIp'|'chassisId'|'sysName'|'ifName'|'ifIndex'|'mac'|'vendorId:<ns>'),
-             key_value
-             UNIQUE(topology_id, element_kind, element_ref, key_type, key_value)
 
-attachment   id, topology_id, element_kind, element_ref,
-             scope('node'|'subgraph'|'topology-default'),
-             kind('access'|'policy'|'metrics-binding'),
-             attachment_key,           -- attachmentKey(): 'access:snmp'|'policy'|'metrics-binding:<sourceId>'
-             source,                   -- 'authored' | data_source_id  (provenance)
-             priority,
-             payload_json              -- {community,version} | {mode,intervalMs} |
-                                       -- {sourceId,hostId,interfaceIdentity,interfaceName,bandwidth}
-
-suppression  topology_id, element_kind, element_ref, attachment_key   PK(all)   -- human delete
-exclusion    topology_id, key_type, key_value                         PK(all)   -- hidden node by identity
+### ② Identity, dependency, intent (the mapping/dependency tables — FK children)
 ```
-- `element_ref` is **identity-anchored** (resolve joins by identity, so refs survive
-  re-id / re-scan). An authored attachment on an *observed* node = rows here keyed by
-  that node's identity, no document node required.
-- **The metrics mapping = `attachment WHERE kind='metrics-binding'`** — one row per
-  (element, source), queryable and partially updatable. `access` returns to relational
-  (reverses the `snmp_credentials`→JSON regression).
+identity      element_id  TEXT REFERENCES element(id) ON DELETE CASCADE,
+              topology_id TEXT NOT NULL,            -- denormalized for the cross-element match index
+              key_type    TEXT,  key_value TEXT,    -- 'mgmtIp'|'chassisId'|'sysName'|'ifName'|'ifIndex'|'mac'|'vendorId:<ns>'
+              PRIMARY KEY (element_id, key_type, key_value)   WITHOUT ROWID
+
+attachment    id            INTEGER PRIMARY KEY,    -- internal rowid (payload can be >200B → keep rowid)
+              topology_id   TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
+              element_id    TEXT REFERENCES element(id) ON DELETE CASCADE,  -- NULL ⇔ scope='topology-default'
+              scope         TEXT,                   -- 'node' | 'subgraph' | 'topology-default'
+              kind          TEXT,                   -- 'access' | 'policy' | 'metrics-binding'
+              attachment_key TEXT,                  -- attachmentKey(): 'access:snmp'|'policy'|'metrics-binding:<sourceId>'
+              target_source_id TEXT REFERENCES data_sources(id) ON DELETE CASCADE,  -- ★ metrics-binding's dependency target (NULL otherwise)
+              payload_json  TEXT                    -- kind leaves: {community,version} | {mode,intervalMs}
+                                                    --   | {hostId,interfaceIdentity,interfaceName,bandwidth}
+              UNIQUE (element_id, attachment_key)   -- one slot per (element, key); authored layer
+
+suppression   element_id TEXT REFERENCES element(id) ON DELETE CASCADE, attachment_key TEXT,
+              PRIMARY KEY (element_id, attachment_key)   WITHOUT ROWID
+
+exclusion     topology_id TEXT REFERENCES topologies(id) ON DELETE CASCADE, key_type TEXT, key_value TEXT,
+              PRIMARY KEY (topology_id, key_type, key_value)   WITHOUT ROWID   -- identity-keyed, topology-level
+```
+- **The `attachment` table is the authored contribution** (always top priority at
+  resolve), so it needs no `source`/`priority` columns — both are implied. Reintroduce
+  them only if observed attachments are ever promoted into this table.
+- **`target_source_id` is the dependency edge made real:** "what binds to source X" is
+  an indexed query, and deleting a data source **cascades** its bindings away (detach is
+  app logic: delete `attachment WHERE kind='metrics-binding' AND target_source_id=?`).
+  The host/interface match keys stay in `payload_json` (promote to columns if a query
+  needs them).
+- **`element.id` is the stable anchor**, not identity. `identity` rows are the *match
+  keys* resolve uses to cluster an authored element with observed contributions; an
+  identity-less hand-drawn node simply has no `identity` rows and matches by id only.
+  `topology-default` attachments carry `element_id = NULL`.
 
 ## Projection / ingestion (the round-trip contract)
 
 ```
 buildGraph(topologyId): NetworkGraph
-  = authored_graph.doc_json  (structure + payload)
-    ⊕ re-attach attachment/identity/exclusion rows by identity   → authored NetworkGraph
+  = SELECT element/link/identity/attachment/suppression/exclusion rows for the topology
+    (one indexed scan each — NOT per element), assemble into an authored NetworkGraph.
 ingestGraph(topologyId, graph)
-  = split graph → authored_graph.doc_json (structure)            (upsert, version++)
-    + identity / attachment / exclusion / suppression rows       (replace by key)
+  = upsert element/link rows (payload_json), replace identity/attachment/suppression by
+    key, exclusions — all in ONE transaction. FK ON DELETE CASCADE removes the children
+    of any element the import drops (no manual orphan sweep).
 ```
-- **Lossless:** `buildGraph(ingestGraph(g)) ≡ g` (modulo server ids / resolve-only
-  fields). A golden round-trip test guards this before structure migrates.
-- **`resolve()` is unchanged** — it already stitches an authored `NetworkGraph` with
-  observed snapshots by identity × key × priority. We feed it `buildGraph()` output
-  instead of `readManualGraph()`. Output still materializes to `topology_resolved_graph`.
+- **Lossless:** `buildGraph(ingestGraph(g)) ≡ g` (modulo resolve-only fields). A golden
+  round-trip test guards this from stage 1.
+- **`resolve()` is structurally unchanged** but **the complexity moves, it isn't
+  removed:** `buildGraph` is a new, non-trivial component that must reproduce the exact
+  authored-`NetworkGraph` the merge expects. resolve still folds authored ⊕ observed by
+  identity × key × priority; we feed it `buildGraph()` instead of `readManualGraph()`.
 - **Declarative apply** = `ingestGraph` (import a `NetworkGraph`); **export** =
-  `buildGraph` (or the resolved projection). The editor (neted) and any file-based
-  workflow operate the real data through this — the "JSON-operable" surface.
+  `buildGraph` (or the resolved projection). The editor and any file workflow operate
+  the real data through this — the JSON-operable surface.
 
-## Scope: two persistence worlds
+## Scope: two persistence worlds (and the unresolved strategic risk)
 
-- **`apps/server` (SQLite)** — this redesign. Gains ②-document + ②-relations.
-- **`apps/editor` (neted, IndexedDB)** — its own local working store + product
-  library; **out of scope.** It interoperates via `NetworkGraph` JSON (= a declarative
-  apply client). Editor⇄server convergence is a future question; the round-trip
-  contract is what makes it possible later.
-- **Equipment / icons** live in ②-document payload (matching `Node.spec`/`productId`
-  snapshot semantics). A server-side `product` table is a *later* refinement (promote
-  when a shared library / query need is real) — not required for the hybrid.
+- **`apps/server` (SQLite)** — this redesign.
+- **`apps/editor` (neted, IndexedDB)** — its own local store + product library.
+- **M4 — STRATEGIC OPEN QUESTION (not dodged):** server and editor would then hold the
+  *same authored domain* (graph, products) in **two different models** = two sources of
+  truth long-term. Stated intended end-state: **the server DB is canonical; the editor
+  becomes a client of the server through the `NetworkGraph` round-trip API** (or remains
+  a standalone tool that explicitly imports/exports). The round-trip contract is the
+  bridge. Convergence is tracked as its own effort — **flagged, not solved here.**
+- **Equipment / icons** live in `element.payload_json` (matching `Node.spec`/`productId`
+  snapshot semantics). A server-side `product` table is a later refinement (promote when
+  a shared library / query need is real).
 
-## Staged migration (each stage ships independently)
+## Staged migration (dependency order; each stage ships independently)
 
-0. **Design + cleanup.** This doc. Drop dead tables (`manual_source_graph`,
-   `snmp_credentials` — created by deleted migrations, 0 refs, 0 rows).
-1. **`metrics-binding` → `attachment` + `identity`.** Highest pain, identity-keyed,
-   independent. `reconcileBindings` writes rows; `buildGraph` re-attaches them;
-   `resolve()` unchanged. Backfill from Manual `graph_json`.
-2. **`policy` + `access` → `attachment`; `exclusion` + `suppression` → tables.**
-   Retire `ensureManualSource` for these; reverse the credentials regression.
-3. **Authored structure → `authored_graph`.** Stand up `buildGraph`/`ingestGraph` +
-   the golden round-trip test. Retire `manual_source_id` / `findManualSourceId`;
-   Manual becomes an optional uniform *hand-drawn source* (its graph = a layer-①
-   snapshot) or is dropped. **#375 known-gap closed.**
-4. **(On demand) generated columns** for hot queries; optional `product` table;
-   `(deferred/maybe never)` normalize *observed* structure (layer ①).
+FK direction dictates the order — `element` must exist before its attachment children.
 
-Per stage, `buildGraph` reads new tables for migrated slices and old `graph_json` for
-the rest (dual-read window); `resolver_version` bumps so the cache rebuilds.
+1. **`element` + `link` + `identity` + `buildGraph`/`ingestGraph` + golden round-trip
+   test.** Authored *structure* moves out of the Manual `graph_json` into rows. The
+   foundation everything else FKs onto.
+2. **`metrics-binding` → `attachment`** (highest-pain mapping; `target_source_id` FK).
+   `reconcileBindings` writes rows; `buildGraph` re-attaches; `resolve()` unchanged.
+3. **`policy` + `access` → `attachment`; `exclusion` + `suppression` → tables.** Reverses
+   the `snmp_credentials`→JSON regression; retires `ensureManualSource` for these.
+4. **Retire `manual_source_id` / `findManualSourceId`.** Manual becomes an optional
+   uniform *hand-drawn source* (its graph = a layer-① snapshot) or is dropped. **#375
+   known-gap closed.** Then on-demand generated columns / optional `product` table.
+0. **Cleanup (any time):** drop dead tables (`manual_source_graph`, `snmp_credentials`
+   — created by deleted migrations, 0 refs, 0 rows).
+
+**Backfill is move-and-strip, not copy (avoids the dual-truth window):** each stage
+moves its slice out of the Manual `graph_json` into rows **and removes it from the
+JSON** in one migration, so a slice is never live in both places. `buildGraph` reads
+rows for migrated slices and the (now-stripped) `graph_json` for the rest; `resolver_version`
+bumps so the cache rebuilds.
 
 ## Performance & indexing
 
-Net effect is **positive**: reads keep today's speed, writes get dramatically
-cheaper. The wins must be earned with index design and N+1 avoidance.
+Reads keep today's speed; writes get dramatically cheaper. Earned with indexes + N+1 avoidance.
 
-- **Read (hot path) — unchanged.** `/context` is served from the materialized ③
-  `topology_resolved_graph` (measured ~19ms / 1475 nodes). The internal model is only
-  touched on rebuild, so relationalizing ② does **not** slow reads.
-- **Write — the big win.** A single binding edit goes from "read → mutate → write the
-  *entire* `graph_json`" (O(graph)) to **one `attachment` row UPSERT/DELETE (O(1))**.
-  This is the headline benefit for the edit-heavy authoring workflow.
-- **Query — indexed, not full-scan.** "bindings for source X", "disabled nodes" become
-  indexed SQL instead of graph-walks over parsed JSON.
-- **Rebuild — comparable; DB is not the bottleneck.** On `composition_revision`
-  invalidation: `① observations (parse) ⊕ ② (doc parse + relations scan) → merge →
-  layout → ③ write`. With the indexes below, ② is an indexed scan per table. The real
-  cost is `computeNetworkLayout` (CPU) and the ③ Map-aware JSON serialize — both
-  unchanged by this design and addressed separately (`performance-scaling.md`).
+- **Read (hot path) — unchanged.** `/context` is served from materialized ③ (~19ms /
+  1475 nodes). ② is touched only on rebuild.
+- **Write — the big win.** A binding edit goes from "read→mutate→write the *entire*
+  `graph_json`" (O(graph)) to **one `attachment` row UPSERT/DELETE (O(1))**.
+- **Query — indexed.** "bindings for source X", "disabled nodes", "what depends on
+  source X" are indexed SQL, not graph-walks.
+- **Rebuild — DB is not the bottleneck.** `computeNetworkLayout` (CPU) + the ③ Map-aware
+  serialize dominate; both unchanged here (`performance-scaling.md`).
 
-**Index every foreign-key column (SQLite does NOT auto-index FKs).** With
-`foreign_keys = ON` and `ON DELETE CASCADE` from `topologies`, deleting a topology runs
-`SELECT … WHERE <child_fk> = ?` per child table — a **full table scan without an index**
-(sqlite.org/foreignkeys.html). So every FK column in the new tables needs an explicit
-index. The compound indexes below already cover the `topology_id` FK by prefix.
+**Index every FK column (SQLite does NOT auto-index FKs).** With `foreign_keys = ON` +
+`ON DELETE CASCADE`, an un-indexed child FK makes each cascade a full table scan
+(sqlite.org/foreignkeys.html). Concretely:
+- `element(topology_id)`, `element(parent_id)`
+- `link(topology_id)`, `link(from_element_id)`, `link(to_element_id)`
+- `attachment(topology_id, element_id)` (per-element fold; covers `element_id` via prefix)
+- `attachment(topology_id, kind)` — "all bindings/policies of a kind"
+- `attachment(target_source_id)` — "what depends on source X" + cascade on source delete
+- `identity` reverse index `(topology_id, key_type, key_value)` — the cross-element merge match
+- `suppression` / `exclusion` / `identity` PKs are their indexes (WITHOUT ROWID)
+- no redundant prefixes; **never index `payload_json`**; cover only small key/existence outputs
 
-**Indexes (design up front; equality → range/order → output; no redundant prefixes):**
-- `attachment(topology_id, element_kind, element_ref)` — per-element fold (also covers
-  `topology_id`-only by prefix → no separate `topology_id` index)
-- `attachment(topology_id, kind, source)` — "bindings by source" queries
-- `identity` PK `(topology_id, element_kind, element_ref, key_type, key_value)`
-  + reverse index `(topology_id, key_type, key_value)` for the merge's identity match
-- `suppression` / `exclusion` — their composite PK IS the index
-- observation prune already supported by `(topology_id, source_id, captured_at DESC)`
-- **Covering** only where the output is small (key/existence checks); do NOT add
-  `payload_json` to an index (large value defeats the point). `COUNT(*)`/`EXISTS` over
-  these indexes stay index-only.
+**Avoid N+1:** `buildGraph` fetches each table **once per topology** and assembles in
+memory — never per-element queries.
 
-**Avoid N+1 (the main pitfall):** `buildGraph` must fetch each relations table **once
-per topology** (single indexed scan) and assemble in memory — never per-element queries.
+**Primary-key strategy.** `element.id` / `link.id` are the graph ids → **TEXT** (must
+round-trip). `attachment` keeps an **`INTEGER PRIMARY KEY`** (payload can exceed the
+WITHOUT-ROWID ~200 B/page-1⁄20 threshold). `identity` / `suppression` / `exclusion` are
+small composite-key tables → **`WITHOUT ROWID`** (~2× faster, ~50% less space; verify
+row size with `sqlite3_analyzer`). External entities (topologies, data_sources) keep
+TEXT nanoid.
 
-**Primary-key strategy (Shumoku-specific — we use nanoid TEXT PKs everywhere).** TEXT
-PKs are a real cost on the high-row-count internal tables: a TEXT PK leaves the hidden
-`rowid` AND stores the string in every index, vs an `INTEGER PRIMARY KEY` which *is* the
-rowid (one fast B-tree, less storage — Android's guidance). So:
-- Keep **TEXT nanoid** for externally-referenced entities (topologies, data_sources —
-  they appear in URLs / the API).
-- **`WITHOUT ROWID` with the natural composite key** for `identity` / `suppression` /
-  `exclusion` — they have composite keys, **small rows**, and no surrogate id is needed.
-  WITHOUT ROWID fits exactly here (~2× faster, ~50% less space) *provided* the row stays
-  **under ~1/20 of a page (~200 B at the 4 KiB page size)** — the sqlite.org rule of
-  thumb; verify with `sqlite3_analyzer`.
-- **Keep a rowid (`INTEGER PRIMARY KEY`)** for `attachment` — `payload_json` can push
-  rows over that ~200 B threshold, and WITHOUT ROWID *hurts* large-row tables (content in
-  interior B-tree nodes lowers fan-out). Index it as above.
-- Decide WITHOUT-ROWID-vs-rowid by **measuring actual row size**, not by guessing.
+**Push work into SQL** (filter/aggregate/exists in queries, not JS loops over parsed
+JSON) — the whole point of relationalizing ②.
 
-**Push work into SQL, don't re-walk JSON in app code.** Filtering / aggregation /
-existence checks belong in queries (SQLite's engine ≫ JS loops), which is the whole
-point of relationalizing ② — e.g. "bindings for source X" is an indexed `WHERE`, not a
-`graph.nodes.flatMap(...)` over a parsed blob. (`COUNT(*)`/`EXISTS`/`LIMIT`, select only
-needed columns.)
+**Connection PRAGMAs.** Shipped in PR #377: `journal_mode=WAL`, `synchronous=NORMAL`,
+`foreign_keys=ON`, `busy_timeout=5000`, `cache_size=-65536`, `temp_store=MEMORY`,
+`mmap_size=256MiB`; `PRAGMA optimize` on close, `ANALYZE` after large backfills.
 
-**Connection PRAGMAs — current gap (fix independently, applies now).** `db/index.ts`
-today sets only `journal_mode=WAL` + `foreign_keys=ON`. Missing the rest of the standard
-production set — most importantly **`busy_timeout`**: it's `0` today, so the moment the
-discovery scheduler writes while the UI reads, a reader/writer collision throws
-`SQLITE_BUSY` instead of waiting. Recommended set on every connection (well-sourced
-2024-2026 values):
-```
-PRAGMA journal_mode = WAL;       -- ✓ already
-PRAGMA foreign_keys = ON;        -- ✓ already
-PRAGMA synchronous = NORMAL;     -- safe + faster with WAL (currently FULL)
-PRAGMA busy_timeout = 5000;      -- ★ currently 0 → SQLITE_BUSY under scheduler+UI contention
-PRAGMA cache_size = -65536;      -- 64 MiB page cache (currently ~2 MiB)
-PRAGMA temp_store = MEMORY;      -- temp B-trees in RAM
-PRAGMA mmap_size = 268435456;    -- 256 MiB mmap → fewer read syscalls
--- page_size = 4096 already set in the file
-```
-Run **`PRAGMA optimize`** on connection close (and periodically) so the planner has
-up-to-date stats; run **`ANALYZE`** after large backfills.
+**`doc_json`/`payload_json` storage.** SQLite 3.51.1 (bun 1.3.4) has JSONB, but **TEXT
+is the default** (we read whole payloads and parse in JS); reserve JSONB + generated
+columns for scalars we actually filter on.
 
-**Storage of `doc_json`.** bun:sqlite here bundles **SQLite 3.51.1**, so the **JSONB type
-(3.45+) is available.** Still, **TEXT is the safe default** (we read the whole doc and
-parse in JS — JSONB's win is for in-DB `json_extract`, which we only do for promoted
-generated columns). Reserve **JSONB + generated columns** for scalars we actually filter
-on (STORED + index for hot filters / expression index for rare ones).
-
-**Other levers:**
-- Batch in **one transaction**: `reconcileBindings`' N-row replace, and `ingestGraph`.
-- Keep using bun:sqlite prepared statements (`.query()` cache).
-
-**Measure with `EXPLAIN QUERY PLAN` (+ SQLite's `.expert`)**, not by guessing — confirm
-every hot query hits an index (no `SCAN TABLE`). Add phase timing (DB read / merge /
-layout / ③ write) around resolve; today only the cache-hit path (~19ms) is measured, the
-rebuild path is what to instrument. (Prior art: Bencher cut response time ~1200× with
-exactly this — targeted compound indexes + a materialized view, found via EXPLAIN.)
+**Measure with `EXPLAIN QUERY PLAN`** — confirm every hot query hits an index
+(no `SCAN TABLE`). Add phase timing (DB read / merge / layout / ③ write) around resolve.
 
 ## Risks / open questions
 
-- **Round-trip golden test must exist before stage 3** or losslessness is unverified.
-- **Backfill** per stage: move the slice out of Manual `graph_json`, then drop it from
-  the JSON (no-backcompat; one-time, then delete the old path).
-- **`element_ref` identity model** — confirm identity-anchored refs handle the
-  "authored attachment on an observed-only node" case (the empty-overlay-node the
-  current code already prunes post-merge).
-- **`doc_json` as JSONB vs TEXT** — confirmed available (bun 1.3.4 → SQLite 3.51.1), but
-  TEXT + `json_extract` generated columns is the safe default; adopt JSONB deliberately
-  as a parse/storage optimization, not by default.
-- **WITHOUT ROWID row-size threshold** — `identity`/`suppression`/`exclusion` must stay
-  under ~200 B/row (4 KiB page) to benefit; verify with `sqlite3_analyzer` before
-  committing to it, else fall back to a rowid table.
-- **Editor convergence / `product` table** — deliberately deferred.
+- **`buildGraph` complexity** — it now owns reconstructing the exact authored
+  `NetworkGraph`; the golden round-trip test must exist from stage 1.
+- **Identity-less authored nodes** — match by `element.id` only (no `identity` rows);
+  confirm resolve's cluster step handles id-only authored members (it does today via the
+  node-id fallback — preserve it).
+- **Detach vs delete of a metrics source** — FK cascades on data-source *delete*; *detach*
+  (removing the m2m junction) must delete the source's bindings in app logic, mirroring
+  PR #375's detach-clears-observations.
+- **`attachment` table = authored only** — observed attachments remain in ① JSON; "query
+  the mapping" is authored-scoped until/unless binding-discovery lands.
+- **No authored history** — `composition_revision` (cache) + `element.…`-level
+  `updated_at` only; there is **no version/undo history** for authored data (dropped the
+  earlier misleading "version" claim). A version/event-log is a separate future feature.
+- **Editor convergence (M4)** — the standing strategic risk above.
 
 ## References (prior art, verified 2026-06)
-- PostgreSQL JSONB hybrid + generated columns: <https://www.architecture-weekly.com/p/postgresql-jsonb-powerful-storage>, <https://richyen.com/postgres/2026/05/11/generated_columns_jsonb.html>
-- Modern hybrid DB architectures (2025): <https://200oksolutions.com/blog/modern-database-architectures-hybrid-approach-sql-nosql-newsql-2025/>
-- SQLite JSON / JSONB + virtual generated columns: <https://sqlite.org/json1.html>, <https://www.dbpro.app/blog/sqlite-json-virtual-columns-indexing>
+- Backstage — entity document + relations table + stitching/orphan-sweep: <https://backstage.io/docs/features/software-catalog/life-of-an-entity/>, <https://backstage.io/docs/features/software-catalog/creating-the-catalog-graph/>
 - Grafana App Platform — K8s-style resources over SQL unified storage: <https://deepwiki.com/grafana/grafana/3.3-folder-management>
-- Backstage — entity document + relations table + stitching: <https://backstage.io/docs/features/software-catalog/life-of-an-entity/>, <https://backstage.io/docs/features/software-catalog/creating-the-catalog-graph/>
-- SQLite performance best practices (Android) — INTEGER PK, compound indexes, WAL+synchronous, transactions, EXPLAIN QUERY PLAN, push work into SQL: <https://developer.android.com/topic/performance/sqlite-performance-best-practices>
-- SQLite performance tuning (Bencher) — compound indexes + materialized view + EXPLAIN/`.expert`, ~1200× win: <https://bencher.dev/learn/engineering/sqlite-performance-tuning/>
-- SQLite foreign keys — FK columns are NOT auto-indexed; index child keys: <https://www.sqlite.org/foreignkeys.html>
-- SQLite WITHOUT ROWID — when it helps (composite PK, <~1/20 page row) vs hurts: <https://www.sqlite.org/withoutrowid.html>
-- SQLite query planner — covering indexes, compound order, redundant-prefix, ANALYZE: <https://www.sqlite.org/queryplanner.html>
-- Production PRAGMA values (synchronous/busy_timeout/cache_size/mmap_size/temp_store): <https://databaseschool.com/articles/sqlite-recommended-pragmas>, <https://cj.rs/blog/sqlite-pragma-cheatsheet-for-performance-and-consistency/>
-- bun:sqlite (journal default DELETE → set WAL; safeIntegers): <https://bun.com/docs/runtime/sqlite>
+- PostgreSQL JSONB + generated columns; modern hybrid (2025): <https://www.architecture-weekly.com/p/postgresql-jsonb-powerful-storage>, <https://200oksolutions.com/blog/modern-database-architectures-hybrid-approach-sql-nosql-newsql-2025/>
+- SQLite JSON/JSONB + virtual generated columns: <https://sqlite.org/json1.html>, <https://www.dbpro.app/blog/sqlite-json-virtual-columns-indexing>
+- SQLite foreign keys — FK columns are NOT auto-indexed: <https://www.sqlite.org/foreignkeys.html>
+- SQLite WITHOUT ROWID — composite PK, <~1/20-page rows: <https://www.sqlite.org/withoutrowid.html>
+- SQLite query planner — covering indexes, compound order, ANALYZE: <https://www.sqlite.org/queryplanner.html>
+- Production PRAGMAs: <https://databaseschool.com/articles/sqlite-recommended-pragmas>; bun:sqlite: <https://bun.com/docs/runtime/sqlite>
 
 ## Relationship to existing docs
-- `topology-composition-store.md` — predecessor; its identity-keyed-store intent is realized here; `metrics-binding`-as-attachment = stage-1 input.
-- `manual-source-unification.md` — its known-gap is closed by stages 1–3.
+- `topology-composition-store.md` — predecessor; its identity-keyed-store intent is realized here.
+- `manual-source-unification.md` — its known-gap is closed by stages 1–4.
 - `topology-ui-ia.md` — unaffected (UI reads the same projected graph).

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -1,0 +1,239 @@
+# DB-native persistence — document + relations, the modern hybrid
+
+> Status: DRAFT (2026-06-07). Design of record for the follow-up to PR #375 (#362).
+> Supersedes the storage framing in `topology-composition-store.md` and the
+> known-gap in `manual-source-unification.md`. No backward compatibility.
+
+## Thesis
+
+The server conflated two "types":
+
+1. **`@shumoku/core`'s `NetworkGraph`** — the library's interchange / serialization
+   format (parser output, renderer input, every export). JSON-shaped, correctly so.
+   **Stays untouched.**
+2. **The server's persistence model** — what the *application* stores and queries.
+   It was just (1) pickled as a blob; three refactors (`content_json` →
+   `config_json.graph` → `topology_observations.graph_json`) only *moved* the blob,
+   never cutting the **"core type == storage model"** coupling. That debt surfaces as:
+   editing the composed graph spawns a phantom Manual source; "Manual is uniform"
+   is skin-deep; the metrics mapping can't be queried, indexed, or partially updated.
+
+> **North star.** The **DB is canonical**. `NetworkGraph` (JSON) is a **lossless,
+> bidirectional operation surface**: read/export *projects* the DB to a graph;
+> write/import *decomposes* a graph into the DB; `JSON → DB → JSON` is identical for
+> real data. Nothing is DB-only-inexpressible-in-JSON, nothing is JSON-only-bypassing-DB.
+
+## Chosen architecture: document + relations (the modern hybrid)
+
+Researching how "DB-backed but JSON-operable" tools are actually built (2024–2025)
+shows a clear convergence — **not** "fully normalize everything," and **not** "one
+big blob," but a hybrid:
+
+- **Storage = document + generated-column indexes.** Store the resource as JSON(B);
+  *promote only the queried fields* to generated columns + indexes. Postgres
+  (JSONB + generated columns/expression indexes) and **SQLite ≥ 3.45 (2024): JSONB
+  type + virtual generated columns over `json_extract` + indexes** both do this
+  natively. You keep the document AND get B-tree query speed — no false choice.
+- **Relations = a normalized edge/dependency table.** Backstage stores entities as
+  documents but emits a dedicated **`relations` table** for the graph edges (used for
+  traversal, orphan detection, cascade delete). Edges/keys are normalized; payload
+  is document.
+- **Resource model + declarative apply + reconcile.** Grafana's App Platform now
+  models dashboards as **K8s-style resources (metadata/spec/status, apiVersion)** over
+  a **SQL unified storage** backend, with a declarative API. Processing = `spec ⊕
+  observed → reconcile/stitch → materialized status`.
+
+**The split-canonical rule** (this is the key line):
+
+> **Edges, dependencies, and identity keys = normalized relational tables (truth).**
+> **Element payload (label, equipment/spec, icon, style, position) = JSON document
+> (truth) + generated columns for the scalars you query.**
+> Neither "all tables" nor "all blob."
+
+This solves the user's stated concerns exactly: the **mapping / dependency** data
+becomes relational rows (queryable, partial-updatable, merge-by-identity), while
+equipment/icons/style stay in the document (promote to generated columns only if a
+query needs them — no over-normalization).
+
+## Three layers
+
+| Layer | Contents | Storage |
+| --- | --- | --- |
+| **① External input** | per-source raw scans | **JSON snapshot (keep)** — `topology_observations.graph_json` |
+| **② Internal — document** | authored *structure*: nodes/links/subgraphs/terminations + payload (label, equipment/spec, **icon**, style, position) | **JSONB document (canonical)** + generated columns as needed |
+| **② Internal — relations** | identity keys, **metrics-binding (the mapping)**, policy, access, exclusions, suppressions | **normalized tables (canonical)** |
+| **③ Output** | resolved graph, exports | **materialized JSON (keep)** — `topology_resolved_graph` (= the "stitched/final entity") |
+
+Each fact has exactly one home: structure → ②-document or ① (observed); dependency /
+intent / identity → ②-relations. No double truth.
+
+## Schema (END STATE)
+
+### Existing (unchanged)
+```
+topologies              id, name, share_token, composition_revision, ts…   -- shell
+data_sources            id, name, type, config_json, status…
+topology_data_sources   id, topology_id, data_source_id, purpose, sync_mode, priority, last_synced_at…
+topology_observations   …, graph_json                       -- ① INPUT (JSON snapshot)
+topology_resolved_graph topology_id, graph_json, layout_json, … built_revision, resolver_version
+                                                            -- ③ OUTPUT (materialized stitch)
+```
+
+### ②-document — authored structure (replaces "the Manual source's graph")
+```
+authored_graph
+  topology_id   TEXT PK FK
+  doc_json      TEXT (JSONB)   -- authored NetworkGraph STRUCTURE: nodes/links/subgraphs/
+                               -- terminations/pins + payload (label, spec/equipment, icon,
+                               -- style, position). MINUS dependency/intent attachments
+                               -- (those are relations rows).
+  version       INTEGER        -- bump per save (cheap history; cf. Grafana dashboard_version)
+  updated_at    INTEGER
+  -- Promote queried scalars as generated columns + indexes WHEN a query needs them, e.g.:
+  --   node_count INT GENERATED ALWAYS AS (json_array_length(doc_json,'$.nodes')) VIRTUAL
+  -- Don't pre-normalize; add on demand.
+```
+Topology-owned. **Not a Manual source.** This kills "editing spawns a Manual."
+
+### ②-relations — identity, dependency, intent (the "mapping/dependency tables")
+```
+identity     id, topology_id, element_kind('node'|'port'|'subgraph'), element_ref,
+             key_type('mgmtIp'|'chassisId'|'sysName'|'ifName'|'ifIndex'|'mac'|'vendorId:<ns>'),
+             key_value
+             UNIQUE(topology_id, element_kind, element_ref, key_type, key_value)
+
+attachment   id, topology_id, element_kind, element_ref,
+             scope('node'|'subgraph'|'topology-default'),
+             kind('access'|'policy'|'metrics-binding'),
+             attachment_key,           -- attachmentKey(): 'access:snmp'|'policy'|'metrics-binding:<sourceId>'
+             source,                   -- 'authored' | data_source_id  (provenance)
+             priority,
+             payload_json              -- {community,version} | {mode,intervalMs} |
+                                       -- {sourceId,hostId,interfaceIdentity,interfaceName,bandwidth}
+
+suppression  topology_id, element_kind, element_ref, attachment_key   PK(all)   -- human delete
+exclusion    topology_id, key_type, key_value                         PK(all)   -- hidden node by identity
+```
+- `element_ref` is **identity-anchored** (resolve joins by identity, so refs survive
+  re-id / re-scan). An authored attachment on an *observed* node = rows here keyed by
+  that node's identity, no document node required.
+- **The metrics mapping = `attachment WHERE kind='metrics-binding'`** — one row per
+  (element, source), queryable and partially updatable. `access` returns to relational
+  (reverses the `snmp_credentials`→JSON regression).
+
+## Projection / ingestion (the round-trip contract)
+
+```
+buildGraph(topologyId): NetworkGraph
+  = authored_graph.doc_json  (structure + payload)
+    ⊕ re-attach attachment/identity/exclusion rows by identity   → authored NetworkGraph
+ingestGraph(topologyId, graph)
+  = split graph → authored_graph.doc_json (structure)            (upsert, version++)
+    + identity / attachment / exclusion / suppression rows       (replace by key)
+```
+- **Lossless:** `buildGraph(ingestGraph(g)) ≡ g` (modulo server ids / resolve-only
+  fields). A golden round-trip test guards this before structure migrates.
+- **`resolve()` is unchanged** — it already stitches an authored `NetworkGraph` with
+  observed snapshots by identity × key × priority. We feed it `buildGraph()` output
+  instead of `readManualGraph()`. Output still materializes to `topology_resolved_graph`.
+- **Declarative apply** = `ingestGraph` (import a `NetworkGraph`); **export** =
+  `buildGraph` (or the resolved projection). The editor (neted) and any file-based
+  workflow operate the real data through this — the "JSON-operable" surface.
+
+## Scope: two persistence worlds
+
+- **`apps/server` (SQLite)** — this redesign. Gains ②-document + ②-relations.
+- **`apps/editor` (neted, IndexedDB)** — its own local working store + product
+  library; **out of scope.** It interoperates via `NetworkGraph` JSON (= a declarative
+  apply client). Editor⇄server convergence is a future question; the round-trip
+  contract is what makes it possible later.
+- **Equipment / icons** live in ②-document payload (matching `Node.spec`/`productId`
+  snapshot semantics). A server-side `product` table is a *later* refinement (promote
+  when a shared library / query need is real) — not required for the hybrid.
+
+## Staged migration (each stage ships independently)
+
+0. **Design + cleanup.** This doc. Drop dead tables (`manual_source_graph`,
+   `snmp_credentials` — created by deleted migrations, 0 refs, 0 rows).
+1. **`metrics-binding` → `attachment` + `identity`.** Highest pain, identity-keyed,
+   independent. `reconcileBindings` writes rows; `buildGraph` re-attaches them;
+   `resolve()` unchanged. Backfill from Manual `graph_json`.
+2. **`policy` + `access` → `attachment`; `exclusion` + `suppression` → tables.**
+   Retire `ensureManualSource` for these; reverse the credentials regression.
+3. **Authored structure → `authored_graph`.** Stand up `buildGraph`/`ingestGraph` +
+   the golden round-trip test. Retire `manual_source_id` / `findManualSourceId`;
+   Manual becomes an optional uniform *hand-drawn source* (its graph = a layer-①
+   snapshot) or is dropped. **#375 known-gap closed.**
+4. **(On demand) generated columns** for hot queries; optional `product` table;
+   `(deferred/maybe never)` normalize *observed* structure (layer ①).
+
+Per stage, `buildGraph` reads new tables for migrated slices and old `graph_json` for
+the rest (dual-read window); `resolver_version` bumps so the cache rebuilds.
+
+## Performance & indexing
+
+Net effect is **positive**: reads keep today's speed, writes get dramatically
+cheaper. The wins must be earned with index design and N+1 avoidance.
+
+- **Read (hot path) — unchanged.** `/context` is served from the materialized ③
+  `topology_resolved_graph` (measured ~19ms / 1475 nodes). The internal model is only
+  touched on rebuild, so relationalizing ② does **not** slow reads.
+- **Write — the big win.** A single binding edit goes from "read → mutate → write the
+  *entire* `graph_json`" (O(graph)) to **one `attachment` row UPSERT/DELETE (O(1))**.
+  This is the headline benefit for the edit-heavy authoring workflow.
+- **Query — indexed, not full-scan.** "bindings for source X", "disabled nodes" become
+  indexed SQL instead of graph-walks over parsed JSON.
+- **Rebuild — comparable; DB is not the bottleneck.** On `composition_revision`
+  invalidation: `① observations (parse) ⊕ ② (doc parse + relations scan) → merge →
+  layout → ③ write`. With the indexes below, ② is an indexed scan per table. The real
+  cost is `computeNetworkLayout` (CPU) and the ③ Map-aware JSON serialize — both
+  unchanged by this design and addressed separately (`performance-scaling.md`).
+
+**Indexes (design up front):**
+- every ②-relations table: `topology_id`
+- `attachment(topology_id, element_kind, element_ref)` — per-element fold
+- `attachment(topology_id, kind, source)` — "bindings by source" queries
+- `identity` UNIQUE `(topology_id, element_kind, element_ref, key_type, key_value)`
+  + reverse `(topology_id, key_type, key_value)` for the merge's identity match
+- observation prune already supported by `(topology_id, source_id, captured_at DESC)`
+
+**Avoid N+1 (the main pitfall):** `buildGraph` must fetch each relations table **once
+per topology** (single indexed scan) and assemble in memory — never per-element queries.
+
+**SQLite levers:**
+- `doc_json` as **TEXT is the safe default** (we read the whole doc and parse in JS);
+  reserve **JSONB + generated columns** for scalars we actually filter on (promote on
+  demand, STORED+index for hot filters / expression index for rare ones).
+- WAL is on (concurrent read during scheduler writes); set `synchronous=NORMAL`,
+  `busy_timeout`, and a sensible `cache_size`/`mmap_size`.
+- Batch in **one transaction**: `reconcileBindings`' N-row replace, and `ingestGraph`.
+- Keep using bun:sqlite prepared statements (`.query()` cache).
+
+**Measure before tuning:** add phase timing (DB read / merge / layout / ③ write) around
+resolve so the bottleneck is data, not a guess. Today only the cache-hit path (~19ms)
+is measured; the rebuild path is what to instrument.
+
+## Risks / open questions
+
+- **Round-trip golden test must exist before stage 3** or losslessness is unverified.
+- **Backfill** per stage: move the slice out of Manual `graph_json`, then drop it from
+  the JSON (no-backcompat; one-time, then delete the old path).
+- **`element_ref` identity model** — confirm identity-anchored refs handle the
+  "authored attachment on an observed-only node" case (the empty-overlay-node the
+  current code already prunes post-merge).
+- **`doc_json` as JSONB vs TEXT** — SQLite JSONB needs 3.45+ and bun:sqlite's bundled
+  SQLite version; verify before relying on the JSONB type (TEXT + `json_extract`
+  generated columns works regardless and is the safe default).
+- **Editor convergence / `product` table** — deliberately deferred.
+
+## References (prior art, verified 2026-06)
+- PostgreSQL JSONB hybrid + generated columns: <https://www.architecture-weekly.com/p/postgresql-jsonb-powerful-storage>, <https://richyen.com/postgres/2026/05/11/generated_columns_jsonb.html>
+- Modern hybrid DB architectures (2025): <https://200oksolutions.com/blog/modern-database-architectures-hybrid-approach-sql-nosql-newsql-2025/>
+- SQLite JSON / JSONB + virtual generated columns: <https://sqlite.org/json1.html>, <https://www.dbpro.app/blog/sqlite-json-virtual-columns-indexing>
+- Grafana App Platform — K8s-style resources over SQL unified storage: <https://deepwiki.com/grafana/grafana/3.3-folder-management>
+- Backstage — entity document + relations table + stitching: <https://backstage.io/docs/features/software-catalog/life-of-an-entity/>, <https://backstage.io/docs/features/software-catalog/creating-the-catalog-graph/>
+
+## Relationship to existing docs
+- `topology-composition-store.md` — predecessor; its identity-keyed-store intent is realized here; `metrics-binding`-as-attachment = stage-1 input.
+- `manual-source-unification.md` — its known-gap is closed by stages 1–3.
+- `topology-ui-ia.md` — unaffected (UI reads the same projected graph).

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -95,8 +95,12 @@ contribution_source
   source_id      TEXT,                           -- this contribution's id (ordinary id)
   data_source_id TEXT REFERENCES data_sources(id) ON DELETE CASCADE,  -- NULL ⇔ the project's own contribution
   priority       INTEGER,                        -- merge precedence; the intrinsic contribution = MAX
+  last_status    TEXT,                           -- last sync: 'ok'|'partial'|'empty'|'failed' (drives the replace strategy; external only)
+  last_ok_at     INTEGER,
   graph_payload_json TEXT,                       -- this contribution's graph-level fields: settings, pins, version, name
   PRIMARY KEY (topology_id, source_id)
+  -- Exactly one intrinsic contribution per topology (guards the lazy-create race):
+  -- CREATE UNIQUE INDEX one_intrinsic ON contribution_source(topology_id) WHERE data_source_id IS NULL;
 
 -- ② Contributions (rows + payload doc column), uniform for every contribution (external + intrinsic)
 contribution_element
@@ -157,21 +161,48 @@ Notes:
 ```
 buildContributions(topologyId): per-source inputs   -- assembled from contribution_* rows (indexed scans)
 resolve(buildContributions(topologyId)) → resolved graph → materialize ③
-  · cluster elements by identity
-  · presence: per cluster, the highest-priority element's `negate` decides (0 present / 1 hidden)
+  · cluster elements by identity (nodes/ports only — see "kind scope")
+  · presence: the PRECISE rule below (NOT "highest row wins")
   · fields & attachments: per key, the highest-priority assertion's sign + payload wins
 buildGraph(topologyId, source_id): NetworkGraph     -- project ONE source's contribution (export/edit; raw ids)
 exportResolved(topologyId): NetworkGraph            -- project the materialized resolved graph (final picture)
 ingestGraph(topologyId, source_id, graph)           -- decompose a graph into that source's rows; ONE txn;
                                                     --   PRAGMA defer_foreign_keys for intra-import forward refs
 ```
+
+**Presence rule (precise — pin this; the golden test alone won't).** Absence of a row is
+**not** an assertion. A cluster is **present iff** at least one contribution has a
+*non-negated* element row for it **and** the highest-priority *opinionated* row (one that
+exists, present-or-hide) is **not** `negate=1`. A contribution with **no row** for a
+cluster expresses **no opinion** — so this preserves today's union semantics (a node any
+source carries is present) while `negate=1` removes by priority. **Never emit a bare
+`negate=0` placeholder row** — `reconcileBindings`-style empty overlay nodes must attach
+to an existing cluster by identity, not pin presence. (This is the live footgun: a stray
+default row would silently pin a node a synced source later drops → a retraction bug.)
+
+**Kind scope.** Identity-clustering + signed presence apply to **nodes and their ports
+only**. `subgraph`/`termination` are **pass-through per source** (resolve has no identity
+key for them today; ids are namespaced per source). So `negate` on a subgraph/termination
+is **reserved, not yet resolved** — do NOT implement subgraph/termination hide until
+resolve gains an identity for them. The "uniform negate" claim is for the kinds the
+merge actually clusters.
+
 - **resolve's clustering + priority field-merge stay; its presence/suppression unify into
   the signed-assertion model and the `'authored'` literal special-cases are removed.** So
-  it is *not* "unchanged" — be honest — but the change is a simplification (one rule:
-  top-priority-sign), not a new merge. Golden test: `resolve(buildContributions(x))`
-  matches the old `resolve(readManual + snapshots)` for representative graphs.
-- **A sync** = `ingestGraph(topology, <data_source_id>, scannedGraph)` (replace that
-  source's rows transactionally; on a failed scan, leave them — status on `topology_data_sources`).
+  it is *not* "unchanged" — be honest — but the change is a simplification, not a new
+  merge. Note suppression-by-any-priority (`attachment.negate`) is a *new* capability
+  resolve must honor (today suppression is authored-only) — part of this rewrite, not free.
+  Golden test: `resolve(buildContributions(x))` matches the old
+  `resolve(readManual + snapshots)` for representative graphs.
+- **A sync's replace strategy is status-driven** (preserves today's `ok`/`partial`/`empty`/
+  `failed` retraction semantics, which `topology_observations` carried per-snapshot and
+  must NOT be lost — store last status + last_ok_at on the source registry):
+  - `ok` → **full replace** of that source's rows (a node missing from the scan is
+    retracted — delete-then-insert);
+  - `partial`/`empty` → **upsert only** (the scan is incomplete; a missing node is NOT
+    authoritative, so don't delete — absence ≠ retraction);
+  - `failed` → **no write** (keep the prior rows untouched).
+  A boolean "did it succeed" is insufficient — these three behaviors need the status.
 - **An editor edit** = write the project's-own contribution (the `data_source_id IS NULL`
   row) incrementally (one attachment/element row = O(1)); never a full-replace, so a crash
   can't wipe it. Import (`ingestGraph` of the whole project graph) is the only full-replace

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -1,7 +1,8 @@
 # DB-native persistence — uniform contributions, one assertion bucket
 
-> Status: DRAFT (2026-06-07, converged after multiple adversarial reviews + user
-> steer). Design of record for the follow-up to PR #375 (#362). No backward compat.
+> Status: DRAFT (2026-06-07, converged after multiple adversarial reviews incl. a Codex
+> macro data-structure review, + user steer). Design of record for the follow-up to PR
+> #375 (#362). No backward compat.
 
 ## ⚠️ Canonical model — read first
 
@@ -86,75 +87,105 @@ topology_data_sources   id, topology_id, data_source_id, purpose, sync_mode, pri
 topology_resolved_graph topology_id, graph_json, layout_json, …, built_revision, resolver_version  -- ③ output
 -- topology_observations: RETIRED (its content becomes contribution_* rows; keep only as a raw audit log if desired)
 
--- ② Per-topology contribution registry. One row per contribution. data_source_id set =
---    external feed; data_source_id NULL = the project's own (intrinsic) contribution
---    (written by the editor, never re-fetched). The intrinsic row is NOT a data_source and
---    NOT in the Sources UI, so "phantom Manual" does not return. No 'human'/'authored' tag.
+-- ② Per-topology contribution registry. One row per contribution. attachment_id set =
+--    external feed (owned by its topology_data_sources attach row); attachment_id NULL =
+--    the project's own (intrinsic) contribution (editor-written, never re-fetched). The
+--    intrinsic row is NOT a data_source and NOT in the Sources UI, so "phantom Manual"
+--    does not return. No 'human'/'authored' tag.
 contribution_source
-  topology_id    TEXT REFERENCES topologies(id) ON DELETE CASCADE,
-  source_id      TEXT,                           -- this contribution's id (ordinary id)
-  data_source_id TEXT REFERENCES data_sources(id) ON DELETE CASCADE,  -- NULL ⇔ the project's own contribution
-  priority       INTEGER,                        -- merge precedence; the intrinsic contribution = MAX
-  last_status    TEXT,                           -- last sync: 'ok'|'partial'|'empty'|'failed' (drives the replace strategy; external only)
-  last_ok_at     INTEGER,
-  graph_payload_json TEXT,                       -- this contribution's graph-level fields: settings, pins, version, name
+  topology_id   TEXT REFERENCES topologies(id) ON DELETE CASCADE,
+  source_id     TEXT,                            -- this contribution's id (ordinary id)
+  attachment_id TEXT REFERENCES topology_data_sources(id) ON DELETE CASCADE,  -- the (topology, source, purpose='topology') attach row; NULL ⇔ intrinsic
+  last_status   TEXT,                            -- 'ok'|'partial'|'empty'|'failed' (external; drives the replace strategy)
+  last_ok_at    INTEGER,
+  graph_payload_json TEXT,                       -- graph-level fields: version, name, description, settings, pins
   PRIMARY KEY (topology_id, source_id)
-  -- Exactly one intrinsic contribution per topology (guards the lazy-create race):
-  -- CREATE UNIQUE INDEX one_intrinsic ON contribution_source(topology_id) WHERE data_source_id IS NULL;
+  -- priority is NOT stored here — it has ONE source of truth: external = the attach row's
+  --   topology_data_sources.priority; intrinsic (attachment_id IS NULL) = MAX. Detach (delete
+  --   of the attach row) cascades the contribution. One intrinsic per topology:
+  -- CREATE UNIQUE INDEX one_intrinsic ON contribution_source(topology_id) WHERE attachment_id IS NULL;
 
 -- ② Contributions (rows + payload doc column), uniform for every contribution (external + intrinsic)
 contribution_element
   id INTEGER PRIMARY KEY,
   topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
-  local_id    TEXT NOT NULL,                     -- element id WITHIN this source (round-trips); never the cross-source key
-  kind        TEXT NOT NULL,                     -- 'node'|'port'|'subgraph'|'termination'
-  parent_local_id TEXT,
-  negate      INTEGER NOT NULL DEFAULT 0,        -- 0 = present (scoop), 1 = hide (identity-only row)
+  local_id    TEXT NOT NULL,                     -- id WITHIN this source (round-trips); never the cross-source key
+  kind        TEXT NOT NULL CHECK (kind IN ('node','port','subgraph','termination')),
+  parent_local_id TEXT,                          -- same-source parent (port→node, node→subgraph, nested subgraph)
+  presence    TEXT CHECK (presence IN ('present','hide')),  -- TRI-STATE: NULL = no opinion (pure identity/attachment anchor) | 'present' = scoop | 'hide'
   payload_json TEXT,
   FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE,
-  UNIQUE (topology_id, source_id, local_id)
+  FOREIGN KEY (topology_id, source_id, parent_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  UNIQUE (topology_id, source_id, local_id),
+  UNIQUE (id, topology_id, source_id)            -- candidate key for composite child FKs (same-source guarantee)
 
 contribution_identity
-  element_id INTEGER REFERENCES contribution_element(id) ON DELETE CASCADE,
-  topology_id TEXT NOT NULL,                     -- denormalized for the cross-source cluster index
-  key_type TEXT, key_value TEXT,
-  PRIMARY KEY (element_id, key_type, key_value)  WITHOUT ROWID
+  element_id  INTEGER, topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
+  key_type TEXT, key_value TEXT,                 -- key_value NORMALIZED at ingest (e.g. lowercased MAC)
+  PRIMARY KEY (element_id, key_type, key_value)  WITHOUT ROWID,
+  FOREIGN KEY (element_id, topology_id, source_id) REFERENCES contribution_element(id, topology_id, source_id) ON DELETE CASCADE
 
 contribution_link
   id INTEGER PRIMARY KEY,
   topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
-  from_local_id TEXT, to_local_id TEXT,
-  negate INTEGER NOT NULL DEFAULT 0,
-  payload_json TEXT,
+  from_node_local_id TEXT, from_port_local_id TEXT,   -- endpoint = node (+ optional port); all same-source elements (FK each)
+  to_node_local_id   TEXT, to_port_local_id   TEXT,
+  presence    TEXT CHECK (presence IN ('present','hide')),
+  payload_json TEXT,                             -- type, arrow, label, bends, cable, style, per-endpoint plug/ip/pin (presentation)
   FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE
+  -- + composite FK each of the four endpoints → contribution_element(local_id, topology_id, source_id)
+
+contribution_link_via                            -- ordered termination transits (Link.via), NORMALIZED (not JSON)
+  link_id INTEGER REFERENCES contribution_link(id) ON DELETE CASCADE,
+  seq     INTEGER, termination_local_id TEXT,    -- a kind='termination' element in the same source
+  PRIMARY KEY (link_id, seq)  WITHOUT ROWID
 
 contribution_attachment
   id INTEGER PRIMARY KEY,
   topology_id TEXT NOT NULL, source_id TEXT NOT NULL,
-  element_id INTEGER REFERENCES contribution_element(id) ON DELETE CASCADE,  -- NULL ⇔ scope='topology-default'
-  scope TEXT, kind TEXT,                         -- 'access'|'policy'|'metrics-binding'
-  attachment_key TEXT,                           -- attachmentKey(): 'access:snmp'|'policy'|'metrics-binding:<sourceId>'
-  target_source_id TEXT REFERENCES data_sources(id) ON DELETE SET NULL,  -- metrics-binding target (non-destructive)
+  element_id  INTEGER,                           -- NULL ⇔ scope='topology-default'
+  scope TEXT CHECK (scope IN ('node','subgraph','topology-default')),
+  kind  TEXT CHECK (kind IN ('access','policy','metrics-binding')),
+  attachment_key TEXT,                           -- generated CENTRALLY by attachmentKey() at ingest (canonical, derived from kind+payload)
+  target_source_id TEXT REFERENCES data_sources(id) ON DELETE CASCADE,  -- metrics-binding dependency target (see note)
   negate INTEGER NOT NULL DEFAULT 0,             -- 0 = assert, 1 = suppress
   payload_json TEXT,
-  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE
+  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE,
+  FOREIGN KEY (element_id, topology_id, source_id) REFERENCES contribution_element(id, topology_id, source_id) ON DELETE CASCADE,
+  UNIQUE (topology_id, source_id, element_id, attachment_key)   -- one slot per (source, element, key)
+  -- topology-default one-slot: CREATE UNIQUE INDEX ON contribution_attachment(topology_id, source_id, attachment_key) WHERE element_id IS NULL;
 ```
-Notes:
-- **One assertion bucket**: scoop/hide are `contribution_element.negate`; assert/suppress
-  are `contribution_attachment.negate`. No separate `exclusion`/`suppressedAttachments`
-  side-channel, no authored-only privilege. (Replaces the old `authored.exclusions`
-  array + `suppressedAttachments`.)
-- **Identity-anchored** (settles the composition-store invariant-6 contradiction):
-  `local_id` is only the intra-source handle; cross-source matching is `contribution_identity`.
-- **`contribution_source` resolves three prior blockers at once**: priority lives here (a
-  value; the intrinsic `data_source_id IS NULL` row = MAX); FK integrity (every contribution
-  FKs a real registry row); retraction is derivable (`data_source_id IS NULL` → never
-  re-fetched → persists; otherwise replaced per sync). Graph-level `settings`/`pins` live in
-  `graph_payload_json` (closes that round-trip gap). No `'human'`/`'authored'` literal anywhere.
-- **Terminations** = `kind='termination'`; `link.via` references the source's own terminations.
-- **Topology-default** = `attachment.element_id NULL`; partial unique index
-  `(topology_id, source_id, attachment_key) WHERE element_id IS NULL` + the symmetric
-  `WHERE element_id IS NOT NULL` for one-slot-per-key.
+Notes (incorporating the Codex macro review):
+- **Tri-state presence (the neutral-anchor fix).** `presence` is NULL / `'present'` / `'hide'`.
+  **NULL = no opinion** — a pure identity/attachment anchor (a binding/policy on an
+  externally-observed node, with no presence claim). `'present'` = scoop; `'hide'` = curate
+  out. This is what lets an attachment FK a real element row **without** pinning presence
+  (the bare-overlay footgun). Suppression of an attachment is `contribution_attachment.negate`.
+- **Ownership via `topology_data_sources`, not global `data_sources`.** `contribution_source.attachment_id`
+  FKs the *attach row* (purpose='topology'), so only attached topology-purpose sources can
+  contribute, **priority has a single source of truth** (the attach row), and **detach
+  cascades** the contribution. The intrinsic contribution has `attachment_id NULL`.
+- **Composite FKs prevent cross-source/cross-topology references.** `(id, topology_id, source_id)`
+  candidate key on `contribution_element`; identity/attachment/link-endpoints/`parent_local_id`
+  all FK through it, so an attachment can't reference another source's element and
+  `identity.topology_id` can't disagree with its element.
+- **Links normalized** — four endpoint FKs (`from/to_node` + optional `from/to_port`) and an
+  ordered `contribution_link_via` relation (terminations). Only bends/cable/style stay in
+  `payload_json`. (A `LinkEndpoint` carries both node and port — both are columns now.)
+- **Identity-anchored** (settles the composition-store invariant-6 contradiction): `local_id`
+  is only the intra-source handle; cross-source matching is `contribution_identity`, with
+  `key_value` normalized at ingest.
+- **`target_source_id` (metrics-binding) is the dependency target — a `data_source`.** Kept
+  global on purpose: a binding may be configured before, or survive detach of, its metrics
+  source — `resolve()` honors a binding only while a **metrics-purpose** attach row for that
+  source exists on the topology (dormant-but-restorable, matching today's `buildMapping`
+  filter). `ON DELETE CASCADE` only fires when the `data_source` is *deleted entirely*
+  (then the binding is meaningless). Detach (removing the metrics attach row) does NOT delete it.
+- **Discriminator drift guarded** — `kind`/`scope` have CHECKs; `attachment_key` is generated
+  centrally by `attachmentKey()` at ingest (the columns are canonical, payload is detail).
+- **Hierarchy single-truth**: `parent_local_id` is the ONLY stored hierarchy; `Subgraph.children[]`
+  is *derived* on projection, never stored (no double authority). Pins are validated refs
+  within the source's graph payload.
 
 ## Resolve / projection / ingestion
 
@@ -170,15 +201,16 @@ ingestGraph(topologyId, source_id, graph)           -- decompose a graph into th
                                                     --   PRAGMA defer_foreign_keys for intra-import forward refs
 ```
 
-**Presence rule (precise — pin this; the golden test alone won't).** Absence of a row is
-**not** an assertion. A cluster is **present iff** at least one contribution has a
-*non-negated* element row for it **and** the highest-priority *opinionated* row (one that
-exists, present-or-hide) is **not** `negate=1`. A contribution with **no row** for a
-cluster expresses **no opinion** — so this preserves today's union semantics (a node any
-source carries is present) while `negate=1` removes by priority. **Never emit a bare
-`negate=0` placeholder row** — `reconcileBindings`-style empty overlay nodes must attach
-to an existing cluster by identity, not pin presence. (This is the live footgun: a stray
-default row would silently pin a node a synced source later drops → a retraction bug.)
+**Presence rule (precise — pin this; the golden test alone won't).** Presence is over the
+tri-state `contribution_element.presence` (`'present'` / `'hide'` / NULL = no opinion). A
+cluster is **present iff** at least one contribution has a `presence='present'` row for it
+**and** the highest-priority *opinionated* row (`'present'` or `'hide'`) is **not** `'hide'`.
+A `presence IS NULL` row is a pure **anchor** (it carries identity / attachments but makes
+**no** presence claim), and a contribution with **no row** for a cluster expresses no
+opinion — so this preserves today's union semantics (a node any source carries is present)
+while `'hide'` removes by priority. An attachment-on-an-observed-node is exactly a
+`presence IS NULL` anchor → it never pins presence (the bare-overlay footgun is structurally
+impossible now, not just discouraged).
 
 **Kind scope.** Identity-clustering + signed presence apply to **nodes and their ports
 only**. `subgraph`/`termination` are **pass-through per source** (resolve has no identity
@@ -209,6 +241,38 @@ merge actually clusters.
   and is one transaction.
 - **No phantom Manual** — the project's own data is rows under the intrinsic
   `contribution_source` row (`data_source_id IS NULL`), never a user-facing data source.
+
+## Round-trip codec (lossless `NetworkGraph` ↔ rows)
+
+`ingestGraph(buildGraph(g)) == g` is the contract; it needs a field-by-field codec, not
+prose. Each `NetworkGraph` / `Node` / `Link` / `Subgraph` field is assigned exactly one
+home — a **column**, a **payload_json** key, or **derived/resolve-only** (never stored):
+
+| Surface | → columns | → `payload_json` | derived / resolve-only |
+| --- | --- | --- | --- |
+| `NetworkGraph` | (per-source) | `version,name,description,settings,pins` in `contribution_source.graph_payload_json` | `nodes/links/subgraphs/terminations` (= rows); `exclusions` (= `presence='hide'` rows) |
+| `Node` | `id`(=local_id), `parent`(=parent_local_id), `kind` | `label,shape,rank,style,position,metadata,spec,productId,ports*` | `provenance,fieldSources` (resolve output) |
+| `NodePort` | `id,parent` | `label,role,connector,speed,faceplate,aliases,connectors` | folded port id (resolve) |
+| `Link` | `id`, four endpoints, `via`(=link_via rows) | `type,arrow,label,bends,cable,style`, per-endpoint `plug/ip/pin` | remapped endpoints (resolve) |
+| `Subgraph` | `id,parent` | `label,direction,style,spec,file,pins` | `children[]` (derived from parent edges) |
+| `Attachment` | `kind,scope,attachment_key,target_source_id,negate` | kind leaves (`community/version`,`mode/intervalMs`,`hostId/interfaceIdentity/…`) | `provenance` (resolve) |
+
+Rules: **empty vs absent is preserved** (a stored `''`/`[]` is distinct from a missing
+key); `description` and every optional field has an explicit home (Codex caught
+`description` missing). Golden fixtures must cover every optional field, empty-vs-absent,
+and a full real graph. The test asserts a **normalized equality** (canonical key order),
+and additionally `resolve(buildContributions(x)) ≡ resolve(old readManual + snapshots)`.
+
+## Priority (one direction, derived, deterministic)
+
+- **One direction: higher wins** (matches `resolve()`'s `+Infinity` for the project layer
+  and its descending sort). `database.md`'s "lower number = higher precedence" wording is
+  **wrong** and must be corrected; migrate existing `topology_data_sources.priority` values
+  to the higher-wins convention explicitly.
+- **Single source of truth**: external priority = the attach row's `topology_data_sources.priority`
+  (not duplicated on `contribution_source`); the intrinsic contribution = MAX.
+- **Deterministic tie-break** for equal priority: contribution revision (newer wins) then
+  `source_id` — never rely on row order.
 
 ## Scaling (why DB-native, not a blob)
 
@@ -272,6 +336,13 @@ identity keys, audit-don't-drop — like the existing `backfillMetricsBindings`)
   assertions is a real change; the golden test (parity with old resolve output) gates it.
 - **`buildContributions` fidelity** — it must reproduce the exact contribution shape the
   merge expects; gated by the golden test.
+- **Identity clustering is non-transitive + collision-blind (EXISTING `resolve.ts` limit,
+  out of scope here but amplified by signed hide).** A bridge observation carrying keys
+  from two clusters joins only the first (no union); weak keys can silently collapse
+  unrelated entities. This is the pre-existing algorithm (resolve.ts:217, acknowledged in
+  topology-source-priority-merge.md); it should become union-find + collision-surfacing in
+  a separate clustering PR before this design's hide-by-priority ships, since a negative
+  assertion on a mis-clustered entity is more harmful than a mis-merged field.
 - **No authored history** — replace/upsert keeps current state only (today's append-only
   Manual observations gave latent undo). Acceptable; an append-only `contribution_event`
   log can be added later without schema change.

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -1,294 +1,255 @@
-# DB-native persistence — document + relations, the modern hybrid
+# DB-native persistence — uniform contributions, document + relations
 
-> Status: DRAFT (2026-06-07, **revised after an adversarial macro review** — see
-> § "Why elements are rows"). Design of record for the follow-up to PR #375 (#362).
-> Supersedes the storage framing in `topology-composition-store.md` and the known-gap
-> in `manual-source-unification.md`. No backward compatibility.
+> Status: DRAFT (2026-06-07, **rewritten to the uniform-contribution model** after
+> review found the previous draft was re-introducing a dissolved "authored layer").
+> Design of record for the follow-up to PR #375 (#362). No backward compatibility.
+
+## ⚠️ Canonical model — read this first (the root-cause fix)
+
+This single statement is the source of truth. Every past round of confusion came from
+re-deriving a privileged "authored / Manual layer" that **does not exist**:
+
+> **There is NO authored layer. There is NO human-vs-machine branch.**
+> A topology is **N source contributions**, each tagged by a `source`
+> (`data_sources.id` *or the literal* `'human'`). The human edit is **just one
+> source** — it differs only by *values*, never by code path:
+> - **priority** — the human contribution has the highest priority (it wins per-field).
+>   "Human wins" = "highest priority number", not an `if (human)`.
+> - **negation** — a *negative assertion* (suppression / exclusion) is a tombstone
+>   contribution; today only `'human'` emits them, but that's usage, not a special case.
+> - **provenance** — `source` is a label the UI reads to mark a value editable; it is
+>   not a layer.
+>
+> `resolve()` clusters all contributions by identity and merges by priority. Storage,
+> merge, and API treat `'human'` **identically** to any data source. **Do not add a
+> special table, code path, or vocabulary for "authored" / "Manual".** This was
+> settled by #335 (Git-like priority merge) and #370 (Manual is a uniform source);
+> this document finishes the job in storage.
+
+If a future change tempts you to special-case the human/Manual contribution — stop.
+That is the recurring bug.
 
 ## Thesis
 
-The server conflated two "types":
+Two "types" were conflated:
 
-1. **`@shumoku/core`'s `NetworkGraph`** — the library's interchange / serialization
-   format (parser output, renderer input, every export). JSON-shaped, correctly so.
-   **Stays untouched.**
-2. **The server's persistence model** — what the *application* stores and queries. It
-   was just (1) pickled as a blob; three refactors (`content_json` →
-   `config_json.graph` → `topology_observations.graph_json`) only *moved* the blob,
-   never cutting the **"core type == storage model"** coupling. That debt surfaces as:
-   editing the composed graph spawns a phantom Manual source; "Manual is uniform" is
-   skin-deep; the metrics mapping can't be queried, indexed, or partially updated.
+1. **`@shumoku/core`'s `NetworkGraph`** — the library's interchange/serialization format
+   (parser output, renderer input, every export). JSON-shaped, correctly so. **Stays.**
+2. **The server's persistence model** — it was just (1) pickled as a blob; three
+   refactors only *moved* the blob (`content_json` → `config_json.graph` →
+   `topology_observations.graph_json`), never cutting the **"core type == storage
+   model"** coupling. Worse, each move kept the *Manual = special* framing alive, so the
+   metrics mapping stayed un-queryable and the "authored layer" kept being re-derived.
 
-> **North star.** The **DB is canonical**. `NetworkGraph` (JSON) is a **lossless,
-> bidirectional operation surface**: read/export *projects* the DB to a graph;
-> write/import *decomposes* a graph into the DB; `JSON → DB → JSON` is identical for
-> real data. Nothing is DB-only-inexpressible-in-JSON, nothing is JSON-only-bypassing-DB.
+> **North star.** The **DB is canonical**. `NetworkGraph` (JSON) is a **lossless
+> projection**: export = project the DB to a graph; import = decompose a graph into
+> contribution rows. The human contribution round-trips like any source's.
 
-## Chosen architecture: document + relations (the modern hybrid)
+## Architecture: uniform per-source contributions (document + relations)
 
-How "DB-backed but JSON-operable" tools are actually built (2024–2026) converges on a
-hybrid — **not** "fully normalize everything," **not** "one big blob":
+Every source — external *and* `'human'` — stores the **same shape**:
 
-- **Storage = rows + a document column.** Backstage stores each catalog *entity* as a
-  row with a JSON document, **plus a normalized `relations` table** for the graph edges
-  (used for traversal, orphan detection, cascade delete). Edges/keys/identity are
-  columns; the rest of the payload is the document.
-- **Promote only what you query.** SQLite ≥ 3.45 / Postgres: keep the payload as
-  JSON(B), lift queried scalars to **generated columns + indexes** on demand.
-- **Resource model + declarative apply + reconcile.** Grafana's App Platform models
-  dashboards as K8s-style resources (metadata/spec/status) over SQL storage; processing
-  is `spec ⊕ observed → reconcile/stitch → materialized status`.
+- **`contribution_element`** rows (node / port / subgraph / **termination**), each with a
+  `payload_json` document column for the un-queried payload (label, spec/equipment,
+  icon, style, position, intra-source structural detail like pins/direction/via/bends).
+- **`contribution_identity`** rows — the multi-key match keys resolve clusters on.
+- **`contribution_link`** rows — edges (endpoints reference the source's own elements).
+- **`contribution_attachment`** rows — **the mapping/policy/access** (metrics-binding's
+  dependency target is an FK column, not buried in JSON).
+- **negations** (suppression / exclusion) — tombstone rows, source-tagged.
 
-**The split-canonical rule** (the key line):
+`resolve()` reads all contribution rows for a topology, **assembles one input entry per
+source** (the same `SnapshotEntry[]` it already consumes), clusters by identity, merges
+by priority, and materializes ③ `topology_resolved_graph`. **Merged entities are never
+persisted** — clustering stays in-memory at read time, exactly as today, so the
+"entity merge/split" problem the composition-store doc deferred (YAGNI) **does not
+arise** (that objection was about persisting *merged* entities; we persist *per-source*
+contributions).
 
-> **Skeleton + edges + dependencies + identity = normalized columns (truth, FK-enforced).**
-> **The rest of an element's payload (spec/equipment, icon, style, position) = a JSON
-> document column on that element's row (truth) + generated columns when queried.**
-> Neither "all tables" nor "all blob."
+**This is the document+relations hybrid applied uniformly:** rows + a payload document
+column (not over-normalized — spec/style/position stay JSON), with the queryable axes
+(identity, attachments, links, the binding's target) as real FK-enforced columns.
 
-Mapping / dependency data becomes real, FK-enforced rows (queryable, partially
-updatable, integrity-checked); equipment/icons/style stay in the per-element document.
+### Why uniform (not "human = rows, observed = JSON")
 
-## Why elements are rows (not one authored-graph blob) — the load-bearing decision
-
-An earlier draft kept all authored structure in a single `authored_graph.doc_json`
-blob and hung the relations off it "by identity." An adversarial review killed that:
-
-- **No referential integrity.** An `attachment`/`identity` row would reference a node
-  *inside a JSON blob* — no FK possible, so orphan rows are structural and need a manual
-  sweep. The old nested-in-blob model got node↔attachment atomicity for free; a blob +
-  side tables *loses* it.
-- **No stable anchor.** Identity is multi-key, mutable, and absent on hand-drawn nodes
-  (the current code falls back to node-id). "Anchor by identity" can't address an
-  identity-less node, and `topology-default` scope has no element at all.
-- **Dependency edge buried in JSON.** A metrics-binding's *target* (`sourceId`, host)
-  in `payload_json` is unqueryable and can't FK-cascade when its data source is deleted
-  — i.e. the "dependency table" wouldn't model the dependency.
-
-**Resolution:** promote the authored skeleton to **per-element rows** (`element`,
-`link`) with a **`payload_json` column** for the un-queried payload. Now identity /
-attachment / suppression are **FK children of `element` with `ON DELETE CASCADE`** (B1
-+ atomicity solved structurally), `element.id` is the stable anchor (B2), and the
-binding's target is an FK column (B3). Payload stays JSON → not over-normalized. This
-is the Backstage shape applied at element granularity.
-
-## Three layers
-
-| Layer | Contents | Storage |
-| --- | --- | --- |
-| **① External input** | per-source raw scans (incl. their inline observed attachments) | **JSON snapshot (keep)** — `topology_observations.graph_json` |
-| **② Internal** | authored elements/links (skeleton columns + payload doc column); identity; **metrics-binding/policy/access** attachments; suppressions; exclusions | **rows + document column (canonical, FK-enforced)** |
-| **③ Output** | resolved graph, exports | **materialized JSON (keep)** — `topology_resolved_graph` (the "stitched/final entity") |
-
-Each *fact* has one home. Note the honest scoping of **②'s `attachment` table = the
-authored layer only**; *observed* attachments stay inline in their observation snapshot
-(① JSON) and are merged at resolve. So "query the mapping" means the authored bindings
-(today the mapping is authored-only by design); if binding-discovery ever emits observed
-bindings, they enter via ① and resolve — revisit promoting them then.
+An earlier draft stored the human contribution as relational rows and observed
+contributions as JSON snapshots. That re-introduced exactly the human-vs-machine split
+#335 dissolved (see Canonical model). The trilemma — *uniformity* vs *queryable O(1)
+mapping* vs *don't-normalize-observed* — is resolved by choosing **uniformity +
+queryability**: normalize **all** contributions to the rows-plus-payload shape. The cost
+is that an external sync writes per-source rows (a transactional replace) instead of one
+JSON blob; in return the mapping is queryable, edits are O(1), and there is one code
+path for everyone.
 
 ## Schema (END STATE)
 
-### Existing (unchanged)
+`source` is `data_sources.id` or the literal `'human'` everywhere. `payload_json` is the
+document column (promote a scalar to a generated column only when a query needs it).
+
 ```
-topologies              id, name, share_token, composition_revision, ts…   -- shell
+-- Existing, unchanged
+topologies              id, name, share_token, composition_revision, …
 data_sources            id, name, type, config_json, status…
-topology_data_sources   id, topology_id, data_source_id, purpose, sync_mode, priority, last_synced_at…
-topology_observations   …, graph_json                       -- ① INPUT (JSON snapshot)
-topology_resolved_graph topology_id, graph_json, layout_json, … built_revision, resolver_version
-                                                            -- ③ OUTPUT (materialized stitch)
+topology_data_sources   id, topology_id, data_source_id, purpose, sync_mode, priority,
+                        last_synced_at, status, consecutive_failures, last_ok_captured_at…
+topology_resolved_graph topology_id, graph_json, layout_json, …, built_revision, resolver_version
+                                                            -- ③ materialized stitch (output)
+-- NOTE: topology_observations (the per-source JSON snapshot) is RETIRED — its content
+-- becomes contribution_* rows. (Or kept only as a raw audit log, decided at migration.)
+
+-- ② Uniform contributions (rows + payload document column)
+contribution_element
+  id            INTEGER PRIMARY KEY,
+  topology_id   TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
+  source        TEXT NOT NULL,                 -- data_source_id | 'human'
+  local_id      TEXT NOT NULL,                 -- element id within this source's assertion (round-trips)
+  kind          TEXT NOT NULL,                 -- 'node'|'port'|'subgraph'|'termination'
+  parent_local_id TEXT,                        -- within the same source
+  payload_json  TEXT,                          -- label, spec/equipment, icon, style, position, intra-source detail
+  UNIQUE (topology_id, source, local_id)
+
+contribution_identity
+  element_id  INTEGER REFERENCES contribution_element(id) ON DELETE CASCADE,
+  topology_id TEXT NOT NULL,                   -- denormalized for the cross-source cluster index
+  key_type    TEXT, key_value TEXT,
+  PRIMARY KEY (element_id, key_type, key_value)  WITHOUT ROWID
+
+contribution_link
+  id INTEGER PRIMARY KEY,
+  topology_id TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
+  source TEXT NOT NULL,
+  from_local_id TEXT, to_local_id TEXT,        -- within source (node or port)
+  payload_json TEXT                            -- type, arrow, label, via, bends, cable, per-endpoint plug/ip/pin
+
+contribution_attachment
+  id INTEGER PRIMARY KEY,
+  topology_id TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
+  source TEXT NOT NULL,
+  element_id INTEGER REFERENCES contribution_element(id) ON DELETE CASCADE,  -- NULL ⇔ scope='topology-default'
+  scope TEXT, kind TEXT,                        -- 'access'|'policy'|'metrics-binding'
+  attachment_key TEXT,                         -- attachmentKey(): 'access:snmp'|'policy'|'metrics-binding:<sourceId>'
+  target_source_id TEXT REFERENCES data_sources(id) ON DELETE SET NULL,  -- metrics-binding dependency target (non-destructive)
+  negate INTEGER NOT NULL DEFAULT 0,           -- 1 = suppression (tombstone for this key)
+  payload_json TEXT                            -- {community,version}|{mode,intervalMs}|{hostId,interfaceIdentity,interfaceName,bandwidth}
+
+contribution_exclusion                          -- identity-keyed negative assertion (hide a node)
+  topology_id TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
+  source TEXT NOT NULL, key_type TEXT, key_value TEXT,
+  PRIMARY KEY (topology_id, source, key_type, key_value)  WITHOUT ROWID
 ```
 
-### ② Authored elements (rows + payload document column)
-```
-element
-  id            TEXT PK            -- the graph node/port/subgraph id (round-trips)
-  topology_id   TEXT NOT NULL  REFERENCES topologies(id) ON DELETE CASCADE
-  kind          TEXT NOT NULL      -- 'node' | 'port' | 'subgraph'
-  parent_id     TEXT  REFERENCES element(id) ON DELETE CASCADE   -- port→node, node→subgraph, subgraph→subgraph
-  payload_json  TEXT               -- un-queried payload: label, spec/equipment, icon, style,
-                                   -- position, metadata. Promote a scalar to a generated
-                                   -- column only when a query needs it.
+Design notes (resolving the review findings):
+- **No human/machine split** — `source` is the only axis; `'human'` is a value. Priority
+  comes from `topology_data_sources.priority` (and `'human'` = top); never an `if`.
+- **Identity-anchored, not id-anchored** — the binding/policy on a node is a
+  `contribution_attachment` whose `contribution_element` carries the node's `identity`
+  rows; resolve clusters it with observed contributions by identity. This honors the
+  composition-store invariant "overrides are identity-keyed" — `local_id` is only the
+  intra-source handle, never the cross-source key.
+- **Terminations have a home** (`kind='termination'`); `link.via` references the source's
+  own termination elements.
+- **Topology-default** = `element_id NULL`; uniqueness via a partial unique index
+  `(topology_id, source, attachment_key) WHERE element_id IS NULL`.
+- **Suppression = `negate=1`** attachment row; **exclusion** = `contribution_exclusion`.
+  Both are ordinary source-tagged contributions (today emitted by `'human'`).
+- **`target_source_id` is non-destructive** — `ON DELETE SET NULL` (and resolve already
+  filters bindings to currently-attached sources), matching today's "detach keeps the
+  binding dormant, doesn't delete it" semantics. No surprise cascade.
+- **Round-trip** — referenceable structure (terminations, pins) are elements/edges;
+  opaque routing/presentation (bends, style, position) is `payload_json`. Enumerate the
+  exact `NetworkGraph` field → column / `payload_json` / resolve-only mapping in the
+  stage-1 PR; the golden test asserts a *normalized* equivalence (canonical key order),
+  not byte-identity.
 
-link
-  id              TEXT PK
-  topology_id     TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE
-  from_element_id TEXT REFERENCES element(id) ON DELETE CASCADE   -- node or port
-  to_element_id   TEXT REFERENCES element(id) ON DELETE CASCADE
-  payload_json    TEXT             -- type, arrow, label, via, bends, cable, style (routing/presentation)
-```
-
-### ② Identity, dependency, intent (the mapping/dependency tables — FK children)
-```
-identity      element_id  TEXT REFERENCES element(id) ON DELETE CASCADE,
-              topology_id TEXT NOT NULL,            -- denormalized for the cross-element match index
-              key_type    TEXT,  key_value TEXT,    -- 'mgmtIp'|'chassisId'|'sysName'|'ifName'|'ifIndex'|'mac'|'vendorId:<ns>'
-              PRIMARY KEY (element_id, key_type, key_value)   WITHOUT ROWID
-
-attachment    id            INTEGER PRIMARY KEY,    -- internal rowid (payload can be >200B → keep rowid)
-              topology_id   TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
-              element_id    TEXT REFERENCES element(id) ON DELETE CASCADE,  -- NULL ⇔ scope='topology-default'
-              scope         TEXT,                   -- 'node' | 'subgraph' | 'topology-default'
-              kind          TEXT,                   -- 'access' | 'policy' | 'metrics-binding'
-              attachment_key TEXT,                  -- attachmentKey(): 'access:snmp'|'policy'|'metrics-binding:<sourceId>'
-              target_source_id TEXT REFERENCES data_sources(id) ON DELETE CASCADE,  -- ★ metrics-binding's dependency target (NULL otherwise)
-              payload_json  TEXT                    -- kind leaves: {community,version} | {mode,intervalMs}
-                                                    --   | {hostId,interfaceIdentity,interfaceName,bandwidth}
-              UNIQUE (element_id, attachment_key)   -- one slot per (element, key); authored layer
-
-suppression   element_id TEXT REFERENCES element(id) ON DELETE CASCADE, attachment_key TEXT,
-              PRIMARY KEY (element_id, attachment_key)   WITHOUT ROWID
-
-exclusion     topology_id TEXT REFERENCES topologies(id) ON DELETE CASCADE, key_type TEXT, key_value TEXT,
-              PRIMARY KEY (topology_id, key_type, key_value)   WITHOUT ROWID   -- identity-keyed, topology-level
-```
-- **The `attachment` table is the authored contribution** (always top priority at
-  resolve), so it needs no `source`/`priority` columns — both are implied. Reintroduce
-  them only if observed attachments are ever promoted into this table.
-- **`target_source_id` is the dependency edge made real:** "what binds to source X" is
-  an indexed query, and deleting a data source **cascades** its bindings away (detach is
-  app logic: delete `attachment WHERE kind='metrics-binding' AND target_source_id=?`).
-  The host/interface match keys stay in `payload_json` (promote to columns if a query
-  needs them).
-- **`element.id` is the stable anchor**, not identity. `identity` rows are the *match
-  keys* resolve uses to cluster an authored element with observed contributions; an
-  identity-less hand-drawn node simply has no `identity` rows and matches by id only.
-  `topology-default` attachments carry `element_id = NULL`.
-
-## Projection / ingestion (the round-trip contract)
+## Projection / ingestion + resolve
 
 ```
-buildGraph(topologyId): NetworkGraph
-  = SELECT element/link/identity/attachment/suppression/exclusion rows for the topology
-    (one indexed scan each — NOT per element), assemble into an authored NetworkGraph.
-ingestGraph(topologyId, graph)
-  = upsert element/link rows (payload_json), replace identity/attachment/suppression by
-    key, exclusions — all in ONE transaction. FK ON DELETE CASCADE removes the children
-    of any element the import drops (no manual orphan sweep).
+buildContributions(topologyId): SnapshotEntry[]   -- one entry per source (incl. 'human'),
+                                                  -- assembled from contribution_* rows (indexed scans)
+resolve(buildContributions(topologyId)) → resolved graph → materialize ③   -- merge UNCHANGED
+
+buildGraph(topologyId): NetworkGraph    -- project the 'human' contribution (export) or the resolved graph
+ingestGraph(topologyId, source, graph)  -- decompose a NetworkGraph into that source's contribution rows
+                                        -- (one transaction; replace that source's rows; PRAGMA defer_foreign_keys
+                                        --  for intra-import forward refs)
 ```
-- **Lossless:** `buildGraph(ingestGraph(g)) ≡ g` (modulo resolve-only fields). A golden
-  round-trip test guards this from stage 1.
-- **`resolve()` is structurally unchanged** but **the complexity moves, it isn't
-  removed:** `buildGraph` is a new, non-trivial component that must reproduce the exact
-  authored-`NetworkGraph` the merge expects. resolve still folds authored ⊕ observed by
-  identity × key × priority; we feed it `buildGraph()` instead of `readManualGraph()`.
-- **Declarative apply** = `ingestGraph` (import a `NetworkGraph`); **export** =
-  `buildGraph` (or the resolved projection). The editor and any file workflow operate
-  the real data through this — the JSON-operable surface.
+- **resolve()'s merge is genuinely unchanged** — its *feed* changes from `(authored
+  object + observation JSON)` to `buildContributions()` rows. The golden test asserts
+  `resolve(buildContributions(x)) ≡ resolve(old readManualGraph+snapshots)`, not just a
+  build round-trip. Complexity moves into `buildContributions`/`ingestGraph`.
+- **A sync** = `ingestGraph(topology, <data_source_id>, scannedGraph)` (replace that
+  source's rows; on a failed scan, leave them — status lives on `topology_data_sources`).
+- **A human edit** = write `'human'` contribution rows directly (O(1) per binding).
+- **No more phantom Manual** — the human contribution is rows tagged `'human'`, owned by
+  the topology; nothing auto-creates a "Manual source".
 
-## Scope: two persistence worlds (and the unresolved strategic risk)
+## Staged migration
 
-- **`apps/server` (SQLite)** — this redesign.
-- **`apps/editor` (neted, IndexedDB)** — its own local store + product library.
-- **M4 — STRATEGIC OPEN QUESTION (not dodged):** server and editor would then hold the
-  *same authored domain* (graph, products) in **two different models** = two sources of
-  truth long-term. Stated intended end-state: **the server DB is canonical; the editor
-  becomes a client of the server through the `NetworkGraph` round-trip API** (or remains
-  a standalone tool that explicitly imports/exports). The round-trip contract is the
-  bridge. Convergence is tracked as its own effort — **flagged, not solved here.**
-- **Equipment / icons** live in `element.payload_json` (matching `Node.spec`/`productId`
-  snapshot semantics). A server-side `product` table is a later refinement (promote when
-  a shared library / query need is real).
+1. **`contribution_element`/`identity`/`link` + `buildContributions` for the `'human'`
+   source** + `ingestGraph`/`buildGraph` + golden round-trip test. Backfill the Manual
+   observation's graph into `'human'` rows; drop Manual-as-authored.
+2. **`contribution_attachment`** — metrics-binding first (`target_source_id` FK), then
+   policy/access; `contribution_exclusion` + `negate` suppression. `reconcileBindings`
+   writes `'human'` attachment rows.
+3. **Observed sources → contributions.** `syncSource` writes `<data_source_id>`
+   contribution rows (replace per source) instead of a `topology_observations` snapshot;
+   resolve feeds from rows; retire `topology_observations` (or keep as a raw audit log).
+4. **Retire** `manual_source_id`/`findManualSourceId`/`ensureManualSource`; on-demand
+   generated columns; optional `product` table. **#375 gap closed; no authored layer left.**
+0. **Cleanup (any time):** `DROP TABLE IF EXISTS manual_source_graph, snmp_credentials`
+   (dead tables from deleted migrations; present only in long-lived dev DBs).
 
-## Staged migration (dependency order; each stage ships independently)
-
-FK direction dictates the order — `element` must exist before its attachment children.
-
-1. **`element` + `link` + `identity` + `buildGraph`/`ingestGraph` + golden round-trip
-   test.** Authored *structure* moves out of the Manual `graph_json` into rows. The
-   foundation everything else FKs onto.
-2. **`metrics-binding` → `attachment`** (highest-pain mapping; `target_source_id` FK).
-   `reconcileBindings` writes rows; `buildGraph` re-attaches; `resolve()` unchanged.
-3. **`policy` + `access` → `attachment`; `exclusion` + `suppression` → tables.** Reverses
-   the `snmp_credentials`→JSON regression; retires `ensureManualSource` for these.
-4. **Retire `manual_source_id` / `findManualSourceId`.** Manual becomes an optional
-   uniform *hand-drawn source* (its graph = a layer-① snapshot) or is dropped. **#375
-   known-gap closed.** Then on-demand generated columns / optional `product` table.
-0. **Cleanup (any time):** drop dead tables (`manual_source_graph`, `snmp_credentials`
-   — created by deleted migrations, 0 refs, 0 rows).
-
-**Backfill is move-and-strip, not copy (avoids the dual-truth window):** each stage
-moves its slice out of the Manual `graph_json` into rows **and removes it from the
-JSON** in one migration, so a slice is never live in both places. `buildGraph` reads
-rows for migrated slices and the (now-stripped) `graph_json` for the rest; `resolver_version`
-bumps so the cache rebuilds.
+Backfill is **imperative TS, not SQL** (it needs `resolve()`/`attachmentKey` slotting,
+identity keys, audit-don't-drop — like the existing `backfillMetricsBindings`).
 
 ## Performance & indexing
 
-Reads keep today's speed; writes get dramatically cheaper. Earned with indexes + N+1 avoidance.
-
-- **Read (hot path) — unchanged.** `/context` is served from materialized ③ (~19ms /
-  1475 nodes). ② is touched only on rebuild.
-- **Write — the big win.** A binding edit goes from "read→mutate→write the *entire*
-  `graph_json`" (O(graph)) to **one `attachment` row UPSERT/DELETE (O(1))**.
-- **Query — indexed.** "bindings for source X", "disabled nodes", "what depends on
-  source X" are indexed SQL, not graph-walks.
-- **Rebuild — DB is not the bottleneck.** `computeNetworkLayout` (CPU) + the ③ Map-aware
-  serialize dominate; both unchanged here (`performance-scaling.md`).
-
-**Index every FK column (SQLite does NOT auto-index FKs).** With `foreign_keys = ON` +
-`ON DELETE CASCADE`, an un-indexed child FK makes each cascade a full table scan
-(sqlite.org/foreignkeys.html). Concretely:
-- `element(topology_id)`, `element(parent_id)`
-- `link(topology_id)`, `link(from_element_id)`, `link(to_element_id)`
-- `attachment(topology_id, element_id)` (per-element fold; covers `element_id` via prefix)
-- `attachment(topology_id, kind)` — "all bindings/policies of a kind"
-- `attachment(target_source_id)` — "what depends on source X" + cascade on source delete
-- `identity` reverse index `(topology_id, key_type, key_value)` — the cross-element merge match
-- `suppression` / `exclusion` / `identity` PKs are their indexes (WITHOUT ROWID)
-- no redundant prefixes; **never index `payload_json`**; cover only small key/existence outputs
-
-**Avoid N+1:** `buildGraph` fetches each table **once per topology** and assembles in
-memory — never per-element queries.
-
-**Primary-key strategy.** `element.id` / `link.id` are the graph ids → **TEXT** (must
-round-trip). `attachment` keeps an **`INTEGER PRIMARY KEY`** (payload can exceed the
-WITHOUT-ROWID ~200 B/page-1⁄20 threshold). `identity` / `suppression` / `exclusion` are
-small composite-key tables → **`WITHOUT ROWID`** (~2× faster, ~50% less space; verify
-row size with `sqlite3_analyzer`). External entities (topologies, data_sources) keep
-TEXT nanoid.
-
-**Push work into SQL** (filter/aggregate/exists in queries, not JS loops over parsed
-JSON) — the whole point of relationalizing ②.
-
-**Connection PRAGMAs.** Shipped in PR #377: `journal_mode=WAL`, `synchronous=NORMAL`,
-`foreign_keys=ON`, `busy_timeout=5000`, `cache_size=-65536`, `temp_store=MEMORY`,
-`mmap_size=256MiB`; `PRAGMA optimize` on close, `ANALYZE` after large backfills.
-
-**`doc_json`/`payload_json` storage.** SQLite 3.51.1 (bun 1.3.4) has JSONB, but **TEXT
-is the default** (we read whole payloads and parse in JS); reserve JSONB + generated
-columns for scalars we actually filter on.
-
-**Measure with `EXPLAIN QUERY PLAN`** — confirm every hot query hits an index
-(no `SCAN TABLE`). Add phase timing (DB read / merge / layout / ③ write) around resolve.
+- **Read (hot path)** — served from materialized ③ (~19ms / 1475 nodes); ② touched only
+  on rebuild. Add a per-topology `authored_revision` (bump on any ② write) stored in ③
+  as `built_from_revision` so staleness is a single integer compare.
+- **Write** — a binding edit = one `contribution_attachment` UPSERT/DELETE (O(1)).
+- **Sync** — per-source transactional row replace; more rows than one blob, but bounded
+  and infrequent, and resolve reads rows instead of parsing N blobs.
+- **Index every FK column** (SQLite does NOT auto-index FKs; cascade deletes full-scan
+  otherwise): `contribution_element(topology_id, source)`, `(parent_local_id)`;
+  `contribution_identity(topology_id, key_type, key_value)` (cross-source cluster);
+  `contribution_attachment(topology_id, source, element_id)`, `(topology_id, kind)`,
+  `(target_source_id)`; `contribution_link(topology_id, source)`, endpoints.
+  No redundant prefixes; never index `payload_json`.
+- **Avoid N+1** — `buildContributions` fetches each table once per topology.
+- **PK strategy** — `INTEGER PRIMARY KEY` for the high-volume contribution tables;
+  `WITHOUT ROWID` for the small composite-key ones (`contribution_identity`,
+  `contribution_exclusion`) if rows stay <~200 B (verify with `sqlite3_analyzer`);
+  TEXT nanoid only for externally-referenced entities (topologies, data_sources).
+- **PRAGMAs** shipped in PR #377 (WAL, synchronous=NORMAL, foreign_keys=ON,
+  busy_timeout=5000, cache_size=-65536, temp_store=MEMORY, mmap_size=256MiB; optimize on
+  close). `defer_foreign_keys` within `ingestGraph` for forward refs.
+- **`payload_json`** TEXT by default (SQLite 3.51.1 has JSONB; reserve it + generated
+  columns for filtered scalars). Verify hot queries with `EXPLAIN QUERY PLAN`.
 
 ## Risks / open questions
 
-- **`buildGraph` complexity** — it now owns reconstructing the exact authored
-  `NetworkGraph`; the golden round-trip test must exist from stage 1.
-- **Identity-less authored nodes** — match by `element.id` only (no `identity` rows);
-  confirm resolve's cluster step handles id-only authored members (it does today via the
-  node-id fallback — preserve it).
-- **Detach vs delete of a metrics source** — FK cascades on data-source *delete*; *detach*
-  (removing the m2m junction) must delete the source's bindings in app logic, mirroring
-  PR #375's detach-clears-observations.
-- **`attachment` table = authored only** — observed attachments remain in ① JSON; "query
-  the mapping" is authored-scoped until/unless binding-discovery lands.
-- **No authored history** — `composition_revision` (cache) + `element.…`-level
-  `updated_at` only; there is **no version/undo history** for authored data (dropped the
-  earlier misleading "version" claim). A version/event-log is a separate future feature.
-- **Editor convergence (M4)** — the standing strategic risk above.
+- **Sync cost** — observed scans become row-replaces; measure vs the old single-blob
+  write before committing stage 3 (the only stage that touches the observed path).
+- **`buildContributions` fidelity** — golden test gates it (must equal the old resolve
+  feed), since the merge depends on exact contribution shape.
+- **No authored history** — replace/upsert keeps current state only; today's append-only
+  Manual observations gave latent undo. Acceptable (no UI uses it); the per-source-row
+  shape lets an append-only `contribution_event` log be added later without schema change.
+- **Editor (apps/editor, IndexedDB) convergence** — standing strategic risk; intended
+  end-state: server canonical, editor a `NetworkGraph` round-trip client. Not solved here.
+- **Terminology purge** — residual "authored layer" wording in `manual-source-unification.md`,
+  `topology-composition-store.md`, and core type comments is the root cause of repeated
+  confusion; align them to the Canonical model above as a follow-up.
 
-## References (prior art, verified 2026-06)
-- Backstage — entity document + relations table + stitching/orphan-sweep: <https://backstage.io/docs/features/software-catalog/life-of-an-entity/>, <https://backstage.io/docs/features/software-catalog/creating-the-catalog-graph/>
+## References (verified 2026-06)
+- Backstage entity-document + relations table + stitching (relations are a regenerated cache; we choose FK-enforced — a deliberate divergence): <https://backstage.io/docs/features/software-catalog/life-of-an-entity/>
 - Grafana App Platform — K8s-style resources over SQL unified storage: <https://deepwiki.com/grafana/grafana/3.3-folder-management>
-- PostgreSQL JSONB + generated columns; modern hybrid (2025): <https://www.architecture-weekly.com/p/postgresql-jsonb-powerful-storage>, <https://200oksolutions.com/blog/modern-database-architectures-hybrid-approach-sql-nosql-newsql-2025/>
-- SQLite JSON/JSONB + virtual generated columns: <https://sqlite.org/json1.html>, <https://www.dbpro.app/blog/sqlite-json-virtual-columns-indexing>
-- SQLite foreign keys — FK columns are NOT auto-indexed: <https://www.sqlite.org/foreignkeys.html>
-- SQLite WITHOUT ROWID — composite PK, <~1/20-page rows: <https://www.sqlite.org/withoutrowid.html>
-- SQLite query planner — covering indexes, compound order, ANALYZE: <https://www.sqlite.org/queryplanner.html>
+- SQLite JSON/JSONB + generated columns: <https://sqlite.org/json1.html>; FK not auto-indexed: <https://www.sqlite.org/foreignkeys.html>; WITHOUT ROWID: <https://www.sqlite.org/withoutrowid.html>; query planner: <https://www.sqlite.org/queryplanner.html>
 - Production PRAGMAs: <https://databaseschool.com/articles/sqlite-recommended-pragmas>; bun:sqlite: <https://bun.com/docs/runtime/sqlite>
 
 ## Relationship to existing docs
-- `topology-composition-store.md` — predecessor; its identity-keyed-store intent is realized here.
-- `manual-source-unification.md` — its known-gap is closed by stages 1–4.
-- `topology-ui-ia.md` — unaffected (UI reads the same projected graph).
+- `topology-source-priority-merge.md` / #335 — the Canonical model is its storage-side completion.
+- `topology-composition-store.md` — its identity-keyed-store intent realized; its observed-normalization YAGNI is respected (we persist per-source contributions, never merged entities).
+- `manual-source-unification.md` — #375 known-gap closed; its residual "authored" wording to be purged.
+- `topology-ui-ia.md` — unaffected (UI reads the projected graph).


### PR DESCRIPTION
@
Design of record for the next arc: move the server off "core type pickled as a blob"
to a DB-native model. Follow-up to #375 (#362). **Design doc only — no code.**

## Thesis
DB is canonical; `NetworkGraph` (JSON) is a lossless bidirectional operation surface
(`JSON → DB → JSON` identical). The blob was only ever relocated
(`content_json` → `config_json.graph` → `topology_observations.graph_json`); the
"core type == storage model" coupling was never cut. That debt → editing the composed
graph spawns a phantom Manual source; "Manual is uniform" is skin-deep; the metrics
mapping can not be queried/indexed/partially-updated.

## Chosen architecture — document + relations hybrid (web-verified 2024–2026)
**Split-canonical rule:** edges / dependencies / identity = normalized tables (truth);
element payload (label / equipment / icon / style / position) = JSON document (truth) +
generated columns for queried scalars. Neither all-tables nor all-blob.

- **②-document** `authored_graph` — topology-owned authored structure (replaces
  Manual-as-authored), generated columns on demand
- **②-relations** `identity` / `attachment` (access|policy|**metrics-binding**) /
  `suppression` / `exclusion`, identity-anchored
- `resolve()` = stitch, **unchanged**, via `buildGraph()` / `ingestGraph()`
- ① observations = JSON input (keep) · ③ resolved_graph = materialized output (keep)

## Included
- Staged migration: 0 cleanup → 1 metrics-binding → 2 policy/access + exclusion/suppression
  → 3 authored structure (retires `manual_source_id`, **closes the #375 known-gap**) → 4 on-demand
- JSON↔DB round-trip contract (lossless = acceptance test; import = declarative apply)
- Performance & indexing (reads unchanged via ③ cache; writes O(1); index plan; N+1
  avoidance; SQLite JSONB / generated-column / WAL levers)
- Prior art: Grafana App Platform (K8s-style resources over SQL), Backstage (entity doc +
  relations table), SQLite ≥3.45 JSONB + virtual generated columns

## Review ask
Please sanity-check the **split-canonical boundary**, the **`authored_graph` +
relations** schema, the **round-trip/identity-anchoring** model, and the **staging order**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@