### PR TITLE
perf(server): set the standard SQLite production PRAGMAs on the connection

### DIFF
--- a/apps/server/api/src/db/index.ts
+++ b/apps/server/api/src/db/index.ts
@@ -42,11 +42,29 @@ export function initDatabase(dataDir: string = '/data'): Database {
 
   db = new Database(dbPath)
 
-  // Enable WAL mode for better concurrent access
-  db.exec('PRAGMA journal_mode = WAL')
+  // Connection-level tuning. journal_mode + page_size persist in the file; the
+  // rest are per-connection and must be set on every open. We use a single
+  // shared connection (getDatabase singleton), so setting them here covers the
+  // whole app. Values follow the standard SQLite production set.
+  // See apps/server/docs/design/db-native-persistence.md § Performance.
 
-  // Enable foreign key enforcement (SQLite disables by default)
+  // WAL: one writer + many concurrent readers (the discovery scheduler writes
+  // while the UI reads). Persists in the file.
+  db.exec('PRAGMA journal_mode = WAL')
+  // With WAL, NORMAL is the safe + faster choice (atomic, never corrupts; only a
+  // tiny window of last-commit loss on power loss). Default FULL fsyncs every commit.
+  db.exec('PRAGMA synchronous = NORMAL')
+  // Foreign-key enforcement (SQLite disables it by default).
   db.exec('PRAGMA foreign_keys = ON')
+  // Wait up to 5s for a lock instead of throwing SQLITE_BUSY immediately — the
+  // scheduler-writes-while-UI-reads collision would otherwise surface as errors.
+  db.exec('PRAGMA busy_timeout = 5000')
+  // 64 MiB page cache (negative = KiB). Default is ~2 MiB.
+  db.exec('PRAGMA cache_size = -65536')
+  // Build temp B-trees (sorts, etc.) in RAM rather than on disk.
+  db.exec('PRAGMA temp_store = MEMORY')
+  // Memory-map up to 256 MiB of the DB file → fewer read syscalls.
+  db.exec('PRAGMA mmap_size = 268435456')
 
   // Run migrations (creates tables and applies updates)
   runMigrations(db)
@@ -61,6 +79,13 @@ export function initDatabase(dataDir: string = '/data'): Database {
  */
 export function closeDatabase(): void {
   if (db) {
+    // Let SQLite refresh query-planner stats for indexes it has seen this run
+    // (cheap; no-op when nothing needs updating).
+    try {
+      db.exec('PRAGMA optimize')
+    } catch {
+      // Best-effort — never block shutdown on stats.
+    }
     db.close()
     db = null
     console.log('[Database] Connection closed')


### PR DESCRIPTION
@
Quick-win from the DB-tuning review (independent of the persistence redesign #376).

`db/index.ts` set only `journal_mode=WAL` + `foreign_keys=ON`. The rest of the standard
production PRAGMA set was missing — most importantly **`busy_timeout` was `0`**, so the
moment the discovery scheduler writes while the UI reads, the collision throws
`SQLITE_BUSY` instead of waiting.

## Change
On the single shared connection (`initDatabase`):
```
synchronous = NORMAL    -- safe + faster with WAL (was FULL)
busy_timeout = 5000     -- ★ wait for locks (was 0 → instant SQLITE_BUSY)
cache_size = -65536     -- 64 MiB page cache (was ~2 MiB)
temp_store = MEMORY     -- temp B-trees in RAM
mmap_size = 268435456   -- 256 MiB mmap → fewer read syscalls
```
Plus `PRAGMA optimize` on close (keeps query-planner stats fresh).

## Verification
- typecheck ✔ · api tests 29 pass ✔ · biome ✔
- Confirmed all values applied via the real `initDatabase` path: `synchronous=1`,
  `foreign_keys=1`, `busy_timeout=5000`, `cache_size=-65536`, `temp_store=2`,
  `mmap_size=268435456`.

Env: bun 1.3.4 bundles SQLite 3.51.1. Values per the standard 2024–2026 production set
(see `db-native-persistence.md` § Performance). FK-column indexing is a separate
follow-up (lands with the relations-table schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@