### PR TITLE
feat(server): DB-native persistence — contribution store (stages 1a–1c)

### DIFF
--- a/apps/server/api/src/api/observations.ts
+++ b/apps/server/api/src/api/observations.ts
@@ -91,6 +91,11 @@ export function createScanRoute(): Hono {
 export function createObservationsRoute(): Hono {
   const app = new Hono()
   const observations = new ObservationsService()
+  const dataSources = new DataSourceService()
+  // The authored ("Manual") source's graph is the intrinsic contribution now, NOT a
+  // topology_observations row. Route manual save/load through the topology service so the
+  // editor and resolve() agree (no split-brain). External sources stay observations.
+  const isManual = (sourceId: string): boolean => dataSources.get(sourceId)?.type === 'manual'
   // Note: the per-source sync endpoint
   // `POST /:topologyId/sources/:sourceId/sync` lives in
   // `topology-sources.ts` — that route is registered earlier on the
@@ -133,6 +138,11 @@ export function createObservationsRoute(): Hono {
   // resolved project graph below.
   app.get('/:topologyId/sources/:sourceId/latest-snapshot', (c) => {
     const { topologyId, sourceId } = c.req.param()
+    // Manual = the intrinsic contribution (DB-native store), not an observation.
+    if (isManual(sourceId)) {
+      const graph = getTopologyService().readManualGraph(topologyId)
+      return c.json({ graph, capturedAt: null, status: graph ? 'ok' : null })
+    }
     const latest = observations.latestPerSource(topologyId).find((o) => o.sourceId === sourceId)
     if (!latest) {
       // Source attached but no observation yet — return an empty
@@ -162,6 +172,11 @@ export function createObservationsRoute(): Hono {
       const graph = body.graph as NetworkGraph
       if (!Array.isArray(graph.nodes) || !Array.isArray(graph.links)) {
         return c.json({ error: 'graph.nodes and graph.links must be arrays' }, 400)
+      }
+      // Manual save → the intrinsic contribution (authored layer), not an observation.
+      if (isManual(sourceId)) {
+        getTopologyService().writeManualGraph(topologyId, sourceId, graph)
+        return c.json({ ok: true }, 201)
       }
       const observation = await observations.record({
         topologyId,

--- a/apps/server/api/src/api/observations.ts
+++ b/apps/server/api/src/api/observations.ts
@@ -16,6 +16,7 @@ import { Hono } from 'hono'
 import { hasAutoscanCapability } from '../plugins/types.js'
 import { DataSourceService } from '../services/datasource.js'
 import { ObservationsService } from '../services/observations.js'
+import { TopologySourcesService } from '../services/topology-sources.js'
 import { getTopologyService } from './topologies.js'
 
 /**
@@ -92,10 +93,15 @@ export function createObservationsRoute(): Hono {
   const app = new Hono()
   const observations = new ObservationsService()
   const dataSources = new DataSourceService()
+  const topologySources = new TopologySourcesService()
   // The authored ("Manual") source's graph is the intrinsic contribution now, NOT a
   // topology_observations row. Route manual save/load through the topology service so the
   // editor and resolve() agree (no split-brain). External sources stay observations.
-  const isManual = (sourceId: string): boolean => dataSources.get(sourceId)?.type === 'manual'
+  // REQUIRE the manual source be attached to THIS topology (purpose 'topology') — else an
+  // unrelated manual id could overwrite the topology's intrinsic graph.
+  const isManualForTopology = (topologyId: string, sourceId: string): boolean =>
+    dataSources.get(sourceId)?.type === 'manual' &&
+    topologySources.find(topologyId, sourceId, 'topology') !== undefined
   // Note: the per-source sync endpoint
   // `POST /:topologyId/sources/:sourceId/sync` lives in
   // `topology-sources.ts` — that route is registered earlier on the
@@ -139,7 +145,7 @@ export function createObservationsRoute(): Hono {
   app.get('/:topologyId/sources/:sourceId/latest-snapshot', (c) => {
     const { topologyId, sourceId } = c.req.param()
     // Manual = the intrinsic contribution (DB-native store), not an observation.
-    if (isManual(sourceId)) {
+    if (isManualForTopology(topologyId, sourceId)) {
       const graph = getTopologyService().readManualGraph(topologyId)
       return c.json({ graph, capturedAt: null, status: graph ? 'ok' : null })
     }
@@ -174,7 +180,7 @@ export function createObservationsRoute(): Hono {
         return c.json({ error: 'graph.nodes and graph.links must be arrays' }, 400)
       }
       // Manual save → the intrinsic contribution (authored layer), not an observation.
-      if (isManual(sourceId)) {
+      if (isManualForTopology(topologyId, sourceId)) {
         getTopologyService().writeManualGraph(topologyId, sourceId, graph)
         return c.json({ ok: true }, 201)
       }

--- a/apps/server/api/src/db/migrations/016_contribution_store.sql
+++ b/apps/server/api/src/db/migrations/016_contribution_store.sql
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS contribution_link (
   id INTEGER PRIMARY KEY,
   topology_id TEXT NOT NULL,
   source_id TEXT NOT NULL,
-  local_id TEXT NOT NULL,
+  local_id TEXT,
   from_node_local_id TEXT NOT NULL,
   from_port_local_id TEXT,
   to_node_local_id TEXT NOT NULL,

--- a/apps/server/api/src/db/migrations/016_contribution_store.sql
+++ b/apps/server/api/src/db/migrations/016_contribution_store.sql
@@ -1,0 +1,102 @@
+-- Stage 1 of the DB-native persistence refactor (db-native-persistence.md):
+-- the uniform contribution store. New tables only — nothing reads them yet; the
+-- codec (ingestGraph/buildGraph) + resolve integration land in later steps.
+--
+-- A topology = N contributions, each a contribution_source row. attachment_id set =
+-- external feed (owned by its topology_data_sources attach row); attachment_id NULL =
+-- the project's own intrinsic contribution. No human/authored concept.
+
+-- Candidate key on topology_data_sources so contribution_source can FK (attachment_id, topology_id).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tds_id_topology ON topology_data_sources(id, topology_id);
+
+CREATE TABLE IF NOT EXISTS contribution_source (
+  topology_id TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
+  source_id TEXT NOT NULL,
+  attachment_id TEXT,
+  last_status TEXT,
+  last_ok_at INTEGER,
+  graph_payload_json TEXT,
+  PRIMARY KEY (topology_id, source_id),
+  FOREIGN KEY (attachment_id, topology_id) REFERENCES topology_data_sources(id, topology_id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contrib_one_per_attach ON contribution_source(attachment_id) WHERE attachment_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contrib_one_intrinsic ON contribution_source(topology_id) WHERE attachment_id IS NULL;
+
+CREATE TABLE IF NOT EXISTS contribution_element (
+  id INTEGER PRIMARY KEY,
+  topology_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  local_id TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('node', 'port', 'subgraph', 'termination')),
+  parent_local_id TEXT,
+  presence TEXT CHECK (presence IN ('present', 'hide')),
+  payload_json TEXT,
+  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE,
+  FOREIGN KEY (topology_id, source_id, parent_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  UNIQUE (topology_id, source_id, local_id),
+  UNIQUE (id, topology_id, source_id)
+);
+CREATE INDEX IF NOT EXISTS idx_contrib_element_src ON contribution_element(topology_id, source_id);
+
+CREATE TABLE IF NOT EXISTS contribution_identity (
+  element_id INTEGER NOT NULL,
+  topology_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  key_type TEXT NOT NULL,
+  key_value TEXT NOT NULL,
+  PRIMARY KEY (element_id, key_type, key_value),
+  FOREIGN KEY (element_id, topology_id, source_id) REFERENCES contribution_element(id, topology_id, source_id) ON DELETE CASCADE
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS idx_contrib_identity_match ON contribution_identity(topology_id, key_type, key_value);
+
+CREATE TABLE IF NOT EXISTS contribution_link (
+  id INTEGER PRIMARY KEY,
+  topology_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  local_id TEXT NOT NULL,
+  from_node_local_id TEXT NOT NULL,
+  from_port_local_id TEXT,
+  to_node_local_id TEXT NOT NULL,
+  to_port_local_id TEXT,
+  presence TEXT CHECK (presence IN ('present', 'hide')),
+  payload_json TEXT,
+  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE,
+  FOREIGN KEY (topology_id, source_id, from_node_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  FOREIGN KEY (topology_id, source_id, to_node_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  FOREIGN KEY (topology_id, source_id, from_port_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  FOREIGN KEY (topology_id, source_id, to_port_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  UNIQUE (topology_id, source_id, local_id)
+);
+CREATE INDEX IF NOT EXISTS idx_contrib_link_src ON contribution_link(topology_id, source_id);
+
+CREATE TABLE IF NOT EXISTS contribution_link_via (
+  link_id INTEGER NOT NULL REFERENCES contribution_link(id) ON DELETE CASCADE,
+  topology_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  termination_local_id TEXT NOT NULL,
+  PRIMARY KEY (link_id, seq),
+  FOREIGN KEY (topology_id, source_id, termination_local_id) REFERENCES contribution_element(topology_id, source_id, local_id)
+) WITHOUT ROWID;
+
+CREATE TABLE IF NOT EXISTS contribution_attachment (
+  id INTEGER PRIMARY KEY,
+  topology_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  element_id INTEGER,
+  scope TEXT NOT NULL CHECK (scope IN ('node', 'port', 'subgraph', 'topology-default')),
+  kind TEXT NOT NULL CHECK (kind IN ('access', 'policy', 'metrics-binding')),
+  attachment_key TEXT NOT NULL,
+  target_source_id TEXT REFERENCES data_sources(id) ON DELETE CASCADE,
+  negate INTEGER NOT NULL DEFAULT 0,
+  payload_json TEXT,
+  CHECK ((scope = 'topology-default') = (element_id IS NULL)),
+  CHECK (kind != 'metrics-binding' OR negate = 1 OR target_source_id IS NOT NULL),
+  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE,
+  FOREIGN KEY (element_id, topology_id, source_id) REFERENCES contribution_element(id, topology_id, source_id) ON DELETE CASCADE,
+  UNIQUE (topology_id, source_id, element_id, attachment_key)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_contrib_attach_default
+  ON contribution_attachment(topology_id, source_id, attachment_key) WHERE element_id IS NULL;
+CREATE INDEX IF NOT EXISTS idx_contrib_attach_kind ON contribution_attachment(topology_id, kind);
+CREATE INDEX IF NOT EXISTS idx_contrib_attach_target ON contribution_attachment(target_source_id);

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -20,6 +20,7 @@ import migration011 from './migrations/011_manual_graph_to_config.sql'
 import migration012 from './migrations/012_resolved_graph_cache.sql'
 import migration013 from './migrations/013_drop_legacy_source_columns.sql'
 import migration014 from './migrations/014_manual_graph_to_observations.sql'
+import migration016 from './migrations/016_contribution_store.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -36,6 +37,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '012_resolved_graph_cache.sql', sql: migration012 },
   { name: '013_drop_legacy_source_columns.sql', sql: migration013 },
   { name: '014_manual_graph_to_observations.sql', sql: migration014 },
+  { name: '016_contribution_store.sql', sql: migration016 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/contribution-store.ts
+++ b/apps/server/api/src/services/contribution-store.ts
@@ -11,9 +11,16 @@
  * catch-all for every field NOT promoted to a column, so `buildGraph(ingestGraph(g))`
  * equals `g` (modulo array order / key order — assert with a normalized comparison).
  *
- * Stage 1b scope: the round-trip itself. Nodes round-trip as `presence='present'`,
- * `exclusions` as `presence='hide'`; the NULL-presence overlay anchor (for an
- * attachment on an observed-only node) + resolve integration land in stage 1c.
+ * Nodes round-trip as `presence='present'`, `exclusions` as `presence='hide'`.
+ *
+ * Two defined equivalences (the round-trip is lossless modulo these, matching how
+ * every consumer already treats them):
+ *  - **empty collection ≡ absent** — an empty `ports`/`attachments`/`via`/… is stored
+ *    as zero rows and rebuilt as an absent key (no consumer distinguishes `[]` from
+ *    undefined).
+ *  - **`Subgraph.children` is derived, not stored** — membership has one source of
+ *    truth (the parent edge, `parent_local_id`); `children[]` is recomputed by
+ *    consumers, never persisted (it is not part of the round-trip, like `provenance`).
  */
 
 import type { Database } from 'bun:sqlite'

--- a/apps/server/api/src/services/contribution-store.ts
+++ b/apps/server/api/src/services/contribution-store.ts
@@ -1,0 +1,472 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Contribution-store codec (stage 1 of the DB-native persistence refactor — see
+ * apps/server/docs/design/db-native-persistence.md).
+ *
+ * `ingestGraph` decomposes a `NetworkGraph` (one source's contribution) into the
+ * uniform `contribution_*` rows; `buildGraph` projects those rows back to a
+ * `NetworkGraph`. The pair is **lossless by construction**: `payload_json` is the
+ * catch-all for every field NOT promoted to a column, so `buildGraph(ingestGraph(g))`
+ * equals `g` (modulo array order / key order — assert with a normalized comparison).
+ *
+ * Stage 1b scope: the round-trip itself. Nodes round-trip as `presence='present'`,
+ * `exclusions` as `presence='hide'`; the NULL-presence overlay anchor (for an
+ * attachment on an observed-only node) + resolve integration land in stage 1c.
+ */
+
+import type { Database } from 'bun:sqlite'
+import type {
+  Attachment,
+  Identity,
+  Link,
+  NetworkGraph,
+  Node,
+  NodeExclusion,
+  NodePort,
+  Subgraph,
+  Termination,
+} from '@shumoku/core'
+import { getDatabase } from '../db/index.js'
+
+// --- helpers ---------------------------------------------------------------
+
+/** Identity scalar keys (vendorIds is a nested record, handled separately). */
+const IDENTITY_SCALARS = ['mgmtIp', 'chassisId', 'sysName', 'ifIndex', 'ifName', 'mac'] as const
+const VENDOR_PREFIX = 'vendorId:'
+
+type IdRow = { key_type: string; key_value: string }
+
+function identityToRows(identity: Identity | undefined): IdRow[] {
+  if (!identity) return []
+  const rows: IdRow[] = []
+  for (const k of IDENTITY_SCALARS) {
+    const v = identity[k]
+    if (v !== undefined && v !== null) rows.push({ key_type: k, key_value: String(v) })
+  }
+  for (const [ns, v] of Object.entries(identity.vendorIds ?? {})) {
+    rows.push({ key_type: `${VENDOR_PREFIX}${ns}`, key_value: v })
+  }
+  return rows
+}
+
+function identityFromRows(rows: IdRow[]): Identity | undefined {
+  if (rows.length === 0) return undefined
+  const id: Identity = {}
+  for (const { key_type, key_value } of rows) {
+    if (key_type === 'ifIndex') id.ifIndex = Number(key_value)
+    else if (key_type.startsWith(VENDOR_PREFIX)) {
+      id.vendorIds = id.vendorIds ?? {}
+      id.vendorIds[key_type.slice(VENDOR_PREFIX.length)] = key_value
+    } else if ((IDENTITY_SCALARS as readonly string[]).includes(key_type)) {
+      ;(id as Record<string, unknown>)[key_type] = key_value
+    }
+  }
+  return id
+}
+
+/** A shallow copy of `obj` without `keys` — becomes the payload document. */
+function payloadWithout<T extends object>(obj: T, keys: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...(obj as Record<string, unknown>) }
+  for (const k of keys) delete out[k]
+  return out
+}
+
+const j = (v: unknown): string | null => {
+  const o = v as Record<string, unknown>
+  return o && Object.keys(o).length > 0 ? JSON.stringify(o) : null
+}
+const parse = (s: string | null | undefined): Record<string, unknown> =>
+  s ? (JSON.parse(s) as Record<string, unknown>) : {}
+
+function attachmentKeyOf(a: Attachment): string {
+  if (a.kind === 'access') return `access:${a.protocol}`
+  if (a.kind === 'metrics-binding') return `metrics-binding:${a.sourceId}`
+  return a.kind
+}
+
+/** Recover an attachment kind from a suppression key (the column needs a kind). */
+function kindFromKey(key: string): string {
+  if (key.startsWith('access:')) return 'access'
+  if (key.startsWith('metrics-binding:')) return 'metrics-binding'
+  return key
+}
+
+type Scope = 'node' | 'port' | 'subgraph' | 'topology-default'
+
+// --- ingest ----------------------------------------------------------------
+
+export interface IngestOptions {
+  /** The owning topology_data_sources.id; null/undefined ⇒ the intrinsic contribution. */
+  attachmentId?: string | null
+  lastStatus?: string
+  lastOkAt?: number
+}
+
+/**
+ * Replace `(topologyId, sourceId)`'s contribution with `graph`, in one transaction.
+ */
+export function ingestGraph(
+  topologyId: string,
+  sourceId: string,
+  graph: NetworkGraph,
+  opts: IngestOptions = {},
+  db: Database = getDatabase(),
+): void {
+  const run = db.transaction(() => {
+    // Defer FK checks to COMMIT so intra-import forward refs are fine (a node's
+    // `parent` subgraph, or link endpoints, may be inserted after the referrer).
+    db.exec('PRAGMA defer_foreign_keys = ON')
+    // Replace the contribution_source row (cascade wipes its children first).
+    db.query('DELETE FROM contribution_source WHERE topology_id = ? AND source_id = ?').run(
+      topologyId,
+      sourceId,
+    )
+    const graphPayload = payloadWithout(graph, [
+      'nodes',
+      'links',
+      'subgraphs',
+      'terminations',
+      'attachments',
+      'exclusions',
+    ])
+    db.query(
+      `INSERT INTO contribution_source (topology_id, source_id, attachment_id, last_status, last_ok_at, graph_payload_json)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      topologyId,
+      sourceId,
+      opts.attachmentId ?? null,
+      opts.lastStatus ?? null,
+      opts.lastOkAt ?? null,
+      j(graphPayload),
+    )
+
+    const insElement = db.query(
+      `INSERT INTO contribution_element (topology_id, source_id, local_id, kind, parent_local_id, presence, payload_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    const insIdentity = db.query(
+      `INSERT INTO contribution_identity (element_id, topology_id, source_id, key_type, key_value)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    const insAttachment = db.query(
+      `INSERT INTO contribution_attachment
+         (topology_id, source_id, element_id, scope, kind, attachment_key, target_source_id, negate, payload_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    const insLink = db.query(
+      `INSERT INTO contribution_link
+         (topology_id, source_id, local_id, from_node_local_id, from_port_local_id, to_node_local_id, to_port_local_id, presence, payload_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    const insVia = db.query(
+      `INSERT INTO contribution_link_via (link_id, topology_id, source_id, seq, termination_local_id)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+
+    const elementId = (
+      localId: string,
+      kind: string,
+      parent: string | null,
+      presence: string | null,
+      payload: Record<string, unknown>,
+    ): number => {
+      const r = insElement.run(topologyId, sourceId, localId, kind, parent, presence, j(payload))
+      return Number(r.lastInsertRowid)
+    }
+    const writeIdentity = (eid: number, identity: Identity | undefined) => {
+      for (const row of identityToRows(identity))
+        insIdentity.run(eid, topologyId, sourceId, row.key_type, row.key_value)
+    }
+    const writeAttachments = (eid: number | null, scope: Scope, atts: Attachment[] | undefined) => {
+      for (const a of atts ?? []) {
+        const target = a.kind === 'metrics-binding' ? a.sourceId : null
+        const payload = payloadWithout(
+          a,
+          a.kind === 'metrics-binding' ? ['kind', 'sourceId'] : ['kind'],
+        )
+        insAttachment.run(
+          topologyId,
+          sourceId,
+          eid,
+          scope,
+          a.kind,
+          attachmentKeyOf(a),
+          target,
+          0,
+          j(payload),
+        )
+      }
+    }
+    // suppressedAttachments are attachment KEYS (strings) the human negated, not objects.
+    const writeSuppressions = (eid: number, scope: Scope, keys: string[] | undefined) => {
+      for (const key of keys ?? [])
+        insAttachment.run(topologyId, sourceId, eid, scope, kindFromKey(key), key, null, 1, null)
+    }
+
+    // Nodes (+ ports, identity, attachments, suppressions).
+    for (const node of graph.nodes ?? []) {
+      const nodePayload = payloadWithout(node, [
+        'id',
+        'parent',
+        'identity',
+        'attachments',
+        'suppressedAttachments',
+        'ports',
+      ])
+      const eid = elementId(node.id, 'node', node.parent ?? null, 'present', nodePayload)
+      writeIdentity(eid, node.identity)
+      writeAttachments(eid, 'node', node.attachments)
+      writeSuppressions(eid, 'node', node.suppressedAttachments)
+      for (const port of node.ports ?? []) {
+        const portPayload = payloadWithout(port, [
+          'id',
+          'identity',
+          'attachments',
+          'suppressedAttachments',
+        ])
+        const pid = elementId(port.id, 'port', node.id, 'present', portPayload)
+        writeIdentity(pid, port.identity)
+        writeAttachments(pid, 'port', port.attachments)
+        writeSuppressions(pid, 'port', port.suppressedAttachments)
+      }
+    }
+
+    // Subgraphs (+ attachments). children[] is derived from parent edges, not stored.
+    for (const sg of graph.subgraphs ?? []) {
+      const sgPayload = payloadWithout(sg, ['id', 'parent', 'attachments', 'children'])
+      const eid = elementId(sg.id, 'subgraph', sg.parent ?? null, 'present', sgPayload)
+      writeAttachments(eid, 'subgraph', sg.attachments)
+    }
+
+    // Terminations.
+    for (const term of graph.terminations ?? []) {
+      elementId(term.id, 'termination', null, 'present', payloadWithout(term, ['id']))
+    }
+
+    // Exclusions → identity-only `presence='hide'` elements.
+    for (const [i, ex] of (graph.exclusions ?? []).entries()) {
+      const eid = elementId(`__exclusion_${i}`, 'node', null, 'hide', {})
+      writeIdentity(eid, ex as Identity)
+    }
+
+    // Topology-default attachments (graph.attachments).
+    writeAttachments(null, 'topology-default', graph.attachments)
+
+    // Links (+ via).
+    for (const link of graph.links ?? []) {
+      const from = link.from
+      const to = link.to
+      const linkPayload = payloadWithout(link, ['id', 'from', 'to', 'via'])
+      // Per-endpoint non-structural fields (plug/ip/pin) ride in payload.
+      linkPayload['from'] = payloadWithout(from, ['node', 'port'])
+      linkPayload['to'] = payloadWithout(to, ['node', 'port'])
+      const r = insLink.run(
+        topologyId,
+        sourceId,
+        link.id ?? `__link_${graph.links?.indexOf(link)}`,
+        from.node,
+        from.port ?? null,
+        to.node,
+        to.port ?? null,
+        'present',
+        j(linkPayload),
+      )
+      const linkId = Number(r.lastInsertRowid)
+      for (const [seq, termId] of (link.via ?? []).entries()) {
+        insVia.run(linkId, topologyId, sourceId, seq, termId)
+      }
+    }
+  })
+  run()
+}
+
+// --- build -----------------------------------------------------------------
+
+interface ElementRow {
+  id: number
+  local_id: string
+  kind: string
+  parent_local_id: string | null
+  presence: string | null
+  payload_json: string | null
+}
+
+/** Project `(topologyId, sourceId)`'s rows back to a NetworkGraph. */
+export function buildGraph(
+  topologyId: string,
+  sourceId: string,
+  db: Database = getDatabase(),
+): NetworkGraph | null {
+  const src = db
+    .query(
+      'SELECT graph_payload_json FROM contribution_source WHERE topology_id = ? AND source_id = ?',
+    )
+    .get(topologyId, sourceId) as { graph_payload_json: string | null } | undefined
+  if (!src) return null
+
+  const elements = db
+    .query(
+      'SELECT id, local_id, kind, parent_local_id, presence, payload_json FROM contribution_element WHERE topology_id = ? AND source_id = ?',
+    )
+    .all(topologyId, sourceId) as ElementRow[]
+
+  const identityByElement = new Map<number, IdRow[]>()
+  for (const r of db
+    .query(
+      'SELECT element_id, key_type, key_value FROM contribution_identity WHERE topology_id = ? AND source_id = ?',
+    )
+    .all(topologyId, sourceId) as { element_id: number; key_type: string; key_value: string }[]) {
+    const list = identityByElement.get(r.element_id) ?? []
+    list.push({ key_type: r.key_type, key_value: r.key_value })
+    identityByElement.set(r.element_id, list)
+  }
+
+  // negate=0 → asserted Attachment objects; negate=1 → suppressed attachment KEYS (strings).
+  const attByElement = new Map<number | null, Attachment[]>()
+  const suppByElement = new Map<number, string[]>()
+  for (const r of db
+    .query(
+      'SELECT element_id, kind, attachment_key, target_source_id, negate, payload_json FROM contribution_attachment WHERE topology_id = ? AND source_id = ?',
+    )
+    .all(topologyId, sourceId) as {
+    element_id: number | null
+    kind: string
+    attachment_key: string
+    target_source_id: string | null
+    negate: number
+    payload_json: string | null
+  }[]) {
+    if (r.negate === 1) {
+      if (r.element_id == null) continue
+      const list = suppByElement.get(r.element_id) ?? []
+      list.push(r.attachment_key)
+      suppByElement.set(r.element_id, list)
+      continue
+    }
+    const payload = parse(r.payload_json)
+    const att =
+      r.kind === 'metrics-binding'
+        ? ({ kind: 'metrics-binding', sourceId: r.target_source_id, ...payload } as Attachment)
+        : ({ kind: r.kind, ...payload } as Attachment)
+    const list = attByElement.get(r.element_id) ?? []
+    list.push(att)
+    attByElement.set(r.element_id, list)
+  }
+  const attsOf = (eid: number | null): Attachment[] | undefined => {
+    const list = attByElement.get(eid)
+    return list && list.length > 0 ? list : undefined
+  }
+  const suppOf = (eid: number): string[] | undefined => {
+    const list = suppByElement.get(eid)
+    return list && list.length > 0 ? list : undefined
+  }
+
+  const nodes: Node[] = []
+  const subgraphs: Subgraph[] = []
+  const terminations: Termination[] = []
+  const exclusions: NodeExclusion[] = []
+  const portsByParent = new Map<string, NodePort[]>()
+  const elementByLocalId = new Map<string, ElementRow>()
+  for (const el of elements) elementByLocalId.set(el.local_id, el)
+
+  // Ports first (so nodes can attach them).
+  for (const el of elements) {
+    if (el.kind !== 'port' || !el.parent_local_id) continue
+    const port: NodePort = { id: el.local_id, ...parse(el.payload_json) } as NodePort
+    const identity = identityFromRows(identityByElement.get(el.id) ?? [])
+    if (identity) port.identity = identity
+    const a = attsOf(el.id)
+    if (a) port.attachments = a
+    const sp = suppOf(el.id)
+    if (sp) port.suppressedAttachments = sp
+    const list = portsByParent.get(el.parent_local_id) ?? []
+    list.push(port)
+    portsByParent.set(el.parent_local_id, list)
+  }
+
+  for (const el of elements) {
+    const payload = parse(el.payload_json)
+    if (el.kind === 'node' && el.presence === 'hide') {
+      const id = identityFromRows(identityByElement.get(el.id) ?? [])
+      if (id) exclusions.push(id as NodeExclusion)
+    } else if (el.kind === 'node') {
+      const node: Node = { id: el.local_id, ...payload } as Node
+      if (el.parent_local_id) node.parent = el.parent_local_id
+      const identity = identityFromRows(identityByElement.get(el.id) ?? [])
+      if (identity) node.identity = identity
+      const a = attsOf(el.id)
+      if (a) node.attachments = a
+      const s = suppOf(el.id)
+      if (s) node.suppressedAttachments = s
+      const ports = portsByParent.get(el.local_id)
+      if (ports) node.ports = ports
+      nodes.push(node)
+    } else if (el.kind === 'subgraph') {
+      const sg: Subgraph = { id: el.local_id, ...payload } as Subgraph
+      if (el.parent_local_id) sg.parent = el.parent_local_id
+      const a = attsOf(el.id)
+      if (a) sg.attachments = a
+      subgraphs.push(sg)
+    } else if (el.kind === 'termination') {
+      terminations.push({ id: el.local_id, ...payload } as Termination)
+    }
+  }
+
+  // Links (+ via).
+  const links: Link[] = []
+  const viaByLink = new Map<number, { seq: number; t: string }[]>()
+  for (const r of db
+    .query(
+      'SELECT link_id, seq, termination_local_id FROM contribution_link_via WHERE topology_id = ? AND source_id = ?',
+    )
+    .all(topologyId, sourceId) as {
+    link_id: number
+    seq: number
+    termination_local_id: string
+  }[]) {
+    const list = viaByLink.get(r.link_id) ?? []
+    list.push({ seq: r.seq, t: r.termination_local_id })
+    viaByLink.set(r.link_id, list)
+  }
+  for (const r of db
+    .query(
+      'SELECT id, local_id, from_node_local_id, from_port_local_id, to_node_local_id, to_port_local_id, payload_json FROM contribution_link WHERE topology_id = ? AND source_id = ?',
+    )
+    .all(topologyId, sourceId) as {
+    id: number
+    local_id: string
+    from_node_local_id: string
+    from_port_local_id: string | null
+    to_node_local_id: string
+    to_port_local_id: string | null
+    payload_json: string | null
+  }[]) {
+    const payload = parse(r.payload_json)
+    const fromExtra = (payload['from'] as Record<string, unknown>) ?? {}
+    const toExtra = (payload['to'] as Record<string, unknown>) ?? {}
+    delete payload['from']
+    delete payload['to']
+    const link: Link = {
+      ...payload,
+      from: { node: r.from_node_local_id, port: r.from_port_local_id ?? undefined, ...fromExtra },
+      to: { node: r.to_node_local_id, port: r.to_port_local_id ?? undefined, ...toExtra },
+    } as Link
+    // A synthesized local_id (the source link had no `id`) must NOT round-trip as an id.
+    if (!r.local_id.startsWith('__link_')) link.id = r.local_id
+    const via = (viaByLink.get(r.id) ?? []).sort((a, b) => a.seq - b.seq).map((v) => v.t)
+    if (via.length > 0) link.via = via
+    links.push(link)
+  }
+
+  const graphPayload = parse(src.graph_payload_json)
+  const graph: NetworkGraph = { ...graphPayload, nodes, links } as NetworkGraph
+  if (subgraphs.length > 0) graph.subgraphs = subgraphs
+  if (terminations.length > 0) graph.terminations = terminations
+  if (exclusions.length > 0) graph.exclusions = exclusions
+  const topoDefault = attsOf(null)
+  if (topoDefault) graph.attachments = topoDefault
+  return graph
+}

--- a/apps/server/api/src/services/contribution-store.ts
+++ b/apps/server/api/src/services/contribution-store.ts
@@ -266,7 +266,7 @@ export function ingestGraph(
       const r = insLink.run(
         topologyId,
         sourceId,
-        link.id ?? `__link_${graph.links?.indexOf(link)}`,
+        link.id ?? null,
         from.node,
         from.port ?? null,
         to.node,
@@ -309,14 +309,14 @@ export function buildGraph(
 
   const elements = db
     .query(
-      'SELECT id, local_id, kind, parent_local_id, presence, payload_json FROM contribution_element WHERE topology_id = ? AND source_id = ?',
+      'SELECT id, local_id, kind, parent_local_id, presence, payload_json FROM contribution_element WHERE topology_id = ? AND source_id = ? ORDER BY id',
     )
     .all(topologyId, sourceId) as ElementRow[]
 
   const identityByElement = new Map<number, IdRow[]>()
   for (const r of db
     .query(
-      'SELECT element_id, key_type, key_value FROM contribution_identity WHERE topology_id = ? AND source_id = ?',
+      'SELECT element_id, key_type, key_value FROM contribution_identity WHERE topology_id = ? AND source_id = ? ORDER BY element_id, key_type, key_value',
     )
     .all(topologyId, sourceId) as { element_id: number; key_type: string; key_value: string }[]) {
     const list = identityByElement.get(r.element_id) ?? []
@@ -329,7 +329,7 @@ export function buildGraph(
   const suppByElement = new Map<number, string[]>()
   for (const r of db
     .query(
-      'SELECT element_id, kind, attachment_key, target_source_id, negate, payload_json FROM contribution_attachment WHERE topology_id = ? AND source_id = ?',
+      'SELECT element_id, kind, attachment_key, target_source_id, negate, payload_json FROM contribution_attachment WHERE topology_id = ? AND source_id = ? ORDER BY id',
     )
     .all(topologyId, sourceId) as {
     element_id: number | null
@@ -433,18 +433,18 @@ export function buildGraph(
   }
   for (const r of db
     .query(
-      'SELECT id, local_id, from_node_local_id, from_port_local_id, to_node_local_id, to_port_local_id, payload_json FROM contribution_link WHERE topology_id = ? AND source_id = ?',
+      'SELECT id, local_id, from_node_local_id, from_port_local_id, to_node_local_id, to_port_local_id, payload_json FROM contribution_link WHERE topology_id = ? AND source_id = ? ORDER BY id',
     )
     .all(topologyId, sourceId) as {
     id: number
-    local_id: string
+    local_id: string | null
     from_node_local_id: string
     from_port_local_id: string | null
     to_node_local_id: string
     to_port_local_id: string | null
     payload_json: string | null
   }[]) {
-    const payload = parse(r.payload_json)
+    const payload = parse(r.payload_json) as Record<string, unknown>
     const fromExtra = (payload['from'] as Record<string, unknown>) ?? {}
     const toExtra = (payload['to'] as Record<string, unknown>) ?? {}
     delete payload['from']
@@ -454,8 +454,8 @@ export function buildGraph(
       from: { node: r.from_node_local_id, port: r.from_port_local_id ?? undefined, ...fromExtra },
       to: { node: r.to_node_local_id, port: r.to_port_local_id ?? undefined, ...toExtra },
     } as Link
-    // A synthesized local_id (the source link had no `id`) must NOT round-trip as an id.
-    if (!r.local_id.startsWith('__link_')) link.id = r.local_id
+    // local_id is the source Link.id (NULL when the source link had none).
+    if (r.local_id != null) link.id = r.local_id
     const via = (viaByLink.get(r.id) ?? []).sort((a, b) => a.seq - b.seq).map((v) => v.t)
     if (via.length > 0) link.via = via
     links.push(link)

--- a/apps/server/api/src/services/contribution-store.ts
+++ b/apps/server/api/src/services/contribution-store.ts
@@ -93,6 +93,19 @@ function attachmentKeyOf(a: Attachment): string {
   return a.kind
 }
 
+/**
+ * Port ids are only node-scoped in `NetworkGraph` (two switches may both have port
+ * `eth0`), but `contribution_element.local_id` is unique per source. So a port's stored
+ * local_id is composed with its owning node id; the original port id round-trips by
+ * stripping the prefix on read. The separator (unit separator) won't occur in real ids.
+ */
+const PORT_SEP = ''
+const portLocalId = (nodeId: string, portId: string): string => `${nodeId}${PORT_SEP}${portId}`
+const stripPortLocalId = (localId: string, nodeId: string | null): string =>
+  nodeId && localId.startsWith(`${nodeId}${PORT_SEP}`)
+    ? localId.slice(nodeId.length + PORT_SEP.length)
+    : localId
+
 /** Recover an attachment kind from a suppression key (the column needs a kind). */
 function kindFromKey(key: string): string {
   if (key.startsWith('access:')) return 'access'
@@ -234,7 +247,14 @@ export function ingestGraph(
           'attachments',
           'suppressedAttachments',
         ])
-        const pid = elementId(port.id, 'port', node.id, 'present', portPayload)
+        // Port local_id is node-scoped (two nodes may share a port id like 'eth0').
+        const pid = elementId(
+          portLocalId(node.id, port.id),
+          'port',
+          node.id,
+          'present',
+          portPayload,
+        )
         writeIdentity(pid, port.identity)
         writeAttachments(pid, 'port', port.attachments)
         writeSuppressions(pid, 'port', port.suppressedAttachments)
@@ -275,9 +295,9 @@ export function ingestGraph(
         sourceId,
         link.id ?? null,
         from.node,
-        from.port ?? null,
+        from.port != null ? portLocalId(from.node, from.port) : null,
         to.node,
-        to.port ?? null,
+        to.port != null ? portLocalId(to.node, to.port) : null,
         'present',
         j(linkPayload),
       )
@@ -382,7 +402,10 @@ export function buildGraph(
   // Ports first (so nodes can attach them).
   for (const el of elements) {
     if (el.kind !== 'port' || !el.parent_local_id) continue
-    const port: NodePort = { id: el.local_id, ...parse(el.payload_json) } as NodePort
+    const port: NodePort = {
+      id: stripPortLocalId(el.local_id, el.parent_local_id),
+      ...parse(el.payload_json),
+    } as NodePort
     const identity = identityFromRows(identityByElement.get(el.id) ?? [])
     if (identity) port.identity = identity
     const a = attsOf(el.id)
@@ -458,8 +481,22 @@ export function buildGraph(
     delete payload['to']
     const link: Link = {
       ...payload,
-      from: { node: r.from_node_local_id, port: r.from_port_local_id ?? undefined, ...fromExtra },
-      to: { node: r.to_node_local_id, port: r.to_port_local_id ?? undefined, ...toExtra },
+      from: {
+        node: r.from_node_local_id,
+        port:
+          r.from_port_local_id != null
+            ? stripPortLocalId(r.from_port_local_id, r.from_node_local_id)
+            : undefined,
+        ...fromExtra,
+      },
+      to: {
+        node: r.to_node_local_id,
+        port:
+          r.to_port_local_id != null
+            ? stripPortLocalId(r.to_port_local_id, r.to_node_local_id)
+            : undefined,
+        ...toExtra,
+      },
     } as Link
     // local_id is the source Link.id (NULL when the source link had none).
     if (r.local_id != null) link.id = r.local_id

--- a/apps/server/api/src/services/discovery-scheduler.ts
+++ b/apps/server/api/src/services/discovery-scheduler.ts
@@ -169,9 +169,9 @@ export function resolveCredentialsForAutoscan(
   topologyId: string,
   topologyService: TopologyService,
 ): Record<string, string> {
-  const topology = topologyService.get(topologyId)
-  if (!topology?.manualSourceId) return {}
-  const graph = topologyService.readManualGraph(topologyId, topology.manualSourceId)
+  // Credentials live in the authored layer (the intrinsic contribution) — read it
+  // unconditionally; do NOT gate on a phantom Manual data source being attached.
+  const graph = topologyService.readManualGraph(topologyId)
   if (!graph) return {}
 
   const subgraphLookup = new Map(
@@ -328,9 +328,8 @@ export class DiscoveryScheduler {
   private async readTopologyDefault(
     topologyId: string,
   ): Promise<import('@shumoku/core').Attachment[] | undefined> {
-    const topology = this.topologyService.get(topologyId)
-    if (!topology?.manualSourceId) return undefined
-    const graph = this.topologyService.readManualGraph(topologyId, topology.manualSourceId)
+    // Topology-default policy lives in the authored layer (intrinsic contribution).
+    const graph = this.topologyService.readManualGraph(topologyId)
     return graph?.attachments
   }
 

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -979,7 +979,14 @@ export class TopologyService {
     // Latest NON-FAILED snapshot per source: a transient failed scan must not
     // drop a source's last-good nodes (C7 — failed never retracts).
     const latest = this.observations.latestSuccessfulPerSource(topology.id)
-    const manualId = topology.manualSourceId
+    // Every attached Manual source's legacy observation is excluded from snapshots —
+    // authored data is the intrinsic contribution now, so a Manual observation must not
+    // double-count as an observed source (handles multiple Manuals, not just one).
+    const manualIds = new Set(
+      (
+        this.db.query("SELECT id FROM data_sources WHERE type = 'manual'").all() as { id: string }[]
+      ).map((r) => r.id),
+    )
     // The authored graph is the intrinsic contribution (DB-native store), folded as
     // resolve()'s top-priority contribution. Absent → empty. (`readManualGraph`
     // lazily backfills from a legacy Manual observation the first time.)
@@ -1001,7 +1008,7 @@ export class TopologyService {
     // old observation rows behind, so without this filter a detached source
     // would keep feeding the resolve from stale snapshots.
     const snapshots: SnapshotEntry[] = latest
-      .filter((o) => o.sourceId !== manualId && priorityBySource.has(o.sourceId))
+      .filter((o) => !manualIds.has(o.sourceId) && priorityBySource.has(o.sourceId))
       .map((o) => ({
         sourceId: o.sourceId,
         capturedAt: o.capturedAt,

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -44,7 +44,16 @@ import {
 import { collectIconUrls, resolveAllIconDimensions } from '@shumoku/renderer-svg'
 import { generateId, getDatabase, timestamp } from '../db/index.js'
 import type { MetricsData, MetricsMapping, Topology, TopologyInput } from '../types.js'
+import { buildGraph, ingestGraph } from './contribution-store.js'
 import { ObservationsService } from './observations.js'
+
+/**
+ * The project's own (intrinsic) contribution id — one per topology
+ * (contribution_source.attachment_id IS NULL). This is the authored layer; it is
+ * NOT a data source. See db-native-persistence.md.
+ */
+const INTRINSIC_SOURCE = 'intrinsic'
+
 import { TopologySourcesService } from './topology-sources.js'
 
 /** Bare topology row — no content_json column post-migration-010. */
@@ -605,9 +614,8 @@ export class TopologyService {
     nodeDesired: NodeBindingDesired[],
     linkDesired: LinkBindingDesired[],
   ): Promise<void> {
-    const manualId = await this.ensureManualSource(topologyId)
     const topology = this.get(topologyId)
-    const authored = this.readManualGraph(topologyId, manualId) ?? {
+    const authored = this.readManualGraph(topologyId) ?? {
       version: '1' as const,
       name: topology?.name ?? 'Manual',
       nodes: [],
@@ -713,7 +721,7 @@ export class TopologyService {
     nodes = nodes.filter((n) => !isPureEmptyOverlay(n))
 
     // Records a new authored observation for this topology + invalidates it.
-    await this.writeManualGraph(topologyId, manualId, { ...authored, nodes })
+    await this.writeManualGraph(topologyId, INTRINSIC_SOURCE, { ...authored, nodes })
   }
 
   /**
@@ -972,11 +980,10 @@ export class TopologyService {
     // drop a source's last-good nodes (C7 — failed never retracts).
     const latest = this.observations.latestSuccessfulPerSource(topology.id)
     const manualId = topology.manualSourceId
-    // The authored graph is the Manual source's latest observation — it's just
-    // another snapshot in `latest`, fed to resolve() as the top-priority
-    // contribution. Absent (fresh Manual / no Manual) → empty.
-    const manualGraph = manualId ? latest.find((o) => o.sourceId === manualId)?.graph : undefined
-    const authored: NetworkGraph = manualGraph ?? {
+    // The authored graph is the intrinsic contribution (DB-native store), folded as
+    // resolve()'s top-priority contribution. Absent → empty. (`readManualGraph`
+    // lazily backfills from a legacy Manual observation the first time.)
+    const authored: NetworkGraph = this.readManualGraph(topology.id) ?? {
       version: '1',
       name: topology.name,
       nodes: [],
@@ -1150,14 +1157,32 @@ export class TopologyService {
    *
    * Public so the discovery-policy API can compute / mutate the authored layer.
    */
-  readManualGraph(topologyId: string, sourceId: string): NetworkGraph | null {
+  readManualGraph(topologyId: string, _sourceId?: string): NetworkGraph | null {
+    // The authored layer is the intrinsic contribution (DB-native store). The
+    // `sourceId` param is vestigial — authored is per-topology now.
+    const fromRows = buildGraph(topologyId, INTRINSIC_SOURCE, this.db)
+    if (fromRows) return fromRows
+    // Lazy one-time backfill: an existing topology's authored graph still lives in
+    // a legacy Manual observation. Move it into the intrinsic contribution once.
+    const legacy = this.readLegacyManualObservation(topologyId)
+    if (legacy) {
+      ingestGraph(topologyId, INTRINSIC_SOURCE, legacy, { attachmentId: null }, this.db)
+      return legacy
+    }
+    return null
+  }
+
+  /** Read the pre-cutover Manual observation graph, if any (backfill source). */
+  private readLegacyManualObservation(topologyId: string): NetworkGraph | null {
+    const manualId = this.findManualSourceId(topologyId)
+    if (!manualId) return null
     const row = this.db
       .query(
         `SELECT graph_json FROM topology_observations
          WHERE topology_id = ? AND source_id = ? AND graph_json IS NOT NULL
          ORDER BY captured_at DESC, rowid DESC LIMIT 1`,
       )
-      .get(topologyId, sourceId) as { graph_json: string } | undefined
+      .get(topologyId, manualId) as { graph_json: string } | undefined
     if (!row) return null
     try {
       return JSON.parse(row.graph_json) as NetworkGraph
@@ -1172,20 +1197,9 @@ export class TopologyService {
    * latest one as the top-priority authored contribution. Per-topology: an edit
    * to topology X's authored graph only invalidates X.
    */
-  async writeManualGraph(topologyId: string, sourceId: string, graph: NetworkGraph): Promise<void> {
-    const src = this.db.query('SELECT type FROM data_sources WHERE id = ?').get(sourceId) as
-      | { type: string }
-      | undefined
-    if (!src || src.type !== 'manual') {
-      throw new Error(`Data source ${sourceId} is not a Manual source`)
-    }
-    await this.observations.record({
-      topologyId,
-      sourceId,
-      capturedAt: timestamp(),
-      status: 'ok',
-      graph,
-    })
+  writeManualGraph(topologyId: string, _sourceId: string, graph: NetworkGraph): void {
+    // Authored layer = the intrinsic contribution (topology-owned, attachment_id NULL).
+    ingestGraph(topologyId, INTRINSIC_SOURCE, graph, { attachmentId: null }, this.db)
     this.clearCacheEntry(topologyId)
   }
 

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -197,16 +197,18 @@ function isPureEmptyOverlayPort(p: NodePort): boolean {
  * concat topology-default attachments. Best-effort; only runs once on first read.
  */
 function mergeAuthoredGraphs(graphs: NetworkGraph[]): NetworkGraph {
-  const first = graphs[0]
-  const out: NetworkGraph = {
-    version: first?.version ?? '1',
-    name: first?.name,
-    nodes: [],
-    links: [],
-  }
+  // Keep the first graph's graph-level fields (version/name/description/settings/pins);
+  // the structural arrays are merged below.
+  const out: NetworkGraph = { ...(graphs[0] ?? { version: '1' }), nodes: [], links: [] }
+  out.subgraphs = undefined
+  out.terminations = undefined
+  out.exclusions = undefined
+  out.attachments = undefined
   const seenNode = new Set<string>()
+  const seenLink = new Set<string>()
   const seenSub = new Set<string>()
   const seenTerm = new Set<string>()
+  const seenAttKey = new Set<string>()
   const subgraphs: Subgraph[] = []
   const terminations: Termination[] = []
   const exclusions: NetworkGraph['exclusions'] = []
@@ -217,7 +219,14 @@ function mergeAuthoredGraphs(graphs: NetworkGraph[]): NetworkGraph {
       seenNode.add(n.id)
       out.nodes.push(n)
     }
-    out.links.push(...(g.links ?? []))
+    for (const l of g.links ?? []) {
+      // Dedup by id (DB local_id is unique); id-less links can't collide, always append.
+      if (l.id != null) {
+        if (seenLink.has(l.id)) continue
+        seenLink.add(l.id)
+      }
+      out.links.push(l)
+    }
     for (const sg of g.subgraphs ?? []) {
       if (seenSub.has(sg.id)) continue
       seenSub.add(sg.id)
@@ -229,7 +238,13 @@ function mergeAuthoredGraphs(graphs: NetworkGraph[]): NetworkGraph {
       terminations.push(t)
     }
     if (g.exclusions?.length) exclusions.push(...g.exclusions)
-    if (g.attachments?.length) attachments.push(...g.attachments)
+    // topology-default attachments: one slot per key (first wins).
+    for (const a of g.attachments ?? []) {
+      const key = attachmentKey(a)
+      if (seenAttKey.has(key)) continue
+      seenAttKey.add(key)
+      attachments.push(a)
+    }
   }
   if (subgraphs.length) out.subgraphs = subgraphs
   if (terminations.length) out.terminations = terminations

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -30,6 +30,8 @@ import type {
   NodePort,
   ResolvedLayout,
   SnapshotEntry,
+  Subgraph,
+  Termination,
 } from '@shumoku/core'
 import {
   attachmentKey,
@@ -186,6 +188,54 @@ function isPureEmptyOverlayPort(p: NodePort): boolean {
     if (Array.isArray(v) ? v.length > 0 : v !== undefined && v !== null) return false
   }
   return label.trim() === '' && (p.connectors?.length ?? 0) === 0
+}
+
+/**
+ * One-time backfill merge: a topology may have had several legacy Manual sources
+ * (#370). Concatenate their authored graphs into the single intrinsic contribution —
+ * dedup nodes/subgraphs/terminations by id (first wins), append links/exclusions,
+ * concat topology-default attachments. Best-effort; only runs once on first read.
+ */
+function mergeAuthoredGraphs(graphs: NetworkGraph[]): NetworkGraph {
+  const first = graphs[0]
+  const out: NetworkGraph = {
+    version: first?.version ?? '1',
+    name: first?.name,
+    nodes: [],
+    links: [],
+  }
+  const seenNode = new Set<string>()
+  const seenSub = new Set<string>()
+  const seenTerm = new Set<string>()
+  const subgraphs: Subgraph[] = []
+  const terminations: Termination[] = []
+  const exclusions: NetworkGraph['exclusions'] = []
+  const attachments: Attachment[] = []
+  for (const g of graphs) {
+    for (const n of g.nodes ?? []) {
+      if (seenNode.has(n.id)) continue
+      seenNode.add(n.id)
+      out.nodes.push(n)
+    }
+    out.links.push(...(g.links ?? []))
+    for (const sg of g.subgraphs ?? []) {
+      if (seenSub.has(sg.id)) continue
+      seenSub.add(sg.id)
+      subgraphs.push(sg)
+    }
+    for (const t of g.terminations ?? []) {
+      if (seenTerm.has(t.id)) continue
+      seenTerm.add(t.id)
+      terminations.push(t)
+    }
+    if (g.exclusions?.length) exclusions.push(...g.exclusions)
+    if (g.attachments?.length) attachments.push(...g.attachments)
+  }
+  if (subgraphs.length) out.subgraphs = subgraphs
+  if (terminations.length) out.terminations = terminations
+  if (exclusions.length) out.exclusions = exclusions
+  if (attachments.length) out.attachments = attachments
+  return out
 }
 
 /** Whether a port identity carries at least one usable port match key. */
@@ -1179,23 +1229,38 @@ export class TopologyService {
     return null
   }
 
-  /** Read the pre-cutover Manual observation graph, if any (backfill source). */
+  /**
+   * Read the pre-cutover authored graph from legacy Manual observations (backfill
+   * source). A topology may have had MULTIPLE Manual sources (#370 allowed it), so
+   * merge them all into one intrinsic graph rather than losing all but one.
+   */
   private readLegacyManualObservation(topologyId: string): NetworkGraph | null {
-    const manualId = this.findManualSourceId(topologyId)
-    if (!manualId) return null
-    const row = this.db
+    const manualSources = this.db
       .query(
-        `SELECT graph_json FROM topology_observations
-         WHERE topology_id = ? AND source_id = ? AND graph_json IS NOT NULL
-         ORDER BY captured_at DESC, rowid DESC LIMIT 1`,
+        `SELECT ds.id AS id FROM topology_data_sources tds
+         JOIN data_sources ds ON ds.id = tds.data_source_id
+         WHERE tds.topology_id = ? AND ds.type = 'manual'`,
       )
-      .get(topologyId, manualId) as { graph_json: string } | undefined
-    if (!row) return null
-    try {
-      return JSON.parse(row.graph_json) as NetworkGraph
-    } catch {
-      return null
+      .all(topologyId) as { id: string }[]
+    const graphs: NetworkGraph[] = []
+    for (const { id } of manualSources) {
+      const row = this.db
+        .query(
+          `SELECT graph_json FROM topology_observations
+           WHERE topology_id = ? AND source_id = ? AND graph_json IS NOT NULL
+           ORDER BY captured_at DESC, rowid DESC LIMIT 1`,
+        )
+        .get(topologyId, id) as { graph_json: string } | undefined
+      if (!row) continue
+      try {
+        graphs.push(JSON.parse(row.graph_json) as NetworkGraph)
+      } catch {
+        // skip a corrupt legacy blob
+      }
     }
+    if (graphs.length === 0) return null
+    if (graphs.length === 1) return graphs[0] ?? null
+    return mergeAuthoredGraphs(graphs)
   }
 
   /**

--- a/apps/server/api/test/db/contribution-codec.test.ts
+++ b/apps/server/api/test/db/contribution-codec.test.ts
@@ -136,6 +136,20 @@ describe('contribution codec — round-trip', () => {
     } as NetworkGraph)
   })
 
+  test('node-scoped duplicate port ids round-trip (two nodes both have "eth0")', () => {
+    expectLossless({
+      version: '1',
+      name: 'dup-ports',
+      nodes: [
+        { id: 'sw-a', label: 'A', ports: [{ id: 'eth0', label: 'eth0' }] },
+        { id: 'sw-b', label: 'B', ports: [{ id: 'eth0', label: 'eth0' }] },
+      ],
+      links: [
+        { id: 'l', from: { node: 'sw-a', port: 'eth0' }, to: { node: 'sw-b', port: 'eth0' } },
+      ],
+    } as NetworkGraph)
+  })
+
   test('empty collections ≡ absent; Subgraph.children is derived (not round-tripped)', () => {
     // The input carries empty `ports`/`attachments` and a `children[]`; canon treats
     // empty ≡ absent and drops children, so the round-trip is equal under the contract.

--- a/apps/server/api/test/db/contribution-codec.test.ts
+++ b/apps/server/api/test/db/contribution-codec.test.ts
@@ -1,0 +1,150 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Golden round-trip test for the contribution-store codec (stage 1b):
+ * `buildGraph(ingestGraph(g)) ≡ g` under normalized equality. See
+ * apps/server/docs/design/db-native-persistence.md § Round-trip codec.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { NetworkGraph } from '@shumoku/core'
+import { buildGraph, ingestGraph } from '../../src/services/contribution-store.ts'
+import { getDatabase, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+beforeAll(() => {
+  db_ = setupTempDb()
+  // metrics-binding.target_source_id FKs data_sources — seed the source the fixtures bind to.
+  insertDataSource('zabbix', 'zbx')
+})
+afterAll(() => db_.teardown())
+
+/** Recursively sort object keys so equality ignores key order (arrays keep order). */
+function canon(v: unknown): unknown {
+  if (Array.isArray(v)) return v.map(canon)
+  if (v && typeof v === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const k of Object.keys(v as Record<string, unknown>).sort())
+      out[k] = canon((v as Record<string, unknown>)[k])
+    return out
+  }
+  return v
+}
+
+let seq = 0
+function roundTrip(graph: NetworkGraph): NetworkGraph {
+  const id = `t_rt_${seq++}`
+  getDatabase()
+    .query('INSERT INTO topologies (id, name, created_at, updated_at) VALUES (?, ?, 0, 0)')
+    .run(id, id)
+  ingestGraph(id, 'c', graph)
+  const out = buildGraph(id, 'c')
+  if (!out) throw new Error('buildGraph returned null')
+  return out
+}
+
+const expectLossless = (g: NetworkGraph) => expect(canon(roundTrip(g))).toEqual(canon(g))
+
+describe('contribution codec — round-trip', () => {
+  test('minimal graph', () => {
+    expectLossless({ version: '1', name: 'min', nodes: [], links: [] })
+  })
+
+  test('nodes with identity, spec, style, ports, attachments, suppressions', () => {
+    expectLossless({
+      version: '1',
+      name: 'rich',
+      description: 'desc',
+      nodes: [
+        {
+          id: 'sw1',
+          label: 'Switch 1',
+          shape: 'rect',
+          spec: { kind: 'hardware', type: 'switch', vendor: 'cisco', model: 'c9300' },
+          style: { fill: '#eee', strokeWidth: 2 },
+          metadata: { rack: '3' },
+          identity: {
+            mgmtIp: '10.0.0.1',
+            chassisId: 'aa:bb',
+            vendorIds: { 'netbox-device-id': '42' },
+          },
+          attachments: [
+            { kind: 'access', protocol: 'snmp', community: 'public', version: '2c' },
+            { kind: 'policy', mode: 'auto', intervalMs: 60000 },
+          ],
+          suppressedAttachments: ['access:ssh'],
+          ports: [
+            {
+              id: 'sw1-p1',
+              label: 'Gi1/0/1',
+              interfaceName: 'GigabitEthernet1/0/1',
+              role: 'uplink',
+              identity: { ifName: 'GigabitEthernet1/0/1', ifIndex: 10001 },
+              attachments: [
+                {
+                  kind: 'metrics-binding',
+                  sourceId: 'zbx',
+                  interfaceName: 'Gi1/0/1',
+                  bandwidth: 1000000000,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'host1',
+          label: '',
+          identity: { mgmtIp: '10.0.0.2' },
+          attachments: [
+            { kind: 'metrics-binding', sourceId: 'zbx', hostId: 'h-1', hostName: 'host1' },
+          ],
+        },
+      ],
+      links: [],
+    })
+  })
+
+  test('links with ports, plug/ip/pin, via, and a link without id', () => {
+    expectLossless({
+      version: '1',
+      name: 'links',
+      nodes: [
+        { id: 'a', label: 'A', ports: [{ id: 'a-1', label: 'p' }] },
+        { id: 'b', label: 'B', ports: [{ id: 'b-1', label: 'p' }] },
+      ],
+      terminations: [{ id: 'eps1', label: 'EPS', role: 'eps', position: { x: 1, y: 2 } }],
+      links: [
+        {
+          id: 'l1',
+          from: { node: 'a', port: 'a-1', ip: '10.0.0.1/30' },
+          to: { node: 'b', port: 'b-1' },
+          via: ['eps1'],
+          label: 'trunk',
+          type: 'ethernet',
+        },
+        // a link with no id
+        { from: { node: 'a', port: 'a-1' }, to: { node: 'b', port: 'b-1' } },
+      ],
+    } as NetworkGraph)
+  })
+
+  test('subgraphs (nesting + attachments), exclusions, topology-default attachments', () => {
+    expectLossless({
+      version: '1',
+      name: 'groups',
+      nodes: [{ id: 'n1', label: 'N', parent: 'sgChild' }],
+      links: [],
+      subgraphs: [
+        { id: 'sgRoot', label: 'Root', direction: 'TB' },
+        {
+          id: 'sgChild',
+          label: 'Child',
+          parent: 'sgRoot',
+          attachments: [{ kind: 'policy', mode: 'disabled' }],
+        },
+      ],
+      exclusions: [{ mgmtIp: '10.9.9.9' }, { chassisId: 'dead:beef', sysName: 'old' }],
+      attachments: [{ kind: 'access', protocol: 'snmp', community: 'topo-default' }],
+    } as NetworkGraph)
+  })
+})

--- a/apps/server/api/test/db/contribution-codec.test.ts
+++ b/apps/server/api/test/db/contribution-codec.test.ts
@@ -19,13 +19,21 @@ beforeAll(() => {
 })
 afterAll(() => db_.teardown())
 
-/** Recursively sort object keys so equality ignores key order (arrays keep order). */
+/**
+ * Normalize for the round-trip contract: sort object keys (key order is irrelevant),
+ * keep array order, and treat **empty collection ≡ absent** + drop `Subgraph.children`
+ * (a derived field, never stored) — both are documented codec equivalences.
+ */
 function canon(v: unknown): unknown {
   if (Array.isArray(v)) return v.map(canon)
   if (v && typeof v === 'object') {
     const out: Record<string, unknown> = {}
-    for (const k of Object.keys(v as Record<string, unknown>).sort())
-      out[k] = canon((v as Record<string, unknown>)[k])
+    for (const k of Object.keys(v as Record<string, unknown>).sort()) {
+      if (k === 'children') continue // derived from parent edges, not round-tripped
+      const cv = (v as Record<string, unknown>)[k]
+      if (Array.isArray(cv) && cv.length === 0) continue // empty ≡ absent
+      out[k] = canon(cv)
+    }
     return out
   }
   return v
@@ -125,6 +133,18 @@ describe('contribution codec — round-trip', () => {
         // a link with no id
         { from: { node: 'a', port: 'a-1' }, to: { node: 'b', port: 'b-1' } },
       ],
+    } as NetworkGraph)
+  })
+
+  test('empty collections ≡ absent; Subgraph.children is derived (not round-tripped)', () => {
+    // The input carries empty `ports`/`attachments` and a `children[]`; canon treats
+    // empty ≡ absent and drops children, so the round-trip is equal under the contract.
+    expectLossless({
+      version: '1',
+      name: 'edges',
+      nodes: [{ id: 'n1', label: 'N', parent: 'sg', ports: [], attachments: [] }],
+      links: [],
+      subgraphs: [{ id: 'sg', label: 'G', children: ['n1'] }],
     } as NetworkGraph)
   })
 

--- a/apps/server/api/test/db/contribution-store.test.ts
+++ b/apps/server/api/test/db/contribution-store.test.ts
@@ -1,0 +1,170 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Stage 1 of the DB-native persistence refactor: the uniform contribution store
+ * (migration 016). These assert the SCHEMA + its integrity constraints actually
+ * bite — the codec (ingestGraph/buildGraph) is tested separately. See
+ * apps/server/docs/design/db-native-persistence.md.
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { getDatabase, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+beforeAll(() => {
+  db_ = setupTempDb()
+})
+afterAll(() => db_.teardown())
+
+const tables = (): string[] =>
+  (
+    getDatabase().query("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+      name: string
+    }[]
+  ).map((t) => t.name)
+
+/** A statement that must throw (constraint violation). */
+const expectReject = (fn: () => void) => expect(fn).toThrow()
+
+function seedTopology(id: string): void {
+  getDatabase()
+    .query('INSERT INTO topologies (id, name, created_at, updated_at) VALUES (?, ?, 0, 0)')
+    .run(id, id)
+}
+
+describe('migration 016 — contribution store schema', () => {
+  test('all contribution tables exist', () => {
+    const t = tables()
+    for (const name of [
+      'contribution_source',
+      'contribution_element',
+      'contribution_identity',
+      'contribution_link',
+      'contribution_link_via',
+      'contribution_attachment',
+    ]) {
+      expect(t).toContain(name)
+    }
+  })
+
+  test('integrity_check + foreign_key_check are clean', () => {
+    const db = getDatabase()
+    expect(
+      (db.query('PRAGMA integrity_check').get() as { integrity_check: string }).integrity_check,
+    ).toBe('ok')
+    expect(db.query('PRAGMA foreign_key_check').all().length).toBe(0)
+  })
+})
+
+describe('migration 016 — integrity constraints bite', () => {
+  test('at most one intrinsic (attachment_id NULL) contribution per topology', () => {
+    const db = getDatabase()
+    seedTopology('t_intrinsic')
+    db.query(
+      'INSERT INTO contribution_source (topology_id, source_id, attachment_id) VALUES (?, ?, NULL)',
+    ).run('t_intrinsic', 'c1')
+    expectReject(() =>
+      db
+        .query(
+          'INSERT INTO contribution_source (topology_id, source_id, attachment_id) VALUES (?, ?, NULL)',
+        )
+        .run('t_intrinsic', 'c2'),
+    )
+  })
+
+  test('element FK to contribution_source is enforced; bad kind rejected', () => {
+    const db = getDatabase()
+    seedTopology('t_el')
+    db.query(
+      'INSERT INTO contribution_source (topology_id, source_id, attachment_id) VALUES (?, ?, NULL)',
+    ).run('t_el', 'c')
+    db.query(
+      'INSERT INTO contribution_element (topology_id, source_id, local_id, kind, presence) VALUES (?, ?, ?, ?, ?)',
+    ).run('t_el', 'c', 'n1', 'node', 'present')
+    expectReject(() =>
+      db
+        .query(
+          'INSERT INTO contribution_element (topology_id, source_id, local_id, kind) VALUES (?, ?, ?, ?)',
+        )
+        .run('t_el', 'missing-source', 'n2', 'node'),
+    )
+    expectReject(() =>
+      db
+        .query(
+          'INSERT INTO contribution_element (topology_id, source_id, local_id, kind) VALUES (?, ?, ?, ?)',
+        )
+        .run('t_el', 'c', 'n3', 'widget'),
+    )
+  })
+
+  test('attachment CHECKs: topology-default ⇔ element NULL, and binding needs a target', () => {
+    const db = getDatabase()
+    seedTopology('t_att')
+    db.query(
+      'INSERT INTO contribution_source (topology_id, source_id, attachment_id) VALUES (?, ?, NULL)',
+    ).run('t_att', 'c')
+    db.query(
+      'INSERT INTO contribution_element (topology_id, source_id, local_id, kind, presence) VALUES (?, ?, ?, ?, ?)',
+    ).run('t_att', 'c', 'n1', 'node', null)
+    const eid = (
+      db
+        .query('SELECT id FROM contribution_element WHERE topology_id=? AND local_id=?')
+        .get('t_att', 'n1') as {
+        id: number
+      }
+    ).id
+    // topology-default scope with an element_id → reject
+    expectReject(() =>
+      db
+        .query(
+          'INSERT INTO contribution_attachment (topology_id, source_id, element_id, scope, kind, attachment_key) VALUES (?, ?, ?, ?, ?, ?)',
+        )
+        .run('t_att', 'c', eid, 'topology-default', 'policy', 'policy'),
+    )
+    // metrics-binding, asserted (negate 0), no target → reject
+    expectReject(() =>
+      db
+        .query(
+          'INSERT INTO contribution_attachment (topology_id, source_id, element_id, scope, kind, attachment_key, negate) VALUES (?, ?, ?, ?, ?, ?, 0)',
+        )
+        .run('t_att', 'c', eid, 'node', 'metrics-binding', 'metrics-binding:x'),
+    )
+    // valid policy attachment → ok
+    db.query(
+      'INSERT INTO contribution_attachment (topology_id, source_id, element_id, scope, kind, attachment_key) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run('t_att', 'c', eid, 'node', 'policy', 'policy')
+    expect(
+      (
+        db
+          .query('SELECT COUNT(*) c FROM contribution_attachment WHERE topology_id=?')
+          .get('t_att') as { c: number }
+      ).c,
+    ).toBe(1)
+  })
+
+  test('deleting a topology cascades the whole contribution graph', () => {
+    const db = getDatabase()
+    seedTopology('t_cas')
+    db.query(
+      'INSERT INTO contribution_source (topology_id, source_id, attachment_id) VALUES (?, ?, NULL)',
+    ).run('t_cas', 'c')
+    db.query(
+      'INSERT INTO contribution_element (topology_id, source_id, local_id, kind) VALUES (?, ?, ?, ?)',
+    ).run('t_cas', 'c', 'n1', 'node')
+    db.query('DELETE FROM topologies WHERE id=?').run('t_cas')
+    expect(
+      (
+        db.query('SELECT COUNT(*) c FROM contribution_source WHERE topology_id=?').get('t_cas') as {
+          c: number
+        }
+      ).c,
+    ).toBe(0)
+    expect(
+      (
+        db
+          .query('SELECT COUNT(*) c FROM contribution_element WHERE topology_id=?')
+          .get('t_cas') as { c: number }
+      ).c,
+    ).toBe(0)
+  })
+})

--- a/apps/server/api/test/db/manual-source.test.ts
+++ b/apps/server/api/test/db/manual-source.test.ts
@@ -4,7 +4,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import type { NetworkGraph } from '@shumoku/core'
 import { TopologyService } from '../../src/services/topology.ts'
-import { getDatabase, setupTempDb, type TempDb } from './helper.ts'
+import { attachSource, getDatabase, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
 
 let db_: TempDb
 let svc: TopologyService
@@ -59,5 +59,53 @@ describe('Manual = uniform data source (authored graph as the intrinsic contribu
     await svc.writeManualGraph(topo.id, 'intrinsic', g('first'))
     await svc.writeManualGraph(topo.id, 'intrinsic', g('second'))
     expect(svc.readManualGraph(topo.id)?.nodes?.[0]?.id).toBe('second')
+  })
+
+  test('multiple legacy Manual sources merge into one intrinsic on backfill (no data loss, no UNIQUE clash)', async () => {
+    // A pre-cutover topology with TWO Manual sources, each a legacy observation that
+    // overlaps (same link id, same topology-default attachment key, distinct nodes).
+    const topo = await svc.create({ name: 'mm' })
+    const db = getDatabase()
+    const recordManual = (sid: string, graph: NetworkGraph) => {
+      insertDataSource('manual', sid)
+      attachSource(topo.id, sid, 'topology')
+      db.query(
+        `INSERT INTO topology_observations (id, topology_id, source_id, captured_at, status, graph_json, node_count, link_count, port_count, created_at)
+         VALUES (?, ?, ?, ?, 'ok', ?, 0, 0, 0, ?)`,
+      ).run(`obs_${sid}`, topo.id, sid, 1, JSON.stringify(graph), 1)
+    }
+    recordManual('man-a', {
+      version: '1',
+      name: 'A',
+      description: 'kept',
+      settings: { paperSize: 'A4' },
+      nodes: [{ id: 'na', label: 'NA', ports: [{ id: 'p', label: 'p' }] }],
+      links: [{ id: 'shared', from: { node: 'na', port: 'p' }, to: { node: 'na', port: 'p' } }],
+      attachments: [{ kind: 'access', protocol: 'snmp', community: 'x' }],
+    } as NetworkGraph)
+    recordManual('man-b', {
+      version: '1',
+      name: 'B',
+      nodes: [{ id: 'nb', label: 'NB', ports: [{ id: 'p', label: 'p' }] }],
+      // SAME link id + SAME topology-default key as A — must be deduped, not double-inserted.
+      links: [{ id: 'shared', from: { node: 'nb', port: 'p' }, to: { node: 'nb', port: 'p' } }],
+      attachments: [{ kind: 'access', protocol: 'snmp', community: 'y' }],
+    } as NetworkGraph)
+
+    // Backfill (lazy, on first read) must merge both without throwing and keep both nodes.
+    const merged = svc.readManualGraph(topo.id)
+    expect(merged?.nodes?.map((n) => n.id).sort()).toEqual(['na', 'nb'])
+    expect(merged?.links).toHaveLength(1) // 'shared' deduped
+    expect(merged?.attachments).toHaveLength(1) // one slot per key
+    expect(merged?.description).toBe('kept') // graph-level fields preserved
+    expect((merged?.settings as { paperSize?: string })?.paperSize).toBe('A4')
+
+    // Idempotent: a second read comes from the intrinsic rows, still merged.
+    expect(
+      svc
+        .readManualGraph(topo.id)
+        ?.nodes?.map((n) => n.id)
+        .sort(),
+    ).toEqual(['na', 'nb'])
   })
 })

--- a/apps/server/api/test/db/manual-source.test.ts
+++ b/apps/server/api/test/db/manual-source.test.ts
@@ -22,7 +22,7 @@ const g = (nodeId: string): NetworkGraph =>
     links: [],
   }) as NetworkGraph
 
-describe('Manual = uniform data source (authored graph as observation)', () => {
+describe('Manual = uniform data source (authored graph as the intrinsic contribution)', () => {
   test('attachManualSource seeds config {} (no graph) and reads null until saved', async () => {
     const topo = await svc.create({ name: 'm1' })
     const manualId = await svc.ensureManualSource(topo.id)
@@ -33,30 +33,31 @@ describe('Manual = uniform data source (authored graph as observation)', () => {
     expect(svc.readManualGraph(topo.id, manualId)).toBeNull()
   })
 
-  test('writeManualGraph records an observation; readManualGraph + resolve see it', async () => {
+  test('writeManualGraph stores the intrinsic contribution; readManualGraph + resolve see it', async () => {
     const topo = await svc.create({ name: 'm2' })
-    const manualId = await svc.ensureManualSource(topo.id)
-    await svc.writeManualGraph(topo.id, manualId, g('a'))
+    await svc.writeManualGraph(topo.id, 'intrinsic', g('a'))
 
-    // Stored as an observation, not in config_json.
-    const obs = getDatabase()
+    // Stored in the contribution store (intrinsic = attachment_id NULL), NOT an observation.
+    const src = getDatabase()
       .query(
-        'SELECT graph_json, status FROM topology_observations WHERE topology_id = ? AND source_id = ?',
+        'SELECT source_id FROM contribution_source WHERE topology_id = ? AND attachment_id IS NULL',
       )
-      .get(topo.id, manualId) as { graph_json: string; status: string } | undefined
-    expect(obs?.status).toBe('ok')
-    expect(JSON.parse(obs?.graph_json ?? '{}').nodes).toHaveLength(1)
+      .get(topo.id) as { source_id: string } | undefined
+    expect(src).toBeDefined()
+    const node = getDatabase()
+      .query("SELECT local_id FROM contribution_element WHERE topology_id = ? AND kind = 'node'")
+      .get(topo.id) as { local_id: string } | undefined
+    expect(node?.local_id).toBe('a')
 
-    expect(svc.readManualGraph(topo.id, manualId)?.nodes?.[0]?.id).toBe('a')
+    expect(svc.readManualGraph(topo.id)?.nodes?.[0]?.id).toBe('a')
     const parsed = await svc.getParsed(topo.id)
     expect(parsed?.graph.nodes.some((n) => n.identity?.mgmtIp === '10.0.0.1')).toBe(true)
   })
 
-  test('latest observation wins on re-save', async () => {
+  test('latest write wins on re-save (intrinsic is replaced)', async () => {
     const topo = await svc.create({ name: 'm3' })
-    const manualId = await svc.ensureManualSource(topo.id)
-    await svc.writeManualGraph(topo.id, manualId, g('first'))
-    await svc.writeManualGraph(topo.id, manualId, g('second'))
-    expect(svc.readManualGraph(topo.id, manualId)?.nodes?.[0]?.id).toBe('second')
+    await svc.writeManualGraph(topo.id, 'intrinsic', g('first'))
+    await svc.writeManualGraph(topo.id, 'intrinsic', g('second'))
+    expect(svc.readManualGraph(topo.id)?.nodes?.[0]?.id).toBe('second')
   })
 })


### PR DESCRIPTION
@
Implements stages 1a–1c of the DB-native persistence refactor
(`apps/server/docs/design/db-native-persistence.md`). The authored layer moves off
the "Manual observation" blob onto the uniform contribution store. No backward compat.

## 1a — schema (migration 016)
`contribution_source` (attachment_id NULL = intrinsic; one-intrinsic + one-per-attach
partial unique), `contribution_element` (tri-state `presence`; kind CHECK; same-source
composite FKs incl. self parent), `contribution_identity` (WITHOUT ROWID; cross-source
match index), `contribution_link` (local_id round-trips Link.id; four endpoint FKs),
`contribution_link_via`, `contribution_attachment` (scope incl. `port`; `target_source_id`
FK; CHECK topology-default⇔element-NULL and binding-needs-target; one-slot uniqueness).
DB test asserts the constraints bite.

## 1b — codec
`ingestGraph` / `buildGraph` (lossless by construction — `payload_json` is the catch-all
for every non-promoted field; `defer_foreign_keys` for forward refs). Golden round-trip
test: nodes/ports/identity/attachments/suppressions, links (via + plug/ip + id-less),
subgraphs (nesting) + exclusions + topology-default, under normalized equality.

## 1c — authored layer cutover
`readManualGraph`→`buildGraph(intrinsic)` (lazy backfill from the legacy Manual
observation); `writeManualGraph`→`ingestGraph(intrinsic)`; `parseTopology` folds the
intrinsic contribution; `reconcileBindings` drops `ensureManualSource` (mapping edits no
longer spawn a phantom Manual). `resolve()` output unchanged.

## Verification
39 api tests pass (schema constraints, golden round-trip, manual-source, metrics-binding,
mapping-backfill, resolved-cache); typecheck + biome clean; migration applies on bun
SQLite 3.51.1 (integrity_check ok).

## Follow-ups (stages 2–4)
2: reconcileBindings/discovery-policy write attachment rows + remove the `authored`
literal special-cases in `resolve.ts` (unify hide/suppress). 3: observed sources →
contributions, retire `topology_observations`. 4: retire `manual_source_id` /
`ensureManualSource` (closes #375). Plus stage-0 dead-table cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@