### PR TITLE
chore(server): stage 0 — drop dead tables

### DIFF
--- a/apps/server/api/src/db/migrations/017_drop_dead_tables.sql
+++ b/apps/server/api/src/db/migrations/017_drop_dead_tables.sql
@@ -1,0 +1,6 @@
+-- Stage 0 cleanup: drop dead tables left in long-lived dev DBs by deleted migrations.
+-- `manual_source_graph` and `snmp_credentials` are created by no current migration and
+-- have zero code references; a fresh DB never has them. DROP IF EXISTS is a no-op on
+-- fresh DBs and a structural cleanup on existing ones.
+DROP TABLE IF EXISTS manual_source_graph;
+DROP TABLE IF EXISTS snmp_credentials;

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -21,6 +21,7 @@ import migration012 from './migrations/012_resolved_graph_cache.sql'
 import migration013 from './migrations/013_drop_legacy_source_columns.sql'
 import migration014 from './migrations/014_manual_graph_to_observations.sql'
 import migration016 from './migrations/016_contribution_store.sql'
+import migration017 from './migrations/017_drop_dead_tables.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -38,6 +39,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '013_drop_legacy_source_columns.sql', sql: migration013 },
   { name: '014_manual_graph_to_observations.sql', sql: migration014 },
   { name: '016_contribution_store.sql', sql: migration016 },
+  { name: '017_drop_dead_tables.sql', sql: migration017 },
 ]
 
 interface MigrationRecord {


### PR DESCRIPTION
Stage 0 of the DB-native cleanup. Migration 017 drops manual_source_graph + snmp_credentials (dead tables from deleted migrations; 0 code refs; absent on fresh DBs). Verified dropped-when-present / no-op otherwise; db tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)