### PR TITLE
feat(server): discovery-policy writes intrinsic (no phantom Manual on policy edit)

### DIFF
--- a/apps/server/api/src/api/discovery-policy.ts
+++ b/apps/server/api/src/api/discovery-policy.ts
@@ -15,8 +15,8 @@
  *             suppressedAttachments?: string[]|null } // node: keys to remove
  *     → { effective: EffectiveDiscoveryPolicy }
  *
- * The overlay lives on the authored (Manual) layer; PATCH auto-attaches a
- * Manual source on first use. A node that exists ONLY in a discovered
+ * The overlay lives on the topology's intrinsic contribution (the project's own
+ * authored layer — no Manual data source is created). A node that exists ONLY in a discovered
  * snapshot just works — detection already grabbed it, so we materialize a
  * minimal authored entry from its resolved identity and apply the
  * attachments. (Subgraph scope still 409s — a discovered-only subgraph has
@@ -254,8 +254,7 @@ export function createDiscoveryPolicyApi(): Hono {
     const topology = service.get(topologyId)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
 
-    const manualId = await service.ensureManualSource(topologyId)
-    const authored = service.readManualGraph(topologyId, manualId) ?? {
+    const authored = service.readManualGraph(topologyId) ?? {
       version: '1' as const,
       name: topology.name,
       nodes: [],
@@ -386,7 +385,7 @@ export function createDiscoveryPolicyApi(): Hono {
       }
     }
 
-    await service.writeManualGraph(topologyId, manualId, next)
+    service.writeManualGraph(topologyId, '', next)
     service.clearCacheEntry(topologyId)
 
     // Recompute the affected effective policy for the response.
@@ -452,8 +451,7 @@ export function createDiscoveryPolicyApi(): Hono {
     if (!ex) return c.json({ error: 'body must include mgmtIp, chassisId, or sysName' }, 400)
     const topology = service.get(topologyId)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
-    const manualId = await service.ensureManualSource(topologyId)
-    const authored = service.readManualGraph(topologyId, manualId) ?? {
+    const authored = service.readManualGraph(topologyId) ?? {
       version: '1' as const,
       name: topology.name,
       nodes: [],
@@ -461,7 +459,7 @@ export function createDiscoveryPolicyApi(): Hono {
     }
     const exclusions = [...(authored.exclusions ?? [])]
     if (!exclusions.some((e) => exclusionKey(e) === exclusionKey(ex))) exclusions.push(ex)
-    await service.writeManualGraph(topologyId, manualId, { ...authored, exclusions })
+    service.writeManualGraph(topologyId, '', { ...authored, exclusions })
     service.clearCacheEntry(topologyId)
     return c.json({ exclusions })
   })
@@ -472,14 +470,12 @@ export function createDiscoveryPolicyApi(): Hono {
     if (!ex) return c.json({ error: 'body must include mgmtIp, chassisId, or sysName' }, 400)
     const topology = service.get(topologyId)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
-    const manualId = service.findManualSourceId(topologyId)
-    if (!manualId) return c.json({ exclusions: [] })
-    const authored = service.readManualGraph(topologyId, manualId)
+    const authored = service.readManualGraph(topologyId)
     if (!authored) return c.json({ exclusions: [] })
     const exclusions = (authored.exclusions ?? []).filter(
       (e) => exclusionKey(e) !== exclusionKey(ex),
     )
-    await service.writeManualGraph(topologyId, manualId, { ...authored, exclusions })
+    service.writeManualGraph(topologyId, '', { ...authored, exclusions })
     service.clearCacheEntry(topologyId)
     return c.json({ exclusions })
   })
@@ -492,9 +488,7 @@ export function createDiscoveryPolicyApi(): Hono {
     const topologyId = c.req.param('id')
     const topology = service.get(topologyId)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
-    const manualId = service.findManualSourceId(topologyId)
-    if (!manualId) return c.json({ cleared: false, reason: 'no authored layer' })
-    const authored = service.readManualGraph(topologyId, manualId)
+    const authored = service.readManualGraph(topologyId)
     if (!authored) return c.json({ cleared: false, reason: 'no authored graph' })
     // Strip overlay: drop attachments from every node/subgraph, the topology
     // default, and all exclusions. Keep the nodes themselves out entirely —
@@ -507,7 +501,7 @@ export function createDiscoveryPolicyApi(): Hono {
       attachments: undefined,
       exclusions: undefined,
     }
-    await service.writeManualGraph(topologyId, manualId, cleared)
+    service.writeManualGraph(topologyId, '', cleared)
     service.clearCacheEntry(topologyId)
     return c.json({ cleared: true })
   })


### PR DESCRIPTION
Discovery-policy edits route to the topology's intrinsic contribution instead of ensureManualSource/findManualSourceId, removing the last edit path that auto-spawned a Manual data source. 42 api tests pass; typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)