### PR TITLE
refactor(core): rename provenance vocabulary 'authored' → 'intrinsic' (stage 2b)

### DIFF
--- a/apps/server/api/src/api/discovery-policy.ts
+++ b/apps/server/api/src/api/discovery-policy.ts
@@ -363,8 +363,8 @@ export function createDiscoveryPolicyApi(): Hono {
             // the observed name shows through. Only when there's nothing left
             // to author (no attachments, no suppression) AND a real observation
             // backs the node do we drop the entry entirely (a full Reset =
-            // remove the human contribution), so it re-resolves to the bare
-            // observed state. For an authored-only node with nothing left,
+            // remove the project's own contribution), so it re-resolves to the
+            // bare observed state. For an intrinsic-only node with nothing left,
             // deleting would destroy real data — so keep it (with '' label).
             const hasAttach = Array.isArray(target.attachments) && target.attachments.length > 0
             const hasSuppress =

--- a/apps/server/api/src/services/contribution-store.ts
+++ b/apps/server/api/src/services/contribution-store.ts
@@ -13,14 +13,18 @@
  *
  * Nodes round-trip as `presence='present'`, `exclusions` as `presence='hide'`.
  *
- * Two defined equivalences (the round-trip is lossless modulo these, matching how
+ * Three defined equivalences (the round-trip is lossless modulo these, matching how
  * every consumer already treats them):
  *  - **empty collection ≡ absent** — an empty `ports`/`attachments`/`via`/… is stored
  *    as zero rows and rebuilt as an absent key (no consumer distinguishes `[]` from
  *    undefined).
  *  - **`Subgraph.children` is derived, not stored** — membership has one source of
  *    truth (the parent edge, `parent_local_id`); `children[]` is recomputed by
- *    consumers, never persisted (it is not part of the round-trip, like `provenance`).
+ *    consumers, never persisted.
+ *  - **`provenance` / `fieldSources` are derived, not stored** — they are stamped by
+ *    `resolve()` onto its OUTPUT; a contribution is an INPUT, so they are stripped on
+ *    ingest and re-derived on every resolve. Storing one would let a stale value (e.g.
+ *    an old `provenance.source`) leak through a recompute.
  */
 
 import type { Database } from 'bun:sqlite'
@@ -235,6 +239,11 @@ export function ingestGraph(
         'attachments',
         'suppressedAttachments',
         'ports',
+        // resolve()-derived annotations — never an input, so never stored (a
+        // contribution is an input). Re-derived on every resolve. Storing a
+        // stale one (e.g. an old `provenance.source`) would be a latent footgun.
+        'provenance',
+        'fieldSources',
       ])
       const eid = elementId(node.id, 'node', node.parent ?? null, 'present', nodePayload)
       writeIdentity(eid, node.identity)
@@ -246,6 +255,7 @@ export function ingestGraph(
           'identity',
           'attachments',
           'suppressedAttachments',
+          'provenance',
         ])
         // Port local_id is node-scoped (two nodes may share a port id like 'eth0').
         const pid = elementId(
@@ -263,7 +273,13 @@ export function ingestGraph(
 
     // Subgraphs (+ attachments). children[] is derived from parent edges, not stored.
     for (const sg of graph.subgraphs ?? []) {
-      const sgPayload = payloadWithout(sg, ['id', 'parent', 'attachments', 'children'])
+      const sgPayload = payloadWithout(sg, [
+        'id',
+        'parent',
+        'attachments',
+        'children',
+        'provenance',
+      ])
       const eid = elementId(sg.id, 'subgraph', sg.parent ?? null, 'present', sgPayload)
       writeAttachments(eid, 'subgraph', sg.attachments)
     }
@@ -286,7 +302,7 @@ export function ingestGraph(
     for (const link of graph.links ?? []) {
       const from = link.from
       const to = link.to
-      const linkPayload = payloadWithout(link, ['id', 'from', 'to', 'via'])
+      const linkPayload = payloadWithout(link, ['id', 'from', 'to', 'via', 'provenance'])
       // Per-endpoint non-structural fields (plug/ip/pin) ride in payload.
       linkPayload['from'] = payloadWithout(from, ['node', 'port'])
       linkPayload['to'] = payloadWithout(to, ['node', 'port'])

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -85,7 +85,7 @@ function rowToTopology(row: TopologyRow): Topology {
  * `topology_resolved_graph` artifacts built by an older version are treated as
  * stale and recomputed without a manual purge.
  */
-const RESOLVER_VERSION = 1
+const RESOLVER_VERSION = 2
 
 /**
  * Map-aware JSON round-trip. `LayoutResult` / `ResolvedLayout` are Map-heavy

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -546,14 +546,14 @@ export interface NodeExclusion {
 export type DiscoveryMode = 'auto' | 'observe' | 'disabled'
 
 /** Where a resolved attachment's value came from. Mirrors `@shumoku/core`'s
- *  `Provenance`. `source === 'authored'` marks a human-set value; any other
- *  source is the value a discovery source supplied. The UI uses this as an
- *  annotation ("your value" vs "from <source>"), NOT as a read-only gate —
+ *  `Provenance`. `source === 'intrinsic'` marks a project-owned (your own) value;
+ *  any other source is the value a discovery source supplied. The UI uses this as
+ *  an annotation ("your value" vs "from <source>"), NOT as a read-only gate —
  *  every value is editable. resolve() stamps it; freshly-authored local
  *  attachments omit it until the next round-trip. */
 export interface Provenance {
   source: string
-  state?: 'confirmed' | 'authored-only' | 'discovered-only' | 'conflicting'
+  state?: 'confirmed' | 'intrinsic-only' | 'discovered-only' | 'conflicting'
   observedAt?: number
 }
 

--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -12,7 +12,7 @@
      *  resolver. Optional — undefined for graphs that pre-date the model. */
     provenance?: {
       source: string
-      state?: 'confirmed' | 'authored-only' | 'discovered-only' | 'conflicting'
+      state?: 'confirmed' | 'intrinsic-only' | 'discovered-only' | 'conflicting'
       observedAt?: number
     }
     /** Identity keys used by the resolver to match this node across

--- a/apps/server/web/src/lib/discovery-attachments.test.ts
+++ b/apps/server/web/src/lib/discovery-attachments.test.ts
@@ -19,15 +19,15 @@ describe('accessKey', () => {
 })
 
 describe('isAuthoredAttachment', () => {
-  it('authored when provenance.source is "authored"', () => {
+  it('intrinsic when provenance.source is "intrinsic"', () => {
     expect(
-      isAuthoredAttachment({ kind: 'policy', mode: 'auto', provenance: { source: 'authored' } }),
+      isAuthoredAttachment({ kind: 'policy', mode: 'auto', provenance: { source: 'intrinsic' } }),
     ).toBe(true)
   })
-  it('authored when provenance is absent (fresh local attachment)', () => {
+  it('intrinsic when provenance is absent (fresh local attachment)', () => {
     expect(isAuthoredAttachment({ kind: 'access', protocol: 'ssh' })).toBe(true)
   })
-  it('not authored when provenance.source is a discovery source', () => {
+  it('not intrinsic when provenance.source is a discovery source', () => {
     expect(
       isAuthoredAttachment({
         kind: 'access',
@@ -54,11 +54,11 @@ describe('unifyAccessRows (one editable row per protocol — no two-tier)', () =
   })
 
   it('an override and its observed value collapse into ONE row (override + fallback both kept)', () => {
-    const authored: Attachment[] = [{ kind: 'access', protocol: 'snmp', community: 'override' }]
+    const intrinsic: Attachment[] = [{ kind: 'access', protocol: 'snmp', community: 'override' }]
     const observed: Attachment[] = [
       { kind: 'access', protocol: 'snmp', community: 'public', provenance: { source: 'scan:1' } },
     ]
-    const rows = unifyAccessRows(authored, observed)
+    const rows = unifyAccessRows(intrinsic, observed)
     expect(rows).toHaveLength(1) // one row, not two layers
     expect(rows[0]?.authored?.kind === 'access' ? rows[0]?.authored?.protocol : undefined).toBe(
       'snmp',
@@ -66,8 +66,8 @@ describe('unifyAccessRows (one editable row per protocol — no two-tier)', () =
     expect(rows[0]?.observed).toBeDefined() // the observed value is the revert target
   })
 
-  it('mixes overridden snmp, a pure-authored ssh, and leaves policy out', () => {
-    const authored: Attachment[] = [
+  it('mixes overridden snmp, a pure-intrinsic ssh, and leaves policy out', () => {
+    const intrinsic: Attachment[] = [
       { kind: 'access', protocol: 'snmp', community: 'mine' },
       { kind: 'access', protocol: 'ssh', username: 'admin' },
       { kind: 'policy', mode: 'disabled' },
@@ -75,21 +75,21 @@ describe('unifyAccessRows (one editable row per protocol — no two-tier)', () =
     const observed: Attachment[] = [
       { kind: 'access', protocol: 'snmp', community: 'public', provenance: { source: 'scan:1' } },
     ]
-    const rows = unifyAccessRows(authored, observed)
+    const rows = unifyAccessRows(intrinsic, observed)
     expect(rows.map((r) => r.protocol)).toEqual(['snmp', 'ssh'])
     const ssh = rows.find((r) => r.protocol === 'ssh')
     expect(ssh?.authored).toBeDefined()
-    expect(ssh?.observed).toBeUndefined() // pure authored → remove deletes it outright
+    expect(ssh?.observed).toBeUndefined() // pure intrinsic → remove deletes it outright
   })
 })
 
 describe('stripProvenance', () => {
-  it('drops provenance so the value PATCHes as a plain authored attachment', () => {
+  it('drops provenance so the value PATCHes as a plain intrinsic attachment', () => {
     const a: Attachment = {
       kind: 'access',
       protocol: 'snmp',
       community: 'x',
-      provenance: { source: 'authored' },
+      provenance: { source: 'intrinsic' },
     }
     expect(stripProvenance(a)).toEqual({ kind: 'access', protocol: 'snmp', community: 'x' })
   })

--- a/apps/server/web/src/lib/discovery-attachments.ts
+++ b/apps/server/web/src/lib/discovery-attachments.ts
@@ -28,12 +28,13 @@ export function accessKey(protocol: AccessAttachment['protocol']): string {
 
 /**
  * The operator owns this attachment (its value is theirs) when resolve
- * tagged it `authored`, or when it has no provenance yet — a freshly-added
- * local attachment before its next round-trip. Anything else is the value a
- * source currently supplies (shown, editable, annotated with its origin).
+ * tagged it `intrinsic` (the project's own contribution), or when it has no
+ * provenance yet — a freshly-added local attachment before its next round-trip.
+ * Anything else is the value a source currently supplies (shown, editable,
+ * annotated with its origin).
  */
 export function isAuthoredAttachment(a: Attachment): boolean {
-  return a.provenance === undefined || a.provenance.source === 'authored'
+  return a.provenance === undefined || a.provenance.source === 'intrinsic'
 }
 
 /** Drop the resolve-stamped provenance so the value can be edited / PATCHed

--- a/apps/server/web/src/routes/(app)/topologies/[id]/composition/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/composition/+page.svelte
@@ -149,8 +149,8 @@
         counts.total++
         const md = (node.metadata ?? {}) as Record<string, unknown>
         const label = Array.isArray(node.label) ? node.label.join(' ') : (node.label ?? node.id)
-        // Prefer the observing source: once a node has an authored override
-        // its provenance.source flips to 'authored', but discovery still
+        // Prefer the observing source: once a node has a project override
+        // its provenance.source flips to 'intrinsic', but discovery still
         // needs the source that saw it (resolve stamps `observedSource`).
         const sourceId =
           (typeof md['observedSource'] === 'string'

--- a/libs/@shumoku/core/src/models/observation.test.ts
+++ b/libs/@shumoku/core/src/models/observation.test.ts
@@ -14,8 +14,8 @@ import type { Identity, Link, NetworkGraph, Node, NodePort, Provenance, Subgraph
 describe('observation model types', () => {
   describe('Provenance', () => {
     it('accepts the minimum required shape (source only)', () => {
-      const p: Provenance = { source: 'authored' }
-      expect(p.source).toBe('authored')
+      const p: Provenance = { source: 'intrinsic' }
+      expect(p.source).toBe('intrinsic')
     })
 
     it('accepts an open string source (no union enforcement)', () => {
@@ -26,7 +26,7 @@ describe('observation model types', () => {
     })
 
     it('accepts each state value the resolver assigns', () => {
-      const states = ['confirmed', 'authored-only', 'discovered-only', 'conflicting'] as const
+      const states = ['confirmed', 'intrinsic-only', 'discovered-only', 'conflicting'] as const
       for (const state of states) {
         const p: Provenance = { source: 's', state, observedAt: 1700000000000 }
         expect(p.state).toBe(state)
@@ -104,9 +104,9 @@ describe('observation model types', () => {
       const sub: Subgraph = {
         id: 'sg1',
         label: 'Tier',
-        provenance: { source: 'authored' },
+        provenance: { source: 'intrinsic' },
       }
-      expect(sub.provenance?.source).toBe('authored')
+      expect(sub.provenance?.source).toBe('intrinsic')
     })
   })
 

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -38,10 +38,22 @@ export interface IconDimensions {
  * `Alert.source` (see `@shumoku/core/plugin-types.ts`).
  */
 export interface Provenance {
-  /** Source identifier. `'authored'` is a reserved value for human edits. */
+  /**
+   * Source identifier. `'intrinsic'` is the reserved value for the project's own
+   * contribution (the topology's intrinsic, project-owned assertions — what the
+   * editor writes). It is NOT a "human" layer: it's the ownership/lifecycle
+   * distinction (intrinsic vs external feed), the only one the model keeps. Any
+   * other value is an external source id (open string, like `Alert.source`).
+   */
   source: string
-  /** Set by the resolver. Snapshots leave this undefined. */
-  state?: 'confirmed' | 'authored-only' | 'discovered-only' | 'conflicting'
+  /**
+   * Set by the resolver. Snapshots leave this undefined.
+   * - `intrinsic-only`: only the project's own contribution asserts it
+   * - `discovered-only`: only external feed(s) assert it
+   * - `confirmed`: both
+   * - `conflicting`: external feeds disagree (no intrinsic value to settle it)
+   */
+  state?: 'confirmed' | 'intrinsic-only' | 'discovered-only' | 'conflicting'
   /** Unix ms — when the source observed this value. */
   observedAt?: number
 }
@@ -398,12 +410,12 @@ export type Attachment = AccessAttachment | PolicyAttachment | MetricsBindingAtt
 
 /**
  * Provenance stamped by `resolve()` onto every attachment in the resolved
- * graph: which source contributed it. The human/authored contribution
- * carries `source: 'authored'`; an observed attachment carries the
- * observing source's id. The discovery UI reads this to render
- * observed-derived rows read-only (no ✕) and human rows editable — the
- * fix for "✕ doesn't remove an observed access". Optional: hand-authored
- * or freshly-saved attachments omit it, and resolve fills it in.
+ * graph: which source contributed it. The project's own (intrinsic)
+ * contribution carries `source: 'intrinsic'`; an observed attachment carries
+ * the observing source's id. The discovery UI reads this to render
+ * observed-derived rows read-only (no ✕) and intrinsic rows editable — the
+ * fix for "✕ doesn't remove an observed access". Optional: freshly-saved
+ * attachments omit it, and resolve fills it in.
  */
 export interface AttachmentMeta {
   provenance?: Provenance
@@ -605,11 +617,10 @@ export interface Node {
   /**
    * Per-field provenance stamped by `resolve()`: maps a field name
    * (`label` / `spec` / `parent` …) to the source id that won it in the
-   * priority merge. `'authored'` means the human contribution supplied the
-   * value. Diagnostic / UI affordance (e.g. show whether the displayed name
-   * is a human override or the observed name) — not load-bearing for
-   * rendering. Omitted on hand-authored nodes that never went through
-   * resolve.
+   * priority merge. `'intrinsic'` means the project's own contribution supplied
+   * the value. Diagnostic / UI affordance (e.g. show whether the displayed name
+   * is a project override or the observed name) — not load-bearing for
+   * rendering. Omitted on nodes that never went through resolve.
    */
   fieldSources?: Record<string, string>
 

--- a/libs/@shumoku/core/src/observation/metrics-binding.test.ts
+++ b/libs/@shumoku/core/src/observation/metrics-binding.test.ts
@@ -110,15 +110,15 @@ describe('metricsBindingOf', () => {
 })
 
 describe('resolve folds metrics-binding by identity (re-sync follow)', () => {
-  it('authored node binding lands on the identity-matched observed node', () => {
+  it('intrinsic node binding lands on the identity-matched observed node', () => {
     // The keystone: the binding is keyed by identity (mgmtIp), so it follows
     // the device even though the observed snapshot uses a different positional
     // id. Re-sync / reorder can never detach it.
-    const authored: NetworkGraph = {
+    const intrinsic: NetworkGraph = {
       version: '1.0',
       nodes: [
         {
-          id: 'authored-1',
+          id: 'intrinsic-1',
           label: '',
           shape: 'rect',
           identity: { mgmtIp: '10.0.0.1' },
@@ -139,19 +139,19 @@ describe('resolve folds metrics-binding by identity (re-sync follow)', () => {
         links: [],
       },
     }
-    const out = resolve(authored, [observed])
+    const out = resolve(intrinsic, [observed])
     expect(out.nodes).toHaveLength(1)
     const mapping = deriveMappingFromGraph(out)
     const resolvedId = out.nodes[0]?.id ?? ''
     expect(mapping.nodes[resolvedId]).toEqual({ hostId: '42', hostName: 'host-42' })
   })
 
-  it('authored port binding folds onto the identity-matched port; human can suppress it', () => {
+  it('intrinsic port binding folds onto the identity-matched port; human can suppress it', () => {
     const makeAuthored = (suppress: boolean): NetworkGraph => ({
       version: '1.0',
       nodes: [
         {
-          id: 'authored-1',
+          id: 'intrinsic-1',
           label: '',
           shape: 'rect',
           identity: { mgmtIp: '10.0.0.1' },
@@ -207,21 +207,21 @@ describe('resolve folds metrics-binding by identity (re-sync follow)', () => {
   })
 
   it('link binding survives port folding: endpoint port id is remapped so the binding is discoverable', () => {
-    // The observed link references the OBSERVED port id; the authored overlay
+    // The observed link references the OBSERVED port id; the intrinsic overlay
     // carries the binding on a port with a different id but the same identity.
-    // After fold there is one port (the authored id wins) and the link endpoint
+    // After fold there is one port (the intrinsic id wins) and the link endpoint
     // must be remapped to it, else deriveMappingFromGraph can't find the binding.
-    const authored: NetworkGraph = {
+    const intrinsic: NetworkGraph = {
       version: '1.0',
       nodes: [
         {
-          id: 'authored-a',
+          id: 'intrinsic-a',
           label: '',
           shape: 'rect',
           identity: { mgmtIp: '10.0.0.1' },
           ports: [
             {
-              id: 'authored-port',
+              id: 'intrinsic-port',
               label: 'Gi0/1',
               connectors: ['rj45'],
               identity: { ifName: 'Gi0/1' },
@@ -271,7 +271,7 @@ describe('resolve folds metrics-binding by identity (re-sync follow)', () => {
       },
     }
 
-    const out = resolve(authored, [observed])
+    const out = resolve(intrinsic, [observed])
     const mapping = deriveMappingFromGraph(out)
     const monitoredNodeId = out.nodes.find((n) => n.identity?.mgmtIp === '10.0.0.1')?.id
     expect(mapping.links['L1']).toEqual({

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -8,7 +8,7 @@ import { nodeIdentityQuality, portIdentityQuality, resolve, type SnapshotEntry }
 
 /**
  * Skeleton-level resolve() behavior. Covers the four end-state
- * cases (confirmed / authored-only / discovered-only / conflicting)
+ * cases (confirmed / intrinsic-only / discovered-only / conflicting)
  * and the critical ifIndex reshuffle scenario. Deeper edge cases
  * (cross-source link dedup, ghost endpoints, full retraction
  * hysteresis) are intentionally deferred — see resolve.ts header.
@@ -33,16 +33,16 @@ describe('resolve()', () => {
   })
 
   describe('empty inputs', () => {
-    it('empty authored, no snapshots → empty resolved', () => {
+    it('empty intrinsic, no snapshots → empty resolved', () => {
       const out = resolve(emptyGraph(), [])
       expect(out.nodes).toEqual([])
       expect(out.links).toEqual([])
     })
   })
 
-  describe('authored-only', () => {
-    it('node present only in authored → state = authored-only', () => {
-      const authored: NetworkGraph = {
+  describe('intrinsic-only', () => {
+    it('node present only in intrinsic → state = intrinsic-only', () => {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -53,10 +53,10 @@ describe('resolve()', () => {
           },
         ],
       }
-      const out = resolve(authored, [])
+      const out = resolve(intrinsic, [])
       expect(out.nodes).toHaveLength(1)
-      expect(out.nodes[0]?.provenance?.state).toBe('authored-only')
-      expect(out.nodes[0]?.provenance?.source).toBe('authored')
+      expect(out.nodes[0]?.provenance?.state).toBe('intrinsic-only')
+      expect(out.nodes[0]?.provenance?.source).toBe('intrinsic')
     })
   })
 
@@ -86,12 +86,12 @@ describe('resolve()', () => {
   })
 
   describe('synthetic id collision (adopt path)', () => {
-    it('authored node carrying a `discovered:N` id does not collide with synthesized ids', () => {
+    it('intrinsic node carrying a `discovered:N` id does not collide with synthesized ids', () => {
       // Reproduces the adopt path: a discovered node materialized into the
-      // authored graph keeps its synthesized `discovered:0` id. A later
+      // intrinsic graph keeps its synthesized `discovered:0` id. A later
       // resolve must not hand that same id to a fresh discovered cluster —
       // duplicate ids crash the keyed grid in the UI.
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -114,21 +114,21 @@ describe('resolve()', () => {
           ],
         },
       }
-      const out = resolve(authored, [snap])
+      const out = resolve(intrinsic, [snap])
       const ids = out.nodes.map((n) => n.id)
       expect(out.nodes).toHaveLength(3)
       expect(new Set(ids).size).toBe(ids.length) // all unique — no duplicate key
-      expect(ids).toContain('discovered:0') // authored node kept its id
+      expect(ids).toContain('discovered:0') // intrinsic node kept its id
     })
   })
 
-  describe('confirmed (authored + snapshot agree on identity)', () => {
-    it('authored mgmtIp matches snapshot mgmtIp → confirmed', () => {
-      const authored: NetworkGraph = {
+  describe('confirmed (intrinsic + snapshot agree on identity)', () => {
+    it('intrinsic mgmtIp matches snapshot mgmtIp → confirmed', () => {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
-            id: 'authored-r1',
+            id: 'intrinsic-r1',
             label: 'R1',
             shape: 'rect',
             identity: { mgmtIp: '10.0.0.1' },
@@ -151,18 +151,18 @@ describe('resolve()', () => {
           ],
         },
       }
-      const out = resolve(authored, [snap])
+      const out = resolve(intrinsic, [snap])
       expect(out.nodes).toHaveLength(1)
       expect(out.nodes[0]?.provenance?.state).toBe('confirmed')
       // identity merged
       expect(out.nodes[0]?.identity?.chassisId).toBe('aa:bb')
-      // cluster id prefers authored
-      expect(out.nodes[0]?.id).toBe('authored-r1')
+      // cluster id prefers intrinsic
+      expect(out.nodes[0]?.id).toBe('intrinsic-r1')
     })
   })
 
-  describe('authored overlay is thin (community/name on top of observed)', () => {
-    // The authored layer is an OVERLAY, not a replacement node. A
+  describe('intrinsic overlay is thin (community/name on top of observed)', () => {
+    // The intrinsic layer is an OVERLAY, not a replacement node. A
     // community-only overlay carries identity + attachments (+ a mirrored
     // label, since Node.label is required) and must NOT blank the device's
     // observed facts — the bug where "adding a community made the device's
@@ -187,7 +187,7 @@ describe('resolve()', () => {
     }
 
     it('observed facts show through under a community-only overlay', () => {
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -200,14 +200,14 @@ describe('resolve()', () => {
           },
         ],
       }
-      const out = resolve(authored, [observed])
+      const out = resolve(intrinsic, [observed])
       expect(out.nodes).toHaveLength(1)
       const n = out.nodes[0]
       expect(n?.provenance?.state).toBe('confirmed')
       // observed facts survived
       expect(n?.metadata?.['readVia']).toBe('snmp')
       expect(n?.ports).toHaveLength(1)
-      // authored attachment applied
+      // intrinsic attachment applied
       const acc = (n?.attachments ?? []).find((a) => a.kind === 'access' && a.protocol === 'snmp')
       expect(
         acc && acc.kind === 'access' && acc.protocol === 'snmp' ? acc.community : undefined,
@@ -216,7 +216,7 @@ describe('resolve()', () => {
 
     it('a policy-only overlay does NOT wipe an observed access attachment', () => {
       // network-scan stamps the community it read with as an observed access
-      // attachment. An authored overlay that only sets a policy must merge in,
+      // attachment. An intrinsic overlay that only sets a policy must merge in,
       // not replace — otherwise the scan-discovered community vanishes and the
       // autoscan scheduler can't resolve it.
       const observedWithAccess: SnapshotEntry = {
@@ -237,7 +237,7 @@ describe('resolve()', () => {
           ],
         },
       }
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -248,15 +248,15 @@ describe('resolve()', () => {
           },
         ],
       }
-      const n = resolve(authored, [observedWithAccess]).nodes[0]
+      const n = resolve(intrinsic, [observedWithAccess]).nodes[0]
       const acc = (n?.attachments ?? []).find((a) => a.kind === 'access' && a.protocol === 'snmp')
       expect(
         acc && acc.kind === 'access' && acc.protocol === 'snmp' ? acc.community : undefined,
       ).toBe('public') // observed community survived
-      expect((n?.attachments ?? []).some((a) => a.kind === 'policy')).toBe(true) // authored applied
+      expect((n?.attachments ?? []).some((a) => a.kind === 'policy')).toBe(true) // intrinsic applied
     })
 
-    it('an authored access overrides an observed access of the same protocol', () => {
+    it('an intrinsic access overrides an observed access of the same protocol', () => {
       const observedWithAccess: SnapshotEntry = {
         sourceId: 'network-scan:1',
         capturedAt: 1000,
@@ -274,7 +274,7 @@ describe('resolve()', () => {
           ],
         },
       }
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -285,7 +285,7 @@ describe('resolve()', () => {
           },
         ],
       }
-      const n = resolve(authored, [observedWithAccess]).nodes[0]
+      const n = resolve(intrinsic, [observedWithAccess]).nodes[0]
       const accs = (n?.attachments ?? []).filter(
         (a) => a.kind === 'access' && a.protocol === 'snmp',
       )
@@ -298,7 +298,7 @@ describe('resolve()', () => {
 
     it('observed label tracks a source rename when the overlay sets no name', () => {
       // attach-only overlay stores '' (no rename). Source then renames.
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -323,13 +323,13 @@ describe('resolve()', () => {
           ],
         },
       }
-      const out = resolve(authored, [renamed])
+      const out = resolve(intrinsic, [renamed])
       // mirrored placeholder must NOT freeze the name — observed rename wins.
       expect(stringOf(out.nodes[0]?.label)).toBe('sw-core-renamed')
     })
 
     it('an explicit rename overrides the observed label', () => {
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -339,7 +339,7 @@ describe('resolve()', () => {
           },
         ],
       }
-      const out = resolve(authored, [observed])
+      const out = resolve(intrinsic, [observed])
       expect(stringOf(out.nodes[0]?.label)).toBe('MY-RENAME')
     })
   })
@@ -350,18 +350,18 @@ describe('resolve()', () => {
         { id: 'a', label: 'keep', identity: { mgmtIp: '10.0.0.1' } },
         { id: 'b', label: 'junk', identity: { mgmtIp: '10.0.0.2' } },
       ])
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         exclusions: [{ mgmtIp: '10.0.0.2' }],
       }
-      const out = resolve(authored, [snap])
+      const out = resolve(intrinsic, [snap])
       const ips = out.nodes.map((n) => n.identity?.mgmtIp)
       expect(ips).toContain('10.0.0.1')
       expect(ips).not.toContain('10.0.0.2')
     })
 
     it('exclusion is identity-keyed: survives an ephemeral node-id change', () => {
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         exclusions: [{ mgmtIp: '10.0.0.2' }],
       }
@@ -372,16 +372,16 @@ describe('resolve()', () => {
       const t2 = makeSnap('network-scan:1', 2000, [
         { id: 'discovered:99', label: 'junk', identity: { mgmtIp: '10.0.0.2' } },
       ])
-      expect(resolve(authored, [t1]).nodes).toHaveLength(0)
-      expect(resolve(authored, [t2]).nodes).toHaveLength(0)
+      expect(resolve(intrinsic, [t1]).nodes).toHaveLength(0)
+      expect(resolve(intrinsic, [t2]).nodes).toHaveLength(0)
     })
 
     it('matches via any identity key (chassisId hide catches mgmtIp-found node)', () => {
       const snap: SnapshotEntry = makeSnap('network-scan:1', 1000, [
         { id: 'a', label: 'junk', identity: { mgmtIp: '10.0.0.5', chassisId: 'aa:bb' } },
       ])
-      const authored: NetworkGraph = { ...emptyGraph(), exclusions: [{ chassisId: 'aa:bb' }] }
-      expect(resolve(authored, [snap]).nodes).toHaveLength(0)
+      const intrinsic: NetworkGraph = { ...emptyGraph(), exclusions: [{ chassisId: 'aa:bb' }] }
+      expect(resolve(intrinsic, [snap]).nodes).toHaveLength(0)
     })
 
     it('a multi-key exclusion still matches when one key changed (ANY, not ALL)', () => {
@@ -390,11 +390,11 @@ describe('resolve()', () => {
       const snap: SnapshotEntry = makeSnap('network-scan:1', 1000, [
         { id: 'a', label: 'junk', identity: { mgmtIp: '10.0.0.5', sysName: 'new-name' } },
       ])
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         exclusions: [{ mgmtIp: '10.0.0.5', sysName: 'old-name' }],
       }
-      expect(resolve(authored, [snap]).nodes).toHaveLength(0)
+      expect(resolve(intrinsic, [snap]).nodes).toHaveLength(0)
     })
 
     it('drops links incident to a hidden node', () => {
@@ -417,8 +417,8 @@ describe('resolve()', () => {
           ],
         },
       }
-      const authored: NetworkGraph = { ...emptyGraph(), exclusions: [{ mgmtIp: '10.0.0.2' }] }
-      const out = resolve(authored, [snap])
+      const intrinsic: NetworkGraph = { ...emptyGraph(), exclusions: [{ mgmtIp: '10.0.0.2' }] }
+      const out = resolve(intrinsic, [snap])
       expect(out.nodes).toHaveLength(1)
       expect(out.links).toHaveLength(0)
     })
@@ -427,12 +427,12 @@ describe('resolve()', () => {
       const snap: SnapshotEntry = makeSnap('network-scan:1', 1000, [
         { id: 'a', label: 'a', identity: { mgmtIp: '10.0.0.1' } },
       ])
-      const authored: NetworkGraph = { ...emptyGraph(), exclusions: [{}] }
-      expect(resolve(authored, [snap]).nodes).toHaveLength(1)
+      const intrinsic: NetworkGraph = { ...emptyGraph(), exclusions: [{}] }
+      expect(resolve(intrinsic, [snap]).nodes).toHaveLength(1)
     })
   })
 
-  describe('confirmed (≥2 snapshots agree, no authored)', () => {
+  describe('confirmed (≥2 snapshots agree, no intrinsic)', () => {
     it('two snapshots sharing chassisId → 1 cluster, confirmed', () => {
       const a: SnapshotEntry = makeSnap('netbox:1', 1000, [
         { id: 'a-r1', label: 'R1', identity: { chassisId: 'aa', sysName: 'r1' } },
@@ -484,8 +484,8 @@ describe('resolve()', () => {
   })
 
   describe('failed snapshots are ignored', () => {
-    it('failed snapshot does not retract authored nodes', () => {
-      const authored: NetworkGraph = {
+    it('failed snapshot does not retract intrinsic nodes', () => {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -502,15 +502,15 @@ describe('resolve()', () => {
         status: 'failed',
         graph: null,
       }
-      const out = resolve(authored, [failed])
+      const out = resolve(intrinsic, [failed])
       expect(out.nodes).toHaveLength(1)
-      expect(out.nodes[0]?.provenance?.state).toBe('authored-only')
+      expect(out.nodes[0]?.provenance?.state).toBe('intrinsic-only')
     })
   })
 
   describe('links carry provenance', () => {
-    it('authored link gets authored-only state', () => {
-      const authored: NetworkGraph = {
+    it('intrinsic link gets intrinsic-only state', () => {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           { id: 'a', label: 'A', shape: 'rect' },
@@ -518,15 +518,15 @@ describe('resolve()', () => {
         ],
         links: [{ from: { node: 'a', port: 'p1' }, to: { node: 'b', port: 'p2' } }],
       }
-      const out = resolve(authored, [])
+      const out = resolve(intrinsic, [])
       expect(out.links).toHaveLength(1)
-      expect(out.links[0]?.provenance?.state).toBe('authored-only')
+      expect(out.links[0]?.provenance?.state).toBe('intrinsic-only')
     })
   })
 
   // -------------------------------------------------------------------------
   // Priority field merge — the heart of the redesign. All sources (incl. the
-  // human/authored graph) are equal, priority-ordered contributions; per
+  // human/intrinsic graph) are equal, priority-ordered contributions; per
   // field the highest-priority contribution that holds a value wins.
   // -------------------------------------------------------------------------
   describe('priority field merge (C1)', () => {
@@ -582,7 +582,7 @@ describe('resolve()', () => {
       expect(n?.ports?.[0]?.identity?.ifName).toBe('Gi0/1')
     })
 
-    it('human (authored) outranks every observed source per field', () => {
+    it('human (intrinsic) outranks every observed source per field', () => {
       const lo: SnapshotEntry = {
         sourceId: 'network-scan:1',
         capturedAt: 1000,
@@ -602,7 +602,7 @@ describe('resolve()', () => {
           ],
         },
       }
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -612,10 +612,10 @@ describe('resolve()', () => {
           },
         ],
       }
-      const n = resolve(authored, [lo]).nodes[0]
+      const n = resolve(intrinsic, [lo]).nodes[0]
       // human wins label (it holds one) — "human wins" = "+Infinity priority"
       expect(stringOf(n?.label)).toBe('HUMAN-RENAME')
-      expect(n?.fieldSources?.['label']).toBe('authored')
+      expect(n?.fieldSources?.['label']).toBe('intrinsic')
       // human held no spec/ports → observed still flows through
       expect(n?.spec?.kind === 'hardware' ? n.spec.model : undefined).toBe('observed-model')
       expect(n?.ports).toHaveLength(1)
@@ -706,7 +706,7 @@ describe('resolve()', () => {
       }
       // Partial node: identity + a policy attachment. label '' is NOT a
       // sentinel here — it just fails hasValue, so no name claim is made.
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -717,7 +717,7 @@ describe('resolve()', () => {
           },
         ],
       }
-      const n = resolve(authored, [observed]).nodes[0]
+      const n = resolve(intrinsic, [observed]).nodes[0]
       // observed name shows through; the human made no label claim
       expect(stringOf(n?.label)).toBe('sw-core')
       expect(n?.fieldSources?.['label']).toBe('network-scan:1')
@@ -751,7 +751,7 @@ describe('resolve()', () => {
           ],
         },
       }
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -762,13 +762,13 @@ describe('resolve()', () => {
           },
         ],
       }
-      const n = resolve(authored, [observed]).nodes[0]
+      const n = resolve(intrinsic, [observed]).nodes[0]
       const snmp = (n?.attachments ?? []).find((a) => a.kind === 'access' && a.protocol === 'snmp')
       const ssh = (n?.attachments ?? []).find((a) => a.kind === 'access' && a.protocol === 'ssh')
       // observed access is attributed to the observing source (UI: read-only)
       expect(snmp?.provenance?.source).toBe('network-scan:1')
-      // human access is attributed to 'authored' (UI: editable / ✕)
-      expect(ssh?.provenance?.source).toBe('authored')
+      // human access is attributed to 'intrinsic' (UI: editable / ✕)
+      expect(ssh?.provenance?.source).toBe('intrinsic')
     })
 
     it('a human access that overrides an observed one is attributed to the human', () => {
@@ -789,7 +789,7 @@ describe('resolve()', () => {
           ],
         },
       }
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -800,7 +800,7 @@ describe('resolve()', () => {
           },
         ],
       }
-      const n = resolve(authored, [observed]).nodes[0]
+      const n = resolve(intrinsic, [observed]).nodes[0]
       const accs = (n?.attachments ?? []).filter(
         (a) => a.kind === 'access' && a.protocol === 'snmp',
       )
@@ -809,7 +809,7 @@ describe('resolve()', () => {
       expect(a && a.kind === 'access' && a.protocol === 'snmp' ? a.community : undefined).toBe(
         'override',
       )
-      expect(a?.provenance?.source).toBe('authored')
+      expect(a?.provenance?.source).toBe('intrinsic')
     })
   })
 
@@ -861,11 +861,11 @@ describe('resolve()', () => {
       const n = resolve(withHuman, [observed]).nodes[0]
       expect(stringOf(n?.label)).toBe('MY-NAME')
       expect(communityOf(n)).toBe('private')
-      expect(n?.fieldSources?.['label']).toBe('authored')
+      expect(n?.fieldSources?.['label']).toBe('intrinsic')
     })
 
     it('dropping the human contribution returns the node to the observed name + community', () => {
-      // Reset = the node's entry is gone from the authored graph.
+      // Reset = the node's entry is gone from the intrinsic graph.
       const n = resolve(emptyGraph(), [observed]).nodes[0]
       expect(stringOf(n?.label)).toBe('scan-name') // observed name surfaces
       expect(communityOf(n)).toBe('public') // observed community surfaces
@@ -914,7 +914,7 @@ describe('resolve()', () => {
     })
 
     it('a human overlay (policy=disabled) persists when no observed snapshot carries it', () => {
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -937,10 +937,10 @@ describe('resolve()', () => {
           nodes: [{ id: 'x', label: 'X', shape: 'rect', identity: { mgmtIp: '10.0.0.1' } }],
         },
       }
-      const out = resolve(authored, [other])
+      const out = resolve(intrinsic, [other])
       const disabled = out.nodes.find((n) => n.identity?.mgmtIp === '10.0.0.9')
       expect(disabled).toBeDefined()
-      expect(disabled?.provenance?.state).toBe('authored-only')
+      expect(disabled?.provenance?.state).toBe('intrinsic-only')
       expect((disabled?.attachments ?? []).some((a) => a.kind === 'policy')).toBe(true)
     })
 
@@ -961,11 +961,11 @@ describe('resolve()', () => {
         '10.0.0.2',
       ])
       // human kept .1 → it persists even though the source dropped it.
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [{ id: 'kept', label: 'kept', identity: { mgmtIp: '10.0.0.1' } }],
       }
-      const ips = resolve(authored, [latest])
+      const ips = resolve(intrinsic, [latest])
         .nodes.map((n) => n.identity?.mgmtIp)
         .sort()
       expect(ips).toEqual(['10.0.0.1', '10.0.0.2'])
@@ -1039,7 +1039,7 @@ describe('resolve()', () => {
   // Human suppression — the negative counterpart to an override. The human
   // can remove an attachment a source supplied; it stays gone across re-scans
   // (the assertion persists) and returns only when the human contribution is
-  // dropped (Reset). No observed/authored layers — just add / override /
+  // dropped (Reset). No observed/intrinsic layers — just add / override /
   // remove on one node.
   // -------------------------------------------------------------------------
   describe('human suppression of an observed attachment', () => {
@@ -1065,7 +1065,7 @@ describe('resolve()', () => {
     }
 
     it('a suppressed key is dropped even though the source supplies it', () => {
-      const authored: NetworkGraph = {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -1076,7 +1076,7 @@ describe('resolve()', () => {
           },
         ],
       }
-      const n = resolve(authored, [observed]).nodes[0]
+      const n = resolve(intrinsic, [observed]).nodes[0]
       // snmp removed by the human; ssh (not suppressed) still shows
       expect((n?.attachments ?? []).some((a) => a.kind === 'access' && a.protocol === 'snmp')).toBe(
         false,
@@ -1184,7 +1184,7 @@ describe('resolve()', () => {
       expect(out.nodes).toHaveLength(1) // one thing, not three
       const n = out.nodes[0]
       expect(stringOf(n?.label)).toBe('MY-NAME') // human won the one field it touched
-      expect(n?.fieldSources?.['label']).toBe('authored')
+      expect(n?.fieldSources?.['label']).toBe('intrinsic')
       // untouched fields flow through from whoever holds them (priority order)
       expect(n?.spec?.kind === 'hardware' ? n.spec.model : undefined).toBe('C9300') // NetBox (10)
       expect(n?.ports?.[0]?.identity?.ifName).toBe('Gi0/1') // scan
@@ -1258,7 +1258,7 @@ describe('resolve()', () => {
       expect(n?.provenance?.observedAt).toBe(1_700_000_000_000)
     })
 
-    it('an authored-only node (never observed) has no observedAt', () => {
+    it('an intrinsic-only node (never observed) has no observedAt', () => {
       const human: NetworkGraph = {
         ...emptyGraph(),
         nodes: [{ id: 'n', label: 'X', identity: { mgmtIp: '10.0.0.8' } }],
@@ -1366,8 +1366,8 @@ describe('resolve()', () => {
       expect(rack?.parent).toBe('src-a:1:site')
     })
 
-    it('leaves authored subgraph ids raw, and authored parent wins on a shared node', () => {
-      const authored: NetworkGraph = {
+    it('leaves intrinsic subgraph ids raw, and intrinsic parent wins on a shared node', () => {
+      const intrinsic: NetworkGraph = {
         ...emptyGraph(),
         nodes: [
           {
@@ -1375,10 +1375,10 @@ describe('resolve()', () => {
             label: 'R1',
             shape: 'rect',
             identity: { mgmtIp: '10.0.0.1' },
-            parent: 'authored-sg',
+            parent: 'intrinsic-sg',
           },
         ],
-        subgraphs: [{ id: 'authored-sg', label: 'Authored group' }],
+        subgraphs: [{ id: 'intrinsic-sg', label: 'Authored group' }],
       }
       const snap: SnapshotEntry = {
         sourceId: 'src-a:1',
@@ -1398,15 +1398,15 @@ describe('resolve()', () => {
           subgraphs: [{ id: 'sg-2', label: 'Source A group' }],
         },
       }
-      const out = resolve(authored, [snap])
+      const out = resolve(intrinsic, [snap])
       const ids = out.subgraphs?.map((s) => s.id) ?? []
-      expect(ids).toContain('authored-sg') // raw — authored owns the id space
+      expect(ids).toContain('intrinsic-sg') // raw — intrinsic owns the id space
       expect(ids).toContain('src-a:1:sg-2')
-      // same identity (10.0.0.1) clusters into one node; authored parent wins
+      // same identity (10.0.0.1) clusters into one node; intrinsic parent wins
       const r1 = out.nodes.find((n) => n.label === 'R1')
-      expect(r1?.parent).toBe('authored-sg')
-      expect(out.subgraphs?.find((s) => s.id === 'authored-sg')?.provenance?.source).toBe(
-        'authored',
+      expect(r1?.parent).toBe('intrinsic-sg')
+      expect(out.subgraphs?.find((s) => s.id === 'intrinsic-sg')?.provenance?.source).toBe(
+        'intrinsic',
       )
     })
   })

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1297,6 +1297,26 @@ describe('resolve()', () => {
       expect(out.nodes[0]?.parent).toBe('src-a:1:sg-2')
     })
 
+    it('restamps subgraph provenance — a stale inbound provenance never survives', () => {
+      // A subgraph whose stored input still carries an old provenance (e.g. a
+      // pre-rename `source: 'authored'`) must NOT leak that into the resolved
+      // output: resolve is the sole authority and always restamps.
+      const intrinsic = {
+        ...emptyGraph(),
+        subgraphs: [
+          {
+            id: 'sg-stale',
+            label: 'Rack',
+            // biome-ignore lint/suspicious/noExplicitAny: deliberately injecting a stale value
+            provenance: { source: 'authored', state: 'authored-only' } as any,
+          },
+        ],
+      }
+      const out = resolve(intrinsic, [])
+      expect(out.subgraphs?.[0]?.provenance?.source).toBe('intrinsic')
+      expect(out.subgraphs?.[0]?.provenance?.state).toBe('intrinsic-only')
+    })
+
     it('keeps same-id subgraphs from two sources distinct (collision-safe)', () => {
       const a: SnapshotEntry = {
         sourceId: 'src-a:1',

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -792,12 +792,17 @@ function namespaceSourceSubgraphs(graph: NetworkGraph, sourceId: string): Networ
 }
 
 /**
- * Fold subgraphs from EVERY contribution (authored + each source), stamping
+ * Fold subgraphs from EVERY contribution (intrinsic + each source), stamping
  * provenance. Source subgraph ids were namespaced per source at contribution
  * time (see namespaceSourceSubgraphs), and resolved nodes carry the matching
  * namespaced `parent`, so membership resolves without collisions. No
  * cross-source dedup yet — subgraphs have no identity key, so each source keeps
- * its own groups; a subgraph that already carries provenance is left as-is.
+ * its own groups.
+ *
+ * Provenance is ALWAYS restamped (not `?? s.provenance`) so resolve is the sole
+ * authority — same as nodes/links. A subgraph whose stored input still carries
+ * stale provenance (e.g. an old `source: 'authored'` round-tripped into a
+ * contribution) can't leak the old value into the resolved output.
  */
 function foldSubgraphs(contributions: Contribution[]): Subgraph[] | undefined {
   const all: Subgraph[] = []
@@ -807,7 +812,7 @@ function foldSubgraphs(contributions: Contribution[]): Subgraph[] | undefined {
     for (const s of contrib.graph.subgraphs) {
       all.push({
         ...s,
-        provenance: s.provenance ?? { source: contrib.sourceId, state },
+        provenance: { source: contrib.sourceId, state },
       })
     }
   }

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -19,25 +19,26 @@ import { keyHash, nodeIdentityKeys, portIdentityKeys } from './identity.js'
 import type { ResolvedGraph, ResolveOptions, SnapshotEntry } from './types.js'
 
 /**
- * Resolve an authored NetworkGraph against any number of source
- * snapshots into a single graph whose every entity carries
+ * Resolve the project's own (intrinsic) NetworkGraph against any number of
+ * source snapshots into a single graph whose every entity carries
  * `provenance`.
  *
  * Model: **all sources are equal, priority-ordered contributions.** The
- * authored (human) graph is just the top-priority source; observed
- * snapshots carry their own priority (mirroring
+ * intrinsic (project-owned) graph is just the top-priority contribution;
+ * observed snapshots carry their own priority (mirroring
  * `topology_data_sources.priority`). resolve clusters contributions by
  * identity (any-key match — orthogonal to priority) and then, **per
  * field**, the highest-priority contribution that actually holds a value
  * wins (`priority desc, capturedAt desc`). A field nobody holds is
- * omitted. This is the "Git-like" merge: a human who only renamed a node
+ * omitted. This is the "Git-like" merge: an edit that only renamed a node
  * keeps the observed ports/community flowing through untouched.
  *
- * There is intentionally NO `authored ===` special-casing in the field
- * merge — "human wins" falls out of "human has the highest priority". The
- * literal `'authored'` survives only as the human contribution's source
- * *label*, so the UI can tell a human-set value from an observed one
- * (per-field `fieldSources`, per-attachment `provenance`).
+ * There is intentionally NO `=== 'intrinsic'` special-casing in the field
+ * merge — "the project's edits win" falls out of "intrinsic has the highest
+ * priority". The reserved id `'intrinsic'` survives only as that
+ * contribution's source *label*, so the UI can tell a project-set value from
+ * an observed one (per-field `fieldSources`, per-attachment `provenance`). It
+ * is ownership (intrinsic vs external), NOT a human-vs-machine layer.
  *
  * See `apps/server/docs/design/topology-source-priority-merge.md`.
  */
@@ -62,9 +63,9 @@ export function resolve(
   // stay documented knobs for when snapshot history is fed in.
   //
   // Invariants that MUST hold regardless of priority (covered by tests):
-  //   - The human/authored contribution is never retracted. A node the
-  //     operator touched (rename, access, or a policy=disabled overlay) is
-  //     an authored contribution, so it persists until Reset.
+  //   - The intrinsic (project-owned) contribution is never retracted. A node
+  //     the operator touched (rename, access, or a policy=disabled overlay) is
+  //     an intrinsic contribution, so it persists until Reset.
   //   - A 'failed' snapshot is ignored — never read as a retraction.
   //   - When real hysteresis lands it must gate on
   //     `absenceImpliesRetraction(effectivePolicyForNode(authored, node))`
@@ -74,13 +75,14 @@ export function resolve(
   void _staleThreshold
   void _retractAfter
 
-  // 1. Gather valid contributions. The authored graph is the top-priority
-  //    contribution ("human wins" = "human outranks every source"); every
-  //    non-failed snapshot is a contribution at its own priority. Identity
-  //    clustering ignores priority; only the field merge consults it.
+  // 1. Gather valid contributions. The intrinsic graph is the top-priority
+  //    contribution ("the project's edits win" = "intrinsic outranks every
+  //    source"); every non-failed snapshot is a contribution at its own
+  //    priority. Identity clustering ignores priority; only the field merge
+  //    consults it.
   const contributions: Contribution[] = [
     {
-      sourceId: 'authored',
+      sourceId: 'intrinsic',
       priority: Number.POSITIVE_INFINITY,
       capturedAt: Number.POSITIVE_INFINITY,
       graph: authored,
@@ -93,8 +95,8 @@ export function resolve(
       priority: snap.priority ?? 0,
       capturedAt: snap.capturedAt,
       // Namespace this source's subgraph ids (and the node.parent refs into
-      // them) so groups from different sources can't collide. Authored keeps
-      // the raw id space (it's the top-priority, human-owned layer).
+      // them) so groups from different sources can't collide. The intrinsic
+      // contribution keeps the raw id space (it's the top-priority, project-owned one).
       graph: namespaceSourceSubgraphs(snap.graph, snap.sourceId),
     })
   }
@@ -246,7 +248,7 @@ function clusterNodes(contributions: Contribution[]): NodeCluster[] {
       // synthetic `discovered:N` can't collide with an authored node that
       // happens to carry the same id.
       let id: string
-      if (member.sourceId === 'authored') {
+      if (member.sourceId === 'intrinsic') {
         id = member.node.id
       } else {
         do {
@@ -276,7 +278,7 @@ function clusterNodes(contributions: Contribution[]): NodeCluster[] {
   // about id preference only — it does NOT decide field winners (priority
   // does, in foldNodeCluster) and does NOT decide identity (any-key match).
   for (const contrib of contributions) {
-    if (contrib.sourceId !== 'authored') continue
+    if (contrib.sourceId !== 'intrinsic') continue
     for (const node of contrib.graph.nodes) {
       claim({
         sourceId: contrib.sourceId,
@@ -287,7 +289,7 @@ function clusterNodes(contributions: Contribution[]): NodeCluster[] {
     }
   }
   for (const contrib of contributions) {
-    if (contrib.sourceId === 'authored') continue
+    if (contrib.sourceId === 'intrinsic') continue
     for (const node of contrib.graph.nodes) {
       claim({
         sourceId: contrib.sourceId,
@@ -339,8 +341,8 @@ function foldNodeCluster(cluster: NodeCluster): { node: Node; portRemap: Array<[
     throw new Error('empty cluster')
   }
 
-  const hasAuthored = cluster.members.some((m) => m.sourceId === 'authored')
-  const observerCount = cluster.members.filter((m) => m.sourceId !== 'authored').length
+  const hasIntrinsic = cluster.members.some((m) => m.sourceId === 'intrinsic')
+  const observerCount = cluster.members.filter((m) => m.sourceId !== 'intrinsic').length
 
   // Identity: union of all members' identity keys (keep first non-empty value)
   const mergedIdentity = mergeIdentities(cluster.members.map((m) => m.node.identity))
@@ -362,7 +364,7 @@ function foldNodeCluster(cluster: NodeCluster): { node: Node; portRemap: Array<[
   const mergedMetadata = mergeMetadata(ranked)
   // Preserve the observing source for the discovery UI ("Tracked by" line,
   // which source to Probe). Highest-ranked non-authored member.
-  const primaryObserver = ranked.find((m) => m.sourceId !== 'authored')
+  const primaryObserver = ranked.find((m) => m.sourceId !== 'intrinsic')
   if (primaryObserver && mergedMetadata['observedSource'] === undefined) {
     mergedMetadata['observedSource'] = primaryObserver.sourceId
   }
@@ -375,7 +377,7 @@ function foldNodeCluster(cluster: NodeCluster): { node: Node; portRemap: Array<[
   const suppressed = Array.from(
     new Set(
       cluster.members
-        .filter((m) => m.sourceId === 'authored')
+        .filter((m) => m.sourceId === 'intrinsic')
         .flatMap((m) => m.node.suppressedAttachments ?? []),
     ),
   )
@@ -412,7 +414,7 @@ function foldNodeCluster(cluster: NodeCluster): { node: Node; portRemap: Array<[
     ...(ports ? { ports } : {}),
     ...(Object.keys(fieldSources).length > 0 ? { fieldSources } : {}),
     ...(suppressed.length > 0 ? { suppressedAttachments: suppressed } : {}),
-    provenance: deriveNodeProvenance(cluster, observerCount, hasAuthored),
+    provenance: deriveNodeProvenance(cluster, observerCount, hasIntrinsic),
   }
 
   // Factual: if multiple *non-authored* sources disagree on `label`, mark
@@ -423,7 +425,7 @@ function foldNodeCluster(cluster: NodeCluster): { node: Node; portRemap: Array<[
   const labelObservations = collectField(cluster.members, (n) => stringLabel(n.label)).filter((o) =>
     hasValue(o.value),
   )
-  if (!hasAuthored && labelObservations.length > 1) {
+  if (!hasIntrinsic && labelObservations.length > 1) {
     const distinct = new Set(labelObservations.map((o) => o.value))
     if (distinct.size > 1) {
       resolved.provenance = {
@@ -439,21 +441,21 @@ function foldNodeCluster(cluster: NodeCluster): { node: Node; portRemap: Array<[
 function deriveNodeProvenance(
   cluster: NodeCluster,
   observerCount: number,
-  hasAuthored: boolean,
+  hasIntrinsic: boolean,
 ): Provenance {
   // State derivation:
-  //   authored + observed → confirmed
-  //   authored only       → authored-only
-  //   observed only       → discovered-only (1 source) or confirmed (≥2 agreeing)
+  //   intrinsic + observed → confirmed
+  //   intrinsic only       → intrinsic-only
+  //   observed only        → discovered-only (1 source) or confirmed (≥2 agreeing)
   let state: Provenance['state']
-  if (hasAuthored && observerCount > 0) state = 'confirmed'
-  else if (hasAuthored) state = 'authored-only'
+  if (hasIntrinsic && observerCount > 0) state = 'confirmed'
+  else if (hasIntrinsic) state = 'intrinsic-only'
   else if (observerCount >= 2) state = 'confirmed'
   else state = 'discovered-only'
 
-  // Pick a canonical source label: authored wins, otherwise latest observer.
-  let source = 'authored'
-  if (!hasAuthored) {
+  // Pick a canonical source label: intrinsic wins, otherwise latest observer.
+  let source = 'intrinsic'
+  if (!hasIntrinsic) {
     const latest = [...cluster.members].sort((a, b) => b.capturedAt - a.capturedAt)[0]
     source = latest?.sourceId ?? 'unknown'
   }
@@ -461,7 +463,7 @@ function deriveNodeProvenance(
   // capturedAt — the human contribution carries `+Infinity` (it's not an
   // observation), and including it would poison the max and drop observedAt
   // (→ "Last seen" blanks out the moment a node is renamed / given a
-  // community). An authored-only node has no finite time → undefined.
+  // community). An intrinsic-only node has no finite time → undefined.
   const latestObserved = cluster.members.reduce(
     (acc, m) => (Number.isFinite(m.capturedAt) && m.capturedAt > acc ? m.capturedAt : acc),
     Number.NEGATIVE_INFINITY,
@@ -688,11 +690,11 @@ function foldPortCluster(members: PortMember[]): NodePort {
   const top = ranked[0]
   if (!top) throw new Error('empty port cluster')
 
-  const hasAuthored = members.some((m) => m.sourceId === 'authored')
-  const observerCount = members.filter((m) => m.sourceId !== 'authored').length
+  const hasIntrinsic = members.some((m) => m.sourceId === 'intrinsic')
+  const observerCount = members.filter((m) => m.sourceId !== 'intrinsic').length
   let state: Provenance['state']
-  if (hasAuthored && observerCount > 0) state = 'confirmed'
-  else if (hasAuthored) state = 'authored-only'
+  if (hasIntrinsic && observerCount > 0) state = 'confirmed'
+  else if (hasIntrinsic) state = 'intrinsic-only'
   else if (observerCount >= 2) state = 'confirmed'
   else state = 'discovered-only'
 
@@ -740,7 +742,7 @@ function foldPortCluster(members: PortMember[]): NodePort {
   const suppressed = Array.from(
     new Set(
       members
-        .filter((m) => m.sourceId === 'authored')
+        .filter((m) => m.sourceId === 'intrinsic')
         .flatMap((m) => m.port.suppressedAttachments ?? []),
     ),
   )
@@ -801,7 +803,7 @@ function foldSubgraphs(contributions: Contribution[]): Subgraph[] | undefined {
   const all: Subgraph[] = []
   for (const contrib of contributions) {
     if (!contrib.graph.subgraphs) continue
-    const state = contrib.sourceId === 'authored' ? 'authored-only' : 'discovered-only'
+    const state = contrib.sourceId === 'intrinsic' ? 'intrinsic-only' : 'discovered-only'
     for (const s of contrib.graph.subgraphs) {
       all.push({
         ...s,
@@ -837,7 +839,7 @@ function foldLinks(
         to,
         provenance: {
           source: contrib.sourceId,
-          state: contrib.sourceId === 'authored' ? 'authored-only' : 'discovered-only',
+          state: contrib.sourceId === 'intrinsic' ? 'intrinsic-only' : 'discovered-only',
           observedAt: Number.isFinite(contrib.capturedAt) ? contrib.capturedAt : undefined,
         },
       })

--- a/libs/@shumoku/core/src/observation/types.ts
+++ b/libs/@shumoku/core/src/observation/types.ts
@@ -26,9 +26,9 @@ export interface SnapshotEntry {
   /**
    * Merge priority for this source — higher wins per field in `resolve()`.
    * Mirrors `topology_data_sources.priority`; defaults to `0` when omitted.
-   * The human/authored contribution always outranks snapshots regardless
-   * of this value. Orthogonal to identity clustering (priority decides the
-   * field winner, never which nodes are the same).
+   * The intrinsic (project-owned) contribution always outranks snapshots
+   * regardless of this value. Orthogonal to identity clustering (priority
+   * decides the field winner, never which nodes are the same).
    */
   priority?: number
   /**


### PR DESCRIPTION
## Summary

Stage 2b of the DB-native persistence arc — completes the **\"no human/authored concept\"** north star in the one place it still survived: the resolved-graph **provenance output vocabulary**.

The storage and field-merge layers were already clean (the merge branches on `priority` only — there is no `if authored` winner special-casing). What remained was the *output annotation*: resolved entities carried `provenance.source: 'authored'` and `state: 'authored-only'` — the human-framed vocabulary. This renames it to the **ownership framing** the adopted model uses (intrinsic vs external; see `db-native-persistence.md`), so the UI and contract finally match the model.

This is **not** the \"low-value internal tag\" the plan originally assumed — `provenance.source`/`state` are a public output contract the discovery UI consumes (`isAuthoredAttachment`, node-detail Access ownership annotation). \"Removing\" the distinction isn't possible (the model keeps intrinsic-vs-external); renaming the human-framed token to the ownership token is the correct realization.

## What changed (behavior-preserving value rename)

- **core `Provenance`**: `source: 'authored'` → `'intrinsic'`; `state: 'authored-only'` → `'intrinsic-only'` (kept `discovered-only`/`confirmed`/`conflicting`). `resolve()` internals: reserved sourceId, `=== 'intrinsic'` branches, `hasIntrinsic`, derivation comments.
- **web**: `api.ts` Provenance mirror, `InteractiveSvgDiagram` inline type, `discovery-attachments.isAuthoredAttachment` (now checks `'intrinsic'`), composition-page annotation comment.
- **server**: `discovery-policy` comment; **`RESOLVER_VERSION` 1 → 2** so persisted `topology_resolved_graph` artifacts carrying the old vocabulary recompute.
- **tests** updated across core (resolve/metrics-binding/observation) + web.

### Deliberately NOT renamed (domain terms, not the provenance contract)
- the `authored` field on web's `UnifiedAccessRow` (means \"operator's override value\"),
- the `isAuthoredAttachment` function name,
- `resolve()`'s `authored` parameter name.

## Verification
- Typecheck clean across all 36 packages.
- Tests: core **298**, server-api **53**, web **73** — all pass.
- Repo-wide grep confirms no remaining `provenance.source`/`state` `'authored'` literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)