### PR TITLE
chore(server): remove dead Manual code surfaced after stage 4

### DIFF
--- a/apps/server/api/src/api/datasources.ts
+++ b/apps/server/api/src/api/datasources.ts
@@ -249,8 +249,8 @@ export function createDataSourcesApi(): Hono {
       if (!dataSource) {
         return c.json({ error: 'Data source not found' }, 404)
       }
-      // A config edit can change resolve inputs (a Manual source's authored
-      // graph lives in config_json.graph) → invalidate attached topologies.
+      // A config edit can change what the source observes on its next sync →
+      // invalidate attached topologies so the cache rebuilds.
       getTopologyService().clearCacheForDataSource(id)
       return c.json({
         ...dataSource,

--- a/apps/server/api/src/api/observations.ts
+++ b/apps/server/api/src/api/observations.ts
@@ -158,58 +158,6 @@ export function createObservationsRoute(): Hono {
     return c.json(o)
   })
 
-  // Latest snapshot for a specific source attached to this topology.
-  // This is how the editor (and any future per-source viewers) reads
-  // the graph the user typed into a given source — separate from the
-  // resolved project graph below.
-  app.get('/:topologyId/sources/:sourceId/latest-snapshot', (c) => {
-    const { topologyId, sourceId } = c.req.param()
-    const latest = observations.latestPerSource(topologyId).find((o) => o.sourceId === sourceId)
-    if (!latest) {
-      // Source attached but no observation yet — return an empty
-      // canvas so the editor can open without a 404 dance.
-      return c.json({ graph: null, capturedAt: null })
-    }
-    return c.json({
-      graph: latest.graph,
-      capturedAt: latest.capturedAt,
-      status: latest.status,
-      observationId: latest.id,
-    })
-  })
-
-  // Record a new observation against a specific (external) source. Fine for any
-  // caller that wants to push a snapshot in. The project's own graph is written
-  // via PUT /:id/graph, not here.
-  app.post('/:topologyId/sources/:sourceId/observation', async (c) => {
-    const { topologyId, sourceId } = c.req.param()
-    try {
-      const body = await c.req.json<{ graph: unknown; status?: string }>()
-      // Light validation — we let resolve() / parser surface errors
-      // downstream; here we just want nodes + links shaped sensibly.
-      if (!body.graph || typeof body.graph !== 'object') {
-        return c.json({ error: 'graph is required' }, 400)
-      }
-      const graph = body.graph as NetworkGraph
-      if (!Array.isArray(graph.nodes) || !Array.isArray(graph.links)) {
-        return c.json({ error: 'graph.nodes and graph.links must be arrays' }, 400)
-      }
-      const observation = await observations.record({
-        topologyId,
-        sourceId,
-        capturedAt: Date.now(),
-        status: (body.status as 'ok' | 'partial' | 'failed' | 'empty') ?? 'ok',
-        graph,
-      })
-      // Invalidate parsed-topology cache so the next /render runs
-      // resolve() against the new observation.
-      getTopologyService().clearCacheEntry(topologyId)
-      return c.json({ observation }, 201)
-    } catch (err) {
-      return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
-    }
-  })
-
   // Resolved graph — the project 's current rendered graph.
   // `TopologyService.parseTopology()` already runs `resolve()` over
   // Manual + every attached source 's latest observation, so

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -1166,7 +1166,6 @@ export class TopologyService {
       ).map((r) => r.source_id),
     )
     for (const tds of this.topologySources.listByPurpose(topologyId, 'topology')) {
-      if (tds.dataSource?.type === 'manual') continue
       if (tds.lastSyncedAt == null) continue
       if (have.has(tds.dataSourceId)) continue
       const row = this.db

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -442,40 +442,6 @@ export const topologies = {
         method: 'POST',
         body: JSON.stringify({ seeds }),
       }),
-
-    /**
-     * Latest observation graph for a specific source attached to this
-     * topology. `graph` is null when the source has no observation yet
-     * (e.g. a freshly-attached source). This is what the Manual editor
-     * loads — explicitly the *source 's* snapshot, not the resolved
-     * project graph.
-     */
-    latestSnapshot: (topologyId: string, sourceId: string) =>
-      request<{
-        graph: NetworkGraph | null
-        capturedAt: number | null
-        status?: 'ok' | 'partial' | 'failed' | 'empty'
-        observationId?: string
-      }>(`/topologies/${topologyId}/sources/${sourceId}/latest-snapshot`),
-
-    /**
-     * Record a new observation against a specific source. Manual
-     * editor save goes through this; any caller pushing a snapshot
-     * (e.g. webhook receivers) can use it too.
-     */
-    recordObservation: (
-      topologyId: string,
-      sourceId: string,
-      graph: NetworkGraph,
-      status?: 'ok' | 'partial' | 'failed' | 'empty',
-    ) =>
-      request<{ observation: { id: string } }>(
-        `/topologies/${topologyId}/sources/${sourceId}/observation`,
-        {
-          method: 'POST',
-          body: JSON.stringify({ graph, status: status ?? 'ok' }),
-        },
-      ),
   },
 
   /**

--- a/apps/server/web/src/routes/(app)/datasources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/+page.svelte
@@ -286,19 +286,6 @@
                             {/if}
                           </span>
                         {/each}
-                        {#if ds.type === 'manual'}
-                          <!-- Manual has no capability flag but it does
-                               contribute topology content; surface a
-                               topology chip so the row reads consistently
-                               with NetBox / SNMP. Same convention as
-                               DataSourceService.listByCapability("topology"). -->
-                          <span
-                            class="text-xs px-1.5 py-0.5 rounded bg-theme-bg text-theme-text-muted"
-                            title="topology"
-                          >
-                            <TreeStructureIcon size={12} />
-                          </span>
-                        {/if}
                       </div>
                     {/if}
                   </div>


### PR DESCRIPTION
Follow-up dead-code sweep after the Manual-source retirement (#383). No behavior change.

- `backfillObservedContributions`: dropped the `type === 'manual'` skip (no manual sources exist post-retirement, which runs before serving).
- web datasources list: dropped the dead `ds.type === 'manual'` topology-chip branch.
- Removed the now-orphaned per-source snapshot API (zero callers since the editor moved to `/intrinsic`): web `latestSnapshot`/`recordObservation` + server routes `GET /:topologyId/sources/:sourceId/latest-snapshot` and `POST .../observation`.
- Refreshed two stale comments referencing `config_json.graph` / Manual.

**DB-native verification**: the only `NetworkGraph` blobs remaining are the audit log (`topology_observations`), the resolved cache (`topology_resolved_graph`), and the codec payload catch-alls — all derived/audit, never canonical. Authored (intrinsic) + observed are decomposed contribution rows.

Typecheck clean (36 pkgs); api 54 / web 73 tests pass; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)