### PR TITLE
docs(server): scrub stale Manual references in datasource comments

### DIFF
--- a/apps/server/api/src/services/datasource.ts
+++ b/apps/server/api/src/services/datasource.ts
@@ -79,10 +79,8 @@ export class DataSourceService {
    *   - explicit `topology` capability (NetBox-style fetchers)
    *   - `autoscan` capability (SNMP-LLDP-style scanners — produce a
    *     topology snapshot via `scan()`)
-   *   - `manual` type (human-typed snapshots via the editor; the
-   *     plugin has no upstream and therefore no capability flag, but
-   *     it still produces topology observations and is structurally
-   *     parallel to the other sources)
+   * (The project's own hand-drawn graph is the intrinsic contribution, not a
+   * data source, so it doesn't appear here.)
    */
   listByCapability(capability: 'topology' | 'metrics' | 'alerts'): DataSource[] {
     const all = this.list()

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -29,8 +29,8 @@
   let saving = $state(false)
   let testResult = $state<ConnectionResult | null>(null)
   let testing = $state(false)
-  // Form state. Non-manual config is rendered + edited via <SchemaForm> from
-  // the plugin's configSchema; Manual keeps the graph editor below.
+  // Form state. Config is rendered + edited via <SchemaForm> from the plugin's
+  // configSchema — generic across all data source types.
   let formName = $state('')
   let config = $state<Record<string, unknown>>({})
   let pluginTypes = $state<DataSourcePluginInfo[]>([])


### PR DESCRIPTION
Comment-only cleanup: listByCapability docstring + datasources/[id] form comment no longer reference the removed Manual type. No code change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)