### PR TITLE
refactor(server): project overlay for operator curation; Manual = uniform hand-drawn source

### DIFF
--- a/apps/server/api/src/api/datasources.ts
+++ b/apps/server/api/src/api/datasources.ts
@@ -249,8 +249,8 @@ export function createDataSourcesApi(): Hono {
       if (!dataSource) {
         return c.json({ error: 'Data source not found' }, 404)
       }
-      // A config edit can change resolve inputs (a Manual source's authored
-      // graph lives in config_json.graph) → invalidate attached topologies.
+      // A config edit can change resolve inputs (priority / connection) →
+      // invalidate attached topologies so they recompute.
       getTopologyService().clearCacheForDataSource(id)
       return c.json({
         ...dataSource,

--- a/apps/server/api/src/api/discovery-policy.ts
+++ b/apps/server/api/src/api/discovery-policy.ts
@@ -254,7 +254,7 @@ export function createDiscoveryPolicyApi(): Hono {
     const topology = service.get(topologyId)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
 
-    const authored = service.readManualGraph(topologyId) ?? {
+    const authored = service.readProjectOverlay(topologyId) ?? {
       version: '1' as const,
       name: topology.name,
       nodes: [],
@@ -385,7 +385,7 @@ export function createDiscoveryPolicyApi(): Hono {
       }
     }
 
-    await service.writeManualGraph(topologyId, next)
+    await service.writeProjectOverlay(topologyId, next)
     service.clearCacheEntry(topologyId)
 
     // Recompute the affected effective policy for the response.
@@ -451,7 +451,7 @@ export function createDiscoveryPolicyApi(): Hono {
     if (!ex) return c.json({ error: 'body must include mgmtIp, chassisId, or sysName' }, 400)
     const topology = service.get(topologyId)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
-    const authored = service.readManualGraph(topologyId) ?? {
+    const authored = service.readProjectOverlay(topologyId) ?? {
       version: '1' as const,
       name: topology.name,
       nodes: [],
@@ -459,7 +459,7 @@ export function createDiscoveryPolicyApi(): Hono {
     }
     const exclusions = [...(authored.exclusions ?? [])]
     if (!exclusions.some((e) => exclusionKey(e) === exclusionKey(ex))) exclusions.push(ex)
-    await service.writeManualGraph(topologyId, { ...authored, exclusions })
+    await service.writeProjectOverlay(topologyId, { ...authored, exclusions })
     service.clearCacheEntry(topologyId)
     return c.json({ exclusions })
   })
@@ -470,12 +470,12 @@ export function createDiscoveryPolicyApi(): Hono {
     if (!ex) return c.json({ error: 'body must include mgmtIp, chassisId, or sysName' }, 400)
     const topology = service.get(topologyId)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
-    const authored = service.readManualGraph(topologyId)
+    const authored = service.readProjectOverlay(topologyId)
     if (!authored) return c.json({ exclusions: [] })
     const exclusions = (authored.exclusions ?? []).filter(
       (e) => exclusionKey(e) !== exclusionKey(ex),
     )
-    await service.writeManualGraph(topologyId, { ...authored, exclusions })
+    await service.writeProjectOverlay(topologyId, { ...authored, exclusions })
     service.clearCacheEntry(topologyId)
     return c.json({ exclusions })
   })
@@ -488,7 +488,7 @@ export function createDiscoveryPolicyApi(): Hono {
     const topologyId = c.req.param('id')
     const topology = service.get(topologyId)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
-    const authored = service.readManualGraph(topologyId)
+    const authored = service.readProjectOverlay(topologyId)
     if (!authored) return c.json({ cleared: false, reason: 'no authored graph' })
     // Strip overlay: drop attachments from every node/subgraph, the topology
     // default, and all exclusions. Keep the nodes themselves out entirely —
@@ -501,7 +501,7 @@ export function createDiscoveryPolicyApi(): Hono {
       attachments: undefined,
       exclusions: undefined,
     }
-    await service.writeManualGraph(topologyId, cleared)
+    await service.writeProjectOverlay(topologyId, cleared)
     service.clearCacheEntry(topologyId)
     return c.json({ cleared: true })
   })

--- a/apps/server/api/src/api/discovery-policy.ts
+++ b/apps/server/api/src/api/discovery-policy.ts
@@ -15,10 +15,11 @@
  *             suppressedAttachments?: string[]|null } // node: keys to remove
  *     → { effective: EffectiveDiscoveryPolicy }
  *
- * The overlay lives on the topology's intrinsic contribution (the project's own
- * authored layer — no Manual data source is created). A node that exists ONLY in a discovered
- * snapshot just works — detection already grabbed it, so we materialize a
- * minimal authored entry from its resolved identity and apply the
+ * The overlay lives on the PROJECT OVERLAY — the project's own top-priority
+ * contribution (`attachment_id` NULL, `source_id='intrinsic'`). It is NOT a data
+ * source: writing it never creates/attaches a Manual source. A node that exists
+ * ONLY in a discovered snapshot just works — detection already grabbed it, so we
+ * materialize a minimal overlay entry from its resolved identity and apply the
  * attachments. (Subgraph scope still 409s — a discovered-only subgraph has
  * no identity to materialize from.)
  *

--- a/apps/server/api/src/api/observations.ts
+++ b/apps/server/api/src/api/observations.ts
@@ -144,10 +144,11 @@ export function createObservationsRoute(): Hono {
   // resolved project graph below.
   app.get('/:topologyId/sources/:sourceId/latest-snapshot', (c) => {
     const { topologyId, sourceId } = c.req.param()
-    // Manual = its own contribution (DB-native), not an observation. Target THIS
-    // Manual source (a topology can have several).
+    // A hand-drawn Manual source stores its graph as its own contribution
+    // (DB-native), not an observation. Target THIS source (a topology can have
+    // several Manual sources).
     if (isManualForTopology(topologyId, sourceId)) {
-      const graph = getTopologyService().readManualGraph(topologyId, sourceId)
+      const graph = getTopologyService().readManualSourceGraph(topologyId, sourceId)
       return c.json({ graph, capturedAt: null, status: graph ? 'ok' : null })
     }
     const latest = observations.latestPerSource(topologyId).find((o) => o.sourceId === sourceId)
@@ -180,11 +181,12 @@ export function createObservationsRoute(): Hono {
       if (!Array.isArray(graph.nodes) || !Array.isArray(graph.links)) {
         return c.json({ error: 'graph.nodes and graph.links must be arrays' }, 400)
       }
-      // Manual save → the Manual source's own contribution (DB-native), not an
-      // observation row. Manual is a uniform source; writeManualGraph ingests its
-      // graph keyed by its attach row, like any source.
+      // A hand-drawn Manual source's save → its own contribution (DB-native), not
+      // an observation row, keyed by its attach row like any source. (Operator
+      // curation — exclusions/bindings/overrides — does NOT come through here; it
+      // goes to the project overlay via the discovery-policy / mapping APIs.)
       if (isManualForTopology(topologyId, sourceId)) {
-        await getTopologyService().writeManualGraph(topologyId, graph, sourceId)
+        await getTopologyService().writeManualSourceGraph(topologyId, sourceId, graph)
         return c.json({ ok: true }, 201)
       }
       const observation = await observations.record({
@@ -225,6 +227,41 @@ export function createObservationsRoute(): Hono {
         .filter((o) => o.sourceId !== parsed.topologySourceId || o.graph !== null).length
 
       return c.json({ graph: parsed.graph, snapshotCount })
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
+    }
+  })
+
+  // Topology display settings (edge style / spline mode). These are project-level
+  // presentation prefs, NOT source content, so they live on the project overlay's
+  // graph-level `settings`. Read-modify-write the overlay's settings only — never
+  // touches nodes/exclusions/bindings (no clobber). No Manual source involved.
+  app.get('/:id/display-settings', (c) => {
+    const id = c.req.param('id')
+    const overlay = getTopologyService().readProjectOverlay(id)
+    const settings = (overlay?.settings ?? {}) as Record<string, unknown>
+    return c.json({
+      edgeStyle: settings['edgeStyle'] ?? 'orthogonal',
+      splineMode: settings['splineMode'] ?? 'sloppy',
+    })
+  })
+
+  app.put('/:id/display-settings', async (c) => {
+    const id = c.req.param('id')
+    try {
+      const body = await c.req.json<{ edgeStyle?: string; splineMode?: string }>()
+      const svc = getTopologyService()
+      const overlay: NetworkGraph = svc.readProjectOverlay(id) ?? {
+        version: '1',
+        nodes: [],
+        links: [],
+      }
+      const settings = { ...(overlay.settings ?? {}) } as Record<string, unknown>
+      if (body.edgeStyle !== undefined) settings['edgeStyle'] = body.edgeStyle
+      if (body.edgeStyle === 'splines') settings['splineMode'] = body.splineMode ?? 'sloppy'
+      else delete settings['splineMode']
+      await svc.writeProjectOverlay(id, { ...overlay, settings })
+      return c.json({ ok: true })
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
     }

--- a/apps/server/api/src/api/observations.ts
+++ b/apps/server/api/src/api/observations.ts
@@ -16,7 +16,6 @@ import { Hono } from 'hono'
 import { hasAutoscanCapability } from '../plugins/types.js'
 import { DataSourceService } from '../services/datasource.js'
 import { ObservationsService } from '../services/observations.js'
-import { TopologySourcesService } from '../services/topology-sources.js'
 import { getTopologyService } from './topologies.js'
 
 /**
@@ -92,16 +91,9 @@ export function createScanRoute(): Hono {
 export function createObservationsRoute(): Hono {
   const app = new Hono()
   const observations = new ObservationsService()
-  const dataSources = new DataSourceService()
-  const topologySources = new TopologySourcesService()
-  // The authored ("Manual") source's graph is the intrinsic contribution now, NOT a
-  // topology_observations row. Route manual save/load through the topology service so the
-  // editor and resolve() agree (no split-brain). External sources stay observations.
-  // REQUIRE the manual source be attached to THIS topology (purpose 'topology') — else an
-  // unrelated manual id could overwrite the topology's intrinsic graph.
-  const isManualForTopology = (topologyId: string, sourceId: string): boolean =>
-    dataSources.get(sourceId)?.type === 'manual' &&
-    topologySources.find(topologyId, sourceId, 'topology') !== undefined
+  // Every source — external feed AND a hand-drawn Manual source — saves/loads its
+  // graph through the same observation path (record → materialize). No per-type
+  // branch; the human is just the "scanner" for a Manual source.
   // Note: the per-source sync endpoint
   // `POST /:topologyId/sources/:sourceId/sync` lives in
   // `topology-sources.ts` — that route is registered earlier on the
@@ -144,13 +136,8 @@ export function createObservationsRoute(): Hono {
   // resolved project graph below.
   app.get('/:topologyId/sources/:sourceId/latest-snapshot', (c) => {
     const { topologyId, sourceId } = c.req.param()
-    // A hand-drawn Manual source stores its graph as its own contribution
-    // (DB-native), not an observation. Target THIS source (a topology can have
-    // several Manual sources).
-    if (isManualForTopology(topologyId, sourceId)) {
-      const graph = getTopologyService().readManualSourceGraph(topologyId, sourceId)
-      return c.json({ graph, capturedAt: null, status: graph ? 'ok' : null })
-    }
+    // Every source — including a hand-drawn Manual source — reads its latest graph
+    // from the observation log; no manual-specific branch.
     const latest = observations.latestPerSource(topologyId).find((o) => o.sourceId === sourceId)
     if (!latest) {
       // Source attached but no observation yet — return an empty
@@ -181,14 +168,11 @@ export function createObservationsRoute(): Hono {
       if (!Array.isArray(graph.nodes) || !Array.isArray(graph.links)) {
         return c.json({ error: 'graph.nodes and graph.links must be arrays' }, 400)
       }
-      // A hand-drawn Manual source's save → its own contribution (DB-native), not
-      // an observation row, keyed by its attach row like any source. (Operator
-      // curation — exclusions/bindings/overrides — does NOT come through here; it
-      // goes to the project overlay via the discovery-policy / mapping APIs.)
-      if (isManualForTopology(topologyId, sourceId)) {
-        await getTopologyService().writeManualSourceGraph(topologyId, sourceId, graph)
-        return c.json({ ok: true }, 201)
-      }
+      // Every source saves the same way — record an observation, which materializes
+      // into the contribution store. A hand-drawn Manual source's editor save comes
+      // through here too (the human is the "scanner"); no manual-specific branch.
+      // (Operator curation — exclusions/bindings/overrides — does NOT come through
+      // here; it goes to the project overlay via the discovery-policy / mapping APIs.)
       const observation = await observations.record({
         topologyId,
         sourceId,

--- a/apps/server/api/src/api/observations.ts
+++ b/apps/server/api/src/api/observations.ts
@@ -190,12 +190,11 @@ export function createObservationsRoute(): Hono {
   })
 
   // Resolved graph — the project 's current rendered graph.
-  // `TopologyService.parseTopology()` already runs `resolve()` over
-  // Manual + every attached source 's latest observation, so
-  // `parsed.graph` IS the resolved graph. The previous version of
-  // this endpoint re-ran `resolve()` with `parsed.graph` as the
-  // authored layer AND the same latest snapshots again, which
-  // double-counted every link (a snapshot of 7 links came out as 14).
+  // `TopologyService.parseTopology()` already runs `resolve()` over the project
+  // overlay + every attached source 's contribution, so `parsed.graph` IS the
+  // resolved graph. The previous version of this endpoint re-ran `resolve()` with
+  // `parsed.graph` as the `authored` input AND the same latest snapshots again,
+  // which double-counted every link (a snapshot of 7 links came out as 14).
   // Just hand back what parseTopology already computed.
   app.get('/:id/resolved', async (c) => {
     const id = c.req.param('id')
@@ -205,7 +204,7 @@ export function createObservationsRoute(): Hono {
       if (!parsed) return c.json({ error: 'not found' }, 404)
 
       // snapshotCount stays useful — it tells the UI how many sources
-      // were folded in beyond the authored Manual graph.
+      // were folded in beyond the project overlay.
       const snapshotCount = observations
         .latestPerSource(id)
         .filter((o) => o.sourceId !== parsed.topologySourceId || o.graph !== null).length

--- a/apps/server/api/src/api/topology-sources.ts
+++ b/apps/server/api/src/api/topology-sources.ts
@@ -269,8 +269,9 @@ topologySourcesApi.put('/:topologyId/sources', async (c) => {
  * Capability dispatch (autoscan → scan(), else fetchTopology()),
  * records the result as an observation snapshot, updates the
  * retraction hysteresis counter, and invalidates the parsed-topology
- * cache so the next render runs resolve(). `content_json` is never
- * touched here — that 's the authored layer, owned by the editor.
+ * cache so the next render runs resolve(). This records ONLY this source's
+ * own contribution; the project overlay (operator curation) and other
+ * sources' contributions are never touched here.
  *
  * Replaces the legacy multi-source-merge implementation; multi-source
  * folding now happens at read time inside `resolve()`. Use

--- a/apps/server/api/src/db/migrations/016_contribution_store.sql
+++ b/apps/server/api/src/db/migrations/016_contribution_store.sql
@@ -3,8 +3,11 @@
 -- codec (ingestGraph/buildGraph) + resolve integration land in later steps.
 --
 -- A topology = N contributions, each a contribution_source row. attachment_id set =
--- external feed (owned by its topology_data_sources attach row); attachment_id NULL =
--- the project's own intrinsic contribution. No human/authored concept.
+-- a source contribution (owned by its topology_data_sources attach row — external
+-- feed OR an explicitly-added hand-drawn Manual source); attachment_id NULL = the
+-- PROJECT OVERLAY (one per topology), the operator's curation — exclusions /
+-- overrides / metrics bindings / display settings — owned by the project, not a
+-- data source. resolve() folds the overlay as the top-priority `authored` input.
 
 -- Candidate key on topology_data_sources so contribution_source can FK (attachment_id, topology_id).
 CREATE UNIQUE INDEX IF NOT EXISTS idx_tds_id_topology ON topology_data_sources(id, topology_id);

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -481,10 +481,10 @@ export class Server {
     this.topologySourcesService = new TopologySourcesService()
     this.dataSourceService = new DataSourceService()
     await this.topologyService.initializeSample()
-    // One-shot: re-home any legacy NULL-"intrinsic" authored contribution into a
-    // real Manual data source (corrects the intrinsic drift). MUST run before the
-    // metrics backfill, which writes the authored graph via the Manual path.
-    await this.topologyService.migrateIntrinsicToManual()
+    // One-shot: move operator content out of Manual data sources into each
+    // topology's project overlay, then retire the Manual sources. MUST run before
+    // the metrics backfill, which writes bindings into the project overlay.
+    await this.topologyService.migrateManualToProject()
     // One-shot: migrate legacy mapping_json → identity-keyed metrics bindings.
     await this.topologyService.backfillMetricsBindings()
 

--- a/apps/server/api/src/services/discovery-scheduler.ts
+++ b/apps/server/api/src/services/discovery-scheduler.ts
@@ -9,7 +9,9 @@
  * source is always an explicit human action ("Sync now" / webhook) — discovery
  * does not start on its own. So an attached-but-never-synced source (a valid
  * intermediate state: config wired, not yet pulled) is simply not in the
- * working set. Manual is the authored layer and is never fetched at all.
+ * working set. A hand-drawn Manual source has no upstream, so it is never synced
+ * (it stays out of the working set the same way) — it is an ordinary source, not
+ * a special layer. (Operator curation lives in the project overlay, never fetched.)
  *
  * Decision per (topology, source) on each tick:
  *
@@ -90,7 +92,7 @@ export async function syncSource(
 
   try {
     if (hasAutoscanCapability(plugin)) {
-      // Resolve per-target SNMP credentials from the authored layer's
+      // Resolve per-target SNMP credentials from the project overlay's
       // discovery-policy chain (topology default → subgraph → node).
       // The plugin doesn't know about credential entities — we pass it
       // a flat ip→community map and it uses that wherever a key matches.
@@ -152,8 +154,8 @@ function backoffFor(failCount: number): number {
 }
 
 /**
- * Walk a topology's authored Manual graph and resolve every node's
- * effective discovery policy. For nodes with both an `identity.mgmtIp`
+ * Walk a topology's project overlay (the operator's curation) and resolve every
+ * node's effective discovery policy. For nodes with both an `identity.mgmtIp`
  * and a resolved `community` (set on the node, or inherited from a
  * subgraph / topology default), emit an entry in the returned map keyed
  * by the mgmt IP. Nodes with no community (or no mgmt IP) are absent —
@@ -169,7 +171,7 @@ export function resolveCredentialsForAutoscan(
   topologyId: string,
   topologyService: TopologyService,
 ): Record<string, string> {
-  // Credentials live in the authored layer (the intrinsic contribution) — read it
+  // Credentials live in the project overlay (the intrinsic contribution) — read it
   // unconditionally; do NOT gate on a phantom Manual data source being attached.
   const graph = topologyService.readProjectOverlay(topologyId)
   if (!graph) return {}
@@ -325,7 +327,7 @@ export class DiscoveryScheduler {
   private async readTopologyDefault(
     topologyId: string,
   ): Promise<import('@shumoku/core').Attachment[] | undefined> {
-    // Topology-default policy lives in the authored layer (intrinsic contribution).
+    // Topology-default policy lives in the project overlay (intrinsic contribution).
     const graph = this.topologyService.readProjectOverlay(topologyId)
     return graph?.attachments
   }

--- a/apps/server/api/src/services/discovery-scheduler.ts
+++ b/apps/server/api/src/services/discovery-scheduler.ts
@@ -265,12 +265,9 @@ export class DiscoveryScheduler {
         // state — the source has been synced at least once (`lastSyncedAt` set),
         // so it has observations to refresh. The first sync is always an explicit
         // human action ("Sync now" / webhook); discovery never bootstraps itself.
-        // Manual is the authored layer and is never fetched at all. So the working
-        // set is the established, non-manual sources — anything else has nothing
-        // to refresh and must not be touched here.
-        const sources = attached.filter(
-          (s) => s.dataSource?.type !== 'manual' && s.lastSyncedAt != null,
-        )
+        // A hand-drawn Manual source is never fetched (no upstream), so it is never
+        // synced → `lastSyncedAt` stays null → already excluded here. No type branch.
+        const sources = attached.filter((s) => s.lastSyncedAt != null)
         if (sources.length === 0) continue
 
         // The topology default policy gates every source on this topology

--- a/apps/server/api/src/services/discovery-scheduler.ts
+++ b/apps/server/api/src/services/discovery-scheduler.ts
@@ -171,7 +171,7 @@ export function resolveCredentialsForAutoscan(
 ): Record<string, string> {
   // Credentials live in the authored layer (the intrinsic contribution) — read it
   // unconditionally; do NOT gate on a phantom Manual data source being attached.
-  const graph = topologyService.readManualGraph(topologyId)
+  const graph = topologyService.readProjectOverlay(topologyId)
   if (!graph) return {}
 
   const subgraphLookup = new Map(
@@ -329,7 +329,7 @@ export class DiscoveryScheduler {
     topologyId: string,
   ): Promise<import('@shumoku/core').Attachment[] | undefined> {
     // Topology-default policy lives in the authored layer (intrinsic contribution).
-    const graph = this.topologyService.readManualGraph(topologyId)
+    const graph = this.topologyService.readProjectOverlay(topologyId)
     return graph?.attachments
   }
 

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -177,14 +177,13 @@ export class ObservationsService {
    *
    * The contribution is keyed by `(topology_id, source_id = data_sources.id)` and
    * owned by its topology-purpose attach row (`attachment_id`), so detaching the
-   * source cascades the contribution away. Skipped when:
+   * source cascades the contribution away. This is the SAME path for every source,
+   * including a hand-drawn Manual source — its editor save records an observation
+   * here (the human is the "scanner"), with no manual-specific branch. Skipped when:
    *   - `status === 'failed'` — a failed scan carries no information, so it must
    *     NOT replace the source's last-good contribution (C7);
    *   - the source isn't attached for the `topology` purpose (preview scans,
    *     metrics-only sources) — there is nothing to contribute to the graph;
-   *   - the source is a Manual one — a hand-drawn source has no scan; its graph is
-   *     written directly via `TopologyService.writeManualSourceGraph` (the editor),
-   *     not through the observation/scan path;
    *   - this snapshot is OLDER than the stored contribution — out-of-order
    *     delivery (a slow scan landing after a newer one) must not regress the
    *     canonical state. Preserves the old `MAX(captured_at)` selection.
@@ -196,13 +195,12 @@ export class ObservationsService {
     if (input.status === 'failed') return
     const attach = this.db
       .query(
-        `SELECT tds.id AS attach_id, ds.type AS ds_type
+        `SELECT tds.id AS attach_id
          FROM topology_data_sources tds
-         JOIN data_sources ds ON ds.id = tds.data_source_id
          WHERE tds.topology_id = ? AND tds.data_source_id = ? AND tds.purpose = 'topology'`,
       )
-      .get(input.topologyId, input.sourceId) as { attach_id: string; ds_type: string } | undefined
-    if (!attach || attach.ds_type === 'manual') return
+      .get(input.topologyId, input.sourceId) as { attach_id: string } | undefined
+    if (!attach) return
     // Out-of-order guard: never let a strictly older scan replace newer canonical
     // state (re-applying the same capturedAt is fine — idempotent replace).
     const existing = this.db

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -182,8 +182,9 @@ export class ObservationsService {
    *     NOT replace the source's last-good contribution (C7);
    *   - the source isn't attached for the `topology` purpose (preview scans,
    *     metrics-only sources) — there is nothing to contribute to the graph;
-   *   - the source is a Manual one — its graph is the intrinsic contribution,
-   *     written via `TopologyService.writeManualGraph`, not an observation;
+   *   - the source is a Manual one — a hand-drawn source has no scan; its graph is
+   *     written directly via `TopologyService.writeManualSourceGraph` (the editor),
+   *     not through the observation/scan path;
    *   - this snapshot is OLDER than the stored contribution — out-of-order
    *     delivery (a slow scan landing after a newer one) must not regress the
    *     canonical state. Preserves the old `MAX(captured_at)` selection.

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -1029,8 +1029,8 @@ export class TopologyService {
     }
     // Source priority feeds the resolver's field merge: when two sources
     // observe the same device, the higher-priority source wins each field it
-    // holds. Mirrors `topology_data_sources.priority`. The Manual/authored
-    // contribution always outranks these (handled inside resolve()).
+    // holds. Mirrors `topology_data_sources.priority`. The project overlay
+    // always outranks these (handled inside resolve() as the `authored` input).
     const priorityBySource = new Map<string, number>()
     for (const tds of this.topologySources.listByTopology(topology.id)) {
       priorityBySource.set(tds.dataSourceId, tds.priority)
@@ -1127,9 +1127,9 @@ export class TopologyService {
    * in `topology_observations` but no `contribution_source` row yet. Without this,
    * its nodes would vanish from the diagram until the next sync — and a manual-mode
    * source might never auto-resync. So for each attached topology source that lacks
-   * a contribution, materialize its latest non-failed audit snapshot (mirrors the
-   * intrinsic's lazy backfill in `readManualGraph`). Idempotent: once a contribution
-   * exists, the source is skipped, so this degrades to a cheap existence check.
+   * a contribution, materialize its latest non-failed audit snapshot. Idempotent:
+   * once a contribution exists, the source is skipped, so this degrades to a cheap
+   * existence check.
    *
    * GUARD on `lastSyncedAt != null` — the "data exists IFF attached AND synced"
    * invariant. A freshly (re-)attached source (incl. after a bulk source replace)
@@ -1309,8 +1309,10 @@ export class TopologyService {
   }
 
   /**
-   * Read the pre-DB-native authored graph from legacy Manual observations. A
-   * topology may have had MULTIPLE Manual sources (#370), so merge them.
+   * MIGRATION-ONLY: read the pre-refactor operator content from legacy Manual
+   * observations (a topology may have had MULTIPLE Manual sources, #370), so
+   * `migrateManualToProject` can fold it into the project overlay. Not used by the
+   * live read path.
    */
   private readLegacyManualObservation(topologyId: string): NetworkGraph | null {
     const manualSources = this.db
@@ -1401,7 +1403,7 @@ export class TopologyService {
     let migrated = 0
     for (const { topology_id } of topoRows) {
       // Merge every Manual source's contribution + any legacy Manual observation
-      // for this topology (the old `readManualGraph` semantics).
+      // for this topology (one-shot fold of all pre-refactor operator content).
       const manualSources = this.db
         .query(
           `SELECT ds.id AS id FROM topology_data_sources tds
@@ -1545,9 +1547,8 @@ export class TopologyService {
 
   /**
    * Invalidate every topology attached to a given data source. Used when the
-   * data source itself changes (config edit — e.g. a Manual source's authored
-   * graph lives in its config_json — or deletion) so attached topologies don't
-   * serve a stale resolved artifact.
+   * data source itself changes (config edit — priority / connection — or
+   * deletion) so attached topologies don't serve a stale resolved artifact.
    */
   clearCacheForDataSource(dataSourceId: string): void {
     const rows = this.db

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -4,19 +4,21 @@
  *
  * Storage model: the `topologies` table holds only the topology shell
  * (name, share_token, composition_revision). Sources live in
- * `topology_data_sources` (m2m). Each contribution — the project's own authored
- * graph AND every external source's latest observed graph — is stored DB-native
- * in the `contribution_*` store (decomposed into queryable element/link/
- * attachment rows; see db-native-persistence.md). `topology_observations` is now
- * just the append-only audit/history log. The metrics mapping is `metrics-binding`
+ * `topology_data_sources` (m2m). Every contribution is stored DB-native in the
+ * `contribution_*` store (decomposed into queryable element/link/attachment rows;
+ * see db-native-persistence.md). `topology_observations` is now just the
+ * append-only audit/history log. The metrics mapping is `metrics-binding`
  * attachments on the resolved graph (no `mapping_json`); the resolved graph +
  * layout are materialized in `topology_resolved_graph`.
  *
- * The editor 's "save" routes through `writeManualGraph`, which ingests the
- * hand-drawn graph as the **Manual data source's own contribution** (a uniform
- * source, `attachment_id` = its attach row — equal to every other source, just
- * top-priority and hand-edited). There is no `content_json` column and no special
- * "intrinsic" layer; the Manual source is folded by `resolve()` like any source.
+ * Two kinds of contribution, distinguished by `attachment_id`:
+ *   - **source contributions** (`attachment_id` set) — every attached source's
+ *     latest graph, INCLUDING an explicitly-added hand-drawn Manual source. Written
+ *     by sync / the Manual editor (`writeManualSourceGraph`). Folded by priority.
+ *   - **the project overlay** (`attachment_id` NULL, {@link PROJECT_SOURCE}) — the
+ *     operator's curation: exclusions, overrides, metrics bindings, display
+ *     settings. Written by `writeProjectOverlay` (never spawns a data source).
+ *     Fed to `resolve()` as the top-priority `authored` input.
  */
 
 import type { Database } from 'bun:sqlite'
@@ -50,12 +52,19 @@ import type { MetricsData, MetricsMapping, Topology, TopologyInput } from '../ty
 import { buildGraph, ingestGraph } from './contribution-store.js'
 
 /**
- * LEGACY source_id of the drifted "intrinsic" authored contribution
- * (attachment_id NULL). Retained ONLY for `migrateIntrinsicToManual` to find and
- * re-home those rows into a real Manual data source. Nothing else writes it — the
- * authored graph is the Manual source's own contribution now.
+ * Sentinel `source_id` of the **project overlay** — the project's own
+ * top-priority contribution (`attachment_id` NULL, one per topology, enforced by
+ * `idx_contrib_one_intrinsic`). It is NOT a data source: it holds the operator's
+ * curation over the composed result — exclusions (`presence='hide'`), field
+ * overrides, metrics bindings, and graph-level display settings (edge style).
+ * `resolve()` folds it as the top-priority `authored` input. The value is kept as
+ * `'intrinsic'` so the existing partial unique index applies with no migration.
+ *
+ * This is the contrast to a Manual *data source* (`attachment_id` set): Manual is
+ * now ONLY for explicitly-added hand-drawn graphs and is folded like any other
+ * source. Curation never spawns a Manual source — it writes the project overlay.
  */
-const INTRINSIC_SOURCE = 'intrinsic'
+const PROJECT_SOURCE = 'intrinsic'
 
 import { TopologySourcesService } from './topology-sources.js'
 
@@ -72,9 +81,8 @@ function rowToTopology(row: TopologyRow): Topology {
   return {
     id: row.id,
     name: row.name,
-    // contentJson + manualSourceId populated by withManual() at the call site.
-    // No mappingJson (derived from bindings) and no topology/metrics source
-    // pointers (the m2m topology_data_sources table is the model now).
+    // Topology is just the shell. No content, no source pointers — sources live
+    // in the m2m topology_data_sources table; mappingJson is derived from bindings.
     shareToken: row.share_token ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -363,24 +371,11 @@ export class TopologyService {
   }
 
   /**
-   * Attach `manualSourceId` to a bare Topology row. Public API
-   * intentionally does NOT carry the Manual snapshot here — the
-   * editor / settings UI reads it through
-   * `GET /api/topologies/:id/sources/:sid/latest-snapshot` instead.
-   * Mixing snapshot content into the Topology shell was structurally
-   * confusing (Topology.contentJson read like "project JSON" when it
-   * was really one source 's input).
-   */
-  private hydrateManualId(topology: Topology): Topology {
-    const manualId = this.findManualSourceId(topology.id)
-    if (!manualId) return topology
-    return { ...topology, manualSourceId: manualId }
-  }
-
-  /**
    * Find the Manual data source id attached to a topology, if any.
    * Returns the *data source* id (PK of `data_sources`), not the
-   * junction row id.
+   * junction row id. (A topology may have several Manual sources; this
+   * returns the first — used only for internal "is X the manual source"
+   * checks, not as a privileged per-topology pointer.)
    */
   findManualSourceId(topologyId: string): string | undefined {
     const row = this.db
@@ -429,48 +424,26 @@ export class TopologyService {
     return { dataSourceId: dsId }
   }
 
-  /**
-   * Get all topologies from the database. Hydrates `manualSourceId`
-   * via a single JOIN so list-page links can point straight at the
-   * Manual source 's detail page.
-   */
+  /** Get all topologies from the database (shells only). */
   list(): Topology[] {
-    const rows = this.db
-      .query(
-        `SELECT t.*, ds.id AS manual_source_id
-         FROM topologies t
-         LEFT JOIN topology_data_sources tds ON tds.topology_id = t.id
-         LEFT JOIN data_sources ds ON ds.id = tds.data_source_id AND ds.type = 'manual'
-         GROUP BY t.id
-         ORDER BY t.name ASC`,
-      )
-      .all() as (TopologyRow & { manual_source_id: string | null })[]
-    return rows.map((row) => {
-      const base = rowToTopology(row)
-      if (row.manual_source_id) base.manualSourceId = row.manual_source_id
-      return base
-    })
+    const rows = this.db.query('SELECT * FROM topologies ORDER BY name ASC').all() as TopologyRow[]
+    return rows.map((row) => rowToTopology(row))
   }
 
-  /**
-   * Get a single topology by ID, with contentJson hydrated from the
-   * latest Manual observation.
-   */
+  /** Get a single topology shell by ID. */
   get(id: string): Topology | null {
     const row = this.db.query('SELECT * FROM topologies WHERE id = ?').get(id) as
       | TopologyRow
       | undefined
-    return row ? this.hydrateManualId(rowToTopology(row)) : null
+    return row ? rowToTopology(row) : null
   }
 
-  /**
-   * Get a topology by name.
-   */
+  /** Get a topology shell by name. */
   getByName(name: string): Topology | null {
     const row = this.db.query('SELECT * FROM topologies WHERE name = ?').get(name) as
       | TopologyRow
       | undefined
-    return row ? this.hydrateManualId(rowToTopology(row)) : null
+    return row ? rowToTopology(row) : null
   }
 
   /**
@@ -679,7 +652,7 @@ export class TopologyService {
     linkDesired: LinkBindingDesired[],
   ): Promise<void> {
     const topology = this.get(topologyId)
-    const authored = this.readManualGraph(topologyId) ?? {
+    const authored = this.readProjectOverlay(topologyId) ?? {
       version: '1' as const,
       name: topology?.name ?? 'Manual',
       nodes: [],
@@ -784,8 +757,8 @@ export class TopologyService {
     })
     nodes = nodes.filter((n) => !isPureEmptyOverlay(n))
 
-    // Records a new authored observation for this topology + invalidates it.
-    await this.writeManualGraph(topologyId, { ...authored, nodes })
+    // Bindings are operator curation → the project overlay (no Manual source).
+    await this.writeProjectOverlay(topologyId, { ...authored, nodes })
   }
 
   /**
@@ -1031,19 +1004,21 @@ export class TopologyService {
    *
    * The resolver runs here over two DB-native pools, both read from the
    * contribution store (`contribution_*`):
-   *   - the Manual source's contribution — the project's hand-drawn graph —
+   *   - the PROJECT OVERLAY (attachment_id NULL) — the operator's curation —
    *     fills the `authored` slot (top priority);
-   *   - every OTHER attached source's contribution becomes a `SnapshotEntry` in
-   *     `snapshots` (the Manual source is excluded so it isn't double-counted).
+   *   - every attached source's contribution becomes a `SnapshotEntry` in
+   *     `snapshots` — including an explicitly-added hand-drawn Manual source,
+   *     which is just an ordinary source here (no special-casing).
    *
-   * With no Manual source, `authored` is an empty graph — the diagram is
-   * whatever the external sources produced.
+   * With no overlay, `authored` is an empty graph — the diagram is whatever the
+   * attached sources produced.
    */
   private async parseTopology(topology: Topology): Promise<ParsedTopology> {
-    // The authored graph is the Manual source's own contribution (DB-native), folded
-    // as resolve()'s top-priority contribution. Absent → empty. (`readManualGraph`
-    // also falls back to a legacy Manual observation during the transition.)
-    const authored: NetworkGraph = this.readManualGraph(topology.id) ?? {
+    // The `authored` slot is the PROJECT OVERLAY (DB-native, attachment_id NULL):
+    // the operator's curation — exclusions, overrides, metrics bindings, settings —
+    // folded as resolve()'s top-priority contribution. Absent → empty. A hand-drawn
+    // Manual source is NOT here; it's an ordinary source in `snapshots` below.
+    const authored: NetworkGraph = this.readProjectOverlay(topology.id) ?? {
       version: '1',
       name: topology.name,
       nodes: [],
@@ -1091,10 +1066,11 @@ export class TopologyService {
   }
 
   /**
-   * The observed snapshots feeding `resolve()` — one per external source, read
-   * DB-native from the contribution store (NOT the audit log). Each external
-   * source's latest graph is its `contribution_source` row (attachment_id NOT
-   * NULL); `buildGraph` projects the decomposed rows back to a NetworkGraph.
+   * The snapshots feeding `resolve()` — one per attached source, read DB-native
+   * from the contribution store (NOT the audit log). Each source's latest graph is
+   * its `contribution_source` row (attachment_id NOT NULL); `buildGraph` projects
+   * the decomposed rows back to a NetworkGraph. A hand-drawn Manual source is an
+   * ordinary entry here; only the project overlay (NULL) is fed elsewhere.
    *
    * Properties this inherits from how contributions are written
    * (`ObservationsService.materializeContribution`):
@@ -1109,20 +1085,11 @@ export class TopologyService {
     priorityBySource: Map<string, number>,
   ): SnapshotEntry[] {
     this.backfillObservedContributions(topologyId)
-    // The Manual contribution(s) are fed to resolve() as `authored` (top
-    // priority), so exclude EVERY Manual source here (a topology may have several,
-    // #370) or they'd be double-counted as observed snapshots.
-    const manualIds = new Set(
-      (
-        this.db
-          .query(
-            `SELECT ds.id AS id FROM topology_data_sources tds
-             JOIN data_sources ds ON ds.id = tds.data_source_id
-             WHERE tds.topology_id = ? AND ds.type = 'manual'`,
-          )
-          .all(topologyId) as { id: string }[]
-      ).map((r) => r.id),
-    )
+    // Every attached source's contribution (attachment_id NOT NULL) is a snapshot —
+    // INCLUDING a hand-drawn Manual source, now an ordinary source folded by
+    // priority. The project overlay (attachment_id NULL) is fed separately as
+    // `authored`, and the `attachment_id IS NOT NULL` filter already excludes it,
+    // so there is no double-count and no `type='manual'` branch here.
     const rows = this.db
       .query(
         `SELECT source_id, last_status, last_ok_at
@@ -1136,7 +1103,6 @@ export class TopologyService {
     }[]
     const snapshots: SnapshotEntry[] = []
     for (const r of rows) {
-      if (manualIds.has(r.source_id)) continue
       if (!priorityBySource.has(r.source_id)) continue
       const graph = buildGraph(topologyId, r.source_id, this.db)
       if (!graph) continue
@@ -1185,7 +1151,8 @@ export class TopologyService {
       ).map((r) => r.source_id),
     )
     for (const tds of this.topologySources.listByPurpose(topologyId, 'topology')) {
-      if (tds.dataSource?.type === 'manual') continue
+      // A never-synced source (incl. a fresh hand-drawn Manual, syncMode 'manual')
+      // has lastSyncedAt == null → nothing to backfill. No type='manual' branch.
       if (tds.lastSyncedAt == null) continue
       if (have.has(tds.dataSourceId)) continue
       const row = this.db
@@ -1331,30 +1298,31 @@ export class TopologyService {
   }
 
   /**
-   * Read the Manual source's graph for a topology. Manual is a uniform data
-   * source: its hand-drawn graph is its own `contribution_source`
-   * (`attachment_id` = its attach row), read back via `buildGraph` like any
-   * source. Returns null when no Manual source is attached / nothing drawn yet.
+   * Read the PROJECT OVERLAY — the project's own top-priority contribution
+   * (`attachment_id` NULL, `source_id` = {@link PROJECT_SOURCE}). Holds the
+   * operator's curation: exclusions, field overrides, metrics bindings, and
+   * graph-level display settings. Fed to `resolve()` as `authored`. Returns null
+   * when the project has no overlay yet.
    *
-   * Public so the discovery-policy API can read the Manual contribution to mutate.
+   * Public so the discovery-policy / mapping APIs can read it to mutate.
    */
-  readManualGraph(topologyId: string, sourceId?: string): NetworkGraph | null {
-    // Target the SPECIFIC Manual source when the caller names one (the editor
-    // passes the route's :sourceId) — a topology may have several Manual sources
-    // (#370), so reading "the first" would surface the wrong one. Fall back to the
-    // first attached Manual when no id is given (discovery-policy / single-Manual).
-    const manualId =
-      sourceId && this.manualAttachId(topologyId, sourceId)
-        ? sourceId
-        : this.findManualSourceId(topologyId)
-    if (manualId) {
-      const fromRows = buildGraph(topologyId, manualId, this.db)
-      if (fromRows) return fromRows
-    }
-    // Transitional: a pre-DB-native authored graph may still sit in a legacy
-    // Manual observation. Surface it (the startup migration moves it into the
-    // Manual contribution; this is the read-path safety net until that runs).
+  readProjectOverlay(topologyId: string): NetworkGraph | null {
+    const fromRows = buildGraph(topologyId, PROJECT_SOURCE, this.db)
+    if (fromRows) return fromRows
+    // Transitional: until `migrateManualToProject` runs, the operator's content may
+    // still sit in legacy Manual observations. Surface it as the overlay.
     return this.readLegacyManualObservation(topologyId)
+  }
+
+  /**
+   * Read an explicitly-added hand-drawn Manual source's graph (its own
+   * `contribution_source`, `attachment_id` = its attach row). This is ordinary
+   * source content — the editor reads it to populate its canvas. Returns null when
+   * the source isn't attached here or nothing is drawn yet.
+   */
+  readManualSourceGraph(topologyId: string, sourceId: string): NetworkGraph | null {
+    if (!this.manualAttachId(topologyId, sourceId)) return null
+    return buildGraph(topologyId, sourceId, this.db)
   }
 
   /**
@@ -1392,113 +1360,151 @@ export class TopologyService {
   }
 
   /**
-   * Persist the Manual source's graph. Manual is a uniform data source, so its
-   * graph is ingested as ITS OWN contribution (`attachment_id` = its attach row)
-   * — identical to how an observed source's graph is stored, just hand-edited and
-   * top-priority. Writes the SPECIFIC Manual source when one is named (the editor
-   * passes the route's :sourceId — so editing Manual B never clobbers Manual A);
-   * otherwise find-or-creates one (discovery-policy / first edit) so the write
-   * always has a home. resolve() folds it as the top-priority contribution.
-   * Per-topology: an edit to topology X only invalidates X.
+   * Persist the PROJECT OVERLAY (attachment_id NULL, {@link PROJECT_SOURCE}). This
+   * is where ALL operator curation lands — exclusions, overrides, metrics bindings,
+   * display settings. It is owned by the project, NOT a data source: writing it
+   * never creates or attaches a Manual source (no phantom spawn, no orphan).
+   * `idx_contrib_one_intrinsic` keeps it to one per topology. resolve() folds it as
+   * the top-priority `authored` contribution. Per-topology: an edit to X invalidates X.
    */
-  async writeManualGraph(
-    topologyId: string,
-    graph: NetworkGraph,
-    sourceId?: string,
-  ): Promise<void> {
-    const manualId =
-      sourceId && this.manualAttachId(topologyId, sourceId)
-        ? sourceId
-        : await this.ensureManualSource(topologyId)
-    const attachId = this.manualAttachId(topologyId, manualId)
+  async writeProjectOverlay(topologyId: string, graph: NetworkGraph): Promise<void> {
     ingestGraph(
       topologyId,
-      manualId,
+      PROJECT_SOURCE,
       graph,
-      { attachmentId: attachId ?? null, lastStatus: 'ok', lastOkAt: timestamp() },
+      { attachmentId: null, lastStatus: 'ok', lastOkAt: timestamp() },
       this.db,
     )
     this.clearCacheEntry(topologyId)
   }
 
   /**
-   * Find-or-create the Manual data source attached to this topology. Returns its
-   * data-source id. Called when an edit / override lands — the Manual source is a
-   * normal, visible, equal source that holds the operator's contribution (it is
-   * not auto-attached on topology create; it appears the first time you edit).
+   * Persist an explicitly-added hand-drawn Manual source's graph as ITS OWN
+   * contribution (`attachment_id` = its attach row), exactly like an observed
+   * source — just hand-edited. The Manual source MUST already be attached (added
+   * via the Sources list); there is no find-or-create, so curation can never spawn
+   * one. Throws if the source isn't attached to this topology.
    */
-  async ensureManualSource(topologyId: string): Promise<string> {
-    const existing = this.findManualSourceId(topologyId)
-    if (existing) return existing
-    const { dataSourceId } = await this.attachManualSource(topologyId, 'topology')
-    return dataSourceId
+  async writeManualSourceGraph(
+    topologyId: string,
+    sourceId: string,
+    graph: NetworkGraph,
+  ): Promise<void> {
+    const attachId = this.manualAttachId(topologyId, sourceId)
+    if (!attachId) {
+      throw new Error(`Manual source ${sourceId} is not attached to topology ${topologyId}`)
+    }
+    ingestGraph(
+      topologyId,
+      sourceId,
+      graph,
+      { attachmentId: attachId, lastStatus: 'ok', lastOkAt: timestamp() },
+      this.db,
+    )
+    this.clearCacheEntry(topologyId)
   }
 
   /**
-   * One-shot migration: re-home the legacy `data_source_id IS NULL` "intrinsic"
-   * contribution (the drifted authored layer) into a real Manual data source, so
-   * Manual is a uniform source again (db-native-persistence.md canonical model).
-   * Runs at startup, settings-guarded. For each topology that has a NULL-intrinsic
-   * contribution with actual content, ensure a Manual source and ingest the graph
-   * as ITS contribution; then drop the NULL row (empty intrinsics are just dropped,
-   * no Manual spawned).
+   * One-shot migration: move all operator content out of `type='manual'` DATA
+   * SOURCES into each topology's PROJECT OVERLAY (attachment_id NULL), then RETIRE
+   * the Manual data sources entirely. This realizes the model where curation is
+   * project-owned and Manual is reserved for future explicit hand-drawn sources
+   * (manual-source-unification.md Known-gap; no backward compat — legacy Manual
+   * sources are folded into the overlay and removed). Runs at startup, settings-guarded.
+   *
+   * For each topology with Manual content, merge it (a topology could have several
+   * Manual sources + legacy observations) and ingest it as the overlay — but never
+   * clobber an overlay that already has content. Then delete every Manual data
+   * source: dropping its attach row cascades its contribution, and the global
+   * delete also sweeps orphaned (unattached) Manual rows.
    */
-  async migrateIntrinsicToManual(): Promise<void> {
+  async migrateManualToProject(): Promise<void> {
     const flag = this.db
-      .query("SELECT value FROM settings WHERE key = 'intrinsic_to_manual_migrated'")
+      .query("SELECT value FROM settings WHERE key = 'manual_to_project_migrated'")
       .get() as { value: string } | undefined
     if (flag?.value === '1') return
 
-    const rows = this.db
+    const hasContent = (g: NetworkGraph | null): boolean =>
+      !!g &&
+      ((g.nodes?.length ?? 0) > 0 ||
+        (g.links?.length ?? 0) > 0 ||
+        (g.subgraphs?.length ?? 0) > 0 ||
+        (g.terminations?.length ?? 0) > 0 ||
+        (g.attachments?.length ?? 0) > 0 ||
+        (g.exclusions?.length ?? 0) > 0)
+
+    const topoRows = this.db
       .query(
-        `SELECT DISTINCT topology_id FROM contribution_source
-         WHERE attachment_id IS NULL AND source_id = ?`,
+        `SELECT DISTINCT tds.topology_id AS topology_id
+         FROM topology_data_sources tds
+         JOIN data_sources ds ON ds.id = tds.data_source_id
+         WHERE ds.type = 'manual'`,
       )
-      .all(INTRINSIC_SOURCE) as { topology_id: string }[]
+      .all() as { topology_id: string }[]
     let migrated = 0
-    for (const { topology_id } of rows) {
-      const graph = buildGraph(topology_id, INTRINSIC_SOURCE, this.db)
-      const hasContent =
-        !!graph &&
-        ((graph.nodes?.length ?? 0) > 0 ||
-          (graph.links?.length ?? 0) > 0 ||
-          (graph.subgraphs?.length ?? 0) > 0 ||
-          (graph.terminations?.length ?? 0) > 0 ||
-          (graph.attachments?.length ?? 0) > 0 ||
-          (graph.exclusions?.length ?? 0) > 0)
-      if (graph && hasContent) {
-        const manualId = await this.ensureManualSource(topology_id)
-        // Never clobber: if a Manual source already holds content, IT is the
-        // authoritative authored graph and the NULL-intrinsic row is stale — keep
-        // the Manual contribution, just drop the NULL row below.
-        if (!buildGraph(topology_id, manualId, this.db)) {
-          const attachId = this.manualAttachId(topology_id, manualId)
-          ingestGraph(
-            topology_id,
-            manualId,
-            graph,
-            { attachmentId: attachId ?? null, lastStatus: 'ok', lastOkAt: timestamp() },
-            this.db,
-          )
-          migrated++
-        }
-      }
-      // Drop the legacy NULL-intrinsic row (cascade removes its element rows).
-      this.db
+    for (const { topology_id } of topoRows) {
+      // Merge every Manual source's contribution + any legacy Manual observation
+      // for this topology (the old `readManualGraph` semantics).
+      const manualSources = this.db
         .query(
-          'DELETE FROM contribution_source WHERE topology_id = ? AND source_id = ? AND attachment_id IS NULL',
+          `SELECT ds.id AS id FROM topology_data_sources tds
+           JOIN data_sources ds ON ds.id = tds.data_source_id
+           WHERE tds.topology_id = ? AND ds.type = 'manual'
+           ORDER BY ds.created_at ASC, ds.id ASC`,
         )
-        .run(topology_id, INTRINSIC_SOURCE)
+        .all(topology_id) as { id: string }[]
+      const graphs: NetworkGraph[] = []
+      for (const { id } of manualSources) {
+        const g = buildGraph(topology_id, id, this.db)
+        if (g) graphs.push(g)
+      }
+      const legacy = this.readLegacyManualObservation(topology_id)
+      if (legacy) graphs.push(legacy)
+      const content =
+        graphs.length === 0
+          ? null
+          : graphs.length === 1
+            ? (graphs[0] ?? null)
+            : mergeAuthoredGraphs(graphs)
+
+      // Never clobber an overlay that already has content.
+      if (
+        hasContent(content) &&
+        content &&
+        !hasContent(buildGraph(topology_id, PROJECT_SOURCE, this.db))
+      ) {
+        ingestGraph(
+          topology_id,
+          PROJECT_SOURCE,
+          content,
+          { attachmentId: null, lastStatus: 'ok', lastOkAt: timestamp() },
+          this.db,
+        )
+        migrated++
+      }
       this.clearCacheEntry(topology_id)
     }
+
+    // Retire every Manual data source. Deleting the attach row cascades its
+    // contribution (FK ON DELETE CASCADE); the global deletes sweep leftovers and
+    // orphans. Manual is now created fresh, on explicit add, for hand-drawing only.
+    const manualDs = this.db.query("SELECT id FROM data_sources WHERE type = 'manual'").all() as {
+      id: string
+    }[]
+    for (const { id } of manualDs) {
+      this.db.query('DELETE FROM topology_data_sources WHERE data_source_id = ?').run(id)
+      this.db.query('DELETE FROM contribution_source WHERE source_id = ?').run(id)
+      this.db.query('DELETE FROM data_sources WHERE id = ?').run(id)
+    }
+
     this.db
       .query(
-        "INSERT OR REPLACE INTO settings (key, value) VALUES ('intrinsic_to_manual_migrated', '1')",
+        "INSERT OR REPLACE INTO settings (key, value) VALUES ('manual_to_project_migrated', '1')",
       )
       .run()
-    if (migrated > 0) {
+    if (migrated > 0 || manualDs.length > 0) {
       console.log(
-        `[Migration] Re-homed ${migrated} intrinsic contribution(s) into Manual data sources.`,
+        `[Migration] Moved ${migrated} Manual contribution(s) into project overlays; retired ${manualDs.length} Manual data source(s).`,
       )
     }
   }
@@ -1661,11 +1667,10 @@ export class TopologyService {
     // Parse YAML to NetworkGraph
     const graph = await parseYamlToNetworkGraph(mainContent, fileMap)
 
-    // Mirror the user's flow: create the topology shell, then write the parsed
-    // graph as the Manual source's contribution (writeManualGraph find-or-creates
-    // the Manual source — a normal, equal data source — and ingests its graph).
+    // The sample's base graph is the project's own content → the project overlay
+    // (no Manual data source is spawned).
     const created = await this.create({ name: 'Sample Network' })
-    await this.writeManualGraph(created.id, graph)
+    await this.writeProjectOverlay(created.id, graph)
 
     console.log(
       '[TopologyService] Sample network created:',

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -13,8 +13,11 @@
  *
  * Two kinds of contribution, distinguished by `attachment_id`:
  *   - **source contributions** (`attachment_id` set) — every attached source's
- *     latest graph, INCLUDING an explicitly-added hand-drawn Manual source. Written
- *     by sync / the Manual editor (`writeManualSourceGraph`). Folded by priority.
+ *     latest graph, INCLUDING an explicitly-added hand-drawn Manual source. ALL of
+ *     them are written the SAME way: `ObservationsService.record()` →
+ *     `materializeContribution`. A Manual source's editor save is just an
+ *     observation with the human as the "scanner" — no manual-specific path.
+ *     Folded by priority.
  *   - **the project overlay** (`attachment_id` NULL, {@link PROJECT_SOURCE}) — the
  *     operator's curation: exclusions, overrides, metrics bindings, display
  *     settings. Written by `writeProjectOverlay` (never spawns a data source).
@@ -1288,16 +1291,6 @@ export class TopologyService {
   // at the API boundary (api/observations.ts) and at resolve() time.
 
   /**
-   * The topology_data_sources row id (attach row) for this topology's Manual
-   * source, or undefined when none is attached. The contribution is owned by this
-   * attach row — exactly like any other source — so it round-trips through the
-   * standard `attachment_id`-keyed `contribution_*` store.
-   */
-  private manualAttachId(topologyId: string, manualSourceId: string): string | undefined {
-    return this.topologySources.find(topologyId, manualSourceId, 'topology')?.id
-  }
-
-  /**
    * Read the PROJECT OVERLAY — the project's own top-priority contribution
    * (`attachment_id` NULL, `source_id` = {@link PROJECT_SOURCE}). Holds the
    * operator's curation: exclusions, field overrides, metrics bindings, and
@@ -1305,24 +1298,14 @@ export class TopologyService {
    * when the project has no overlay yet.
    *
    * Public so the discovery-policy / mapping APIs can read it to mutate.
+   *
+   * No legacy fallback: `migrateManualToProject` (startup) moves any pre-refactor
+   * operator content into this NULL slot. A hand-drawn Manual *source* now records
+   * its own observations like any source, so reading its observations here would
+   * wrongly conflate source content with the overlay.
    */
   readProjectOverlay(topologyId: string): NetworkGraph | null {
-    const fromRows = buildGraph(topologyId, PROJECT_SOURCE, this.db)
-    if (fromRows) return fromRows
-    // Transitional: until `migrateManualToProject` runs, the operator's content may
-    // still sit in legacy Manual observations. Surface it as the overlay.
-    return this.readLegacyManualObservation(topologyId)
-  }
-
-  /**
-   * Read an explicitly-added hand-drawn Manual source's graph (its own
-   * `contribution_source`, `attachment_id` = its attach row). This is ordinary
-   * source content — the editor reads it to populate its canvas. Returns null when
-   * the source isn't attached here or nothing is drawn yet.
-   */
-  readManualSourceGraph(topologyId: string, sourceId: string): NetworkGraph | null {
-    if (!this.manualAttachId(topologyId, sourceId)) return null
-    return buildGraph(topologyId, sourceId, this.db)
+    return buildGraph(topologyId, PROJECT_SOURCE, this.db)
   }
 
   /**
@@ -1373,32 +1356,6 @@ export class TopologyService {
       PROJECT_SOURCE,
       graph,
       { attachmentId: null, lastStatus: 'ok', lastOkAt: timestamp() },
-      this.db,
-    )
-    this.clearCacheEntry(topologyId)
-  }
-
-  /**
-   * Persist an explicitly-added hand-drawn Manual source's graph as ITS OWN
-   * contribution (`attachment_id` = its attach row), exactly like an observed
-   * source — just hand-edited. The Manual source MUST already be attached (added
-   * via the Sources list); there is no find-or-create, so curation can never spawn
-   * one. Throws if the source isn't attached to this topology.
-   */
-  async writeManualSourceGraph(
-    topologyId: string,
-    sourceId: string,
-    graph: NetworkGraph,
-  ): Promise<void> {
-    const attachId = this.manualAttachId(topologyId, sourceId)
-    if (!attachId) {
-      throw new Error(`Manual source ${sourceId} is not attached to topology ${topologyId}`)
-    }
-    ingestGraph(
-      topologyId,
-      sourceId,
-      graph,
-      { attachmentId: attachId, lastStatus: 'ok', lastOkAt: timestamp() },
       this.db,
     )
     this.clearCacheEntry(topologyId)

--- a/apps/server/api/src/types.ts
+++ b/apps/server/api/src/types.ts
@@ -90,8 +90,6 @@ export interface DataSourceInput {
 export interface Topology {
   id: string
   name: string
-  /** Id of the Manual source attached to this topology, if any. */
-  manualSourceId?: string
   /**
    * Structure / metrics data source ids. No longer stored on the topology row
    * (sources live in `topology_data_sources`); the `/context` response derives

--- a/apps/server/api/test/db/clear-source.test.ts
+++ b/apps/server/api/test/db/clear-source.test.ts
@@ -28,7 +28,7 @@ const graphWith = (nodeId: string): NetworkGraph =>
 describe('clear a source (deleteForSource) → resolve sweeps its orphans', () => {
   test('removes only the cleared source contribution; others survive', async () => {
     const topo = await svc.create({ name: 'clear' })
-    await svc.writeManualGraph(topo.id, graphWith('authored-A'))
+    await svc.writeProjectOverlay(topo.id, graphWith('authored-A'))
 
     const nbId = insertDataSource('netbox', 'nb_clear')
     attachSource(topo.id, nbId, 'topology')

--- a/apps/server/api/test/db/manual-source.test.ts
+++ b/apps/server/api/test/db/manual-source.test.ts
@@ -3,6 +3,7 @@
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import type { NetworkGraph } from '@shumoku/core'
+import { ingestGraph } from '../../src/services/contribution-store.ts'
 import { TopologyService } from '../../src/services/topology.ts'
 import { getDatabase, setupTempDb, type TempDb } from './helper.ts'
 
@@ -22,57 +23,49 @@ const g = (nodeId: string): NetworkGraph =>
     links: [],
   }) as NetworkGraph
 
-describe('Manual = a uniform data source (its graph is its own contribution)', () => {
-  test('no Manual source until something is written → readManualGraph is null', async () => {
+describe('project overlay = the project-owned contribution (attachment_id NULL)', () => {
+  test('no overlay until something is written → readProjectOverlay is null', async () => {
     const topo = await svc.create({ name: 'm1' })
-    expect(svc.findManualSourceId(topo.id)).toBeUndefined()
-    expect(svc.readManualGraph(topo.id)).toBeNull()
+    expect(svc.readProjectOverlay(topo.id)).toBeNull()
   })
 
-  test('writeManualGraph find-or-creates a Manual data source and stores its contribution (attachment_id set)', async () => {
+  test('writeProjectOverlay stores a NULL-attachment contribution and creates NO data source', async () => {
     const topo = await svc.create({ name: 'm2' })
-    await svc.writeManualGraph(topo.id, g('a'))
+    await svc.writeProjectOverlay(topo.id, g('a'))
 
-    // A real type='manual' data source now exists, attached to the topology.
-    const manualId = svc.findManualSourceId(topo.id)
-    expect(manualId).toBeDefined()
-    const ds = getDatabase().query('SELECT type FROM data_sources WHERE id = ?').get(manualId) as
-      | { type: string }
-      | undefined
-    expect(ds?.type).toBe('manual')
+    // No Manual (or any) data source is spawned by curation.
+    expect(svc.findManualSourceId(topo.id)).toBeUndefined()
+    const dsCount = (
+      getDatabase()
+        .query(`SELECT COUNT(*) AS c FROM topology_data_sources WHERE topology_id = ?`)
+        .get(topo.id) as { c: number }
+    ).c
+    expect(dsCount).toBe(0)
 
-    // Its graph is its OWN contribution — attachment_id SET (equal to any source),
-    // NOT a NULL "intrinsic" row.
+    // The overlay is the project-owned contribution: attachment_id NULL, sentinel source_id.
     const src = getDatabase()
       .query(
-        'SELECT source_id, attachment_id FROM contribution_source WHERE topology_id = ? AND source_id = ?',
+        'SELECT source_id, attachment_id FROM contribution_source WHERE topology_id = ? AND attachment_id IS NULL',
       )
-      .get(topo.id, manualId) as { source_id: string; attachment_id: string | null } | undefined
+      .get(topo.id) as { source_id: string; attachment_id: string | null } | undefined
     expect(src).toBeDefined()
-    expect(src?.attachment_id).not.toBeNull()
-    // No NULL-"intrinsic" row exists (bun:sqlite .get() returns null for no row).
-    const intrinsic = getDatabase()
-      .query('SELECT 1 FROM contribution_source WHERE topology_id = ? AND attachment_id IS NULL')
-      .get(topo.id)
-    expect(intrinsic).toBeNull()
+    expect(src?.attachment_id).toBeNull()
+    expect(src?.source_id).toBe('intrinsic')
 
-    expect(svc.readManualGraph(topo.id)?.nodes?.[0]?.id).toBe('a')
+    expect(svc.readProjectOverlay(topo.id)?.nodes?.[0]?.id).toBe('a')
     const parsed = await svc.getParsed(topo.id)
     expect(parsed?.graph.nodes.some((n) => n.identity?.mgmtIp === '10.0.0.1')).toBe(true)
   })
 
-  test('latest write wins on re-save (the Manual contribution is replaced)', async () => {
+  test('latest write wins on re-save (overlay is replaced), still exactly one overlay row', async () => {
     const topo = await svc.create({ name: 'm3' })
-    await svc.writeManualGraph(topo.id, g('first'))
-    await svc.writeManualGraph(topo.id, g('second'))
-    expect(svc.readManualGraph(topo.id)?.nodes?.[0]?.id).toBe('second')
-    // Still exactly one Manual source for THIS topology (find-or-create, not spawn-per-save).
+    await svc.writeProjectOverlay(topo.id, g('first'))
+    await svc.writeProjectOverlay(topo.id, g('second'))
+    expect(svc.readProjectOverlay(topo.id)?.nodes?.[0]?.id).toBe('second')
     const count = (
       getDatabase()
         .query(
-          `SELECT COUNT(*) AS c FROM topology_data_sources tds
-           JOIN data_sources ds ON ds.id = tds.data_source_id
-           WHERE tds.topology_id = ? AND ds.type = 'manual'`,
+          'SELECT COUNT(*) AS c FROM contribution_source WHERE topology_id = ? AND attachment_id IS NULL',
         )
         .get(topo.id) as { c: number }
     ).c
@@ -80,25 +73,62 @@ describe('Manual = a uniform data source (its graph is its own contribution)', (
   })
 })
 
-describe('migrateIntrinsicToManual — re-home the legacy NULL-intrinsic into a Manual source', () => {
-  test('re-homes a NULL-intrinsic contribution into a real Manual data source', async () => {
+describe('Manual = an explicitly-added, ordinary hand-drawn source', () => {
+  test('writeManualSourceGraph requires the source be attached (no find-or-create)', async () => {
+    const topo = await svc.create({ name: 'ms1' })
+    await expect(svc.writeManualSourceGraph(topo.id, 'nope', g('x'))).rejects.toThrow()
+  })
+
+  test('an attached Manual source folds as an ordinary source contribution', async () => {
+    const topo = await svc.create({ name: 'ms2' })
+    const { dataSourceId } = await svc.attachManualSource(topo.id, 'topology')
+    await svc.writeManualSourceGraph(topo.id, dataSourceId, g('hand'))
+
+    // Its contribution is a normal source row: attachment_id SET.
+    const src = getDatabase()
+      .query(
+        'SELECT attachment_id FROM contribution_source WHERE topology_id = ? AND source_id = ?',
+      )
+      .get(topo.id, dataSourceId) as { attachment_id: string | null } | undefined
+    expect(src?.attachment_id).not.toBeNull()
+
+    expect(svc.readManualSourceGraph(topo.id, dataSourceId)?.nodes?.[0]?.id).toBe('hand')
+    const parsed = await svc.getParsed(topo.id)
+    expect(parsed?.graph.nodes.some((n) => n.identity?.mgmtIp === '10.0.0.1')).toBe(true)
+  })
+})
+
+describe('migrateManualToProject — fold legacy Manual sources into the overlay, retire them', () => {
+  test('moves Manual content into the project overlay and deletes the Manual data source', async () => {
     const topo = await svc.create({ name: 'mig' })
-    // Simulate a pre-correction DB: an authored graph stored as the NULL "intrinsic"
-    // contribution (source_id='intrinsic', attachment_id NULL), no Manual source.
-    const { ingestGraph } = await import('../../src/services/contribution-store.ts')
-    ingestGraph(topo.id, 'intrinsic', g('legacy'), { attachmentId: null }, getDatabase())
-    // (one-shot guard may be set from a prior test's run — clear it for this DB)
-    getDatabase().query("DELETE FROM settings WHERE key = 'intrinsic_to_manual_migrated'").run()
+    // Simulate a pre-refactor DB: operator content stored as a Manual data source's
+    // own contribution (attachment_id set).
+    const { dataSourceId } = await svc.attachManualSource(topo.id, 'topology')
+    await svc.writeManualSourceGraph(topo.id, dataSourceId, g('legacy'))
+    // Clear the one-shot guard for this DB.
+    getDatabase().query("DELETE FROM settings WHERE key = 'manual_to_project_migrated'").run()
 
-    await svc.migrateIntrinsicToManual()
+    await svc.migrateManualToProject()
 
-    // The NULL row is gone; the graph now lives in a real Manual source's contribution.
+    // The Manual data source is retired entirely.
+    expect(svc.findManualSourceId(topo.id)).toBeUndefined()
+    const dsLeft = getDatabase().query('SELECT 1 FROM data_sources WHERE id = ?').get(dataSourceId)
+    expect(dsLeft).toBeNull()
+
+    // Content now lives in the project overlay (attachment_id NULL).
+    const overlay = svc.readProjectOverlay(topo.id)
+    expect(overlay?.nodes?.[0]?.id).toBe('legacy')
     const nullRow = getDatabase()
       .query('SELECT 1 FROM contribution_source WHERE topology_id = ? AND attachment_id IS NULL')
       .get(topo.id)
-    expect(nullRow).toBeNull()
-    const manualId = svc.findManualSourceId(topo.id)
-    expect(manualId).toBeDefined()
-    expect(svc.readManualGraph(topo.id)?.nodes?.[0]?.id).toBe('legacy')
+    expect(nullRow).not.toBeNull()
+  })
+
+  test('also re-homes a leftover legacy NULL-intrinsic contribution', async () => {
+    const topo = await svc.create({ name: 'mig2' })
+    // A pre-correction NULL-intrinsic row IS already the overlay slot — it should
+    // simply remain readable as the overlay (no Manual source needed).
+    ingestGraph(topo.id, 'intrinsic', g('older'), { attachmentId: null }, getDatabase())
+    expect(svc.readProjectOverlay(topo.id)?.nodes?.[0]?.id).toBe('older')
   })
 })

--- a/apps/server/api/test/db/manual-source.test.ts
+++ b/apps/server/api/test/db/manual-source.test.ts
@@ -4,6 +4,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import type { NetworkGraph } from '@shumoku/core'
 import { ingestGraph } from '../../src/services/contribution-store.ts'
+import { ObservationsService } from '../../src/services/observations.ts'
 import { TopologyService } from '../../src/services/topology.ts'
 import { getDatabase, setupTempDb, type TempDb } from './helper.ts'
 
@@ -73,26 +74,31 @@ describe('project overlay = the project-owned contribution (attachment_id NULL)'
   })
 })
 
-describe('Manual = an explicitly-added, ordinary hand-drawn source', () => {
-  test('writeManualSourceGraph requires the source be attached (no find-or-create)', async () => {
-    const topo = await svc.create({ name: 'ms1' })
-    await expect(svc.writeManualSourceGraph(topo.id, 'nope', g('x'))).rejects.toThrow()
-  })
-
-  test('an attached Manual source folds as an ordinary source contribution', async () => {
+describe('Manual = an explicitly-added, ordinary hand-drawn source (same save path)', () => {
+  test('a Manual source save records an observation that materializes like any source', async () => {
     const topo = await svc.create({ name: 'ms2' })
     const { dataSourceId } = await svc.attachManualSource(topo.id, 'topology')
-    await svc.writeManualSourceGraph(topo.id, dataSourceId, g('hand'))
+    // The editor save goes through the SAME path as every source: record an
+    // observation (the human is the "scanner") → materializeContribution.
+    const observations = new ObservationsService()
+    await observations.record({
+      topologyId: topo.id,
+      sourceId: dataSourceId,
+      capturedAt: 1,
+      status: 'ok',
+      graph: g('hand'),
+    })
 
-    // Its contribution is a normal source row: attachment_id SET.
+    // Its contribution is a normal source row: attachment_id SET (no NULL overlay).
     const src = getDatabase()
       .query(
         'SELECT attachment_id FROM contribution_source WHERE topology_id = ? AND source_id = ?',
       )
       .get(topo.id, dataSourceId) as { attachment_id: string | null } | undefined
     expect(src?.attachment_id).not.toBeNull()
+    expect(svc.readProjectOverlay(topo.id)).toBeNull() // curation overlay untouched
 
-    expect(svc.readManualSourceGraph(topo.id, dataSourceId)?.nodes?.[0]?.id).toBe('hand')
+    // It folds into the resolved graph as an ordinary source.
     const parsed = await svc.getParsed(topo.id)
     expect(parsed?.graph.nodes.some((n) => n.identity?.mgmtIp === '10.0.0.1')).toBe(true)
   })
@@ -104,7 +110,12 @@ describe('migrateManualToProject — fold legacy Manual sources into the overlay
     // Simulate a pre-refactor DB: operator content stored as a Manual data source's
     // own contribution (attachment_id set).
     const { dataSourceId } = await svc.attachManualSource(topo.id, 'topology')
-    await svc.writeManualSourceGraph(topo.id, dataSourceId, g('legacy'))
+    const attachId = getDatabase()
+      .query(
+        "SELECT id FROM topology_data_sources WHERE topology_id = ? AND data_source_id = ? AND purpose = 'topology'",
+      )
+      .get(topo.id, dataSourceId) as { id: string }
+    ingestGraph(topo.id, dataSourceId, g('legacy'), { attachmentId: attachId.id }, getDatabase())
     // Clear the one-shot guard for this DB.
     getDatabase().query("DELETE FROM settings WHERE key = 'manual_to_project_migrated'").run()
 

--- a/apps/server/api/test/db/mapping-backfill.test.ts
+++ b/apps/server/api/test/db/mapping-backfill.test.ts
@@ -31,7 +31,7 @@ describe('mapping_json backfill (Phase 2 → bindings, then drop column)', () =>
       nodes: [{ id: 'a', label: 'A', shape: 'rect', identity: { mgmtIp: '10.0.0.1' } }],
       links: [],
     } as NetworkGraph
-    await svc.writeManualGraph(topo.id, graph)
+    await svc.writeProjectOverlay(topo.id, graph)
     attachSource(topo.id, insertDataSource('zabbix', 'zbx_bf'), 'metrics')
 
     const nodeAId = (await svc.getParsed(topo.id))?.graph.nodes.find(

--- a/apps/server/api/test/db/metrics-binding.test.ts
+++ b/apps/server/api/test/db/metrics-binding.test.ts
@@ -40,7 +40,7 @@ async function fixture(
     ],
     links: [{ id: 'L1', from: { node: 'a', port: 'pa' }, to: { node: 'b', port: 'pb' } }],
   } as NetworkGraph
-  await svc.writeManualGraph(topo.id, graph)
+  await svc.writeProjectOverlay(topo.id, graph)
   const metricsId = insertDataSource('zabbix', `zbx_${name}`)
   attachSource(topo.id, metricsId, 'metrics')
   const parsed = await svc.getParsed(topo.id)

--- a/apps/server/api/test/db/observed-contribution.test.ts
+++ b/apps/server/api/test/db/observed-contribution.test.ts
@@ -201,15 +201,16 @@ describe('Stage 3: observed graph materializes into the contribution store', () 
     expect(shared?.label).toBe('from-hi')
   })
 
-  test('the Manual source (fed as authored) is not double-counted as an observed snapshot', async () => {
+  test('the project overlay (fed as authored) is not double-counted as an observed snapshot', async () => {
     const topo = await svc.create({ name: 'manual' })
-    await svc.writeManualGraph(topo.id, graphWith('authored'))
-    const manualId = svc.findManualSourceId(topo.id)
+    await svc.writeProjectOverlay(topo.id, graphWith('authored'))
 
-    // Manual is a real source with its OWN contribution (attachment_id set).
-    expect(contribCount(topo.id, manualId ?? '')).toBe(1)
-    // But resolve folds it once (as the top-priority authored contribution); it's
-    // excluded from the observed-snapshot feed so the node never doubles.
+    // The overlay is the project-owned contribution: a single NULL-attachment row,
+    // and NO data source is created.
+    expect(svc.findManualSourceId(topo.id)).toBeUndefined()
+    expect(contribCount(topo.id, 'intrinsic')).toBe(1)
+    // resolve folds it once (as the top-priority authored contribution); the
+    // observed-snapshot feed only reads attachment_id IS NOT NULL, so it never doubles.
     const names = await sysNames(topo.id)
     expect(names.filter((n) => n === 'authored')).toEqual(['authored'])
   })

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -1,8 +1,31 @@
 # DB-native persistence — uniform contributions, one assertion bucket
 
-> Status: ADOPTED (corrected 2026-06-08). Design of record for the DB-native storage of
-> topology contributions. No backward compat. **Read the Canonical model + Drift warning
-> below before changing anything here.**
+> **⚠️ SUPERSEDED IN PART (2026-06, `refactor/project-overlay-contribution`) — read this first.**
+> The storage foundation (contribution_* tables, codec, resolve integration)
+> described below is CURRENT and correct. What changed: **where operator curation
+> lives.** This doc originally said "the operator's choices land on the Manual
+> source" and "an editor edit find-or-creates a `type='manual'` source." That is no
+> longer true and was the root of repeated confusion (Manual sources auto-spawning
+> and orphaning). The corrected model has **two kinds of contribution**:
+>
+> - **Source contributions** (`attachment_id` SET) — every attached source's graph,
+>   INCLUDING an explicitly-added hand-drawn `type='manual'` source. Manual is now
+>   reserved for hand-drawn topology only and folds like any ordinary source.
+> - **The project overlay** (`attachment_id` NULL, sentinel `source_id='intrinsic'`,
+>   one per topology via `idx_contrib_one_intrinsic`) — the operator's curation:
+>   exclusions, field overrides, metrics bindings, display settings. It is owned by
+>   the project, **not a data source**; writing it never creates/attaches anything.
+>   `resolve()` folds it as the top-priority `authored` input.
+>
+> Service surface: `readProjectOverlay`/`writeProjectOverlay` (curation, NULL slot)
+> vs `readManualSourceGraph`/`writeManualSourceGraph` (a hand-drawn source). The
+> one-shot `migrateManualToProject` moved legacy Manual content into the overlay and
+> retired the Manual data sources. `manualSourceId` on `Topology` was removed. Where
+> the text below says "Manual source" for curation, read "project overlay."
+>
+> Status: ADOPTED (corrected 2026-06-08; overlay split 2026-06). Design of record for
+> the DB-native storage of topology contributions. No backward compat. **Read the
+> Canonical model + Drift warning below before changing anything here.**
 >
 > **Shipped (factual timeline):**
 > - **#378** — `contribution_*` store + lossless codec (`ingestGraph`/`buildGraph`). The
@@ -307,14 +330,17 @@ A design doc is not a full DDL; the constraints are proven in code, not prose.
     authoritative, so don't delete — absence ≠ retraction);
   - `failed` → **no write** (keep the prior rows untouched).
   A boolean "did it succeed" is insufficient — these three behaviors need the status.
-- **An editor edit** = write the Manual source's contribution (`writeManualGraph`
-  find-or-creates the `type='manual'` source, then `ingestGraph` into ITS contribution). It
-  is a full per-source replace in one transaction (today's `ingestGraph` is replace-only;
-  incremental per-row writes are a future optimization, not required).
-- **Manual is a normal, visible, equal source** — it appears in the Sources list and is
-  edited as a source (`/datasources/:id` or the topology's Sources). It is NOT
-  auto-attached on topology create (no phantom spawn on a benign action); it appears the
-  first time you edit/override, exactly as #370 specified.
+- **A curation edit** (exclude/override/bind/edge-style) = write the **project
+  overlay** (`writeProjectOverlay` → `ingestGraph` into the NULL-attachment slot). It
+  never creates a data source. Full per-source replace in one transaction (today's
+  `ingestGraph` is replace-only; incremental per-row writes are a future optimization).
+- **A hand-drawn Manual source edit** = `writeManualSourceGraph` ingests into the
+  Manual source's own contribution (`attachment_id` set); the source must already be
+  attached (no find-or-create).
+- **Manual is a normal, visible, equal source** — it appears in the Sources list and
+  is edited as a source (`/datasources/:id` or the topology's Sources). It is added
+  explicitly for hand-drawing; curation does NOT spawn one (no phantom spawn, no
+  orphan). See the banner at the top of this doc for the corrected model.
 
 ## Round-trip codec (lossless `NetworkGraph` ↔ rows)
 
@@ -409,10 +435,11 @@ plan below, WAL, and batched transactions. It is bounded and infrequent, not a w
    like `backfillMetricsBindings`).
 
 Metrics bindings / access / policy / exclusions ride as `contribution_attachment` rows /
-`presence='hide'` element rows on the relevant source's contribution (the operator's
-choices land on the Manual source). The `resolve.ts` field-merge already branches on
-priority only; the residual `'intrinsic'` sentinel there is the contribution-identity label
-for the top-priority input (it is NOT a storage layer — see #382 / Provenance).
+`presence='hide'` element rows on the **project overlay** (`attachment_id` NULL,
+`source_id='intrinsic'`) — the operator's curation, owned by the project, not a Manual
+source. The `resolve.ts` field-merge branches on priority only; the `'intrinsic'`
+sentinel is both the overlay's `source_id` and resolve's top-priority contribution-identity
+label (it is NOT a storage layer — see #382 / Provenance).
 
 **Not pursued / deferred** (NOT part of this storage design — separate scope): incremental
 per-row editor writes (current editor save is a per-source replace); on-demand generated

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -10,15 +10,18 @@
 >
 > - **Source contributions** (`attachment_id` SET) — every attached source's graph,
 >   INCLUDING an explicitly-added hand-drawn `type='manual'` source. Manual is now
->   reserved for hand-drawn topology only and folds like any ordinary source.
+>   reserved for hand-drawn topology only and uses the **same save path as every
+>   source**: `ObservationsService.record()` → `materializeContribution` (the human
+>   is just the "scanner"). No manual-specific write method or `type='manual'` branch
+>   in the save/load/materialize path. It folds like any ordinary source.
 > - **The project overlay** (`attachment_id` NULL, sentinel `source_id='intrinsic'`,
 >   one per topology via `idx_contrib_one_intrinsic`) — the operator's curation:
 >   exclusions, field overrides, metrics bindings, display settings. It is owned by
 >   the project, **not a data source**; writing it never creates/attaches anything.
 >   `resolve()` folds it as the top-priority `authored` input.
 >
-> Service surface: `readProjectOverlay`/`writeProjectOverlay` (curation, NULL slot)
-> vs `readManualSourceGraph`/`writeManualSourceGraph` (a hand-drawn source). The
+> Service surface: `readProjectOverlay`/`writeProjectOverlay` (curation, NULL slot).
+> A hand-drawn source reads/writes via the ordinary observation endpoints. The
 > one-shot `migrateManualToProject` moved legacy Manual content into the overlay and
 > retired the Manual data sources. `manualSourceId` on `Topology` was removed. Where
 > the text below says "Manual source" for curation, read "project overlay."
@@ -334,9 +337,10 @@ A design doc is not a full DDL; the constraints are proven in code, not prose.
   overlay** (`writeProjectOverlay` → `ingestGraph` into the NULL-attachment slot). It
   never creates a data source. Full per-source replace in one transaction (today's
   `ingestGraph` is replace-only; incremental per-row writes are a future optimization).
-- **A hand-drawn Manual source edit** = `writeManualSourceGraph` ingests into the
-  Manual source's own contribution (`attachment_id` set); the source must already be
-  attached (no find-or-create).
+- **A hand-drawn Manual source edit** = the editor records an observation via the
+  ordinary `POST /:tid/sources/:sid/observation` endpoint, which materializes into
+  the Manual source's own contribution (`attachment_id` set) — the SAME path as any
+  source (no manual-specific method, no find-or-create).
 - **Manual is a normal, visible, equal source** — it appears in the Sources list and
   is edited as a source (`/datasources/:id` or the topology's Sources). It is added
   explicitly for hand-drawing; curation does NOT spawn one (no phantom spawn, no

--- a/apps/server/docs/design/manual-source-unification.md
+++ b/apps/server/docs/design/manual-source-unification.md
@@ -15,8 +15,9 @@
 > is now reserved for **explicitly-added hand-drawn graphs only**, folded like any
 > ordinary source. A one-shot startup migration (`migrateManualToProject`) moved
 > all legacy Manual content into each topology's overlay and retired the Manual
-> data sources. See `topology.ts` (`readProjectOverlay`/`writeProjectOverlay` vs
-> `writeManualSourceGraph`) and `db-native-persistence.md`.
+> data sources. A hand-drawn Manual source uses the SAME save path as every source
+> (record observation → materialize); only curation has a dedicated writer
+> (`writeProjectOverlay`). See `topology.ts` and `db-native-persistence.md`.
 >
 > --- original gap (kept for history) ---
 >

--- a/apps/server/docs/design/manual-source-unification.md
+++ b/apps/server/docs/design/manual-source-unification.md
@@ -3,33 +3,41 @@
 > Status: IMPLEMENTED — merged in PR #370. Issue: #368. Supersedes #361. Builds on the composition-store
 > refactor (`topology-composition-store.md`). No backward compatibility.
 
-> **Known gap — "uniform" is only surface-deep (discovered 2026-06, follow-up).**
-> This doc's claim that Manual is *fully* uniform holds for the **attach API,
-> `resolve()` merge, and Sources UI** — but the **authoring machinery still
-> special-cases Manual**, so the premise doesn't fully hold end-to-end:
+> **✅ Known gap RESOLVED (2026-06, `refactor/project-overlay-contribution`).**
+> The gap below — "uniform is only surface-deep because curation is funneled into
+> an auto-spawned Manual source" — is fixed. Operator curation (exclusions,
+> overrides, metrics bindings, display settings) now lands in the **project
+> overlay**: a project-owned contribution (`contribution_source.attachment_id`
+> NULL, sentinel `source_id='intrinsic'`, one per topology via
+> `idx_contrib_one_intrinsic`), folded by `resolve()` as the top-priority
+> `authored` input. It is **not a data source** — writing it never creates or
+> attaches anything (no phantom spawn, no orphan). A `type='manual'` data source
+> is now reserved for **explicitly-added hand-drawn graphs only**, folded like any
+> ordinary source. A one-shot startup migration (`migrateManualToProject`) moved
+> all legacy Manual content into each topology's overlay and retired the Manual
+> data sources. See `topology.ts` (`readProjectOverlay`/`writeProjectOverlay` vs
+> `writeManualSourceGraph`) and `db-native-persistence.md`.
 >
-> - Human edits (drawn graph, discovery-policy overrides, **metrics mapping**) are
+> --- original gap (kept for history) ---
+>
+> This doc's claim that Manual is *fully* uniform held for the **attach API,
+> `resolve()` merge, and Sources UI** — but the **authoring machinery special-cased
+> Manual**, so the premise didn't hold end-to-end:
+>
+> - Human edits (drawn graph, discovery-policy overrides, **metrics mapping**) were
 >   funneled into "the topology's Manual" via `ensureManualSource()`, which
->   **auto-creates a Manual** on the first edit. No other source type is ever
->   auto-created. So editing the *composed* result spawns a Manual source — which
->   reads as a leaky abstraction (the edit belongs to the project, not a source).
-> - The authored layer assumes **one canonical Manual per topology** (singular
->   `topologies.manual_source_id`; `findManualSourceId` does `… LIMIT 1`). The
->   removed-cardinality "attach many Manuals" is therefore only theoretical — the
->   authoring layer can meaningfully use just one.
-> - **Metrics mapping is not a DB relation.** `reconcileBindings` writes
->   `metrics-binding:${sourceId}` **attachments into the Manual's authored
->   NetworkGraph**, persisted as **JSON in `topology_observations.graph_json`**.
->   There is no binding/attachment table. It's identity-keyed but JSON-stored, not
->   relational.
+>   **auto-created a Manual** on the first edit. No other source type is ever
+>   auto-created. So editing the *composed* result spawned a Manual source — a
+>   leaky abstraction (the edit belongs to the project, not a source).
+> - The authored layer assumed **one canonical Manual per topology**.
+> - **Metrics mapping** wrote `metrics-binding:${sourceId}` attachments into the
+>   Manual's graph.
 >
-> These share one root cause: the authored layer (graph + overrides + mappings) is
-> modeled as "a JSON graph belonging to a Manual source." The target — separate
-> follow-up — is to make project-owned authored data (overrides + bindings) a
-> **DB relation** folded as top-priority in `resolve()`, leaving Manual as a
-> genuinely just-another-source used only for explicit hand-drawn topology. JSON
-> stays at the boundary; the base becomes relational. Not addressed in the
-> #362 PR (that PR only removed the stale one-per-topology *comments*).
+> These shared one root cause: the authored layer (graph + overrides + mappings) was
+> modeled as "a JSON graph belonging to a Manual source." The fix made project-owned
+> authored data a **DB relation** (the project overlay) folded as top-priority in
+> `resolve()`, leaving Manual as a genuinely just-another-source used only for
+> explicit hand-drawn topology.
 
 ## The problem
 

--- a/apps/server/docs/design/topology-foundation-open-questions.md
+++ b/apps/server/docs/design/topology-foundation-open-questions.md
@@ -52,7 +52,7 @@ v1 でどこまでやる？
 
 ### Q4. v1 で editor をどう扱うか  ✅ **回答済**: (a) v1 は editor 改修ゼロ
 
-editor (neted) は authored layer の編集器だが、observation モデルとの接点をどこまで持たせるか。
+editor (neted) は人の編集（project overlay / 手描きソース）の編集器だが、observation モデルとの接点をどこまで持たせるか。
 
 **選択肢**:
 - (a) **v1 は editor 改修ゼロ**。editor は NetworkGraph をそのまま編集（provenance は無視）（推奨）

--- a/apps/server/docs/design/topology-foundation-schema.md
+++ b/apps/server/docs/design/topology-foundation-schema.md
@@ -20,7 +20,8 @@
 // 新規: 観測モデル用の共通型
 export interface Provenance {
   /** 観測したソースの識別子。`Alert.source` と同じ規約で open string。
-   *  'authored' は人の編集（authored layer）を意味する予約語。 */
+   *  'intrinsic' は project overlay（人の編集＝最優先 contribution）の由来を示す
+   *  予約語。これは **provenance ラベル**であって別の保存層ではない。 */
   source: string
 
   /** resolver が埋める。snapshot 内では未設定でよい。 */

--- a/apps/server/docs/design/topology-foundation-source-attachment.md
+++ b/apps/server/docs/design/topology-foundation-source-attachment.md
@@ -82,7 +82,7 @@ protocol-probes の orchestrator が落とし所を見失う。
 | **Zabbix(topology+metrics) 単体** | Zabbix | Zabbix | 同上 |
 | Zabbix + Discovery | 両方 topology | Zabbix | 同上 + resolve() |
 | 全部 (NetBox + Zabbix + Discovery) | 3 つの topology source | Zabbix | 同上、merge は同じ機構 |
-| **authored + どれか** | authored layer + N sources | … | identity bind が要 |
+| **overlay + どれか** | project overlay + N sources | … | identity bind が要 |
 
 「全部入り」も「単体」もすべて同じ resolve() の入力本数違い、というのが**観測モデル
 の旨味**。code path が分岐しない。

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -473,6 +473,20 @@ export const topologies = {
   },
 
   /**
+   * Topology display settings (edge style / spline mode). Project-level
+   * presentation prefs stored on the project overlay — NOT a Manual source.
+   */
+  displaySettings: {
+    get: (id: string) =>
+      request<{ edgeStyle: string; splineMode: string }>(`/topologies/${id}/display-settings`),
+    set: (id: string, body: { edgeStyle: string; splineMode?: string }) =>
+      request<{ ok: boolean }>(`/topologies/${id}/display-settings`, {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      }),
+  },
+
+  /**
    * Discovery policy — per-node / per-subgraph / topology-default
    * overrides for what the scheduler does (auto / observe / disabled)
    * and how often. The server folds the inheritance chain and returns

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -278,7 +278,7 @@ export const topologies = {
       scoped(`/topologies/${id}/graph`, `/topologies/${id}/graph`),
     ),
 
-  /** Resolved graph = authored layer folded with latest snapshot per source. */
+  /** Resolved graph = project overlay folded with each attached source's contribution. */
   getResolved: (id: string) =>
     request<{ graph: NetworkGraph; snapshotCount: number }>(`/topologies/${id}/resolved`),
 

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -83,7 +83,6 @@ export interface DataSourceInput {
 export interface Topology {
   id: string
   name: string
-  manualSourceId?: string
   topologySourceId?: string
   metricsSourceId?: string
   mappingJson?: string

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -14,7 +14,7 @@
    * here, where the operator might be deciding whether the topology
    * is big enough to keep).
    */
-  import { PencilSimpleIcon, TrashIcon } from 'phosphor-svelte'
+  import { TrashIcon } from 'phosphor-svelte'
   import { onMount } from 'svelte'
   import { goto } from '$app/navigation'
   import { api } from '$lib/api'
@@ -42,54 +42,34 @@
 
   // Re-parse if the topology changes (e.g. user navigates [id]).
   $effect(() => {
-    if (ctx.topology?.manualSourceId) void parseGraphSettings()
+    if (ctx.topology?.id) void parseGraphSettings()
   })
 
   /**
-   * edgeStyle / splineMode live on `NetworkGraph.settings` inside the Manual
-   * source's authored graph, which is now a per-topology observation. Read the
-   * latest snapshot; write by recording a new observation.
+   * edgeStyle / splineMode are project-level display prefs, stored on the project
+   * overlay (NOT a Manual source). Read/write via the topology display-settings
+   * endpoint.
    */
   async function parseGraphSettings() {
-    if (!ctx.topology?.manualSourceId) return
+    if (!ctx.topology?.id) return
     try {
-      const snap = await api.topologies.sources.latestSnapshot(
-        ctx.topology.id,
-        ctx.topology.manualSourceId,
-      )
-      const settings = (
-        snap?.graph as { settings?: { edgeStyle?: string; splineMode?: string } } | null
-      )?.settings
-      edgeStyle = settings?.edgeStyle || 'orthogonal'
-      splineMode = settings?.splineMode || 'sloppy'
+      const settings = await api.topologies.displaySettings.get(ctx.topology.id)
+      edgeStyle = settings.edgeStyle || 'orthogonal'
+      splineMode = settings.splineMode || 'sloppy'
     } catch {
       // Use defaults
     }
   }
 
   async function updateEdgeStyle() {
-    if (!ctx.topology?.manualSourceId) return
+    if (!ctx.topology?.id) return
     savingEdgeStyle = true
     try {
-      const snap = await api.topologies.sources.latestSnapshot(
-        ctx.topology.id,
-        ctx.topology.manualSourceId,
-      )
-      const graph = (snap?.graph ?? { version: '1', nodes: [], links: [] }) as unknown as {
-        settings?: Record<string, unknown>
-        [k: string]: unknown
-      }
-      graph.settings = (graph.settings ?? {}) as Record<string, unknown>
-      graph.settings['edgeStyle'] = edgeStyle
-      if (edgeStyle === 'splines') graph.settings['splineMode'] = splineMode
-      else delete graph.settings['splineMode']
-      await api.topologies.sources.recordObservation(
-        ctx.topology.id,
-        ctx.topology.manualSourceId,
-        graph as unknown as Parameters<typeof api.topologies.sources.recordObservation>[2],
-        'ok',
-      )
-      // Edge-style change is a committed observation → re-render the diagram.
+      await api.topologies.displaySettings.set(ctx.topology.id, {
+        edgeStyle,
+        ...(edgeStyle === 'splines' ? { splineMode } : {}),
+      })
+      // Edge-style change is committed to the overlay → re-render the diagram.
       ctx.bumpRevision()
     } catch (e) {
       console.error('Failed to update edge style:', e)
@@ -247,24 +227,6 @@
       </label>
     </div>
   </div>
-
-  <!-- Actions -->
-  {#if ctx.topology?.manualSourceId}
-    <div class="card">
-      <div class="card-header">
-        <h2 class="font-medium text-theme-text-emphasis">Actions</h2>
-      </div>
-      <div class="card-body">
-        <a
-          href="/datasources/{ctx.topology.manualSourceId}"
-          class="btn btn-secondary w-full justify-center"
-        >
-          <PencilSimpleIcon size={16} class="mr-2" />
-          Edit Manual content
-        </a>
-      </div>
-    </div>
-  {/if}
 
   <!-- Danger zone -->
   <div class="card border-danger/30">

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -381,16 +381,15 @@ export function specDeviceType(spec: NodeSpec | undefined): DeviceType | undefin
  *                  ageing, no drift noise, no stale alerts. Use for
  *                  vendor-managed gear, decommissioned hardware, lab
  *                  segments you want quiet. If you want the node to
- *                  keep displaying with curated values, add it to a
- *                  Manual source — the authored layer carries through
- *                  the resolver regardless of mode.
+ *                  keep displaying with curated values, curate it — the
+ *                  project overlay's overrides carry through the resolver
+ *                  regardless of discovery mode.
  *
  * History: an earlier revision had a fourth mode `manual-only` meaning
- * "authored content is authoritative". That collapses onto `disabled`
- * once you realise the authored layer is independent of discovery
- * mode — the resolver always folds it in. Keeping `manual-only`
- * around invited an impossible state (the mode is meaningless without
- * a Manual source attached).
+ * "the operator's content is authoritative". That collapses onto
+ * `disabled` once you realise the project overlay (the top-priority
+ * contribution) is independent of discovery mode — the resolver always
+ * folds it in. Keeping `manual-only` around invited an impossible state.
  */
 export type DiscoveryMode = 'auto' | 'observe' | 'disabled'
 


### PR DESCRIPTION
## What & why

Realizes the long-documented target (`manual-source-unification.md` Known-gap) that was never implemented and caused repeated すれ違い: **operator curation is project-owned; a Manual data source is just-another-source for explicit hand-drawn topology.**

Root cause of the drift: #370 deferred the project-owned-overrides target; db-native (#378+) made storage relational but kept curation on a Manual source; #383-385 tried to separate it but botched scope and were reverted; #387 over-reverted, collapsing both hand-drawn graphs AND curation back onto an auto-spawned Manual source (which spawned/orphaned Manual sources and made curation read as "editing a Manual source").

## Model (no schema migration — uses existing `contribution_*` slots)

| | `attachment_id` SET | `attachment_id` NULL |
|---|---|---|
| **kind** | source contribution | **project overlay** (one per topology, `idx_contrib_one_intrinsic`) |
| **content** | zabbix/netbox + explicitly-added hand-drawn Manual | exclusions / overrides / metrics bindings / display settings |
| **owner** | a data source | the project (not a data source) |
| **resolve** | folded by priority | top-priority `authored` input |

A hand-drawn Manual source uses the **same save path as every source** (`record observation → materializeContribution`); there is no `type==='manual'` branch in the save/load/materialize/resolve path.

## Changes
- **Backend**: `readProjectOverlay`/`writeProjectOverlay` (NULL slot) for curation; removed `ensureManualSource` (auto-create), `write/readManualGraph`, `write/readManualSourceGraph`, `manualAttachId`, `isManualForTopology`, `manualSourceId`. `materializeContribution` + observation API drop their manual branches. `migrateManualToProject` (startup, guarded) folds legacy Manual content into the overlay and retires Manual data sources (incl. orphans). Edge style → `GET/PUT /topologies/:id/display-settings`.
- **Frontend**: removed the privileged "Edit Manual content" Settings card; edge style reads/writes the overlay.
- **Docs/comments**: purged recurrence-causing "authored/Manual layer" wording across design docs + code; kept resolve's `authored` param + `'intrinsic'` provenance sentinel (legitimate).

## Verification
- Migration (live): moved test5's 138-elem Manual contribution into the overlay, retired 2 Manual sources; resolved graph unchanged (100 nodes / 132 edges).
- Live: adding a Manual source + saving via the normal `/observation` endpoint folds into resolved (100→101→100), loads back via latest-snapshot, never touches the overlay; curation (hide/edge-style) writes the overlay and never spawns a Manual source.
- API 55/55 tests pass; typecheck + biome + svelte-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
