### PR TITLE
feat(server): hide-disconnected toggle + topology-source-modes design doc

### DIFF
--- a/apps/server/api/src/api/observations.ts
+++ b/apps/server/api/src/api/observations.ts
@@ -226,13 +226,18 @@ export function createObservationsRoute(): Hono {
     return c.json({
       edgeStyle: settings['edgeStyle'] ?? 'orthogonal',
       splineMode: settings['splineMode'] ?? 'sloppy',
+      hideDisconnected: settings['hideDisconnected'] ?? false,
     })
   })
 
   app.put('/:id/display-settings', async (c) => {
     const id = c.req.param('id')
     try {
-      const body = await c.req.json<{ edgeStyle?: string; splineMode?: string }>()
+      const body = await c.req.json<{
+        edgeStyle?: string
+        splineMode?: string
+        hideDisconnected?: boolean
+      }>()
       const svc = getTopologyService()
       const overlay: NetworkGraph = svc.readProjectOverlay(id) ?? {
         version: '1',
@@ -242,7 +247,8 @@ export function createObservationsRoute(): Hono {
       const settings = { ...(overlay.settings ?? {}) } as Record<string, unknown>
       if (body.edgeStyle !== undefined) settings['edgeStyle'] = body.edgeStyle
       if (body.edgeStyle === 'splines') settings['splineMode'] = body.splineMode ?? 'sloppy'
-      else delete settings['splineMode']
+      else if (body.edgeStyle !== undefined) delete settings['splineMode']
+      if (body.hideDisconnected !== undefined) settings['hideDisconnected'] = body.hideDisconnected
       await svc.writeProjectOverlay(id, { ...overlay, settings })
       return c.json({ ok: true })
     } catch (err) {

--- a/apps/server/api/src/services/display-filter.test.ts
+++ b/apps/server/api/src/services/display-filter.test.ts
@@ -1,0 +1,49 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { NetworkGraph } from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import { filterDisconnected } from './display-filter.js'
+
+function node(id: string, state: 'discovered-only' | 'intrinsic-only' | 'confirmed') {
+  return { id, label: id, provenance: { source: 's', state } }
+}
+
+describe('filterDisconnected', () => {
+  it('drops degree-0 discovered-only nodes, keeps linked ones', () => {
+    const g: NetworkGraph = {
+      version: '1',
+      nodes: [
+        node('a', 'discovered-only'),
+        node('b', 'discovered-only'),
+        node('orphan', 'discovered-only'),
+      ],
+      links: [{ id: 'l0', from: { node: 'a' }, to: { node: 'b' } }],
+    }
+    const out = filterDisconnected(g)
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('keeps operator-placed (intrinsic) orphans even at degree 0', () => {
+    const g: NetworkGraph = {
+      version: '1',
+      nodes: [
+        node('placed', 'intrinsic-only'),
+        node('confirmed', 'confirmed'),
+        node('junk', 'discovered-only'),
+      ],
+      links: [],
+    }
+    const out = filterDisconnected(g)
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(['confirmed', 'placed'])
+  })
+
+  it('returns the same reference when nothing is dropped (no-op)', () => {
+    const g: NetworkGraph = {
+      version: '1',
+      nodes: [node('a', 'discovered-only'), node('b', 'discovered-only')],
+      links: [{ id: 'l0', from: { node: 'a' }, to: { node: 'b' } }],
+    }
+    expect(filterDisconnected(g)).toBe(g)
+  })
+})

--- a/apps/server/api/src/services/display-filter.ts
+++ b/apps/server/api/src/services/display-filter.ts
@@ -1,0 +1,42 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Post-resolve display filters.
+ *
+ * These run on the FULLY-RESOLVED graph (after `resolve()` has folded every
+ * source + the project overlay) — never on a single source's contribution.
+ * Degree is only defined on the merged graph: a node link-less in one source
+ * may be linked by another, so a per-source evaluation would wrongly drop it.
+ */
+
+import type { NetworkGraph } from '@shumoku/core'
+
+/**
+ * Drop nodes that have no incident link (degree 0), EXCEPT operator-placed
+ * (intrinsic) nodes — an orphan the human put there on purpose stays. Only
+ * auto-discovered orphans (`provenance.state === 'discovered-only'`) are hidden.
+ *
+ * Pure: returns a new graph; never mutates the input. A degree-0 node has no
+ * links by definition, so no link pruning is needed.
+ */
+export function filterDisconnected(graph: NetworkGraph): NetworkGraph {
+  const degree = new Map<string, number>()
+  for (const link of graph.links) {
+    const from = link.from?.node
+    const to = link.to?.node
+    if (from) degree.set(from, (degree.get(from) ?? 0) + 1)
+    if (to) degree.set(to, (degree.get(to) ?? 0) + 1)
+  }
+
+  const nodes = graph.nodes.filter((n) => {
+    if ((degree.get(n.id) ?? 0) > 0) return true
+    // Degree 0: keep only if the operator engaged with it. A purely
+    // auto-discovered orphan is dropped; anything the human placed/touched
+    // (intrinsic-only / confirmed) stays.
+    return n.provenance?.state !== 'discovered-only'
+  })
+
+  if (nodes.length === graph.nodes.length) return graph
+  return { ...graph, nodes }
+}

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -53,6 +53,7 @@ import { collectIconUrls, resolveAllIconDimensions } from '@shumoku/renderer-svg
 import { generateId, getDatabase, timestamp } from '../db/index.js'
 import type { MetricsData, MetricsMapping, Topology, TopologyInput } from '../types.js'
 import { buildGraph, ingestGraph } from './contribution-store.js'
+import { filterDisconnected } from './display-filter.js'
 
 /**
  * Sentinel `source_id` of the **project overlay** — the project's own
@@ -1036,7 +1037,12 @@ export class TopologyService {
       priorityBySource.set(tds.dataSourceId, tds.priority)
     }
     const snapshots = this.readObservedSnapshots(topology.id, priorityBySource)
-    const graph = resolveObservations(authored, snapshots)
+    const resolvedGraph = resolveObservations(authored, snapshots)
+    // Post-resolve display filter (project-level pref on the overlay settings).
+    // Runs on the fully-merged graph — never per-source.
+    const graph = authored.settings?.hideDisconnected
+      ? filterDisconnected(resolvedGraph)
+      : resolvedGraph
 
     // Resolve icon dimensions for URL icons (used by renderer for
     // aspect-preserving sizing).

--- a/apps/server/docs/design/topology-source-modes.md
+++ b/apps/server/docs/design/topology-source-modes.md
@@ -1,0 +1,154 @@
+# Topology Source Modes, Region Scope & Presence Unification
+
+Status: design (2026-06-08). Implementation split into 5 PRs (see end).
+
+Builds on [topology-source-priority-merge.md](./topology-source-priority-merge.md)
+(all-sources-equal field merge), [db-native-persistence.md](./db-native-persistence.md)
+(contribution store), and [topology-composition-store.md](./topology-composition-store.md).
+
+## Motivation
+
+A topology is composed from N sources (`topology_data_sources`) plus the project
+overlay, folded at read time by `resolve()`. Today every source contributes the
+same way: its nodes are asserted present, its links pass straight through, and the
+union of everything is shown. Operators need finer control over *how each source
+participates*:
+
+- **A source should be able to define a scope** ("this NetBox feed owns the DC
+  region; outside it, ignore what it says") and let other sources fill gaps
+  **within** that scope.
+- **A source should be able to enrich without asserting existence** (a metrics or
+  dependency feed that knows facts about devices but should not, by itself, make
+  devices appear).
+- **Disconnected nodes** (a Zabbix host with no LLDP neighbor) should be hideable.
+- **The same physical link** observed by two sources should resolve to one edge.
+
+These were running as separate threads; this doc separates them into five
+orthogonal axes and specifies each.
+
+## The five axes
+
+| Axis | Concern | Touches `resolve()` |
+|------|---------|---------------------|
+| A. Link-layer merge | Cross-source link dedup + field merge | yes |
+| B. Presence unification | scoop / anchor / hide as one resolved claim | yes |
+| C. Region scope | Subgraph becomes a first-class identity-bearing region | yes |
+| D. Composition modes | Per-source role wiring (Scoping / Additive / Enrichment) | yes |
+| E. hideDisconnected | Post-resolve display filter | no |
+
+## Core model decisions
+
+### Presence is one ternary claim (Axis B)
+
+Every contribution makes, per element, one of three claims:
+
+- **scoop** (`present`) — positive: "this element exists." (Default.)
+- **hide** — negative: "this element should not exist." (Stored as `exclusions`.)
+- **anchor** (`NULL` presence) — *no* claim: carries identity / fields /
+  attachments only, to ride onto an element someone else scoops.
+
+Resolution (per identity cluster):
+
+1. If the highest-priority **claim** is `hide` → cluster is dropped.
+2. Else if any member is a **scoop** → present.
+3. Else (only **anchors**) → dropped.
+
+Anchors contribute identity, fields, metadata and attachments to the cluster they
+land on, but never confer presence. This is what makes "the project overlay
+attaches a metrics-binding to a node" safe: the overlay node is an anchor, so when
+every source stops observing the device, the binding evaporates with it instead of
+leaving a ghost node. `anchor` is the missing third state — the schema reserved
+`presence NULL` for it; the codec just never produced it before.
+
+There is **no human/machine layer**: "the project's edit wins" is still just
+"intrinsic has `+Infinity` priority." Presence folds through the same priority
+machinery as every other field.
+
+### Regions are first-class identity-bearing entities (Axis C)
+
+A subgraph stops being a pure visual container. It gains, like a Node:
+
+- `identity` — a multi-key identity (`{ name?, keys: Record<ns,value> }`, e.g.
+  `zabbix-hostgroup:98`, `netbox-site:backbone`, `name:backbone`). Regions from
+  different sources merge by **any-key match**, exactly like node clustering. This
+  also fixes the old "subgraphs can't merge / empty boxes from the losing source"
+  problem.
+- `membership` — zero or more criteria (`{ attr, op, value }` over
+  `hostgroup | subnet | name | tag | …`). A node belongs to a region if its
+  explicit `parent` resolves to that region's cluster **or** its attributes match
+  any membership criterion.
+
+This is why a lower source can fill a gap *within* a region: membership is a
+**predicate**, not the enumerated set the upper source happened to scoop. A device
+the upper source missed still lands in the region if it matches a criterion.
+
+**Bootstrap caveat (same as node identity):** cross-source region merge needs a
+*shared* key. Either sources emit a normalized key (both Zabbix and NetBox emit
+`name:backbone`) or the operator maps them on the overlay. There is no magic that
+equates `zabbix-hostgroup:98` with `netbox-site:backbone` without one of those.
+
+Regions nest via `parent` and merge via `identity` — both supported from the start.
+
+### Composition modes are per-source, two independent knobs (Axis D)
+
+On the **attachment row** (`topology_data_sources`, not `data_sources` — the same
+source can play different roles in different topologies):
+
+- `node_contribution`: `scoop` (default) | `anchor`
+- `link_contribution`: `add` (default) | `update`
+- `scope_role`: `NULL` (default) | `scoping`
+
+Node and link knobs are **independent** (decided): an Enrichment source can be
+`node_contribution=anchor` (adds no devices) yet `link_contribution=add` (asserts a
+new dependency between two already-present devices) — the "knows dependencies, not
+devices" case.
+
+UI presents **role presets** over these knobs; raw knobs are an advanced surface.
+
+| Preset | node | link | scope_role | meaning |
+|--------|------|------|-----------|---------|
+| **Additive** (default) | scoop | add | NULL | adds nodes+links, unions like today |
+| **Scoping** | scoop | add | scoping | defines a closed region; out-of-region clusters dropped |
+| **Enrichment** | anchor | update | NULL | fills fields of existing entities only |
+
+Default on attach is **Additive** — unconstrained, preserves current union
+behavior. Scoping / Enrichment are explicit opt-in.
+
+Resolve wiring:
+
+- `node_contribution=anchor` → the source's nodes are folded as `presence:'anchor'`
+  (Axis B handles the rest).
+- `link_contribution=update` → the source's links contribute fields to an existing
+  link cluster but never create a new link cluster.
+- `scope_role=scoping` → the source's regions are closed: any cluster that is not a
+  member of some closed region is dropped (inclusion predicate — the sibling of the
+  existing `isClusterExcluded` exclusion filter).
+
+### hideDisconnected is post-resolve display (Axis E)
+
+`overlay.settings.hideDisconnected: boolean`. Evaluated **after** resolve, on the
+fully-merged in-scope graph — never per-source (degree is only defined on the
+merged graph; another in-region source may supply the link). Discovered-only
+degree-0 nodes are dropped; nodes carrying an intrinsic (operator-placed)
+contribution are kept even at degree 0.
+
+## Invariants / ratified defaults
+
+- Explicit `parent` outranks membership-criteria match.
+- A node matching multiple regions resolves by priority, then specificity.
+- Link field merge uses the same priority rule (`priority desc, capturedAt desc`)
+  as nodes.
+- Naming: the per-source role is `compositionRole` / the columns above — **not**
+  `mode` (which collides with `DiscoveryMode = auto|observe|disabled`).
+
+## PR breakdown
+
+`resolve.ts`-touching PRs are serialized to avoid merge conflicts.
+
+- **PR1 — E (hideDisconnected).** Independent (no resolve internals). First.
+- **PR2 — B (presence unify + anchor).** Foundation; fixes binding-ghost.
+- **PR3 — A (link dedup).**
+- **PR4 — C (region as first-class entity).**
+- **PR5 — D (composition modes).** Migration `018` (next free number; 017 latest).
+  Needs B + C. May split 5a (schema/types/service/API/UI, behavior still Additive)
+  / 5b (resolve wiring).

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -478,8 +478,13 @@ export const topologies = {
    */
   displaySettings: {
     get: (id: string) =>
-      request<{ edgeStyle: string; splineMode: string }>(`/topologies/${id}/display-settings`),
-    set: (id: string, body: { edgeStyle: string; splineMode?: string }) =>
+      request<{ edgeStyle: string; splineMode: string; hideDisconnected: boolean }>(
+        `/topologies/${id}/display-settings`,
+      ),
+    set: (
+      id: string,
+      body: { edgeStyle?: string; splineMode?: string; hideDisconnected?: boolean },
+    ) =>
       request<{ ok: boolean }>(`/topologies/${id}/display-settings`, {
         method: 'PUT',
         body: JSON.stringify(body),

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -33,6 +33,7 @@
 
   let edgeStyle = $state('orthogonal')
   let splineMode = $state('sloppy')
+  let hideDisconnected = $state(false)
   let savingEdgeStyle = $state(false)
   let deleting = $state(false)
 
@@ -56,8 +57,21 @@
       const settings = await api.topologies.displaySettings.get(ctx.topology.id)
       edgeStyle = settings.edgeStyle || 'orthogonal'
       splineMode = settings.splineMode || 'sloppy'
+      hideDisconnected = settings.hideDisconnected ?? false
     } catch {
       // Use defaults
+    }
+  }
+
+  async function updateHideDisconnected(value: boolean) {
+    if (!ctx.topology?.id) return
+    hideDisconnected = value
+    try {
+      await api.topologies.displaySettings.set(ctx.topology.id, { hideDisconnected: value })
+      // Changes the resolved node set → re-render the diagram.
+      ctx.bumpRevision()
+    } catch (e) {
+      console.error('Failed to update hideDisconnected:', e)
     }
   }
 
@@ -158,6 +172,21 @@
           </select>
         </div>
       {/if}
+
+      <label class="flex items-center justify-between cursor-pointer">
+        <div>
+          <p class="text-sm text-theme-text">Hide Disconnected Nodes</p>
+          <p class="text-xs text-theme-text-muted">
+            Drop auto-discovered nodes that have no links
+          </p>
+        </div>
+        <input
+          type="checkbox"
+          class="toggle"
+          checked={hideDisconnected}
+          onchange={(e) => updateHideDisconnected(e.currentTarget.checked)}
+        >
+      </label>
 
       <hr class="border-theme-border">
 

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -1227,6 +1227,14 @@ export interface GraphSettings {
    * Legend configuration
    */
   legend?: boolean | LegendSettings
+
+  /**
+   * Hide nodes that have no links (degree 0) in the RESOLVED graph.
+   * A project-level display preference: evaluated after resolve() has folded
+   * every source, so a node linked by any source is kept. Operator-placed
+   * (intrinsic) nodes are never hidden — only auto-discovered orphans.
+   */
+  hideDisconnected?: boolean
 }
 
 /**


### PR DESCRIPTION
## What

First slice of the Topology Source composition redesign (see the new `apps/server/docs/design/topology-source-modes.md`).

- **Design doc**: the 5-axis plan — presence unification (scoop/anchor/hide), link-layer dedup, region-as-first-class-entity, per-source composition modes, and this `hideDisconnected` toggle.
- **hideDisconnected (Axis E)**: a project-level display preference that drops auto-discovered degree-0 nodes from the **resolved** graph.

## Behavior

- Evaluated **post-resolve** on the fully-merged graph in `parseTopology` — never per-source (degree is only defined after every source is folded; another source may supply the link).
- Operator-placed (intrinsic) orphans are kept; only `discovered-only` degree-0 nodes are dropped.
- Stored on the project overlay `settings.hideDisconnected`; toggling it bumps `composition_revision` so the resolved-graph cache rebuilds.
- New toggle on the topology Settings page.

## Tests

`apps/server/api/src/services/display-filter.test.ts` — drops discovered orphans, keeps intrinsic orphans + linked nodes, no-op identity when nothing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
