### PR TITLE
feat(core,server): presence anchor — overlay bindings no longer leave ghosts

### DIFF
--- a/apps/server/api/src/services/contribution-store.ts
+++ b/apps/server/api/src/services/contribution-store.ts
@@ -239,13 +239,17 @@ export function ingestGraph(
         'attachments',
         'suppressedAttachments',
         'ports',
+        // presence is promoted to the column (scoop→'present', anchor→NULL).
+        'presence',
         // resolve()-derived annotations — never an input, so never stored (a
         // contribution is an input). Re-derived on every resolve. Storing a
         // stale one (e.g. an old `provenance.source`) would be a latent footgun.
         'provenance',
         'fieldSources',
       ])
-      const eid = elementId(node.id, 'node', node.parent ?? null, 'present', nodePayload)
+      // scoop (default / omitted) → 'present'; anchor → NULL (makes no presence claim).
+      const presence = node.presence === 'anchor' ? null : 'present'
+      const eid = elementId(node.id, 'node', node.parent ?? null, presence, nodePayload)
       writeIdentity(eid, node.identity)
       writeAttachments(eid, 'node', node.attachments)
       writeSuppressions(eid, 'node', node.suppressedAttachments)
@@ -441,6 +445,9 @@ export function buildGraph(
     } else if (el.kind === 'node') {
       const node: Node = { id: el.local_id, ...payload } as Node
       if (el.parent_local_id) node.parent = el.parent_local_id
+      // NULL presence = anchor (no presence claim). 'present' = scoop (default;
+      // left unset so it round-trips with nodes that never carried `presence`).
+      if (el.presence === null) node.presence = 'anchor'
       const identity = identityFromRows(identityByElement.get(el.id) ?? [])
       if (identity) node.identity = identity
       const a = attsOf(el.id)

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -178,8 +178,10 @@ function identitiesMatch(a: Identity | undefined, b: Identity | undefined): bool
 function isPureEmptyOverlay(n: Node): boolean {
   const label = Array.isArray(n.label) ? n.label.join('') : (n.label ?? '')
   // Allow-list the fields a bare binding overlay legitimately carries; any other
-  // populated property keeps the node.
-  const ALLOWED = new Set(['id', 'label', 'identity'])
+  // populated property keeps the node. `presence` is here so a binding-anchor
+  // node (which we tag `presence:'anchor'`) is still droppable once its binding
+  // is cleared — otherwise the leftover `presence` would pin an empty row.
+  const ALLOWED = new Set(['id', 'label', 'identity', 'presence'])
   for (const [k, v] of Object.entries(n)) {
     if (ALLOWED.has(k)) continue
     if (Array.isArray(v) ? v.length > 0 : v !== undefined && v !== null) return false
@@ -700,9 +702,13 @@ export class TopologyService {
         if (!cur) continue
         nodes[idx] = { ...cur, attachments: [...withoutKey(cur.attachments), attachment] }
       } else {
+        // Binding-only node: makes NO presence claim of its own — it's an
+        // anchor for the binding. It folds onto whatever source scoops this
+        // identity, and evaporates (no ghost) once none do.
         nodes.push({
           id: b.nodeId,
           label: '',
+          presence: 'anchor',
           ...(b.identity ? { identity: b.identity } : {}),
           attachments: [attachment],
         })
@@ -720,9 +726,12 @@ export class TopologyService {
       }
       let idx = findNode(b.nodeIdentity, b.monitoredNodeId)
       if (idx < 0) {
+        // Anchor: the monitored node is created only to host the port binding;
+        // it asserts no existence of its own (see the node-binding branch).
         nodes.push({
           id: b.monitoredNodeId,
           label: '',
+          presence: 'anchor',
           ...(b.nodeIdentity ? { identity: b.nodeIdentity } : {}),
           ports: [],
         })

--- a/apps/server/api/test/db/contribution-codec.test.ts
+++ b/apps/server/api/test/db/contribution-codec.test.ts
@@ -181,4 +181,25 @@ describe('contribution codec — round-trip', () => {
       attachments: [{ kind: 'access', protocol: 'snmp', community: 'topo-default' }],
     } as NetworkGraph)
   })
+
+  test('presence anchor round-trips (NULL column); scoop default is absent', () => {
+    expectLossless({
+      version: '1',
+      name: 'presence',
+      nodes: [
+        // anchor: binding-only node, no presence claim. Round-trips via NULL column.
+        {
+          id: 'a1',
+          label: '',
+          presence: 'anchor',
+          identity: { mgmtIp: '10.0.0.1' },
+          attachments: [{ kind: 'metrics-binding', sourceId: 'zbx', hostId: '7' }],
+        },
+        // scoop is the default → stored as 'present', rebuilt WITHOUT a presence
+        // field (canon: a node that never carried `presence` stays that way).
+        { id: 'n2', label: 'N2', identity: { mgmtIp: '10.0.0.2' } },
+      ],
+      links: [],
+    } as NetworkGraph)
+  })
 })

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -523,6 +523,18 @@ export interface Node {
   parent?: string
 
   /**
+   * Presence claim this contribution makes about the node (resolve input only):
+   * - `'scoop'` (default, also when omitted) — positive: "this node exists".
+   * - `'anchor'` — NO presence claim: the node carries identity / attachments
+   *   only, to ride onto a node some OTHER contribution scoops. An anchor-only
+   *   cluster is dropped by resolve(), so e.g. an overlay node that merely holds
+   *   a metrics-binding does not keep a ghost alive once every source stops
+   *   observing the device. (`'hide'` is expressed via `NetworkGraph.exclusions`,
+   *   not here.)
+   */
+  presence?: 'scoop' | 'anchor'
+
+  /**
    * Rank/layer for horizontal alignment
    * Nodes with the same rank value will be placed on the same horizontal level
    */

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -60,6 +60,90 @@ describe('resolve()', () => {
     })
   })
 
+  describe('presence / anchor', () => {
+    it('anchor-only cluster (binding-only overlay, no source) is dropped', () => {
+      const intrinsic: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [
+          {
+            id: 'n1',
+            label: '',
+            presence: 'anchor',
+            identity: { mgmtIp: '10.0.0.1' },
+            attachments: [{ kind: 'metrics-binding', sourceId: 'zbx', hostId: '7' }],
+          },
+        ],
+      }
+      const out = resolve(intrinsic, [])
+      expect(out.nodes).toHaveLength(0)
+    })
+
+    it('anchor + observed scoop → present, and the anchor attachment folds on', () => {
+      const intrinsic: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [
+          {
+            id: 'n1',
+            label: '',
+            presence: 'anchor',
+            identity: { mgmtIp: '10.0.0.1' },
+            attachments: [{ kind: 'metrics-binding', sourceId: 'zbx', hostId: '7' }],
+          },
+        ],
+      }
+      const snap: SnapshotEntry = {
+        sourceId: 'zbx',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [{ id: 's1', label: 'core', identity: { mgmtIp: '10.0.0.1' } }],
+        },
+      }
+      const out = resolve(intrinsic, [snap])
+      expect(out.nodes).toHaveLength(1)
+      expect(out.nodes[0]?.label).toBe('core')
+      expect(out.nodes[0]?.attachments).toEqual([
+        expect.objectContaining({ kind: 'metrics-binding', sourceId: 'zbx', hostId: '7' }),
+      ])
+    })
+
+    it('source retraction drops the node even though an anchor binding remains', () => {
+      // Same overlay anchor as above, but the source no longer observes the
+      // device (empty snapshot) → the cluster is anchor-only → gone (no ghost).
+      const intrinsic: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [
+          {
+            id: 'n1',
+            label: '',
+            presence: 'anchor',
+            identity: { mgmtIp: '10.0.0.1' },
+            attachments: [{ kind: 'metrics-binding', sourceId: 'zbx', hostId: '7' }],
+          },
+        ],
+      }
+      const empty: SnapshotEntry = {
+        sourceId: 'zbx',
+        capturedAt: 2000,
+        status: 'ok',
+        graph: emptyGraph(),
+      }
+      const out = resolve(intrinsic, [empty])
+      expect(out.nodes).toHaveLength(0)
+    })
+
+    it('a plain intrinsic node (scoop, no presence field) still persists unobserved', () => {
+      const intrinsic: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [{ id: 'n1', label: 'R1', identity: { mgmtIp: '10.0.0.9' } }],
+      }
+      const out = resolve(intrinsic, [])
+      expect(out.nodes).toHaveLength(1)
+      expect(out.nodes[0]?.provenance?.state).toBe('intrinsic-only')
+    })
+  })
+
   describe('discovered-only', () => {
     it('node present only in 1 snapshot → state = discovered-only', () => {
       const snap: SnapshotEntry = {

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -104,6 +104,19 @@ export function resolve(
   // 2. Build node clusters by identity keys
   const allClusters = clusterNodes(contributions)
 
+  // 2a. Presence. A cluster exists only if some contribution SCOOPS it
+  //     (`presence !== 'anchor'`, i.e. makes a positive existence claim).
+  //     Anchor-only clusters make no presence claim — they carry identity /
+  //     attachments to ride onto a node someone else scoops — so they are
+  //     dropped. This is what lets an overlay node that merely holds a
+  //     metrics-binding evaporate once every source stops observing the
+  //     device, instead of lingering as a ghost. Anchor members still
+  //     contribute their identity / fields / attachments to clusters that DO
+  //     have a scoop member (the fold below reads every member).
+  const presentClusters = allClusters.filter((c) =>
+    c.members.some((m) => m.node.presence !== 'anchor'),
+  )
+
   // 2b. Drop hidden clusters. A cluster is hidden when its merged identity
   //     matches any exclusion (by mgmtIp / chassisId / sysName). Identity-keyed
   //     so a hide survives re-scans that re-number ephemeral node ids. Dropping
@@ -111,8 +124,8 @@ export function resolve(
   const exclusions = authored.exclusions ?? []
   const nodeClusters =
     exclusions.length > 0
-      ? allClusters.filter((c) => !isClusterExcluded(c, exclusions))
-      : allClusters
+      ? presentClusters.filter((c) => !isClusterExcluded(c, exclusions))
+      : presentClusters
 
   // 3. For each cluster, fold into a single resolved Node
   const resolvedNodes: Node[] = []


### PR DESCRIPTION
## What

Axis B of the [topology-source-modes](../blob/main/apps/server/docs/design/topology-source-modes.md) plan: the third presence state, **anchor**.

Every contribution now makes one of three claims per node:

- **scoop** (default / omitted) — "this node exists"
- **anchor** — *no* presence claim; carries identity / attachments only, to ride onto a node some other contribution scoops
- **hide** — via `NetworkGraph.exclusions` (unchanged)

`resolve()` drops **anchor-only** clusters: a node exists iff some contribution scoops it. Anchor members still contribute identity/fields/attachments to a cluster that has a scoop member (the fold reads every member).

## Why (the bug it fixes)

An overlay node that only holds a `metrics-binding` used to be written as a present node, so it stayed on the diagram as a **ghost** even after every source stopped observing the device. It's now written `presence: 'anchor'`, so it folds onto the observed node while present and **evaporates** (binding and all) on retraction.

## Changes

- **core**: `Node.presence?: 'scoop' | 'anchor'`; `resolve()` `presentClusters` filter.
- **codec**: presence column round-trips (`scoop`→`'present'`, `anchor`→`NULL`); scoop is the default and stays absent on rebuild.
- **server**: `reconcileBindings` writes binding-only nodes as anchor; `isPureEmptyOverlay` allows `presence` so a cleared binding still drops the row.
- **tests**: resolve presence/anchor cases (anchor-only dropped, anchor+scoop folds, retraction drops, plain intrinsic scoop persists) + codec round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
