### PR TITLE
feat(server): composition-mode plumbing on topology sources (PR5a)

### DIFF
--- a/apps/server/api/src/api/topology-sources.ts
+++ b/apps/server/api/src/api/topology-sources.ts
@@ -10,7 +10,13 @@ import { DataSourceService } from '../services/datasource.js'
 import { resolveCredentialsForAutoscan } from '../services/discovery-scheduler.js'
 import { ObservationsService } from '../services/observations.js'
 import { TopologySourcesService } from '../services/topology-sources.js'
-import type { SyncMode, TopologyDataSourceInput } from '../types.js'
+import type {
+  LinkContribution,
+  NodeContribution,
+  ScopeRole,
+  SyncMode,
+  TopologyDataSourceInput,
+} from '../types.js'
 import { mergeProbeIntoSnapshot } from './probe-merge.js'
 import { getTopologyService } from './topologies.js'
 
@@ -30,6 +36,31 @@ function getDataSourceService() {
     _dataSourceService = new DataSourceService()
   }
   return _dataSourceService
+}
+
+/**
+ * Validate the per-source composition-mode knobs (topology-source-modes.md).
+ * Returns an error string, or null when valid. Absent fields are valid (they
+ * fall back to the Additive defaults).
+ */
+function validateCompositionModes(body: {
+  nodeContribution?: unknown
+  linkContribution?: unknown
+  scopeRole?: unknown
+}): string | null {
+  if (
+    body.nodeContribution !== undefined &&
+    !['scoop', 'anchor'].includes(String(body.nodeContribution))
+  )
+    return "nodeContribution must be 'scoop' or 'anchor'"
+  if (
+    body.linkContribution !== undefined &&
+    !['add', 'update'].includes(String(body.linkContribution))
+  )
+    return "linkContribution must be 'add' or 'update'"
+  if (body.scopeRole !== undefined && body.scopeRole !== null && body.scopeRole !== 'scoping')
+    return "scopeRole must be 'scoping' or null"
+  return null
 }
 
 export const topologySourcesApi = new Hono()
@@ -97,6 +128,9 @@ topologySourcesApi.post('/:topologyId/sources', async (c) => {
     return c.json({ error: 'dataSourceId and purpose are required' }, 400)
   }
 
+  const modeError = validateCompositionModes(body)
+  if (modeError) return c.json({ error: modeError }, 400)
+
   // Verify data source exists
   const dataSource = getDataSourceService().get(body.dataSourceId)
   if (!dataSource) {
@@ -140,8 +174,19 @@ topologySourcesApi.put('/:topologyId/sources/:sourceId', async (c) => {
     return c.json({ error: 'Topology data source not found' }, 404)
   }
 
-  const body = await c.req.json<{ syncMode?: SyncMode; priority?: number; optionsJson?: string }>()
+  const body = await c.req.json<{
+    syncMode?: SyncMode
+    priority?: number
+    optionsJson?: string
+    nodeContribution?: NodeContribution
+    linkContribution?: LinkContribution
+    scopeRole?: ScopeRole | null
+  }>()
 
+  const modeError = validateCompositionModes(body)
+  if (modeError) return c.json({ error: modeError }, 400)
+
+  // scopeRole: 'scoping' sets it; explicit null clears it back to additive.
   const updated = getTopologySourcesService().update(sourceId, body)
   if (!updated) {
     return c.json({ error: 'Failed to update' }, 500)

--- a/apps/server/api/src/db/migrations/018_composition_modes.sql
+++ b/apps/server/api/src/db/migrations/018_composition_modes.sql
@@ -1,0 +1,15 @@
+-- Per-source composition modes (topology-source-modes.md, Axis D).
+-- Two independent knobs + a scope role on each topology↔source attachment.
+-- Defaults reproduce today's behavior (Additive: scoop nodes, add links, no scope),
+-- so existing rows are unchanged until the operator opts a source into a role.
+--
+--   node_contribution: 'scoop'  — assert the source's nodes exist (default)
+--                      'anchor' — enrich only; make no node-presence claim
+--   link_contribution: 'add'    — assert new links (default)
+--                      'update' — only update fields of links others assert
+--   scope_role:        NULL     — not scope-defining (default)
+--                      'scoping'— this source's regions are a closed world;
+--                                 clusters outside them are dropped at resolve.
+ALTER TABLE topology_data_sources ADD COLUMN node_contribution TEXT NOT NULL DEFAULT 'scoop';
+ALTER TABLE topology_data_sources ADD COLUMN link_contribution TEXT NOT NULL DEFAULT 'add';
+ALTER TABLE topology_data_sources ADD COLUMN scope_role TEXT;

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -22,6 +22,7 @@ import migration013 from './migrations/013_drop_legacy_source_columns.sql'
 import migration014 from './migrations/014_manual_graph_to_observations.sql'
 import migration016 from './migrations/016_contribution_store.sql'
 import migration017 from './migrations/017_drop_dead_tables.sql'
+import migration018 from './migrations/018_composition_modes.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -40,6 +41,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '014_manual_graph_to_observations.sql', sql: migration014 },
   { name: '016_contribution_store.sql', sql: migration016 },
   { name: '017_drop_dead_tables.sql', sql: migration017 },
+  { name: '018_composition_modes.sql', sql: migration018 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/topology-sources.ts
+++ b/apps/server/api/src/services/topology-sources.ts
@@ -9,6 +9,9 @@ import { generateId, getDatabase, timestamp } from '../db/index.js'
 import type {
   DataSource,
   DataSourcePurpose,
+  LinkContribution,
+  NodeContribution,
+  ScopeRole,
   SyncMode,
   TopologyDataSource,
   TopologyDataSourceInput,
@@ -24,6 +27,9 @@ interface TopologyDataSourceRow {
   last_synced_at: number | null
   priority: number
   options_json: string | null
+  node_contribution: string
+  link_contribution: string
+  scope_role: string | null
   created_at: number
   updated_at: number
   // Joined columns from data_sources
@@ -48,6 +54,9 @@ function rowToTopologyDataSource(row: TopologyDataSourceRow): TopologyDataSource
     lastSyncedAt: row.last_synced_at || undefined,
     priority: row.priority,
     optionsJson: row.options_json || undefined,
+    nodeContribution: (row.node_contribution as NodeContribution) || 'scoop',
+    linkContribution: (row.link_contribution as LinkContribution) || 'add',
+    scopeRole: (row.scope_role as ScopeRole) || undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -213,11 +222,16 @@ export class TopologySourcesService {
       syncMode: syncModeInput,
       priority,
       optionsJson,
+      nodeContribution,
+      linkContribution,
+      scopeRole,
     }: TopologyDataSourceInput,
   ): Promise<TopologyDataSource> {
     const id = await generateId()
     const now = timestamp()
     const syncMode = syncModeInput || 'manual'
+    const nodeContrib = nodeContribution ?? 'scoop'
+    const linkContrib = linkContribution ?? 'add'
 
     // Generate webhook secret if webhook mode
     const webhookSecret = syncMode === 'webhook' ? crypto.randomBytes(32).toString('hex') : null
@@ -229,6 +243,9 @@ export class TopologySourcesService {
       purpose,
       syncMode,
       priority: priority ?? 0,
+      nodeContribution: nodeContrib,
+      linkContribution: linkContrib,
+      scopeRole: scopeRole ?? undefined,
       createdAt: now,
       updatedAt: now,
     }
@@ -236,8 +253,8 @@ export class TopologySourcesService {
     this.db
       .query(
         `INSERT INTO topology_data_sources
-        (id, topology_id, data_source_id, purpose, sync_mode, webhook_secret, priority, options_json, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        (id, topology_id, data_source_id, purpose, sync_mode, webhook_secret, priority, options_json, node_contribution, link_contribution, scope_role, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         id,
@@ -248,6 +265,9 @@ export class TopologySourcesService {
         webhookSecret,
         priority ?? 0,
         optionsJson ?? null,
+        nodeContrib,
+        linkContrib,
+        scopeRole ?? null,
         now,
         now,
       )
@@ -260,7 +280,15 @@ export class TopologySourcesService {
    */
   update(
     id: string,
-    updates: Partial<Pick<TopologyDataSourceInput, 'syncMode' | 'priority' | 'optionsJson'>>,
+    updates: Partial<
+      Pick<
+        TopologyDataSourceInput,
+        'syncMode' | 'priority' | 'optionsJson' | 'nodeContribution' | 'linkContribution'
+      >
+    > & {
+      // null clears scopeRole back to additive; undefined leaves it unchanged.
+      scopeRole?: ScopeRole | null
+    },
   ): TopologyDataSource | null {
     const existing = this.get(id)
     if (!existing) return null
@@ -289,6 +317,21 @@ export class TopologySourcesService {
     if (updates.optionsJson !== undefined) {
       updateParts.push('options_json = ?')
       values.push(updates.optionsJson)
+    }
+
+    if (updates.nodeContribution !== undefined) {
+      updateParts.push('node_contribution = ?')
+      values.push(updates.nodeContribution)
+    }
+
+    if (updates.linkContribution !== undefined) {
+      updateParts.push('link_contribution = ?')
+      values.push(updates.linkContribution)
+    }
+
+    if (updates.scopeRole !== undefined) {
+      updateParts.push('scope_role = ?')
+      values.push(updates.scopeRole ?? null)
     }
 
     if (updateParts.length === 0) return existing

--- a/apps/server/api/src/types.ts
+++ b/apps/server/api/src/types.ts
@@ -115,6 +115,13 @@ export interface TopologyInput {
 export type SyncMode = 'manual' | 'on_view' | 'webhook'
 export type DataSourcePurpose = 'topology' | 'metrics'
 
+// Per-source composition modes (topology-source-modes.md, Axis D). Two
+// independent knobs + a scope role. Defaults = Additive (scoop / add / no scope).
+// NOT named `mode` — that collides with DiscoveryMode (auto|observe|disabled).
+export type NodeContribution = 'scoop' | 'anchor'
+export type LinkContribution = 'add' | 'update'
+export type ScopeRole = 'scoping'
+
 // Source merge is governed by `TopologyDataSource.priority` — the
 // higher-priority source wins each field in resolve() (see
 // `@shumoku/core` resolve() and topology-source-priority-merge.md). The
@@ -130,6 +137,12 @@ export interface TopologyDataSource {
   lastSyncedAt?: number
   priority: number
   optionsJson?: string
+  /** How this source's nodes participate. Default 'scoop'. */
+  nodeContribution: NodeContribution
+  /** How this source's links participate. Default 'add'. */
+  linkContribution: LinkContribution
+  /** When 'scoping', this source's regions are a closed world. Default undefined. */
+  scopeRole?: ScopeRole
   createdAt: number
   updatedAt: number
   // Joined data
@@ -142,6 +155,9 @@ export interface TopologyDataSourceInput {
   syncMode?: SyncMode
   priority?: number
   optionsJson?: string
+  nodeContribution?: NodeContribution
+  linkContribution?: LinkContribution
+  scopeRole?: ScopeRole
 }
 
 export interface Dashboard {

--- a/apps/server/api/test/db/composition-modes.test.ts
+++ b/apps/server/api/test/db/composition-modes.test.ts
@@ -1,0 +1,78 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Per-source composition modes (topology-source-modes.md, Axis D) — service
+ * round-trip: defaults are Additive (scoop / add / no scope); roles persist;
+ * scopeRole clears back to additive with an explicit null.
+ */
+import { afterAll, beforeAll, expect, test } from 'bun:test'
+import { TopologySourcesService } from '../../src/services/topology-sources.ts'
+import { getDatabase, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+beforeAll(() => {
+  db_ = setupTempDb()
+})
+afterAll(() => db_.teardown())
+
+function makeTopology(id: string): void {
+  getDatabase()
+    .query('INSERT INTO topologies (id, name, created_at, updated_at) VALUES (?, ?, 0, 0)')
+    .run(id, id)
+}
+
+test('add() defaults to Additive (scoop / add / no scope)', async () => {
+  makeTopology('t_modes_1')
+  const ds = insertDataSource('zabbix')
+  const svc = new TopologySourcesService()
+  const added = await svc.add('t_modes_1', { dataSourceId: ds, purpose: 'topology' })
+  expect(added.nodeContribution).toBe('scoop')
+  expect(added.linkContribution).toBe('add')
+  expect(added.scopeRole).toBeUndefined()
+
+  const got = svc.get(added.id)
+  expect(got?.nodeContribution).toBe('scoop')
+  expect(got?.linkContribution).toBe('add')
+  expect(got?.scopeRole).toBeUndefined()
+})
+
+test('update() sets a role, and scopeRole clears with explicit null', async () => {
+  makeTopology('t_modes_2')
+  const ds = insertDataSource('netbox')
+  const svc = new TopologySourcesService()
+  const added = await svc.add('t_modes_2', { dataSourceId: ds, purpose: 'topology' })
+
+  // → Enrichment
+  const enriched = svc.update(added.id, { nodeContribution: 'anchor', linkContribution: 'update' })
+  expect(enriched?.nodeContribution).toBe('anchor')
+  expect(enriched?.linkContribution).toBe('update')
+
+  // → Scoping
+  const scoped = svc.update(added.id, {
+    nodeContribution: 'scoop',
+    linkContribution: 'add',
+    scopeRole: 'scoping',
+  })
+  expect(scoped?.scopeRole).toBe('scoping')
+
+  // clear scope back to additive
+  const cleared = svc.update(added.id, { scopeRole: null })
+  expect(cleared?.scopeRole).toBeUndefined()
+})
+
+test('add() honors explicit modes', async () => {
+  makeTopology('t_modes_3')
+  const ds = insertDataSource('prometheus')
+  const svc = new TopologySourcesService()
+  const added = await svc.add('t_modes_3', {
+    dataSourceId: ds,
+    purpose: 'topology',
+    nodeContribution: 'anchor',
+    linkContribution: 'update',
+    scopeRole: 'scoping',
+  })
+  expect(added.nodeContribution).toBe('anchor')
+  expect(added.linkContribution).toBe('update')
+  expect(added.scopeRole).toBe('scoping')
+})

--- a/apps/server/api/test/db/schema.test.ts
+++ b/apps/server/api/test/db/schema.test.ts
@@ -56,4 +56,11 @@ describe('migration chain (001-014)', () => {
       expect(cols).toContain(c)
     }
   })
+
+  test('topology_data_sources has composition-mode columns (018)', () => {
+    const cols = columns('topology_data_sources')
+    for (const c of ['node_contribution', 'link_contribution', 'scope_role']) {
+      expect(cols).toContain(c)
+    }
+  })
 })

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -12,7 +12,10 @@ import type {
   DashboardInput,
   DataSource,
   DataSourceInput,
+  LinkContribution,
   MetricsMapping,
+  NodeContribution,
+  ScopeRole,
   SyncMode,
   Topology,
   TopologyContext,
@@ -348,7 +351,14 @@ export const topologies = {
     update: (
       topologyId: string,
       sourceId: string,
-      updates: { syncMode?: SyncMode; priority?: number; optionsJson?: string },
+      updates: {
+        syncMode?: SyncMode
+        priority?: number
+        optionsJson?: string
+        nodeContribution?: NodeContribution
+        linkContribution?: LinkContribution
+        scopeRole?: ScopeRole | null
+      },
     ) =>
       request<TopologyDataSource>(`/topologies/${topologyId}/sources/${sourceId}`, {
         method: 'PUT',

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -132,6 +132,11 @@ export function serializeMultiFileContent(files: TopologyFile[]): string {
 export type SyncMode = 'manual' | 'on_view' | 'webhook'
 export type DataSourcePurpose = 'topology' | 'metrics'
 
+// Per-source composition modes (topology-source-modes.md, Axis D).
+export type NodeContribution = 'scoop' | 'anchor'
+export type LinkContribution = 'add' | 'update'
+export type ScopeRole = 'scoping'
+
 export interface TopologyDataSource {
   id: string
   topologyId: string
@@ -142,6 +147,9 @@ export interface TopologyDataSource {
   lastSyncedAt?: number
   priority: number
   optionsJson?: string
+  nodeContribution: NodeContribution
+  linkContribution: LinkContribution
+  scopeRole?: ScopeRole
   createdAt: number
   updatedAt: number
   dataSource?: DataSource
@@ -153,6 +161,9 @@ export interface TopologyDataSourceInput {
   syncMode?: SyncMode
   priority?: number
   optionsJson?: string
+  nodeContribution?: NodeContribution
+  linkContribution?: LinkContribution
+  scopeRole?: ScopeRole | null
 }
 
 export interface ApiError {

--- a/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
@@ -30,7 +30,10 @@
   import { topologies } from '$lib/stores'
   import type {
     DataSourcePluginInfo,
+    LinkContribution,
+    NodeContribution,
     PluginConfigSchema,
+    ScopeRole,
     SyncMode,
     TopologyDataSource,
   } from '$lib/types'
@@ -210,6 +213,37 @@
         )
       },
       { reflect },
+    )
+  }
+
+  // Composition role = a preset over the three per-source knobs
+  // (topology-source-modes.md). Default Additive (unconstrained union).
+  type CompositionRole = 'additive' | 'scoping' | 'enrichment'
+  function roleOf(s: TopologyDataSource): CompositionRole {
+    if (s.scopeRole === 'scoping') return 'scoping'
+    if (s.nodeContribution === 'anchor') return 'enrichment'
+    return 'additive'
+  }
+  function setRole(source: TopologyDataSource, role: CompositionRole) {
+    const updates: {
+      nodeContribution: NodeContribution
+      linkContribution: LinkContribution
+      scopeRole: ScopeRole | null
+    } =
+      role === 'scoping'
+        ? { nodeContribution: 'scoop', linkContribution: 'add', scopeRole: 'scoping' }
+        : role === 'enrichment'
+          ? { nodeContribution: 'anchor', linkContribution: 'update', scopeRole: null }
+          : { nodeContribution: 'scoop', linkContribution: 'add', scopeRole: null }
+    void mutate(
+      source.id,
+      () => api.topologies.sources.update(ctx.topologyId, source.id, updates),
+      (updated) => {
+        ctx.currentSources = ctx.currentSources.map((s) =>
+          s.id === source.id ? (updated as TopologyDataSource) : s,
+        )
+      },
+      { reflect: true },
     )
   }
 
@@ -588,6 +622,17 @@
                       <option value="manual">Manual</option>
                       <option value="on_view">On View</option>
                       <option value="webhook">Webhook</option>
+                    </select>
+                    <select
+                      class="input"
+                      style="width: 10rem;"
+                      title="How this source composes into the topology"
+                      value={roleOf(source)}
+                      onchange={(e) => setRole(source, e.currentTarget.value as CompositionRole)}
+                    >
+                      <option value="additive">Additive</option>
+                      <option value="scoping">Scoping</option>
+                      <option value="enrichment">Enrichment</option>
                     </select>
                   </div>
 


### PR DESCRIPTION
## What

Axis D of the [topology-source-modes](../blob/main/apps/server/docs/design/topology-source-modes.md) plan — **schema + surface half** (PR5a). Per-source composition modes on the topology↔source attachment.

Migration **018** adds three knobs to `topology_data_sources`:

| column | values | default |
|---|---|---|
| `node_contribution` | `scoop` / `anchor` | `scoop` |
| `link_contribution` | `add` / `update` | `add` |
| `scope_role` | `scoping` / NULL | NULL |

Defaults reproduce today's **Additive** behavior, so existing rows are unchanged and `resolve()` is **not wired yet** — that's PR5b. This PR is safe/inert behaviorally.

## Changes

- **types** (server + web): `TopologyDataSource(+Input)` gain the knobs; `NodeContribution` / `LinkContribution` / `ScopeRole` unions.
- **service**: `add()` / `update()` read/write the columns; `update()` clears `scope_role` with an explicit `null`.
- **api**: POST/PUT validate the enums.
- **web**: a **Role** select on each source row — `Additive` / `Scoping` / `Enrichment` preset mapping to the three knobs.

## Tests

- `schema.test.ts`: the three columns exist after migration 018.
- `composition-modes.test.ts`: service round-trip — defaults are Additive, role set persists, scope clears with null, explicit modes on add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
