### PR TITLE
feat(core,server): wire composition modes into resolve (PR5b)

### DIFF
--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -51,7 +51,15 @@ import {
 } from '@shumoku/core'
 import { collectIconUrls, resolveAllIconDimensions } from '@shumoku/renderer-svg'
 import { generateId, getDatabase, timestamp } from '../db/index.js'
-import type { MetricsData, MetricsMapping, Topology, TopologyInput } from '../types.js'
+import type {
+  LinkContribution,
+  MetricsData,
+  MetricsMapping,
+  NodeContribution,
+  ScopeRole,
+  Topology,
+  TopologyInput,
+} from '../types.js'
 import { buildGraph, ingestGraph } from './contribution-store.js'
 import { filterDisconnected } from './display-filter.js'
 
@@ -304,6 +312,38 @@ interface LinkBindingDesired {
   portIdentity: Identity | undefined
   interfaceName?: string
   bandwidth?: number
+}
+
+/** A source's composition mode (topology-source-modes.md, Axis D). */
+interface SourceMode {
+  nodeContribution: NodeContribution
+  linkContribution: LinkContribution
+  scopeRole?: ScopeRole
+}
+
+/**
+ * Apply a source's composition mode to its built contribution before it enters
+ * resolve(): anchor its nodes (node_contribution='anchor'), anchor its links
+ * (link_contribution='update'), and/or mark its regions closed
+ * (scope_role='scoping'). Additive (the default) is a no-op. Never mutates input.
+ */
+function applySourceMode(graph: NetworkGraph, mode: SourceMode): NetworkGraph {
+  const anchorNodes = mode.nodeContribution === 'anchor'
+  const anchorLinks = mode.linkContribution === 'update'
+  const closeScope = mode.scopeRole === 'scoping'
+  if (!anchorNodes && !anchorLinks && !closeScope) return graph
+  return {
+    ...graph,
+    nodes: anchorNodes
+      ? graph.nodes.map((n) => ({ ...n, presence: 'anchor' as const }))
+      : graph.nodes,
+    links: anchorLinks
+      ? graph.links.map((l) => ({ ...l, presence: 'anchor' as const }))
+      : graph.links,
+    ...(closeScope && graph.subgraphs
+      ? { subgraphs: graph.subgraphs.map((s) => ({ ...s, scope: 'closed' as const })) }
+      : {}),
+  }
 }
 
 /**
@@ -1042,10 +1082,19 @@ export class TopologyService {
     // holds. Mirrors `topology_data_sources.priority`. The project overlay
     // always outranks these (handled inside resolve() as the `authored` input).
     const priorityBySource = new Map<string, number>()
+    const modeBySource = new Map<string, SourceMode>()
     for (const tds of this.topologySources.listByTopology(topology.id)) {
       priorityBySource.set(tds.dataSourceId, tds.priority)
+      // Composition modes apply to the source's TOPOLOGY contribution only.
+      if (tds.purpose === 'topology') {
+        modeBySource.set(tds.dataSourceId, {
+          nodeContribution: tds.nodeContribution,
+          linkContribution: tds.linkContribution,
+          scopeRole: tds.scopeRole,
+        })
+      }
     }
-    const snapshots = this.readObservedSnapshots(topology.id, priorityBySource)
+    const snapshots = this.readObservedSnapshots(topology.id, priorityBySource, modeBySource)
     const resolvedGraph = resolveObservations(authored, snapshots)
     // Post-resolve display filter (project-level pref on the overlay settings).
     // Runs on the fully-merged graph — never per-source.
@@ -1101,6 +1150,7 @@ export class TopologyService {
   private readObservedSnapshots(
     topologyId: string,
     priorityBySource: Map<string, number>,
+    modeBySource: Map<string, SourceMode>,
   ): SnapshotEntry[] {
     this.backfillObservedContributions(topologyId)
     // Every attached source's contribution (attachment_id NOT NULL) is a snapshot —
@@ -1122,8 +1172,12 @@ export class TopologyService {
     const snapshots: SnapshotEntry[] = []
     for (const r of rows) {
       if (!priorityBySource.has(r.source_id)) continue
-      const graph = buildGraph(topologyId, r.source_id, this.db)
-      if (!graph) continue
+      const built = buildGraph(topologyId, r.source_id, this.db)
+      if (!built) continue
+      // Apply this source's composition mode (anchor nodes/links, closed scope)
+      // before it enters resolve(). Additive (default) is a no-op.
+      const mode = modeBySource.get(r.source_id)
+      const graph = mode ? applySourceMode(built, mode) : built
       snapshots.push({
         sourceId: r.source_id,
         capturedAt: r.last_ok_at ?? 0,

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -890,6 +890,15 @@ export interface Link {
   metadata?: Record<string, unknown>
 
   /**
+   * Presence claim (resolve input only), mirroring `Node.presence`:
+   * - `'scoop'` (default / omitted) — assert this link exists.
+   * - `'anchor'` — NO presence claim: only contribute fields to a link some
+   *   other contribution scoops. A link cluster with only anchor members is
+   *   dropped by resolve(). Set by an `link_contribution: 'update'` source.
+   */
+  presence?: 'scoop' | 'anchor'
+
+  /**
    * Observation provenance (which source last asserted this link).
    * See `Provenance`. Links are identified by their endpoints rather
    * than by a stable identity record, so no `identity` field here.
@@ -1020,6 +1029,13 @@ export interface Subgraph {
    * {@link MembershipCriterion}.
    */
   membership?: MembershipCriterion[]
+
+  /**
+   * Scope marker (resolve input only). `'closed'` makes this region a closed
+   * world: resolve() drops any node cluster that is not a member of some closed
+   * region. Set by a `scope_role: 'scoping'` source. Default (undefined) = open.
+   */
+  scope?: 'closed'
 
   /**
    * Child subgraph IDs

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1700,6 +1700,102 @@ describe('resolve()', () => {
       expect(out.nodes.find((n) => n.label === 'mx88')?.parent).toBe('src:own')
     })
   })
+
+  describe('composition modes (link anchor + scope)', () => {
+    const twoNodes = () => [
+      { id: 'n1', label: 'R1', identity: { mgmtIp: '10.0.0.1' }, ports: [pt('p1', 'e0')] },
+      { id: 'n2', label: 'R2', identity: { mgmtIp: '10.0.0.2' }, ports: [pt('p2', 'e1')] },
+    ]
+    const pt = (id: string, ifName: string) => ({
+      id,
+      label: ifName,
+      connectors: [],
+      identity: { ifName },
+    })
+    const linkN1N2 = (extra: Record<string, unknown>) => ({
+      from: { node: 'n1', port: 'p1' },
+      to: { node: 'n2', port: 'p2' },
+      ...extra,
+    })
+
+    it('an anchor (update-only) link alone creates no edge', () => {
+      const snap: SnapshotEntry = {
+        sourceId: 's',
+        capturedAt: 1,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: twoNodes(),
+          links: [linkN1N2({ presence: 'anchor' })] as NetworkGraph['links'],
+        },
+      }
+      const out = resolve(emptyGraph(), [snap])
+      expect(out.links).toHaveLength(0)
+    })
+
+    it('an anchor link updates fields of a scooped link instead of adding one', () => {
+      const scoop: SnapshotEntry = {
+        sourceId: 'topo',
+        capturedAt: 1,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: twoNodes(),
+          links: [linkN1N2({})] as NetworkGraph['links'],
+        },
+      }
+      const update: SnapshotEntry = {
+        sourceId: 'deps',
+        capturedAt: 2,
+        priority: 5,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: twoNodes(),
+          links: [linkN1N2({ presence: 'anchor', vlan: [42] })] as NetworkGraph['links'],
+        },
+      }
+      const out = resolve(emptyGraph(), [scoop, update])
+      expect(out.links).toHaveLength(1)
+      expect(out.links[0]?.vlan).toEqual([42])
+      expect(out.links[0]?.presence).toBeUndefined() // input-only, never emitted
+    })
+
+    it('a closed region drops out-of-scope clusters, keeps in-region + membership matches', () => {
+      const scoping: SnapshotEntry = {
+        sourceId: 'A',
+        capturedAt: 1,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [{ id: 'a1', label: 'in-region', identity: { mgmtIp: '10.0.0.1' }, parent: 'g' }],
+          subgraphs: [
+            {
+              id: 'g',
+              label: 'Region',
+              scope: 'closed',
+              membership: [{ attr: 'subnet', value: '10.0.0.0/24' }],
+            },
+          ],
+        },
+      }
+      const additive: SnapshotEntry = {
+        sourceId: 'B',
+        capturedAt: 1,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            { id: 'b1', label: 'fills-region', identity: { mgmtIp: '10.0.0.9' } }, // matches subnet
+            { id: 'b2', label: 'out', identity: { mgmtIp: '10.9.0.9' } }, // outside → dropped
+          ],
+        },
+      }
+      const out = resolve(emptyGraph(), [scoping, additive])
+      const labels = out.nodes.map((n) => n.label).sort()
+      expect(labels).toEqual(['fills-region', 'in-region'])
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -124,10 +124,31 @@ export function resolve(
   //     so a hide survives re-scans that re-number ephemeral node ids. Dropping
   //     here (before link folding) also removes links to hidden nodes.
   const exclusions = authored.exclusions ?? []
-  const nodeClusters =
+  const afterExclusions =
     exclusions.length > 0
       ? presentClusters.filter((c) => !isClusterExcluded(c, exclusions))
       : presentClusters
+
+  // 2c. Regions. Cluster subgraphs across contributions by region identity
+  //     (any-key match) — same machinery as nodes. A subgraph with no identity
+  //     stays its own region (keeping its namespaced id).
+  const regions = clusterRegions(contributions)
+  const regionIdRemap = new Map<string, string>()
+  for (const cl of regions) {
+    for (const m of cl.members) regionIdRemap.set(m.subgraph.id, cl.canonicalId)
+  }
+
+  // 2d. Scope. A `scope_role:'scoping'` source marks its regions `scope:'closed'`.
+  //     When any closed region exists the topology is a closed world: a cluster
+  //     survives only if it belongs to some closed region (its parent region is
+  //     closed/descends from one, OR it matches a closed region's membership).
+  //     Dropping here (before fold) means links to out-of-scope nodes dangle and
+  //     drop too. No closed region → no filtering (open world, the default).
+  const scope = buildScopeIndex(regions, regionIdRemap)
+  const nodeClusters =
+    scope.closedRegionIds.size > 0
+      ? afterExclusions.filter((c) => clusterInClosedScope(c, regions, regionIdRemap, scope))
+      : afterExclusions
 
   // 3. For each cluster, fold into a single resolved Node
   const resolvedNodes: Node[] = []
@@ -145,17 +166,10 @@ export function resolve(
     }
   }
 
-  // 3b. Regions. Cluster subgraphs across contributions by region identity
-  //     (any-key match) — same machinery as nodes. A subgraph with no identity
-  //     stays its own region (keeping its namespaced id). Then:
+  // 3b. Region membership for resolved nodes:
   //       - remap every resolved node's `parent` to the merged region's id;
   //       - for a node with NO parent, assign the first region whose membership
   //         criteria match (so a lower source fills a region an upper scooped).
-  const regions = clusterRegions(contributions)
-  const regionIdRemap = new Map<string, string>()
-  for (const cl of regions) {
-    for (const m of cl.members) regionIdRemap.set(m.subgraph.id, cl.canonicalId)
-  }
   for (const node of resolvedNodes) {
     if (node.parent !== undefined) {
       const mapped = regionIdRemap.get(node.parent)
@@ -950,6 +964,71 @@ function ipv4InCidr(ip: string, cidr: string): boolean {
   return (a & mask) === (b & mask)
 }
 
+interface ScopeIndex {
+  /** Canonical ids of regions explicitly marked `scope:'closed'`. */
+  closedRegionIds: Set<string>
+  /** True if `regionId` is closed or descends from a closed region. */
+  inClosedScope: (regionId: string) => boolean
+}
+
+/** Index closed regions + the region parent chain for scope ancestry walks. */
+function buildScopeIndex(
+  clusters: RegionCluster[],
+  regionIdRemap: Map<string, string>,
+): ScopeIndex {
+  const closedRegionIds = new Set<string>()
+  const regionParent = new Map<string, string>()
+  for (const cl of clusters) {
+    if (cl.members.some((m) => m.subgraph.scope === 'closed')) closedRegionIds.add(cl.canonicalId)
+    const ranked = [...cl.members].sort(
+      (a, b) => b.priority - a.priority || b.capturedAt - a.capturedAt,
+    )
+    for (const m of ranked) {
+      if (m.subgraph.parent) {
+        regionParent.set(cl.canonicalId, regionIdRemap.get(m.subgraph.parent) ?? m.subgraph.parent)
+        break
+      }
+    }
+  }
+  const inClosedScope = (regionId: string): boolean => {
+    let cur: string | undefined = regionId
+    const seen = new Set<string>()
+    while (cur && !seen.has(cur)) {
+      seen.add(cur)
+      if (closedRegionIds.has(cur)) return true
+      cur = regionParent.get(cur)
+    }
+    return false
+  }
+  return { closedRegionIds, inClosedScope }
+}
+
+/**
+ * Whether a node cluster belongs to a closed region: its winning parent region
+ * (highest-priority member's `parent`, remapped) is closed/descends from one, OR
+ * any member matches a closed region's membership criteria.
+ */
+function clusterInClosedScope(
+  cluster: NodeCluster,
+  clusters: RegionCluster[],
+  regionIdRemap: Map<string, string>,
+  scope: ScopeIndex,
+): boolean {
+  let parentRegion: string | undefined
+  for (const m of rankMembers(cluster.members)) {
+    if (m.node.parent) {
+      parentRegion = regionIdRemap.get(m.node.parent) ?? m.node.parent
+      break
+    }
+  }
+  if (parentRegion && scope.inClosedScope(parentRegion)) return true
+  for (const cl of clusters) {
+    if (!scope.closedRegionIds.has(cl.canonicalId)) continue
+    for (const m of cluster.members) if (nodeMatchesRegion(m.node, cl)) return true
+  }
+  return false
+}
+
 function mergeRegionIdentities(ids: Array<RegionIdentity | undefined>): RegionIdentity | undefined {
   let name: string | undefined
   const keys: Record<string, string> = {}
@@ -1109,11 +1188,15 @@ function foldLinks(
     }
   }
 
-  // 2. Fold each cluster into one link.
+  // 2. Fold each cluster into one link. A cluster with only anchor members
+  //    (every contributor was link_contribution:'update') makes no presence
+  //    claim → no new edge, exactly like an anchor-only node cluster.
   const links: Link[] = []
   for (const key of order) {
     const members = clusters.get(key)
-    if (members) links.push(foldLinkCluster(members))
+    if (!members) continue
+    if (!members.some((m) => m.link.presence !== 'anchor')) continue
+    links.push(foldLinkCluster(members))
   }
   return links
 }
@@ -1132,7 +1215,7 @@ function linkClusterKey(from: LinkEndpoint, to: LinkEndpoint): string {
 }
 
 /** Link fields owned by the fold itself — never copied through the generic merge. */
-const LINK_FOLD_RESERVED = new Set(['id', 'from', 'to', 'provenance', 'metadata'])
+const LINK_FOLD_RESERVED = new Set(['id', 'from', 'to', 'provenance', 'metadata', 'presence'])
 
 function foldLinkCluster(members: LinkMember[]): Link {
   const ranked = [...members].sort((a, b) => b.priority - a.priority || b.capturedAt - a.capturedAt)


### PR DESCRIPTION
## What

Axis D of the [topology-source-modes](../blob/main/apps/server/docs/design/topology-source-modes.md) plan — **resolve half** (PR5b). Makes the PR5a knobs actually do something.

### core

- **`Link.presence`** (`scoop` | `anchor`) mirrors `Node.presence`. `foldLinks` drops a link cluster with only anchor members → an **update-only** source contributes fields to an existing edge but never creates one.
- **`Subgraph.scope`** (`closed`). When any closed region exists, `resolve()` runs a **closed-world scope filter** (before node fold, so out-of-scope links dangle and drop too): a node cluster survives only if its winning parent region is closed / descends from one, **or** it matches a closed region's membership criteria. No closed region → no filtering (open world, the default).

### server (`topology.ts`)

`readObservedSnapshots` applies each topology source's composition mode to its built contribution before resolve:

- `node_contribution = 'anchor'` → anchors its nodes
- `link_contribution = 'update'` → anchors its links
- `scope_role = 'scoping'` → marks its regions `closed`

**Additive (default) is a no-op**, so existing behavior is unchanged.

`presence` / `scope` are resolve **inputs** — never emitted on resolved entities.

## Tests

`resolve.test.ts` → `composition modes`: anchor link alone → no edge; anchor link updates a scooped edge (fields merge, no dup); closed region drops out-of-scope clusters and keeps membership matches.

## End of the 5-PR series

This completes the topology-source-modes plan: PR1 hideDisconnected, PR2 presence/anchor, PR3 link dedup, PR4 regions-as-entities, PR5a/5b composition modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
