### PR TITLE
fix(server): migration 019 — heal contribution_link.local_id NOT NULL drift

### DIFF
--- a/apps/server/api/src/db/migrations/019_fix_contribution_link_local_id_nullable.sql
+++ b/apps/server/api/src/db/migrations/019_fix_contribution_link_local_id_nullable.sql
@@ -1,0 +1,48 @@
+-- Heal a dev-DB schema drift: contribution_link.local_id must be NULLABLE.
+--
+-- A link's identity is its endpoints, not its id (see core Link type) — id is an
+-- optional passthrough, so id-less links from a source store local_id = NULL.
+-- Migration 016 declares `local_id TEXT` (nullable) and always has in committed
+-- history. But some dev DBs created the table with `local_id TEXT NOT NULL` from
+-- an in-place edit of 016 before it was committed; CREATE TABLE IF NOT EXISTS
+-- never recreated it, so those DBs reject id-less links ("NOT NULL constraint
+-- failed: contribution_link.local_id") — e.g. a TTDB source that omits link ids.
+--
+-- SQLite can't drop a column constraint in place, so rebuild the table to the
+-- canonical 016 shape, preserving rows. Idempotent / safe on already-correct DBs
+-- (it just rebuilds to an identical schema).
+PRAGMA foreign_keys=OFF;
+
+DROP TABLE IF EXISTS contribution_link__new;
+
+CREATE TABLE contribution_link__new (
+  id INTEGER PRIMARY KEY,
+  topology_id TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  local_id TEXT,
+  from_node_local_id TEXT NOT NULL,
+  from_port_local_id TEXT,
+  to_node_local_id TEXT NOT NULL,
+  to_port_local_id TEXT,
+  presence TEXT CHECK (presence IN ('present', 'hide')),
+  payload_json TEXT,
+  FOREIGN KEY (topology_id, source_id) REFERENCES contribution_source(topology_id, source_id) ON DELETE CASCADE,
+  FOREIGN KEY (topology_id, source_id, from_node_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  FOREIGN KEY (topology_id, source_id, to_node_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  FOREIGN KEY (topology_id, source_id, from_port_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  FOREIGN KEY (topology_id, source_id, to_port_local_id) REFERENCES contribution_element(topology_id, source_id, local_id),
+  UNIQUE (topology_id, source_id, local_id)
+);
+
+INSERT INTO contribution_link__new
+  SELECT id, topology_id, source_id, local_id, from_node_local_id, from_port_local_id,
+         to_node_local_id, to_port_local_id, presence, payload_json
+  FROM contribution_link;
+
+DROP TABLE contribution_link;
+
+ALTER TABLE contribution_link__new RENAME TO contribution_link;
+
+CREATE INDEX IF NOT EXISTS idx_contrib_link_src ON contribution_link(topology_id, source_id);
+
+PRAGMA foreign_keys=ON;

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -23,6 +23,7 @@ import migration014 from './migrations/014_manual_graph_to_observations.sql'
 import migration016 from './migrations/016_contribution_store.sql'
 import migration017 from './migrations/017_drop_dead_tables.sql'
 import migration018 from './migrations/018_composition_modes.sql'
+import migration019 from './migrations/019_fix_contribution_link_local_id_nullable.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -42,6 +43,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '016_contribution_store.sql', sql: migration016 },
   { name: '017_drop_dead_tables.sql', sql: migration017 },
   { name: '018_composition_modes.sql', sql: migration018 },
+  { name: '019_fix_contribution_link_local_id_nullable.sql', sql: migration019 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/test/db/schema.test.ts
+++ b/apps/server/api/test/db/schema.test.ts
@@ -63,4 +63,12 @@ describe('migration chain (001-014)', () => {
       expect(cols).toContain(c)
     }
   })
+
+  test('contribution_link.local_id is nullable (019) — id-less links are allowed', () => {
+    const info = getDatabase().query('PRAGMA table_info(contribution_link)').all() as {
+      name: string
+      notnull: number
+    }[]
+    expect(info.find((c) => c.name === 'local_id')?.notnull).toBe(0)
+  })
 })


### PR DESCRIPTION
## What

Corrective migration **019** that heals a dev-DB schema drift: `contribution_link.local_id` must be **nullable**.

## Why

A link's identity is its endpoints — `Link.id` is an optional passthrough, so a source that omits link ids stores `local_id = NULL`. Migration 016 declares `local_id TEXT` (nullable) and always has in committed history. But some dev DBs created the table with `local_id TEXT NOT NULL` from an **in-place edit of 016 before it was committed**; `CREATE TABLE IF NOT EXISTS` never recreated it.

On such a DB, an id-less link fails with `NOT NULL constraint failed: contribution_link.local_id`, the observation is never recorded, and the source shows **"never synced"** — exactly what happened with a TTDB source (TTDB emits id-less links; Zabbix sets `zabbix:link:N` so it was unaffected).

This is **not an app-code bug nor a plugin bug** — both are correct against the committed contract (id-less links are explicitly supported). It's stale local schema. 019 makes any drifted DB self-heal on startup.

## How

SQLite can't drop a column constraint in place, so 019 rebuilds `contribution_link` to the canonical 016 shape (FKs off during the swap, rows + indexes preserved). No-op in spirit on already-correct DBs.

Verified on a `VACUUM INTO` snapshot of the drifted dev DB: **350 link rows preserved, `local_id` NOT NULL → nullable, 0 FK violations.**

## Test

`schema.test.ts`: `contribution_link.local_id` notnull flag is `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
