### PR TITLE
fix(server): ingest tolerates undeclared/empty ports and dangling-node links

### DIFF
--- a/apps/server/api/src/services/contribution-store.ts
+++ b/apps/server/api/src/services/contribution-store.ts
@@ -230,6 +230,23 @@ export function ingestGraph(
         insAttachment.run(topologyId, sourceId, eid, scope, kindFromKey(key), key, null, 1, null)
     }
 
+    // Track inserted node / port local_ids so link folding can enforce the same
+    // referential integrity the FKs require — and stay tolerant where resolve()
+    // is: a link may reference a node that doesn't exist (skip it) or a port the
+    // node never enumerated (synthesize a stub, same shape Zabbix's ensurePort
+    // gives LLDP ports). Without this, a single such link aborts the whole
+    // source's ingest with a FK error.
+    const nodeLocalIds = new Set<string>()
+    const portLocalIds = new Set<string>()
+    const ensurePortElement = (nodeId: string, portId: string): string => {
+      const lid = portLocalId(nodeId, portId)
+      if (!portLocalIds.has(lid)) {
+        elementId(lid, 'port', nodeId, 'present', {})
+        portLocalIds.add(lid)
+      }
+      return lid
+    }
+
     // Nodes (+ ports, identity, attachments, suppressions).
     for (const node of graph.nodes ?? []) {
       const nodePayload = payloadWithout(node, [
@@ -250,6 +267,7 @@ export function ingestGraph(
       // scoop (default / omitted) → 'present'; anchor → NULL (makes no presence claim).
       const presence = node.presence === 'anchor' ? null : 'present'
       const eid = elementId(node.id, 'node', node.parent ?? null, presence, nodePayload)
+      nodeLocalIds.add(node.id)
       writeIdentity(eid, node.identity)
       writeAttachments(eid, 'node', node.attachments)
       writeSuppressions(eid, 'node', node.suppressedAttachments)
@@ -262,13 +280,9 @@ export function ingestGraph(
           'provenance',
         ])
         // Port local_id is node-scoped (two nodes may share a port id like 'eth0').
-        const pid = elementId(
-          portLocalId(node.id, port.id),
-          'port',
-          node.id,
-          'present',
-          portPayload,
-        )
+        const portLid = portLocalId(node.id, port.id)
+        const pid = elementId(portLid, 'port', node.id, 'present', portPayload)
+        portLocalIds.add(portLid)
         writeIdentity(pid, port.identity)
         writeAttachments(pid, 'port', port.attachments)
         writeSuppressions(pid, 'port', port.suppressedAttachments)
@@ -306,6 +320,17 @@ export function ingestGraph(
     for (const link of graph.links ?? []) {
       const from = link.from
       const to = link.to
+      // Drop a link whose endpoint node wasn't declared — resolve() drops these
+      // (dangling endpoint) anyway, and the FK would otherwise abort the whole
+      // source ingest.
+      if (!nodeLocalIds.has(from.node) || !nodeLocalIds.has(to.node)) continue
+      // Empty-string port ≡ no port (matches resolve's `endpoint.port ? …` rule).
+      // A referenced port the node never enumerated gets a synthesized stub so
+      // the FK resolves.
+      const fromPort = from.port ? from.port : undefined
+      const toPort = to.port ? to.port : undefined
+      const fromPortLid = fromPort ? ensurePortElement(from.node, fromPort) : null
+      const toPortLid = toPort ? ensurePortElement(to.node, toPort) : null
       const linkPayload = payloadWithout(link, ['id', 'from', 'to', 'via', 'provenance'])
       // Per-endpoint non-structural fields (plug/ip/pin) ride in payload.
       linkPayload['from'] = payloadWithout(from, ['node', 'port'])
@@ -315,9 +340,9 @@ export function ingestGraph(
         sourceId,
         link.id ?? null,
         from.node,
-        from.port != null ? portLocalId(from.node, from.port) : null,
+        fromPortLid,
         to.node,
-        to.port != null ? portLocalId(to.node, to.port) : null,
+        toPortLid,
         'present',
         j(linkPayload),
       )

--- a/apps/server/api/test/db/contribution-codec.test.ts
+++ b/apps/server/api/test/db/contribution-codec.test.ts
@@ -136,6 +136,30 @@ describe('contribution codec — round-trip', () => {
     } as NetworkGraph)
   })
 
+  test('ingest tolerates undeclared/empty ports and dangling-node links', () => {
+    // A source (e.g. TTDB) may emit links that reference ports the node never
+    // enumerated, empty-string ports, or a node that doesn't exist. resolve()
+    // tolerates all three; ingest must too (not abort the whole source on a FK).
+    const out = roundTrip({
+      version: '1',
+      name: 'robust',
+      nodes: [
+        { id: 'a', label: 'A' },
+        { id: 'b', label: 'B' },
+      ], // no ports declared
+      links: [
+        { from: { node: 'a', port: 'ge-0/0/1' }, to: { node: 'b', port: '' } },
+        { from: { node: 'a' }, to: { node: 'ghost' } }, // dangling → dropped
+      ],
+    } as NetworkGraph)
+    // dangling-node link dropped
+    expect(out.links).toHaveLength(1)
+    // undeclared port synthesized as a stub on 'a'; empty port ≡ no port on 'b'
+    expect(out.links[0]?.from.port).toBe('ge-0/0/1')
+    expect(out.links[0]?.to.port).toBeUndefined()
+    expect(out.nodes.find((n) => n.id === 'a')?.ports?.some((p) => p.id === 'ge-0/0/1')).toBe(true)
+  })
+
   test('node-scoped duplicate port ids round-trip (two nodes both have "eth0")', () => {
     expectLossless({
       version: '1',


### PR DESCRIPTION
Fixes TTDB 'never synced' (FK error on ingest). The contribution-store codec enforced FK integrity stricter than `resolve()`: a source whose links reference ports the node never enumerated, empty-string ports, or a non-existent node aborted the whole source ingest with `FOREIGN KEY constraint failed`. TTDB emits interface labels (+ `port: ''`) with no port inventory.

ingestGraph now matches resolve's tolerance: empty port ≡ no port; an undeclared referenced port gets a synthesized stub element (like Zabbix's ensurePort); a dangling-node link is skipped. Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)