### PR TITLE
fix(server): Sync-all stamps lastSyncedAt per source

### DIFF
--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -542,6 +542,11 @@ export function createTopologiesApi(): Hono {
             status === 'failed' ? 'failed' : 'ok',
             capturedAt,
           )
+          // Stamp lastSyncedAt on the attachment so the UI's per-source "last
+          // synced" reflects a Sync-all too (the per-source /sync route already
+          // does this; without it a source only ever Synced via Sync-all shows
+          // "never synced" despite having recorded observations).
+          getTopologySourcesService().updateLastSynced(source.id)
 
           return {
             sourceId: source.dataSourceId,


### PR DESCRIPTION
`sync-from-source` (Sync all) recorded observations but never stamped `topology_data_sources.last_synced_at`, so a source only ever synced via Sync-all showed **'never synced'** in the UI despite having data (e.g. a freshly added TTDB source). Mirrors the per-source `/sync` route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)