### PR TITLE
feat(core): ordering-driven scope — top source confines lower sources

### DIFF
--- a/apps/server/docs/design/topology-source-modes.md
+++ b/apps/server/docs/design/topology-source-modes.md
@@ -107,12 +107,32 @@ UI presents **role presets** over these knobs; raw knobs are an advanced surface
 
 | Preset | node | link | scope_role | meaning |
 |--------|------|------|-----------|---------|
-| **Additive** (default) | scoop | add | NULL | adds nodes+links, unions like today |
-| **Scoping** | scoop | add | scoping | defines a closed region; out-of-region clusters dropped |
+| **Additive** | scoop | add | NULL | adds nodes+links within the scope |
 | **Enrichment** | anchor | update | NULL | fills fields of existing entities only |
+| **Scoping** (override) | scoop | add | scoping | force this source to define the scope even when it isn't top-priority |
 
-Default on attach is **Additive** — unconstrained, preserves current union
-behavior. Scoping / Enrichment are explicit opt-in.
+**Scope is ordering-driven (decided model 2).** The highest-priority topology
+SOURCE (the intrinsic overlay is excluded — it's curation, not coverage) defines
+the closed world: its regions confine every lower-priority source to within them.
+There is no per-source "is this the scope?" flag for the common case — priority
+already orders the sources, and the top one's coverage *is* the scope. `scope_role`
+is demoted to a manual **override** (force a non-top source to also define scope).
+Scope only activates when a scope-defining source actually contributes regions; a
+single source, or sources with no regions, resolve as an open-world union.
+
+The scope **confines** lower sources — it never drops curation or the scope
+owner's own nodes. A cluster survives iff it (a) has an intrinsic member, (b) has a
+member from a scope-defining source (its own coverage; a lower source merged into
+such a cluster rides along), (c) lands in a closed region by parent, or (d) matches
+a closed region's membership predicate. Otherwise it's an out-of-range node from a
+lower source → dropped (its links dangle and drop too).
+
+> For "Additive = ADD new within the scope" to differ from Enrichment, the scope
+> must be **predicate-based** (region `membership`): a brand-new lower-source node
+> can only be "within scope" if it matches a region predicate. With an enumeration-
+> only scope (a source that emits subgraphs but no `membership`), a new lower node
+> can't be placed in-region, so Additive degenerates to Enrichment (only
+> identity-merged nodes survive). This needs plugins to emit region membership.
 
 Resolve wiring:
 
@@ -120,9 +140,8 @@ Resolve wiring:
   (Axis B handles the rest).
 - `link_contribution=update` → the source's links contribute fields to an existing
   link cluster but never create a new link cluster.
-- `scope_role=scoping` → the source's regions are closed: any cluster that is not a
-  member of some closed region is dropped (inclusion predicate — the sibling of the
-  existing `isClusterExcluded` exclusion filter).
+- scope → the highest-priority source's regions (or an override source's) are
+  closed; `clusterInClosedScope` confines lower sources to them.
 
 ### hideDisconnected is post-resolve display (Axis E)
 

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1761,27 +1761,28 @@ describe('resolve()', () => {
       expect(out.links[0]?.presence).toBeUndefined() // input-only, never emitted
     })
 
-    it('a closed region drops out-of-scope clusters, keeps in-region + membership matches', () => {
+    it('top-priority source defines the scope; a lower source is confined to it', () => {
+      // A (priority 1) is the highest-priority source → its region is the closed
+      // world (ordering-driven, no explicit flag). B (priority 0) is confined:
+      // its node that matches A's region membership is kept (fills the scope),
+      // the out-of-range one is dropped. A's own node is always kept.
       const scoping: SnapshotEntry = {
         sourceId: 'A',
         capturedAt: 1,
+        priority: 1,
         status: 'ok',
         graph: {
           ...emptyGraph(),
           nodes: [{ id: 'a1', label: 'in-region', identity: { mgmtIp: '10.0.0.1' }, parent: 'g' }],
           subgraphs: [
-            {
-              id: 'g',
-              label: 'Region',
-              scope: 'closed',
-              membership: [{ attr: 'subnet', value: '10.0.0.0/24' }],
-            },
+            { id: 'g', label: 'Region', membership: [{ attr: 'subnet', value: '10.0.0.0/24' }] },
           ],
         },
       }
       const additive: SnapshotEntry = {
         sourceId: 'B',
         capturedAt: 1,
+        priority: 0,
         status: 'ok',
         graph: {
           ...emptyGraph(),
@@ -1792,8 +1793,54 @@ describe('resolve()', () => {
         },
       }
       const out = resolve(emptyGraph(), [scoping, additive])
-      const labels = out.nodes.map((n) => n.label).sort()
-      expect(labels).toEqual(['fills-region', 'in-region'])
+      expect(out.nodes.map((n) => n.label).sort()).toEqual(['fills-region', 'in-region'])
+    })
+
+    it('an intrinsic (curated) node is never dropped by scope', () => {
+      const intrinsic: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [{ id: 'op', label: 'operator-placed', identity: { mgmtIp: '10.9.0.1' } }],
+      }
+      // A scope-defining source whose region does NOT contain the intrinsic node.
+      const scoping: SnapshotEntry = {
+        sourceId: 'A',
+        capturedAt: 1,
+        priority: 1,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [{ id: 'a1', label: 'a1', identity: { mgmtIp: '10.0.0.1' }, parent: 'g' }],
+          subgraphs: [{ id: 'g', label: 'Region' }],
+        },
+      }
+      const out = resolve(intrinsic, [scoping])
+      expect(out.nodes.map((n) => n.label).sort()).toEqual(['a1', 'operator-placed'])
+    })
+
+    it('no scope when sources contribute no regions (open-world union)', () => {
+      const a: SnapshotEntry = {
+        sourceId: 'A',
+        capturedAt: 1,
+        priority: 1,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [{ id: 'a1', label: 'a', identity: { mgmtIp: '10.0.0.1' } }],
+        },
+      }
+      const b: SnapshotEntry = {
+        sourceId: 'B',
+        capturedAt: 1,
+        priority: 0,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [{ id: 'b1', label: 'b', identity: { mgmtIp: '10.9.0.1' } }],
+        },
+      }
+      const out = resolve(emptyGraph(), [a, b])
+      // no regions → no closed scope → both kept (union)
+      expect(out.nodes.map((n) => n.label).sort()).toEqual(['a', 'b'])
     })
   })
 })

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -138,16 +138,25 @@ export function resolve(
     for (const m of cl.members) regionIdRemap.set(m.subgraph.id, cl.canonicalId)
   }
 
-  // 2d. Scope. A `scope_role:'scoping'` source marks its regions `scope:'closed'`.
-  //     When any closed region exists the topology is a closed world: a cluster
-  //     survives only if it belongs to some closed region (its parent region is
-  //     closed/descends from one, OR it matches a closed region's membership).
-  //     Dropping here (before fold) means links to out-of-scope nodes dangle and
-  //     drop too. No closed region → no filtering (open world, the default).
-  const scope = buildScopeIndex(regions, regionIdRemap)
+  // 2d. Scope (ordering-driven). The highest-priority topology SOURCE (the
+  //     intrinsic overlay is excluded — it's curation, not coverage) defines the
+  //     closed world: its regions confine every lower source to within them. A
+  //     source may also force itself scope-defining with an explicit
+  //     `scope:'closed'` region (manual override, regardless of priority). When
+  //     such a scope exists, a cluster survives only if it (a) carries an
+  //     intrinsic member — operator curation is never dropped — or (b) carries a
+  //     member from a scope-defining source (its own coverage) or (c) lands in a
+  //     closed region by parent or membership. So a lower source ENRICHES /
+  //     ADDS within the scope but cannot drag in out-of-range nodes. No
+  //     scope-defining region → no filtering (open-world union, e.g. a single
+  //     source or sources that contribute no regions).
+  const scopeDefiningSourceIds = computeScopeDefiningSources(contributions)
+  const scope = buildScopeIndex(regions, regionIdRemap, scopeDefiningSourceIds)
   const nodeClusters =
     scope.closedRegionIds.size > 0
-      ? afterExclusions.filter((c) => clusterInClosedScope(c, regions, regionIdRemap, scope))
+      ? afterExclusions.filter((c) =>
+          clusterInClosedScope(c, regions, regionIdRemap, scope, scopeDefiningSourceIds),
+        )
       : afterExclusions
 
   // 3. For each cluster, fold into a single resolved Node
@@ -965,21 +974,44 @@ function ipv4InCidr(ip: string, cidr: string): boolean {
 }
 
 interface ScopeIndex {
-  /** Canonical ids of regions explicitly marked `scope:'closed'`. */
+  /** Canonical ids of regions owned by a scope-defining source (the closed world). */
   closedRegionIds: Set<string>
   /** True if `regionId` is closed or descends from a closed region. */
   inClosedScope: (regionId: string) => boolean
+}
+
+/**
+ * The sources whose regions form the closed scope: the highest-priority
+ * non-intrinsic source(s), PLUS any source that explicitly marks a region
+ * `scope:'closed'` (manual override regardless of priority). The intrinsic
+ * overlay (+∞) is excluded — it's curation, not coverage, so it never defines
+ * the scope. Empty when there are no non-intrinsic sources.
+ */
+function computeScopeDefiningSources(contributions: Contribution[]): Set<string> {
+  const sources = contributions.filter((c) => c.sourceId !== 'intrinsic')
+  const ids = new Set<string>()
+  if (sources.length === 0) return ids
+  const maxPriority = sources.reduce((m, c) => Math.max(m, c.priority), Number.NEGATIVE_INFINITY)
+  for (const c of sources) {
+    if (c.priority === maxPriority) ids.add(c.sourceId)
+    else if ((c.graph.subgraphs ?? []).some((s) => s.scope === 'closed')) ids.add(c.sourceId)
+  }
+  return ids
 }
 
 /** Index closed regions + the region parent chain for scope ancestry walks. */
 function buildScopeIndex(
   clusters: RegionCluster[],
   regionIdRemap: Map<string, string>,
+  scopeDefiningSourceIds: Set<string>,
 ): ScopeIndex {
   const closedRegionIds = new Set<string>()
   const regionParent = new Map<string, string>()
   for (const cl of clusters) {
-    if (cl.members.some((m) => m.subgraph.scope === 'closed')) closedRegionIds.add(cl.canonicalId)
+    // A region is closed if a scope-defining source contributed (any member of)
+    // it — that includes top-priority sources' regions automatically.
+    if (cl.members.some((m) => scopeDefiningSourceIds.has(m.sourceId)))
+      closedRegionIds.add(cl.canonicalId)
     const ranked = [...cl.members].sort(
       (a, b) => b.priority - a.priority || b.capturedAt - a.capturedAt,
     )
@@ -1004,16 +1036,28 @@ function buildScopeIndex(
 }
 
 /**
- * Whether a node cluster belongs to a closed region: its winning parent region
- * (highest-priority member's `parent`, remapped) is closed/descends from one, OR
- * any member matches a closed region's membership criteria.
+ * Whether a node cluster survives a closed scope. The scope CONFINES lower
+ * sources to the scope-defining source's coverage; it never drops curation or
+ * the scope owner's own nodes. A cluster is in scope if:
+ *   - it carries an intrinsic member (operator curation — never dropped), OR
+ *   - it carries a member from a scope-defining source (the owner's coverage —
+ *     and a lower source that merged into such a cluster rides along), OR
+ *   - its winning parent region is closed / descends from one, OR
+ *   - any member matches a closed region's membership criteria (a lower source
+ *     filling a gap WITHIN the scope by predicate).
+ * Otherwise it's an out-of-range node from a lower source → dropped.
  */
 function clusterInClosedScope(
   cluster: NodeCluster,
   clusters: RegionCluster[],
   regionIdRemap: Map<string, string>,
   scope: ScopeIndex,
+  scopeDefiningSourceIds: Set<string>,
 ): boolean {
+  for (const m of cluster.members) {
+    if (m.sourceId === 'intrinsic') return true
+    if (scopeDefiningSourceIds.has(m.sourceId)) return true
+  }
   let parentRegion: string | undefined
   for (const m of rankMembers(cluster.members)) {
     if (m.node.parent) {


### PR DESCRIPTION
Reworks scope from an explicit per-source flag (model 1) to **ordering-driven** (model 2): the highest-priority topology SOURCE defines the closed world and confines every lower-priority source to within its regions. The intrinsic overlay (+∞) is excluded (curation, not coverage). `scope_role` is demoted to a manual **override**.

Scope **confines** (never drops curation or the scope owner's own nodes): a cluster survives iff it has an intrinsic member, a member from a scope-defining source, a closed parent region, or a closed-region membership match. Activates only when a scope-defining source contributes regions (else open-world union).

Tests: top source confines a lower source; intrinsic never dropped; no regions → union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)