### PR TITLE
fix(core): prune empty subgraphs (no floating boxes) (#403)

### DIFF
--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1481,6 +1481,8 @@ describe('resolve()', () => {
       // output: resolve is the sole authority and always restamps.
       const intrinsic = {
         ...emptyGraph(),
+        // A member node keeps the subgraph (empty subgraphs are pruned).
+        nodes: [{ id: 'n', label: 'N', parent: 'sg-stale' }],
         subgraphs: [
           {
             id: 'sg-stale',
@@ -1549,6 +1551,8 @@ describe('resolve()', () => {
         status: 'ok',
         graph: {
           ...emptyGraph(),
+          // A node in the leaf keeps the rack→site chain (empty regions prune).
+          nodes: [{ id: 'n', label: 'N', identity: { mgmtIp: '10.0.0.1' }, parent: 'rack' }],
           subgraphs: [
             { id: 'site', label: 'Site', children: ['rack'] },
             { id: 'rack', label: 'Rack', parent: 'site' },
@@ -1599,13 +1603,39 @@ describe('resolve()', () => {
       const out = resolve(intrinsic, [snap])
       const ids = out.subgraphs?.map((s) => s.id) ?? []
       expect(ids).toContain('intrinsic-sg') // raw — intrinsic owns the id space
-      expect(ids).toContain('src-a:1:sg-2')
-      // same identity (10.0.0.1) clusters into one node; intrinsic parent wins
+      // same identity (10.0.0.1) clusters into one node; intrinsic parent wins →
+      // the source group sg-2 ends up empty and is pruned (no floating box).
+      expect(ids).not.toContain('src-a:1:sg-2')
       const r1 = out.nodes.find((n) => n.label === 'R1')
       expect(r1?.parent).toBe('intrinsic-sg')
       expect(out.subgraphs?.find((s) => s.id === 'intrinsic-sg')?.provenance?.source).toBe(
         'intrinsic',
       )
+    })
+
+    it('prunes empty subgraphs but keeps non-empty ones nested (no floating boxes)', () => {
+      // Pod has no direct members; only its leaf 5Y has a node. Stage is fully
+      // empty. Result: Stage pruned; 5Y + its ancestor Pod kept and nested.
+      const snap: SnapshotEntry = {
+        sourceId: 'src',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [{ id: 'n', label: 'sw', identity: { mgmtIp: '10.0.0.1' }, parent: 'rack5y' }],
+          subgraphs: [
+            { id: 'pod', label: 'Pod' },
+            { id: 'rack5y', label: '5Y', parent: 'pod' },
+            { id: 'stage', label: 'Stage' }, // fully empty → pruned
+            { id: 'rack6y', label: '6Y', parent: 'pod' }, // empty leaf → pruned
+          ],
+        },
+      }
+      const out = resolve(emptyGraph(), [snap])
+      const labels = (out.subgraphs ?? []).map((s) => s.label).sort()
+      expect(labels).toEqual(['5Y', 'Pod']) // Stage + 6Y pruned
+      const rack = out.subgraphs?.find((s) => s.label === '5Y')
+      expect(rack?.parent).toBe('src:pod') // still nested under its kept ancestor
     })
   })
 

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -197,7 +197,12 @@ export function resolve(
   const resolvedLinks = foldLinks(contributions, clusterById, portIdRemap)
 
   // 5. Subgraphs — fold each region cluster into one merged subgraph.
-  const resolvedSubgraphs = foldRegions(regions, regionIdRemap)
+  // Keep a region only if it has a resolved MEMBER node (directly or via a
+  // descendant), plus its ancestor chain so it nests. Empty regions — e.g. a
+  // confined source's groups whose nodes were dropped/re-parented — are pruned
+  // so they don't render as floating boxes.
+  const keptRegions = computeKeptRegions(resolvedNodes, regions, regionIdRemap)
+  const resolvedSubgraphs = foldRegions(regions, regionIdRemap, keptRegions)
 
   return {
     version: authored.version,
@@ -1117,12 +1122,53 @@ function dedupMembership(crit: MembershipCriterion[]): MembershipCriterion[] {
  * parent / children ids are remapped through the region map. Provenance is
  * ALWAYS restamped so resolve is the sole authority.
  */
+/** Canonical parent of a region cluster (highest-priority member's parent, remapped). */
+function regionParentId(cl: RegionCluster, regionIdRemap: Map<string, string>): string | undefined {
+  const ranked = [...cl.members].sort(
+    (a, b) => b.priority - a.priority || b.capturedAt - a.capturedAt,
+  )
+  for (const m of ranked) {
+    if (m.subgraph.parent) return regionIdRemap.get(m.subgraph.parent) ?? m.subgraph.parent
+  }
+  return undefined
+}
+
+/**
+ * Regions to keep: those with a resolved member node (directly or via a
+ * descendant), plus the full ancestor chain of each so the kept regions nest.
+ * Empty regions are excluded → no floating boxes.
+ */
+function computeKeptRegions(
+  resolvedNodes: Node[],
+  clusters: RegionCluster[],
+  regionIdRemap: Map<string, string>,
+): Set<string> {
+  const parentOf = new Map<string, string>()
+  for (const cl of clusters) {
+    const p = regionParentId(cl, regionIdRemap)
+    if (p) parentOf.set(cl.canonicalId, p)
+  }
+  const kept = new Set<string>()
+  for (const n of resolvedNodes) {
+    let cur: string | undefined = n.parent
+    const seen = new Set<string>()
+    while (cur && !seen.has(cur)) {
+      seen.add(cur)
+      kept.add(cur)
+      cur = parentOf.get(cur)
+    }
+  }
+  return kept
+}
+
 function foldRegions(
   clusters: RegionCluster[],
   regionIdRemap: Map<string, string>,
+  keptRegions: Set<string>,
 ): Subgraph[] | undefined {
   const out: Subgraph[] = []
   for (const cl of clusters) {
+    if (!keptRegions.has(cl.canonicalId)) continue
     const ranked = [...cl.members].sort(
       (a, b) => b.priority - a.priority || b.capturedAt - a.capturedAt,
     )
@@ -1152,7 +1198,11 @@ function foldRegions(
     const parentRaw = pick((s) => s.parent)
     const parent = parentRaw ? (regionIdRemap.get(parentRaw) ?? parentRaw) : undefined
     const childrenRaw = cl.members.flatMap((m) => m.subgraph.children ?? [])
-    const children = [...new Set(childrenRaw.map((c) => regionIdRemap.get(c) ?? c))]
+    const children = [
+      ...new Set(
+        childrenRaw.map((c) => regionIdRemap.get(c) ?? c).filter((c) => keptRegions.has(c)),
+      ),
+    ]
     const direction = pick((s) => s.direction)
     const style = pick((s) => s.style)
     const spec = pick((s) => s.spec)


### PR DESCRIPTION
Closes #403.

resolve() emitted every region cluster regardless of membership, so a confined lower source's groups (whose nodes were dropped or re-parented under scope) rendered as empty **floating-island boxes** (test6: ~50 of TTDB's 62 subgraphs were empty).

Now a region is kept only if it has a resolved member node directly or via a descendant, with its ancestor chain kept so survivors still nest; children refs to pruned regions are dropped. This is **membership-derived** (kept by whether it actually holds resolved nodes), not hardcoded 'nest under the scope' — a lower source's group that legitimately holds in-scope nodes is kept and nested; only the genuinely-empty ones prune. On test6: resolved subgraphs **63 → 13**, no empties.

Tests: updated the three fold/namespacing tests to give their subgraphs a member; added a dedicated prune test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)