### PR TITLE
fix(core): make scope region-centric (drop scope source's out-of-region nodes)

### DIFF
--- a/apps/server/docs/design/topology-source-modes.md
+++ b/apps/server/docs/design/topology-source-modes.md
@@ -120,12 +120,19 @@ is demoted to a manual **override** (force a non-top source to also define scope
 Scope only activates when a scope-defining source actually contributes regions; a
 single source, or sources with no regions, resolve as an open-world union.
 
-The scope **confines** lower sources — it never drops curation or the scope
-owner's own nodes. A cluster survives iff it (a) has an intrinsic member, (b) has a
-member from a scope-defining source (its own coverage; a lower source merged into
-such a cluster rides along), (c) lands in a closed region by parent, or (d) matches
-a closed region's membership predicate. Otherwise it's an out-of-range node from a
-lower source → dropped (its links dangle and drop too).
+The scope is **region-centric**: it is the scope source's REGIONS (e.g. a Zabbix
+host group), and "in scope" means being a member of such a region — NOT merely
+being emitted by the scope source. A cluster survives iff it (a) has an intrinsic
+member that makes a real topology claim (operator curation; a bare metrics-binding
+anchor does NOT count), (b) lands in a closed region by parent / ancestor, or
+(c) matches a closed region's membership predicate. Closed regions are those
+contributed by a scope-defining source OR the operator overlay.
+
+Critically this means the **scope source's own out-of-region nodes are dropped**,
+not just lower sources' — e.g. Zabbix LLDP external neighbors (synthesized for
+connectivity, but sitting outside the fetched host group) are out of scope and
+removed (their links dangle and drop). "Outside the host-group box" = "outside the
+scope", which is the whole point of scoping.
 
 > For "Additive = ADD new within the scope" to differ from Enrichment, the scope
 > must be **predicate-based** (region `membership`): a brand-new lower-source node

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1826,6 +1826,29 @@ describe('resolve()', () => {
       expect(out.nodes.map((n) => n.label).sort()).toEqual(['fills-region', 'in-region'])
     })
 
+    it('scope is region-centric: the scope source’s own out-of-region nodes drop', () => {
+      // Scope = the source's REGIONS, not everything it emits. A node IN the
+      // region is kept; the source's own peripheral node that is in NO region
+      // (e.g. a Zabbix LLDP external neighbor, outside the fetched host group)
+      // is OUT of scope and dropped.
+      const scoping: SnapshotEntry = {
+        sourceId: 'A',
+        capturedAt: 1,
+        priority: 1,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            { id: 'in', label: 'in-region', identity: { mgmtIp: '10.0.0.1' }, parent: 'g' },
+            { id: 'ext', label: 'external-neighbor', identity: { sysName: 'peer' } }, // no region
+          ],
+          subgraphs: [{ id: 'g', label: 'Region' }],
+        },
+      }
+      const out = resolve(emptyGraph(), [scoping])
+      expect(out.nodes.map((n) => n.label)).toEqual(['in-region'])
+    })
+
     it('an intrinsic (curated) node is never dropped by scope', () => {
       const intrinsic: NetworkGraph = {
         ...emptyGraph(),

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -138,25 +138,21 @@ export function resolve(
     for (const m of cl.members) regionIdRemap.set(m.subgraph.id, cl.canonicalId)
   }
 
-  // 2d. Scope (ordering-driven). The highest-priority topology SOURCE (the
-  //     intrinsic overlay is excluded — it's curation, not coverage) defines the
-  //     closed world: its regions confine every lower source to within them. A
-  //     source may also force itself scope-defining with an explicit
-  //     `scope:'closed'` region (manual override, regardless of priority). When
-  //     such a scope exists, a cluster survives only if it (a) carries an
-  //     intrinsic member — operator curation is never dropped — or (b) carries a
-  //     member from a scope-defining source (its own coverage) or (c) lands in a
-  //     closed region by parent or membership. So a lower source ENRICHES /
-  //     ADDS within the scope but cannot drag in out-of-range nodes. No
-  //     scope-defining region → no filtering (open-world union, e.g. a single
-  //     source or sources that contribute no regions).
+  // 2d. Scope (ordering-driven, region-centric). The highest-priority topology
+  //     SOURCE (the intrinsic overlay is excluded as scope DEFINER — it's
+  //     curation, not coverage) makes its REGIONS the closed world. "In scope"
+  //     means being a member of a closed region — NOT merely being emitted by the
+  //     scope source — so even the scope source's own out-of-region nodes (e.g.
+  //     Zabbix LLDP external neighbors, outside the fetched host group) are
+  //     dropped. Closed regions = those from a scope-defining source OR the
+  //     overlay. Operator curation (a real intrinsic node) is always kept. No
+  //     closed region → no filtering (open-world union: a single source / sources
+  //     with no regions / no overlay regions). See clusterInClosedScope.
   const scopeDefiningSourceIds = computeScopeDefiningSources(contributions)
   const scope = buildScopeIndex(regions, regionIdRemap, scopeDefiningSourceIds)
   const nodeClusters =
     scope.closedRegionIds.size > 0
-      ? afterExclusions.filter((c) =>
-          clusterInClosedScope(c, regions, regionIdRemap, scope, scopeDefiningSourceIds),
-        )
+      ? afterExclusions.filter((c) => clusterInClosedScope(c, regions, regionIdRemap, scope))
       : afterExclusions
 
   // 3. For each cluster, fold into a single resolved Node
@@ -1013,9 +1009,13 @@ function buildScopeIndex(
   const closedRegionIds = new Set<string>()
   const regionParent = new Map<string, string>()
   for (const cl of clusters) {
-    // A region is closed if a scope-defining source contributed (any member of)
-    // it — that includes top-priority sources' regions automatically.
-    if (cl.members.some((m) => scopeDefiningSourceIds.has(m.sourceId)))
+    // A region is part of the closed scope if a scope-defining source OR the
+    // operator overlay (intrinsic curation) contributed it. Scope-source regions
+    // (e.g. Zabbix host groups) come in automatically; operator-authored regions
+    // count too, so a node matching their membership is in scope.
+    if (
+      cl.members.some((m) => m.sourceId === 'intrinsic' || scopeDefiningSourceIds.has(m.sourceId))
+    )
       closedRegionIds.add(cl.canonicalId)
     const ranked = [...cl.members].sort(
       (a, b) => b.priority - a.priority || b.capturedAt - a.capturedAt,
@@ -1041,27 +1041,46 @@ function buildScopeIndex(
 }
 
 /**
- * Whether a node cluster survives a closed scope. The scope CONFINES lower
- * sources to the scope-defining source's coverage; it never drops curation or
- * the scope owner's own nodes. A cluster is in scope if:
- *   - it carries an intrinsic member (operator curation — never dropped), OR
- *   - it carries a member from a scope-defining source (the owner's coverage —
- *     and a lower source that merged into such a cluster rides along), OR
+ * Whether an intrinsic (overlay) node makes a real TOPOLOGY claim — operator
+ * curation of a node's existence — rather than merely a metrics-binding anchor.
+ * A binding-only overlay node carries identity + metrics-binding(s) with an empty
+ * label and no other authored content; it asserts nothing about presence/scope.
+ * `presence:'anchor'` says so explicitly; we also detect the binding-only shape
+ * for older data stored as scoop.
+ */
+function intrinsicAssertsTopology(node: Node): boolean {
+  if (node.presence === 'anchor') return false
+  const label = Array.isArray(node.label) ? node.label.join('') : (node.label ?? '')
+  if (label.trim() !== '') return true
+  if (node.spec || node.shape || node.style || node.parent || node.rank || node.productId)
+    return true
+  if ((node.ports?.length ?? 0) > 0) return true
+  if ((node.attachments ?? []).some((a) => a.kind !== 'metrics-binding')) return true
+  return false
+}
+
+/**
+ * Whether a node cluster is IN the closed scope. The scope is the scope-defining
+ * source's REGIONS (e.g. a host group) — being a member of such a region is what
+ * "in scope" means, NOT merely being emitted by the scope source. So a scope
+ * source's own peripheral nodes that aren't in any of its regions (e.g. Zabbix
+ * LLDP external neighbors, which sit outside the fetched host group) are OUT of
+ * scope. A cluster is in scope if:
+ *   - it carries an intrinsic member that makes a real topology claim (operator
+ *     curation — never dropped; a bare metrics-binding doesn't count), OR
  *   - its winning parent region is closed / descends from one, OR
  *   - any member matches a closed region's membership criteria (a lower source
  *     filling a gap WITHIN the scope by predicate).
- * Otherwise it's an out-of-range node from a lower source → dropped.
+ * Otherwise it's outside the scope's regions → dropped.
  */
 function clusterInClosedScope(
   cluster: NodeCluster,
   clusters: RegionCluster[],
   regionIdRemap: Map<string, string>,
   scope: ScopeIndex,
-  scopeDefiningSourceIds: Set<string>,
 ): boolean {
   for (const m of cluster.members) {
-    if (m.sourceId === 'intrinsic') return true
-    if (scopeDefiningSourceIds.has(m.sourceId)) return true
+    if (m.sourceId === 'intrinsic' && intrinsicAssertsTopology(m.node)) return true
   }
   let parentRegion: string | undefined
   for (const m of rankMembers(cluster.members)) {


### PR DESCRIPTION
Scope kept any cluster with a member from the scope-defining source. But the scope is the source's **regions** (e.g. a Zabbix host group), not everything it emits — so Zabbix's LLDP **external neighbors** (synthesized for connectivity, outside the fetched host group) leaked in as nodes 'outside the Scoop'. Bug.

Now **in scope = member of a closed region**: kept if (a) an intrinsic member makes a real topology claim (operator curation; a bare metrics-binding anchor doesn't count — also catches stale binding nodes), (b) winning parent region is closed, or (c) matches a closed region's membership. Closed regions = scope-defining source's OR the overlay's. The 'from scope source → keep' clause is removed, so the scope source's own out-of-region nodes drop too.

On test6 (scope = Backbone Routers): **100 → 63 nodes, all inside the region**, no nodes outside the scope, no floating.

Tests: region-centric drop + existing scope/membership pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)