### PR TITLE
feat(core): cross-source link dedup via interface-name matching (#404)

### DIFF
--- a/libs/@shumoku/core/src/observation/index.ts
+++ b/libs/@shumoku/core/src/observation/index.ts
@@ -4,6 +4,7 @@
 
 export * from './discovery-policy.js'
 export * from './identity.js'
+export * from './interface-name.js'
 export * from './metrics-binding.js'
 export * from './resolve.js'
 export * from './types.js'

--- a/libs/@shumoku/core/src/observation/interface-name.ts
+++ b/libs/@shumoku/core/src/observation/interface-name.ts
@@ -1,0 +1,150 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Interface / port name normalization + cross-system matching.
+ *
+ * Different systems name the same physical port differently:
+ *   NetBox "GE0/1" ↔ Zabbix "Gi1/0/1" ↔ SNMP "GigabitEthernet1/0/1"
+ *   TTDB speed-codes "hg-0/0/0/8" (100G) ↔ Zabbix "HundredGigE0/0/0/8"
+ * and TTDB uses dashes where others use slashes ("hg-0-0-0" ≡ "hg/0/0/0").
+ *
+ * This is the shared core of what the web "auto-mapping" UI uses; resolve()'s
+ * link dedup uses it too, so the same matching governs both metric-binding and
+ * cross-source link folding.
+ */
+
+const PREFIX_GROUPS: [string[], string][] = [
+  [
+    ['eighthundredgigabitethernet', 'eighthundredgigabitether', 'eighthundredgige', 'ehg'],
+    'eighthundredge',
+  ],
+  [
+    ['fourhundredgigabitethernet', 'fourhundredgigabitether', 'fourhundredgige', 'fhg'],
+    'fourhundredge',
+  ],
+  [['hundredgigabitethernet', 'hundredgigabitether', 'hundredgige', 'hu', 'hg'], 'hundredge'],
+  [['fortygigabitethernet', 'fortygigabitether', 'fortygige', 'fo', 'fg'], 'fortyge'],
+  [['twentyfivegigabitethernet', 'twentyfivegige'], 'twentyfivege'],
+  [
+    ['tengigabitethernet', 'tengigabitether', 'tengigaethernet', 'tenge', 'te', 'xge', 'xe', 'xg'],
+    'te',
+  ],
+  [['gigabitethernet', 'gigaethernet', 'gi', 'ge'], 'ge'],
+  [['fastethernet', 'fa', 'fe'], 'fe'],
+  [['ethernet', 'ens', 'enp', 'eno', 'eth', 'en'], 'eth'],
+  [['port-channel', 'portchannel', 'po', 'ae', 'bond'], 'lag'],
+  [['vlan', 'vl', 'irb'], 'vlan'],
+  [['loopback', 'lo'], 'lo'],
+  [['tunnel', 'tu', 'tun'], 'tun'],
+  [['management', 'mgmt', 'me'], 'mgmt'],
+  [['wireless', 'wifi', 'wlan'], 'wlan'],
+  [['wired'], 'wired'],
+  [['serial', 'se'], 'serial'],
+  [['bvi'], 'bvi'],
+]
+
+const SORTED_PREFIX_GROUPS = PREFIX_GROUPS.map(
+  ([synonyms, canonical]) =>
+    [synonyms.slice().sort((a, b) => b.length - a.length), canonical] as [string[], string],
+)
+
+export interface NormalizedInterface {
+  prefix: string
+  numbers: number[]
+  sub: number | null
+  original: string
+}
+
+/**
+ * Normalize an interface name to `{ prefix, numbers, sub }`. The numeric part is
+ * split on `/`, `-`, or `:` so TTDB's dash form ("hg-0-0-0" → [0,0,0]) lines up
+ * with the slash form ("hg/0/0/0" → [0,0,0]).
+ */
+export function normalizeInterfaceName(name: string): NormalizedInterface {
+  const lower = name.toLowerCase().trim()
+
+  let prefix = ''
+  let prefixLen = 0
+  let rest = lower
+
+  for (const [synonyms, canonical] of SORTED_PREFIX_GROUPS) {
+    for (const syn of synonyms) {
+      if (lower.startsWith(syn) && syn.length > prefixLen) {
+        prefix = canonical
+        prefixLen = syn.length
+        rest = lower.slice(syn.length)
+      }
+    }
+  }
+
+  if (!prefix) {
+    const m = lower.match(/^([a-z][a-z-]*)(.*)$/)
+    if (m?.[1] && m[2]) {
+      prefix = m[1]
+      rest = m[2]
+    } else {
+      return { prefix: lower, numbers: [], sub: null, original: name }
+    }
+  }
+
+  // Strip leading separators/non-digits left over from the prefix.
+  rest = rest.replace(/^[^0-9]*/, '')
+
+  const numbers: number[] = []
+  let sub: number | null = null
+
+  if (rest) {
+    // Split on slash, dash, or colon — all act as segment separators.
+    const segments = rest.split(/[/\-:]/)
+    for (const [i, seg] of segments.entries()) {
+      const dotParts = seg.split('.')
+      if (!dotParts[0]) continue
+      const main = Number.parseInt(dotParts[0], 10)
+      if (!Number.isNaN(main)) numbers.push(main)
+      if (i === segments.length - 1 && dotParts.length > 1 && dotParts[1]) {
+        const s = Number.parseInt(dotParts[1], 10)
+        if (!Number.isNaN(s)) sub = s
+      }
+    }
+  }
+
+  return { prefix, numbers, sub, original: name }
+}
+
+/**
+ * Score how well two normalized interface names match (0–1): same canonical
+ * prefix, then port numbers compared right-to-left (rightmost = most specific).
+ */
+export function interfaceMatchScore(a: NormalizedInterface, b: NormalizedInterface): number {
+  if (a.prefix !== b.prefix) return 0
+  if (a.numbers.length === 0 && b.numbers.length === 0) return 1.0
+  if (a.numbers.length === 0 || b.numbers.length === 0) return 0.3
+
+  const aRev = [...a.numbers].reverse()
+  const bRev = [...b.numbers].reverse()
+  const minLen = Math.min(aRev.length, bRev.length)
+  let matched = 0
+  for (let i = 0; i < minLen; i++) {
+    if (aRev[i] === bRev[i]) matched++
+    else break
+  }
+  if (matched === 0) return 0
+  const maxLen = Math.max(aRev.length, bRev.length)
+  return matched === maxLen ? 1.0 : 0.5 + (matched / maxLen) * 0.4
+}
+
+/**
+ * Whether two interface names denote the same physical port. Same canonical
+ * prefix with aligning numbers (score ≥ 0.5), OR — for cross-vocabulary cases
+ * like TTDB's speed-code `hg` vs Juniper `et-` where prefixes differ but the
+ * port number is identical — the full number sequence matches.
+ */
+export function interfaceNamesMatch(a: string, b: string): boolean {
+  if (!a || !b) return false
+  const na = normalizeInterfaceName(a)
+  const nb = normalizeInterfaceName(b)
+  if (interfaceMatchScore(na, nb) >= 0.5) return true
+  if (na.numbers.length > 0 && na.numbers.join('/') === nb.numbers.join('/')) return true
+  return false
+}

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -236,6 +236,53 @@ describe('resolve()', () => {
       const out = resolve(emptyGraph(), [snap])
       expect(out.links).toHaveLength(2)
     })
+
+    it('cross-vocabulary port names fold to one edge (#404)', () => {
+      // Same physical link seen by two sources that NAME the ports differently:
+      //   A: "HundredGigE0/0/0/8" ↔ "HundredGigE0/0/0/1"
+      //   B: "hg-0/0/0/8"         ↔ "515" (Zabbix ifIndex on the far end)
+      // The near end matches across vocabularies; the far end disagrees (ifIndex
+      // vs name) but one matching end is enough → a single edge.
+      const mk = (
+        sourceId: string,
+        capturedAt: number,
+        prefix: string,
+        p1: string,
+        p2: string,
+      ): SnapshotEntry => ({
+        sourceId,
+        capturedAt,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            {
+              id: `${prefix}1`,
+              label: 'R1',
+              identity: { mgmtIp: '10.0.0.1' },
+              ports: [port(`${prefix}1p`, p1)],
+            },
+            {
+              id: `${prefix}2`,
+              label: 'R2',
+              identity: { mgmtIp: '10.0.0.2' },
+              ports: [port(`${prefix}2p`, p2)],
+            },
+          ],
+          links: [
+            {
+              from: { node: `${prefix}1`, port: `${prefix}1p` },
+              to: { node: `${prefix}2`, port: `${prefix}2p` },
+            },
+          ] as NetworkGraph['links'],
+        },
+      })
+      const a = mk('a', 1000, 'a', 'HundredGigE0/0/0/8', 'HundredGigE0/0/0/1')
+      const b = mk('b', 2000, 'b', 'hg-0/0/0/8', '515')
+      const out = resolve(emptyGraph(), [a, b])
+      expect(out.links).toHaveLength(1)
+      expect(out.links[0]?.provenance?.state).toBe('confirmed')
+    })
   })
 
   describe('discovered-only', () => {

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -18,6 +18,7 @@ import {
   type Subgraph,
 } from '../models/types.js'
 import { keyHash, nodeIdentityKeys, portIdentityKeys } from './identity.js'
+import { interfaceNamesMatch } from './interface-name.js'
 import type { ResolvedGraph, ResolveOptions, SnapshotEntry } from './types.js'
 
 /**
@@ -190,7 +191,15 @@ export function resolve(
   }
 
   // 4. Fold links — endpoint node id → cluster id, port id → folded port id.
-  const resolvedLinks = foldLinks(contributions, clusterById, portIdRemap)
+  //    `portNameById` lets cross-source dedup compare interface NAMES (one source
+  //    may key a port "HundredGigE0/0/0/8" where another says "hg-0/0/0/8").
+  const portNameById = new Map<string, string>()
+  for (const node of resolvedNodes) {
+    for (const p of node.ports ?? []) {
+      portNameById.set(p.id, p.interfaceName || p.label || p.id)
+    }
+  }
+  const resolvedLinks = foldLinks(contributions, clusterById, portIdRemap, portNameById)
 
   // 5. Subgraphs — fold each region cluster into one merged subgraph.
   // Keep a region only if it has a resolved MEMBER node (directly or via a
@@ -1264,67 +1273,121 @@ interface LinkMember {
 
 /**
  * Fold links across contributions. Endpoints are first remapped to resolved
- * cluster ids + folded port ids, then links that resolve to the SAME canonical
- * endpoint pair are clustered and folded into one — so the same physical link
- * observed by two sources becomes a single edge. Per field, the highest-priority
- * contribution that holds a value wins (priority desc, capturedAt desc), mirroring
- * the node field merge; `metadata` merges per key. Dangling links (an endpoint
- * whose node didn't survive clustering) are dropped.
+ * cluster ids + folded port ids. Links are then bucketed by NODE PAIR (port
+ * independent) and, within each pair, greedily sub-clustered into the same
+ * physical edge when their endpoints' interface NAMES align — so the same link
+ * observed by two sources that name the ports differently ("HundredGigE0/0/0/8"
+ * vs TTDB's "hg-0/0/0/8", or a Zabbix ifIndex on the far end) still collapses to
+ * one edge (#404). Genuine parallel links between the same pair (distinct ports
+ * on both ends) stay separate. Per field, the highest-priority contribution that
+ * holds a value wins (priority desc, capturedAt desc), mirroring the node field
+ * merge; `metadata` merges per key. Dangling links (an endpoint whose node
+ * didn't survive clustering) are dropped.
  */
 function foldLinks(
   contributions: Contribution[],
   clusterById: Map<string, NodeCluster>,
   portIdRemap: Map<string, string>,
+  portNameById: Map<string, string>,
 ): Link[] {
-  // 1. Remap endpoints and bucket by canonical endpoint pair. First-seen order
-  //    is preserved (contributions are intrinsic-first) for stable output.
-  const clusters = new Map<string, LinkMember[]>()
+  // 1. Remap endpoints and bucket by node pair. First-seen order is preserved
+  //    (contributions are intrinsic-first) for stable output.
+  const buckets = new Map<string, LinkMember[]>()
   const order: string[] = []
   for (const contrib of contributions) {
     for (const link of contrib.graph.links) {
       const from = remapEndpoint(link.from, contrib.sourceId, clusterById, portIdRemap)
       const to = remapEndpoint(link.to, contrib.sourceId, clusterById, portIdRemap)
       if (!from || !to) continue // dangling — endpoint node didn't survive
-      const key = linkClusterKey(from, to)
+      const key = nodePairKey(from, to)
       const member: LinkMember = {
         sourceId: contrib.sourceId,
         priority: contrib.priority,
         capturedAt: contrib.capturedAt,
         link: { ...link, from, to },
       }
-      const existing = clusters.get(key)
+      const existing = buckets.get(key)
       if (existing) existing.push(member)
       else {
-        clusters.set(key, [member])
+        buckets.set(key, [member])
         order.push(key)
       }
     }
   }
 
-  // 2. Fold each cluster into one link. A cluster with only anchor members
+  // 2. Within each node pair, greedily group members that denote the same
+  //    physical edge, then fold each group. A group with only anchor members
   //    (every contributor was link_contribution:'update') makes no presence
   //    claim → no new edge, exactly like an anchor-only node cluster.
   const links: Link[] = []
   for (const key of order) {
-    const members = clusters.get(key)
+    const members = buckets.get(key)
     if (!members) continue
-    if (!members.some((m) => m.link.presence !== 'anchor')) continue
-    links.push(foldLinkCluster(members))
+    const groups: LinkMember[][] = []
+    for (const m of members) {
+      const g = groups.find((grp) => grp.some((other) => samePhysicalLink(m, other, portNameById)))
+      if (g) g.push(m)
+      else groups.push([m])
+    }
+    for (const group of groups) {
+      if (!group.some((m) => m.link.presence !== 'anchor')) continue
+      links.push(foldLinkCluster(group))
+    }
   }
   return links
 }
 
-// Internal Map-key separators (never displayed). Unit / record separators don't
-// occur in node or port ids (namespaced alphanumerics + `:`/`-`/`.`/`/`).
-const NODE_PORT_SEP = '\x1f'
+// Internal Map-key separator (never displayed). Record separator doesn't occur
+// in node ids (namespaced alphanumerics + `:`/`-`/`.`/`/`).
 const ENDPOINT_PAIR_SEP = '\x1e'
 
-/** Canonical, order-independent key for a remapped link's endpoint pair. */
-function linkEndpointKey(e: LinkEndpoint): string {
-  return e.port != null && e.port !== '' ? `${e.node}${NODE_PORT_SEP}${e.port}` : e.node
+/** Canonical, order-independent key for a remapped link's node pair. */
+function nodePairKey(from: LinkEndpoint, to: LinkEndpoint): string {
+  return [from.node, to.node].sort().join(ENDPOINT_PAIR_SEP)
 }
-function linkClusterKey(from: LinkEndpoint, to: LinkEndpoint): string {
-  return [linkEndpointKey(from), linkEndpointKey(to)].sort().join(ENDPOINT_PAIR_SEP)
+
+/**
+ * Canonical endpoint order for a link: the endpoint whose node id sorts first
+ * comes first (for a self-loop, order by port id). This aligns two links on the
+ * same node pair so their corresponding ends can be compared.
+ */
+function canonicalEnds(link: Link): [LinkEndpoint, LinkEndpoint] {
+  const { from, to } = link
+  if (from.node < to.node) return [from, to]
+  if (from.node > to.node) return [to, from]
+  return (from.port ?? '') <= (to.port ?? '') ? [from, to] : [to, from]
+}
+
+function endPortName(end: LinkEndpoint, portNameById: Map<string, string>): string {
+  if (!end.port) return ''
+  return portNameById.get(end.port) ?? end.port
+}
+
+type EndRelation = 'match' | 'conflict' | 'unknown'
+
+function endRelation(a: string, b: string): EndRelation {
+  if (!a || !b) return 'unknown' // at least one side names no port → can't decide
+  return interfaceNamesMatch(a, b) ? 'match' : 'conflict'
+}
+
+/**
+ * Whether two remapped links (already on the same node pair) are the same
+ * physical edge. They are if at least one aligned end's interface names match
+ * — the other end may legitimately disagree because sources speak different
+ * port vocabularies (e.g. a Zabbix ifIndex on the far end). If neither end
+ * names any port, fall back to node-pair identity (the old behavior).
+ */
+function samePhysicalLink(
+  a: LinkMember,
+  b: LinkMember,
+  portNameById: Map<string, string>,
+): boolean {
+  const [a1, a2] = canonicalEnds(a.link)
+  const [b1, b2] = canonicalEnds(b.link)
+  const e1 = endRelation(endPortName(a1, portNameById), endPortName(b1, portNameById))
+  const e2 = endRelation(endPortName(a2, portNameById), endPortName(b2, portNameById))
+  if (e1 === 'match' || e2 === 'match') return true
+  return e1 === 'unknown' && e2 === 'unknown'
 }
 
 /** Link fields owned by the fold itself — never copied through the generic merge. */


### PR DESCRIPTION
## What

Cross-source link dedup so the **same physical link** observed by two sources collapses to one edge, even when the sources name the ports differently. Closes #404.

## Why

`foldLinks` keyed link clusters by canonical endpoint pair **including the folded port id**. When TTDB reports a link as `hg-0/0/0/8` and Zabbix reports the same link as `HundredGigE0/0/0/8` (with a bare ifIndex like `515` on the far end), the port ids never line up, so the merge emitted two parallel edges. On test6 this produced 61 duplicate node-pairs.

## How

- Bucket links by **node pair** (port-independent).
- Within each pair, greedily sub-cluster into the same physical edge when **at least one aligned endpoint's interface NAMES match** (`interfaceNamesMatch`). The other end may legitimately disagree because sources speak different port vocabularies (interface name vs SNMP ifIndex) — one matching end is enough.
- When neither end names a port, fall back to node-pair identity (the previous behavior).
- Genuine parallel links (distinct ports on **both** ends) stay separate.
- Extract the port-name normalization/matching shared with the web "auto-mapping" UI into core `observation/interface-name.ts` — dash-aware so TTDB's `hg-0-0-0` ≡ `hg/0/0/0`. The same matching now governs both metric binding and link folding.

## Test

- New `cross-vocabulary port names fold to one edge (#404)` test models the exact test6 data (`hg-0/0/0/8` ↔ `HundredGigE0/0/0/8`, far end `515` ifIndex) → one `confirmed` edge.
- Existing "parallel links via different ports stay separate" still passes.
- Core: 317 tests green. Full monorepo build: 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
