### PR TITLE
fix(server): Hide Disconnected drops every degree-0 node (flat, no authored layer)

### DIFF
--- a/apps/server/api/src/services/display-filter.test.ts
+++ b/apps/server/api/src/services/display-filter.test.ts
@@ -10,7 +10,7 @@ function node(id: string, state: 'discovered-only' | 'intrinsic-only' | 'confirm
 }
 
 describe('filterDisconnected', () => {
-  it('drops degree-0 discovered-only nodes, keeps linked ones', () => {
+  it('drops degree-0 nodes, keeps linked ones', () => {
     const g: NetworkGraph = {
       version: '1',
       nodes: [
@@ -24,18 +24,22 @@ describe('filterDisconnected', () => {
     expect(out.nodes.map((n) => n.id).sort()).toEqual(['a', 'b'])
   })
 
-  it('keeps operator-placed (intrinsic) orphans even at degree 0', () => {
+  it('drops degree-0 nodes flat — provenance does not privilege them', () => {
+    // No authored layer: an intrinsic-only or confirmed orphan is still an
+    // orphan. Hide-disconnected hides it like any other degree-0 node.
     const g: NetworkGraph = {
       version: '1',
       nodes: [
         node('placed', 'intrinsic-only'),
         node('confirmed', 'confirmed'),
         node('junk', 'discovered-only'),
+        node('a', 'discovered-only'),
+        node('b', 'confirmed'),
       ],
-      links: [],
+      links: [{ id: 'l0', from: { node: 'a' }, to: { node: 'b' } }],
     }
     const out = filterDisconnected(g)
-    expect(out.nodes.map((n) => n.id).sort()).toEqual(['confirmed', 'placed'])
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(['a', 'b'])
   })
 
   it('returns the same reference when nothing is dropped (no-op)', () => {

--- a/apps/server/api/src/services/display-filter.ts
+++ b/apps/server/api/src/services/display-filter.ts
@@ -13,9 +13,15 @@
 import type { NetworkGraph } from '@shumoku/core'
 
 /**
- * Drop nodes that have no incident link (degree 0), EXCEPT operator-placed
- * (intrinsic) nodes — an orphan the human put there on purpose stays. Only
- * auto-discovered orphans (`provenance.state === 'discovered-only'`) are hidden.
+ * Drop every node that has no incident link (degree 0).
+ *
+ * Flat by design: degree is the only criterion. We deliberately do NOT branch on
+ * `provenance.state` (discovered-only / confirmed / intrinsic-only) — that would
+ * re-introduce an "operator-placed nodes are special" authored layer, which the
+ * all-sources-equal model rejects. `provenance.state` is a derived annotation
+ * (how many sources saw it), not a privilege. "Hide disconnected" means hide
+ * disconnected; an operator who wants to keep a standalone planned node just
+ * leaves the toggle off.
  *
  * Pure: returns a new graph; never mutates the input. A degree-0 node has no
  * links by definition, so no link pruning is needed.
@@ -29,13 +35,7 @@ export function filterDisconnected(graph: NetworkGraph): NetworkGraph {
     if (to) degree.set(to, (degree.get(to) ?? 0) + 1)
   }
 
-  const nodes = graph.nodes.filter((n) => {
-    if ((degree.get(n.id) ?? 0) > 0) return true
-    // Degree 0: keep only if the operator engaged with it. A purely
-    // auto-discovered orphan is dropped; anything the human placed/touched
-    // (intrinsic-only / confirmed) stays.
-    return n.provenance?.state !== 'discovered-only'
-  })
+  const nodes = graph.nodes.filter((n) => (degree.get(n.id) ?? 0) > 0)
 
   if (nodes.length === graph.nodes.length) return graph
   return { ...graph, nodes }

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -176,9 +176,7 @@
       <label class="flex items-center justify-between cursor-pointer">
         <div>
           <p class="text-sm text-theme-text">Hide Disconnected Nodes</p>
-          <p class="text-xs text-theme-text-muted">
-            Drop auto-discovered nodes that have no links
-          </p>
+          <p class="text-xs text-theme-text-muted">Drop any node that has no links</p>
         </div>
         <input
           type="checkbox"


### PR DESCRIPTION
## Problem

"Hide Disconnected Nodes" looked dead — toggling it on left link-less nodes on screen.

Root cause: `filterDisconnected` branched on `provenance.state`. It dropped only `discovered-only` orphans and **spared `confirmed` / `intrinsic-only`** ones ("an orphan the human placed stays"). On test6 the 10 link-less virtual/container routers (`xrd.noc`, `cilium-1..3`, `jcnr-1..3`, …) had been **auto-adopted into the project overlay**, so they resolved to `confirmed` — the filter never touched them regardless of the toggle.

## Why this was wrong

That provenance gate re-introduces an "operator-placed nodes are special" **authored layer**, which the all-sources-equal model rejects. `provenance.state` is a derived annotation (how many sources observed a node / whether intrinsic is involved), not a privilege that should change display behavior.

## Fix

`filterDisconnected` is now **flat**: drop every degree-0 node, no `provenance.state` branch. "Hide disconnected" means hide disconnected. An operator who wants to keep a standalone planned node just leaves the toggle off.

- UI hint updated: "Drop auto-discovered nodes that have no links" → "Drop any node that has no links".
- Tests updated: the old "keeps operator-placed orphans" case is replaced by "drops degree-0 flat — provenance does not privilege them".

## Verify

On test6 (63 nodes / 162 links, 10 degree-0 all `confirmed`): with the toggle on, the 10 orphans now drop → 53 nodes. Server tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
