### PR TITLE
fix(server): P0 — stop active data leakage from share links

### DIFF
--- a/apps/server/api/src/api/share-projections.ts
+++ b/apps/server/api/src/api/share-projections.ts
@@ -13,6 +13,7 @@
  * came through.
  */
 
+import type { Alert, NetworkGraph } from '@shumoku/core'
 import { specDeviceType } from '@shumoku/core'
 import type { ParsedTopology } from '../services/topology.js'
 import type { MetricsMapping, Topology } from '../types.js'
@@ -64,14 +65,128 @@ export function publicTopologyContext(parsed: ParsedTopology) {
 }
 
 /**
- * The raw NetworkGraph a shared diagram renders. The full graph is inherently
- * public on any share link (you can't draw the topology without it), so this
- * is intentionally not redacted beyond folding mapping-derived bandwidth in.
+ * The NetworkGraph a shared diagram renders — **sanitized**. Drawing the topology
+ * needs structure (nodes/links/ports/styles/positions), but NOT the sensitive
+ * carriers: node `identity` (mgmtIp / chassisId / sysName), `attachments`
+ * (`access` holds the **SNMP community**, plus policy / metrics-binding),
+ * `metadata`, per-endpoint `ip`, and graph-level `attachments` (topology-default
+ * access/policy) / `exclusions` (hidden nodes' mgmt identities). Those are stripped
+ * here so a share link can't exfiltrate credentials or device inventory.
+ *
+ * P0: strip the known sensitive carriers (a strict improvement). P1 promotes this
+ * to an allow-list render DTO (see #412) so a future field can't leak by default.
  */
+function shareSafeGraph(graph: NetworkGraph): NetworkGraph {
+  const { attachments: _ga, exclusions: _gx, ...rest } = graph
+  return {
+    ...rest,
+    nodes: graph.nodes.map((n) => {
+      const { identity: _i, attachments: _a, metadata: _m, ports, ...node } = n
+      return ports
+        ? {
+            ...node,
+            ports: ports.map((p) => {
+              const { identity: _pi, attachments: _pa, ...port } = p
+              return port
+            }),
+          }
+        : node
+    }),
+    links: graph.links.map((l) => {
+      const { metadata: _lm, ...link } = l as typeof l & { metadata?: unknown }
+      const { ip: _fip, ...from } = link.from
+      const { ip: _tip, ...to } = link.to
+      return { ...link, from, to }
+    }),
+    subgraphs: graph.subgraphs?.map((sg) => {
+      const { attachments: _sa, ...subgraph } = sg
+      return subgraph
+    }),
+  }
+}
+
 export function publicTopologyGraph(parsed: ParsedTopology) {
   return {
     id: parsed.id,
     name: parsed.name,
-    graph: applyMappingBandwidth(parsed.graph, parsed.mapping),
+    graph: shareSafeGraph(applyMappingBandwidth(parsed.graph, parsed.mapping)),
+  }
+}
+
+/**
+ * Allow-listed public projection of a dashboard layout. The raw `layoutJson` is
+ * extensible per-widget config that may carry queries / internal labels / future
+ * unreviewed fields, so we rebuild it from a known shape: grid params + each
+ * widget's id / type / position and only the config keys a public viewer needs to
+ * render. Unknown config keys are dropped (deny-by-default).
+ */
+const PUBLIC_WIDGET_CONFIG_KEYS = [
+  'topologyId',
+  'dataSourceId',
+  'sheetId',
+  'showMetrics',
+  'showLabels',
+  'interactive',
+  'metricType',
+  'title',
+] as const
+
+export function publicDashboardLayout(layoutJson: string): string {
+  try {
+    const layout = JSON.parse(layoutJson) as {
+      columns?: number
+      rowHeight?: number
+      margin?: number
+      widgets?: {
+        id?: string
+        type?: string
+        position?: { x?: number; y?: number; w?: number; h?: number }
+        config?: Record<string, unknown>
+      }[]
+    }
+    const widgets = (layout.widgets ?? []).map((w) => {
+      const config: Record<string, unknown> = {}
+      for (const key of PUBLIC_WIDGET_CONFIG_KEYS) {
+        if (w.config && key in w.config) config[key] = w.config[key]
+      }
+      return { id: w.id, type: w.type, position: w.position, config }
+    })
+    return JSON.stringify({
+      columns: layout.columns,
+      rowHeight: layout.rowHeight,
+      margin: layout.margin,
+      widgets,
+    })
+  } catch {
+    return JSON.stringify({ widgets: [] })
+  }
+}
+
+/**
+ * Allow-listed public projection of an alert. Drops fields that can carry
+ * internal detail: `description` (collector errors / query text), `hostId`,
+ * `source` (which monitoring system), `url` (internal deep-link), `labels`
+ * (arbitrary internal key/values), `receivedAt`. Keeps only what an alert widget
+ * needs to display + map to a node.
+ */
+export function publicAlert(a: Alert): {
+  id: string
+  severity: Alert['severity']
+  status: Alert['status']
+  title: string
+  host?: string
+  nodeId?: string
+  startTime: number
+  endTime?: number
+} {
+  return {
+    id: a.id,
+    severity: a.severity,
+    status: a.status,
+    title: a.title,
+    ...(a.host ? { host: a.host } : {}),
+    ...(a.nodeId ? { nodeId: a.nodeId } : {}),
+    startTime: a.startTime,
+    ...(a.endTime !== undefined ? { endTime: a.endTime } : {}),
   }
 }

--- a/apps/server/api/src/api/share.ts
+++ b/apps/server/api/src/api/share.ts
@@ -11,7 +11,13 @@
 import { Hono } from 'hono'
 import type { AlertQueryOptions } from '../plugins/types.js'
 import { getDashboardService } from './dashboards.js'
-import { publicTopology, publicTopologyContext, publicTopologyGraph } from './share-projections.js'
+import {
+  publicAlert,
+  publicDashboardLayout,
+  publicTopology,
+  publicTopologyContext,
+  publicTopologyGraph,
+} from './share-projections.js'
 import { buildRenderOutput, getDataSourceService, getTopologyService } from './topologies.js'
 
 /** Set of resources a dashboard token is allowed to reach, keyed by kind. */
@@ -64,7 +70,9 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
       if (!parsed) {
         const parseError = service.getParseError(topology.id)
         if (parseError) {
-          return c.json({ error: parseError.message, errorPhase: parseError.phase }, 422)
+          // Generic message: never surface internal parse/connection detail to an
+          // anonymous viewer (it can carry config text / upstream errors).
+          return c.json({ error: 'Topology is currently unavailable' }, 422)
         }
         return c.json({ error: 'Failed to parse topology' }, 500)
       }
@@ -88,7 +96,9 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
       if (!parsed) {
         const parseError = service.getParseError(topology.id)
         if (parseError) {
-          return c.json({ error: parseError.message, errorPhase: parseError.phase }, 422)
+          // Generic message: never surface internal parse/connection detail to an
+          // anonymous viewer (it can carry config text / upstream errors).
+          return c.json({ error: 'Topology is currently unavailable' }, 422)
         }
         return c.json({ error: 'Failed to parse topology' }, 500)
       }
@@ -113,7 +123,9 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
       if (!parsed) {
         const parseError = service.getParseError(topology.id)
         if (parseError) {
-          return c.json({ error: parseError.message, errorPhase: parseError.phase }, 422)
+          // Generic message: never surface internal parse/connection detail to an
+          // anonymous viewer (it can carry config text / upstream errors).
+          return c.json({ error: 'Topology is currently unavailable' }, 422)
         }
         return c.json({ error: 'Failed to parse topology' }, 500)
       }
@@ -136,7 +148,8 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
     return c.json({
       id: dashboard.id,
       name: dashboard.name,
-      layoutJson: dashboard.layoutJson,
+      // Allow-listed layout projection — never the raw extensible layoutJson.
+      layoutJson: publicDashboardLayout(dashboard.layoutJson),
     })
   })
 
@@ -175,7 +188,9 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
       if (!parsed) {
         const parseError = service.getParseError(id)
         if (parseError) {
-          return c.json({ error: parseError.message, errorPhase: parseError.phase }, 422)
+          // Generic message: never surface internal parse/connection detail to an
+          // anonymous viewer (it can carry config text / upstream errors).
+          return c.json({ error: 'Topology is currently unavailable' }, 422)
         }
         return c.json({ error: 'Failed to parse topology' }, 500)
       }
@@ -196,7 +211,9 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
       if (!parsed) {
         const parseError = service.getParseError(id)
         if (parseError) {
-          return c.json({ error: parseError.message, errorPhase: parseError.phase }, 422)
+          // Generic message: never surface internal parse/connection detail to an
+          // anonymous viewer (it can carry config text / upstream errors).
+          return c.json({ error: 'Topology is currently unavailable' }, 422)
         }
         return c.json({ error: 'Failed to parse topology' }, 500)
       }
@@ -223,7 +240,8 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
     if (minSeverity) options.minSeverity = minSeverity as AlertQueryOptions['minSeverity']
     try {
       const alerts = await service.getAlerts(id, options)
-      return c.json(alerts)
+      // Allow-listed projection — drop description / url / labels / source / hostId.
+      return c.json(alerts.map(publicAlert))
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 500)

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -20,6 +20,7 @@ import {
   pluginRegistry,
   registerBundledPlugins,
 } from './plugins/index.js'
+import { isSetupComplete, SESSION_COOKIE, validateSession } from './services/auth.js'
 import { DataSourceService } from './services/datasource.js'
 import { startDiscoveryScheduler, stopDiscoveryScheduler } from './services/discovery-scheduler.js'
 import { startHealthChecker, stopHealthChecker } from './services/health-checker.js'
@@ -27,6 +28,24 @@ import type { ParsedTopology, TopologyService } from './services/topology.js'
 import { TopologySourcesService } from './services/topology-sources.js'
 import { TopologyManager } from './topology.js'
 import type { ClientMessage, ClientState, Config, MetricsData, MetricsMapping } from './types.js'
+
+/**
+ * Validate the admin session straight off a raw `Request` (the WebSocket upgrade
+ * runs in Bun's `fetch`, before Hono, so we parse the Cookie header ourselves
+ * rather than via hono/cookie). Returns true only for a live session.
+ */
+function hasValidSession(req: Request): boolean {
+  const cookie = req.headers.get('cookie')
+  if (!cookie) return false
+  for (const part of cookie.split(';')) {
+    const eq = part.indexOf('=')
+    if (eq === -1) continue
+    if (part.slice(0, eq).trim() !== SESSION_COOKIE) continue
+    const value = decodeURIComponent(part.slice(eq + 1).trim())
+    return validateSession(value)
+  }
+  return false
+}
 
 /**
  * Merge metrics from a later poll into an accumulator. Sources are
@@ -524,6 +543,16 @@ export class Server {
       fetch(req, server) {
         // Handle WebSocket upgrade
         if (new URL(req.url).pathname === '/ws') {
+          // AUTH GATE: the live-metrics socket requires a valid admin session.
+          // It bypasses Hono (and thus authMiddleware), so without this check ANY
+          // anonymous client could subscribe to ANY topology id and receive its
+          // live metrics + internal warnings — a data leak. Public/shared live
+          // metrics will be served separately via a token-scoped channel, NOT here.
+          // (When setup isn't complete there's no password yet — mirror
+          // authMiddleware and allow through.)
+          if (isSetupComplete() && !hasValidSession(req)) {
+            return new Response('Unauthorized', { status: 401 })
+          }
           const upgraded = server.upgrade(req, {
             data: { subscribedTopology: null, filter: { nodes: [], links: [] } },
           })

--- a/apps/server/api/test/share-projections.test.ts
+++ b/apps/server/api/test/share-projections.test.ts
@@ -1,0 +1,159 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, test } from 'bun:test'
+import type { Alert, NetworkGraph } from '@shumoku/core'
+import {
+  publicAlert,
+  publicDashboardLayout,
+  publicTopologyGraph,
+} from '../src/api/share-projections.ts'
+import type { ParsedTopology } from '../src/services/topology.ts'
+
+describe('publicTopologyGraph — strips sensitive carriers from the shared graph', () => {
+  const graph = {
+    version: '1',
+    name: 'secret-net',
+    attachments: [{ kind: 'policy', mode: 'auto' }], // topology-default policy → must drop
+    exclusions: [{ mgmtIp: '10.9.9.9' }], // hidden node's mgmt identity → must drop
+    nodes: [
+      {
+        id: 'sw1',
+        label: 'core-sw',
+        identity: { mgmtIp: '10.0.0.1', chassisId: 'aa:bb', sysName: 'core-sw.local' },
+        metadata: { rack: 'R1' },
+        attachments: [{ kind: 'access', community: 'SUPERSECRET' }], // SNMP community → must drop
+        ports: [
+          {
+            id: 'p1',
+            label: 'Gi0/1',
+            identity: { ifIndex: '1' },
+            attachments: [{ kind: 'access', community: 'PORTSECRET' }],
+          },
+        ],
+      },
+    ],
+    links: [
+      {
+        id: 'l1',
+        from: { node: 'sw1', port: 'p1', ip: '10.0.0.1/30' },
+        to: { node: 'sw2', ip: '10.0.0.2/30' },
+      },
+    ],
+    subgraphs: [{ id: 'g1', label: 'Site A', attachments: [{ kind: 'access', community: 'X' }] }],
+  } as unknown as NetworkGraph
+
+  const parsed = { id: 't1', name: 'secret-net', graph } as unknown as ParsedTopology
+  const out = publicTopologyGraph(parsed).graph
+  const blob = JSON.stringify(out)
+
+  test('no SNMP community anywhere in the output', () => {
+    expect(blob).not.toContain('SUPERSECRET')
+    expect(blob).not.toContain('PORTSECRET')
+    expect(blob.toLowerCase()).not.toContain('community')
+  })
+  test('no node/port identity, metadata, or endpoint ip', () => {
+    expect(blob).not.toContain('mgmtIp')
+    expect(blob).not.toContain('chassisId')
+    expect(blob).not.toContain('sysName')
+    expect(blob).not.toContain('10.0.0.1/30')
+    expect(out.nodes[0]).not.toHaveProperty('identity')
+    expect(out.nodes[0]).not.toHaveProperty('metadata')
+    expect(out.nodes[0]).not.toHaveProperty('attachments')
+    expect(out.nodes[0]?.ports?.[0]).not.toHaveProperty('attachments')
+  })
+  test('no graph-level attachments or exclusions', () => {
+    expect(out).not.toHaveProperty('attachments')
+    expect(out).not.toHaveProperty('exclusions')
+    expect(blob).not.toContain('10.9.9.9')
+  })
+  test('keeps render-relevant structure', () => {
+    expect(out.nodes[0]?.id).toBe('sw1')
+    expect(out.nodes[0]?.label).toBe('core-sw')
+    expect(out.nodes[0]?.ports?.[0]?.id).toBe('p1')
+    expect(out.links[0]?.from.node).toBe('sw1')
+    expect(out.links[0]?.to.node).toBe('sw2')
+  })
+})
+
+describe('publicAlert — allow-listed', () => {
+  const alert = {
+    id: 'a1',
+    severity: 'high',
+    status: 'firing',
+    title: 'Link down',
+    description: 'snmpwalk to 10.0.0.1 community SECRET failed',
+    host: 'core-sw',
+    hostId: 'zbx-12345',
+    nodeId: 'sw1',
+    startTime: 1000,
+    endTime: 2000,
+    source: 'zabbix',
+    url: 'https://internal-zabbix.local/alert/1',
+    labels: { internal_team: 'noc', runbook: 'http://wiki.internal/x' },
+    receivedAt: 1500,
+  } as unknown as Alert
+
+  const out = publicAlert(alert)
+  const blob = JSON.stringify(out)
+
+  test('keeps only display + mapping fields', () => {
+    expect(out).toEqual({
+      id: 'a1',
+      severity: 'high',
+      status: 'firing',
+      title: 'Link down',
+      host: 'core-sw',
+      nodeId: 'sw1',
+      startTime: 1000,
+      endTime: 2000,
+    })
+  })
+  test('drops description / url / labels / source / hostId / receivedAt', () => {
+    for (const leak of [
+      'SECRET',
+      'zbx-12345',
+      'internal-zabbix',
+      'wiki.internal',
+      'zabbix',
+      'snmpwalk',
+    ]) {
+      expect(blob).not.toContain(leak)
+    }
+  })
+})
+
+describe('publicDashboardLayout — allow-listed widget config', () => {
+  test('keeps known config keys, drops unknown ones', () => {
+    const raw = JSON.stringify({
+      columns: 12,
+      rowHeight: 40,
+      margin: 8,
+      widgets: [
+        {
+          id: 'w1',
+          type: 'topology',
+          position: { x: 0, y: 0, w: 6, h: 4 },
+          config: {
+            topologyId: 't1',
+            showLabels: true,
+            // unknown / potentially sensitive keys:
+            query: 'SELECT * WHERE secret',
+            internalUrl: 'http://wiki.internal',
+            apiToken: 'abcd',
+          },
+        },
+      ],
+    })
+    const out = JSON.parse(publicDashboardLayout(raw))
+    expect(out.widgets[0].config).toEqual({ topologyId: 't1', showLabels: true })
+    const blob = JSON.stringify(out)
+    expect(blob).not.toContain('secret')
+    expect(blob).not.toContain('wiki.internal')
+    expect(blob).not.toContain('apiToken')
+    expect(out.columns).toBe(12)
+  })
+  test('malformed layout → empty widgets (no throw)', () => {
+    expect(JSON.parse(publicDashboardLayout('not json'))).toEqual({ widgets: [] })
+  })
+})


### PR DESCRIPTION
Closes #411. Part of #410.

Stop-the-bleeding security fixes for share links (Codex + self review). No new feature — token-scoped SSE live metrics is P1 (#412).

## Fixes
1. **Auth-gate `/ws`** — the live-metrics WebSocket bypassed Hono/auth (upgrade in Bun's `fetch`), so any anonymous client could subscribe to ANY topology id and receive its live metrics + internal parse-error warnings. Now requires a valid admin session. **Verified: anon → 401, bogus → 401, valid session → 101.**
2. **Generic 422** on share endpoints (no `parseError.message`/phase to anonymous viewers).
3. **Sanitize shared graph** — strip `node.identity` (mgmtIp/chassisId/sysName), node/port `attachments` (the `access` attachment carries the **SNMP community**), `metadata`, link endpoint `ip`, graph-level `attachments`/`exclusions`. Was leaking credentials + device inventory to any token holder.
4. **Project dashboard `layoutJson`** (allow-listed widget config) instead of raw JSON.
5. **Project alerts** (allow-list; drop description/url/labels/source/hostId).

Single-admin app, so "share only resources you own" is N/A (the authed sharer owns everything) — dropped from P0.

## Tests
`test/share-projections.test.ts` asserts no community/identity/ip leak in the shared graph + deny-by-default for alerts/layout. API 74/74; typecheck + biome + svelte-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)