### PR TITLE
chore(server): untrack accidental DB backup; ignore data/ backups

### DIFF
--- a/apps/server/.gitignore
+++ b/apps/server/.gitignore
@@ -8,6 +8,8 @@ dist/
 data/*.db
 data/*.db-shm
 data/*.db-wal
+data/*.bak*
+data/*.db.*
 
 # Environment
 .env


### PR DESCRIPTION
Removes an 86MB `data/shumoku.db.bak-*` accidentally committed in #414 (stray `git add -A`; the `*.db` ignore didn't match the `.db.bak-<ts>` suffix). Broadens `apps/server/.gitignore` so DB snapshots can't be committed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)