### PR TITLE
feat(server): live metrics on shared links via token-scoped SSE

### DIFF
--- a/apps/server/api/src/api/share-projections.ts
+++ b/apps/server/api/src/api/share-projections.ts
@@ -16,7 +16,7 @@
 import type { Alert, NetworkGraph } from '@shumoku/core'
 import { specDeviceType } from '@shumoku/core'
 import type { ParsedTopology } from '../services/topology.js'
-import type { MetricsMapping, Topology } from '../types.js'
+import type { MetricsData, MetricsMapping, Topology } from '../types.js'
 import { applyMappingBandwidth } from './topologies.js'
 
 /**
@@ -189,4 +189,28 @@ export function publicAlert(a: Alert): {
     startTime: a.startTime,
     ...(a.endTime !== undefined ? { endTime: a.endTime } : {}),
   }
+}
+
+/**
+ * Allow-listed projection of a live metrics tick for a shared viewer. Nodes keep
+ * ONLY `status` (drops `monitoringError` — SNMP timeout text / internal addrs —
+ * plus `monitoring`/cpu/memory/lastSeen, none of which the shared diagram renders).
+ * Links keep status + the traffic numbers the diagram colors/animates with (that
+ * IS the shared live data). Graph-level `warnings` (parse-error text) are dropped.
+ */
+export function publicMetrics(m: MetricsData): MetricsData {
+  const nodes: MetricsData['nodes'] = {}
+  for (const [id, n] of Object.entries(m.nodes)) nodes[id] = { status: n.status }
+  const links: MetricsData['links'] = {}
+  for (const [id, l] of Object.entries(m.links)) {
+    links[id] = {
+      status: l.status,
+      ...(l.utilization !== undefined ? { utilization: l.utilization } : {}),
+      ...(l.inUtilization !== undefined ? { inUtilization: l.inUtilization } : {}),
+      ...(l.outUtilization !== undefined ? { outUtilization: l.outUtilization } : {}),
+      ...(l.inBps !== undefined ? { inBps: l.inBps } : {}),
+      ...(l.outBps !== undefined ? { outBps: l.outBps } : {}),
+    }
+  }
+  return { nodes, links, timestamp: m.timestamp }
 }

--- a/apps/server/api/src/api/share.ts
+++ b/apps/server/api/src/api/share.ts
@@ -8,17 +8,62 @@
  * `resolveDashboardGrant` middleware, not re-checked per handler).
  */
 
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
+import { streamSSE } from 'hono/streaming'
 import type { AlertQueryOptions } from '../plugins/types.js'
+import { getLatestMetrics, liveSubscriberCount, subscribeMetrics } from '../services/metrics-hub.js'
+import type { MetricsData } from '../types.js'
 import { getDashboardService } from './dashboards.js'
 import {
   publicAlert,
   publicDashboardLayout,
+  publicMetrics,
   publicTopology,
   publicTopologyContext,
   publicTopologyGraph,
 } from './share-projections.js'
 import { buildRenderOutput, getDataSourceService, getTopologyService } from './topologies.js'
+
+/** Global cap on concurrent share metric streams (single-instance backstop). */
+const MAX_SHARE_METRIC_STREAMS = 200
+
+/**
+ * Stream a topology's live metrics to a token-bearing viewer over SSE, projected
+ * by `publicMetrics`. Reads off the central poll cache (metrics-hub) — no second
+ * poll. Sends the cached snapshot immediately, then the newest tick (coalesced —
+ * back-pressure safe), with an idle ping; unsubscribes on abort.
+ */
+function streamTopologyMetrics(c: Context, topologyId: string) {
+  c.header('Cache-Control', 'no-store')
+  return streamSSE(c, async (stream) => {
+    let aborted = false
+    let pending: MetricsData | null = getLatestMetrics(topologyId) ?? null
+    const unsub = subscribeMetrics(topologyId, (m) => {
+      pending = m
+    })
+    stream.onAbort(() => {
+      aborted = true
+      unsub()
+    })
+    let idleTicks = 0
+    while (!aborted) {
+      if (pending) {
+        const next = pending
+        pending = null
+        idleTicks = 0
+        await stream.writeSSE({ data: JSON.stringify(publicMetrics(next)) })
+      } else {
+        idleTicks++
+        if (idleTicks >= 15) {
+          idleTicks = 0
+          await stream.writeSSE({ event: 'ping', data: '' })
+        }
+      }
+      await stream.sleep(1000)
+    }
+    unsub()
+  })
+}
 
 /** Set of resources a dashboard token is allowed to reach, keyed by kind. */
 interface ReachableSet {
@@ -136,6 +181,19 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
     }
   })
 
+  // Live metrics (SSE) for a shared topology link. Token-scoped + projected; reads
+  // the central poll cache via the metrics-hub (no second poll). The token is in the
+  // path like every other share route (consistent posture). Hardening — token
+  // digests, short-lived stream tickets, per-IP caps — is the deferred auth work (#412).
+  app.get('/topologies/:token/metrics/stream', (c) => {
+    const topology = getTopologyService().getByShareToken(c.req.param('token'))
+    if (!topology) return c.json({ error: 'Not found' }, 404)
+    if (liveSubscriberCount() >= MAX_SHARE_METRIC_STREAMS) {
+      return c.json({ error: 'Too many concurrent streams' }, 503)
+    }
+    return streamTopologyMetrics(c, topology.id)
+  })
+
   // Get shared dashboard data
   app.get('/dashboards/:token', (c) => {
     const token = c.req.param('token')
@@ -222,6 +280,17 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 500)
     }
+  })
+
+  // Live metrics (SSE) for a topology widget in a shared dashboard. Same as the
+  // topology door, but the id must be referenced by the dashboard's layout.
+  app.get('/dashboards/:token/topologies/:id/metrics/stream', (c) => {
+    const id = c.req.param('id')
+    if (!c.get('reachable').topologyIds.has(id)) return c.json({ error: 'Not found' }, 404)
+    if (liveSubscriberCount() >= MAX_SHARE_METRIC_STREAMS) {
+      return c.json({ error: 'Too many concurrent streams' }, 503)
+    }
+    return streamTopologyMetrics(c, id)
   })
 
   // Alerts for an alert widget in a shared dashboard.

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -24,6 +24,7 @@ import { isSetupComplete, SESSION_COOKIE, validateSession } from './services/aut
 import { DataSourceService } from './services/datasource.js'
 import { startDiscoveryScheduler, stopDiscoveryScheduler } from './services/discovery-scheduler.js'
 import { startHealthChecker, stopHealthChecker } from './services/health-checker.js'
+import { publishMetrics } from './services/metrics-hub.js'
 import type { ParsedTopology, TopologyService } from './services/topology.js'
 import { TopologySourcesService } from './services/topology-sources.js'
 import { TopologyManager } from './topology.js'
@@ -475,6 +476,9 @@ export class Server {
       if (metrics) {
         this.dbTopologyMetrics.set(topology.id, metrics)
         this.topologyService.updateMetrics(topology.id, metrics)
+        // Feed the hub so token-scoped share SSE streams can read/observe live
+        // metrics off the same central poll (no second poll loop).
+        publishMetrics(topology.id, metrics)
       }
     }
   }

--- a/apps/server/api/src/services/metrics-hub.ts
+++ b/apps/server/api/src/services/metrics-hub.ts
@@ -1,0 +1,68 @@
+/**
+ * Metrics hub — a tiny in-process pub/sub bridging the central metrics poll loop
+ * (in `Server`, server.ts) to the route layer (the share SSE endpoint).
+ *
+ * The poll loop calls `publishMetrics(topologyId, data)` every tick; SSE handlers
+ * read the last snapshot with `getLatestMetrics` and `subscribeMetrics` for live
+ * updates. Single-process / single-instance (same posture as the WS client map and
+ * the login rate-limiter) — no Redis, no new dependency.
+ */
+
+import type { MetricsData } from '../types.js'
+
+type Listener = (data: MetricsData) => void
+
+const latest = new Map<string, MetricsData>()
+const listeners = new Map<string, Set<Listener>>()
+
+/** Total live SSE subscribers across all topologies (for a global connection cap). */
+let subscriberCount = 0
+
+/** Poll loop → hub: cache the latest snapshot and fan out to live subscribers. */
+export function publishMetrics(topologyId: string, data: MetricsData): void {
+  latest.set(topologyId, data)
+  const set = listeners.get(topologyId)
+  if (!set) return
+  for (const listener of set) {
+    try {
+      listener(data)
+    } catch {
+      // a slow/broken subscriber must not break the poll fan-out
+    }
+  }
+}
+
+/** Latest cached metrics for a topology (for the SSE initial event). */
+export function getLatestMetrics(topologyId: string): MetricsData | undefined {
+  return latest.get(topologyId)
+}
+
+/** Current number of live SSE subscribers (global cap enforcement). */
+export function liveSubscriberCount(): number {
+  return subscriberCount
+}
+
+/**
+ * Subscribe to a topology's metric ticks. Returns an unsubscribe function; call it
+ * on stream abort/close so dead clients are cleaned up and the count stays honest.
+ */
+export function subscribeMetrics(topologyId: string, listener: Listener): () => void {
+  let set = listeners.get(topologyId)
+  if (!set) {
+    set = new Set()
+    listeners.set(topologyId, set)
+  }
+  set.add(listener)
+  subscriberCount++
+  let active = true
+  return () => {
+    if (!active) return
+    active = false
+    subscriberCount--
+    const s = listeners.get(topologyId)
+    if (s) {
+      s.delete(listener)
+      if (s.size === 0) listeners.delete(topologyId)
+    }
+  }
+}

--- a/apps/server/api/test/share-projections.test.ts
+++ b/apps/server/api/test/share-projections.test.ts
@@ -6,9 +6,11 @@ import type { Alert, NetworkGraph } from '@shumoku/core'
 import {
   publicAlert,
   publicDashboardLayout,
+  publicMetrics,
   publicTopologyGraph,
 } from '../src/api/share-projections.ts'
 import type { ParsedTopology } from '../src/services/topology.ts'
+import type { MetricsData } from '../src/types.ts'
 
 describe('publicTopologyGraph — strips sensitive carriers from the shared graph', () => {
   const graph = {
@@ -155,5 +157,49 @@ describe('publicDashboardLayout — allow-listed widget config', () => {
   })
   test('malformed layout → empty widgets (no throw)', () => {
     expect(JSON.parse(publicDashboardLayout('not json'))).toEqual({ widgets: [] })
+  })
+})
+
+describe('publicMetrics — node status only, link traffic kept, internals dropped', () => {
+  const m = {
+    nodes: {
+      sw1: {
+        status: 'up',
+        monitoring: 'failing',
+        monitoringError: 'SNMP timeout to 10.0.0.1:161 OID 1.3.6.1',
+        cpu: 42,
+        memory: 80,
+        lastSeen: 1000,
+      },
+    },
+    links: {
+      l1: { status: 'up', utilization: 50, inBps: 1000, outBps: 2000, inUtilization: 40 },
+    },
+    timestamp: 1234,
+    warnings: ['Parse error: secret config text', 'Using insecure HTTP connection'],
+  } as unknown as MetricsData
+
+  const out = publicMetrics(m)
+  const blob = JSON.stringify(out)
+
+  test('node keeps ONLY status (drops monitoringError/monitoring/cpu/memory/lastSeen)', () => {
+    expect(out.nodes.sw1).toEqual({ status: 'up' })
+  })
+  test('link keeps status + traffic numbers', () => {
+    expect(out.links.l1).toEqual({
+      status: 'up',
+      utilization: 50,
+      inUtilization: 40,
+      inBps: 1000,
+      outBps: 2000,
+    })
+  })
+  test('drops warnings and any internal/error text', () => {
+    expect(out.warnings).toBeUndefined()
+    expect(blob).not.toContain('SNMP timeout')
+    expect(blob).not.toContain('10.0.0.1')
+    expect(blob).not.toContain('secret config')
+    expect(blob).not.toContain('monitoringError')
+    expect(out.timestamp).toBe(1234)
   })
 })

--- a/apps/server/web/src/lib/stores/metrics.ts
+++ b/apps/server/web/src/lib/stores/metrics.ts
@@ -73,6 +73,8 @@ interface MetricsGlobal {
   reconnectTimeout: ReturnType<typeof setTimeout> | null
   reconnectAttempts: number
   intentionalDisconnect: boolean
+  /** SSE source for shared (token-scoped) live metrics — anonymous viewers. */
+  sse: EventSource | null
 }
 
 function getGlobal(): MetricsGlobal {
@@ -82,6 +84,7 @@ function getGlobal(): MetricsGlobal {
       reconnectTimeout: null,
       reconnectAttempts: 0,
       intentionalDisconnect: false,
+      sse: null,
     }
   }
   return (globalThis as Record<string, unknown>)[METRICS_WS_KEY] as MetricsGlobal
@@ -228,6 +231,46 @@ function createMetricsStore() {
     update((s) => ({ ...s, subscribedTopology: null, metrics: null }))
   }
 
+  // --- Shared (token-scoped) live metrics over SSE ---
+  // A public/shared viewer has no session, so it can't use the auth-gated `/ws`.
+  // Instead it streams projected metrics from the token-scoped share endpoint.
+  function getShareStreamUrl(token: string): string {
+    const isDev = window.location.port === '5173'
+    const origin = isDev ? 'http://localhost:8080' : window.location.origin
+    return `${origin}/api/share/topologies/${token}/metrics/stream`
+  }
+
+  function disconnectShareStream(): void {
+    if (g.sse) {
+      g.sse.onmessage = null
+      g.sse.onerror = null
+      g.sse.close()
+      g.sse = null
+    }
+    set(initialState)
+  }
+
+  function connectShareStream(token: string): void {
+    disconnectShareStream()
+    try {
+      const es = new EventSource(getShareStreamUrl(token))
+      g.sse = es
+      es.onopen = () => update((s) => ({ ...s, connected: true, error: null }))
+      es.onmessage = (event) => {
+        if (!event.data) return // ignore keep-alive pings
+        try {
+          update((s) => ({ ...s, metrics: JSON.parse(event.data) as MetricsData }))
+        } catch (err) {
+          console.error('[Metrics] Failed to parse share stream message:', err)
+        }
+      }
+      es.onerror = () => update((s) => ({ ...s, connected: false }))
+    } catch (err) {
+      console.error('[Metrics] Failed to open share stream:', err)
+      update((s) => ({ ...s, error: 'Failed to connect' }))
+    }
+  }
+
   return {
     subscribe,
     connect,
@@ -235,6 +278,8 @@ function createMetricsStore() {
     subscribeToTopology,
     setInterval,
     unsubscribe,
+    connectShareStream,
+    disconnectShareStream,
   }
 }
 

--- a/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
+++ b/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/stores'
   import InteractiveSvgDiagram from '$lib/components/InteractiveSvgDiagram.svelte'
   import Logo from '$lib/components/Logo.svelte'
+  import { metricsStore } from '$lib/stores'
 
   let name = $state('')
   let loading = $state(true)
@@ -34,6 +35,8 @@
         const data = await res.json()
         if (cancelled) return
         name = data.name || 'Shared Topology'
+        // Stream token-scoped live metrics (projected) into the diagram.
+        metricsStore.connectShareStream(currentToken)
       } catch {
         if (cancelled) return
         error = 'Failed to load topology'
@@ -44,6 +47,7 @@
 
     return () => {
       cancelled = true
+      metricsStore.disconnectShareStream()
     }
   })
 </script>


### PR DESCRIPTION
Part of #410. **Finishes the share-link feature**: a public/shared topology now shows live node status + link traffic. The auth/token-model hardening (digest-at-rest, short-lived stream tickets, capability split, expiry/rotation/revocation, browser headers) stays deferred in #412 — this ships the feature on the P0-hardened base (#414).

## How
- `services/metrics-hub.ts` — in-process pub/sub bridging the central poll loop → route layer. Poll loop `publishMetrics()`; SSE reads `getLatestMetrics` + `subscribeMetrics`. **No second poll loop.**
- `publicMetrics()` projection — node keeps ONLY `status`; links keep status + utilization/bps; drops `monitoringError`/`monitoring`/cpu/memory/lastSeen + graph `warnings` (parse-error text). Deny-by-default.
- SSE endpoints (`hono/streaming`): `GET /api/share/topologies/:token/metrics/stream` + dashboard-door `…/dashboards/:token/topologies/:id/metrics/stream` (layout-grant gated). Snapshot-then-newest (coalesced/back-pressure-safe), idle ping, abort cleanup, global connection cap. Token in URL path (consistent with all share routes; short-lived ticket deferred).
- Web: `metricsStore.connectShareStream(token)` (EventSource) feeds the SAME `metricsData` store the diagram renders; share page wires it. Auth-gated `/ws` untouched.

## Verified live (anonymous)
SSE → 200 `text/event-stream`; streamed real zabbix metrics **projected** (nodes `{status}` only; links status+utilization+bps; no monitoringError/warnings/community) + keep-alive ping; bad token → 404. New `publicMetrics` unit tests assert the projection. API 77/77; typecheck + biome + svelte-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)