### PR TITLE
fix(server): seal monitoringError leak in share /context (self-pentest finding)

### DIFF
--- a/apps/server/api/src/api/share-projections.ts
+++ b/apps/server/api/src/api/share-projections.ts
@@ -43,6 +43,11 @@ export function publicTopology(
  * narrower than the authenticated `buildTopologyContext`: no `portInfo`
  * (interface names / aliases), no `topologySourceId` / `metricsSourceId`, no
  * raw `mapping`. Used by BOTH share doors so they expose identical shapes.
+ *
+ * `metrics` MUST go through `publicMetrics` — the live poll loop updates
+ * `parsed.metrics` in place with full `NodeMetrics` (monitoringError = SNMP
+ * timeout text / internal addrs, plus monitoring/cpu/memory/lastSeen) and
+ * `warnings` (parse-error text). Shipping it raw leaked internal detail.
  */
 export function publicTopologyContext(parsed: ParsedTopology) {
   return {
@@ -60,7 +65,7 @@ export function publicTopologyContext(parsed: ParsedTopology) {
       standard: l.from.plug?.module?.standard ?? l.to.plug?.module?.standard,
     })),
     subgraphs: parsed.graph.subgraphs || [],
-    metrics: parsed.metrics,
+    metrics: publicMetrics(parsed.metrics),
   }
 }
 

--- a/apps/server/api/test/share-projections.test.ts
+++ b/apps/server/api/test/share-projections.test.ts
@@ -7,6 +7,7 @@ import {
   publicAlert,
   publicDashboardLayout,
   publicMetrics,
+  publicTopologyContext,
   publicTopologyGraph,
 } from '../src/api/share-projections.ts'
 import type { ParsedTopology } from '../src/services/topology.ts'
@@ -201,5 +202,45 @@ describe('publicMetrics — node status only, link traffic kept, internals dropp
     expect(blob).not.toContain('secret config')
     expect(blob).not.toContain('monitoringError')
     expect(out.timestamp).toBe(1234)
+  })
+})
+
+describe('publicTopologyContext — metrics are projected (regression: monitoringError leak)', () => {
+  const parsed = {
+    id: 't1',
+    name: 'ctx',
+    graph: {
+      nodes: [{ id: 'sw1', label: 'core', spec: undefined }],
+      links: [],
+      subgraphs: [],
+    },
+    metrics: {
+      nodes: {
+        sw1: {
+          status: 'down',
+          monitoring: 'failing',
+          monitoringError: 'SNMP timeout to 10.0.0.1:161',
+          cpu: 5,
+          lastSeen: 999,
+        },
+      },
+      links: {},
+      timestamp: 7,
+      warnings: ['Parse error: internal config blob'],
+    },
+  } as unknown as ParsedTopology
+
+  const out = publicTopologyContext(parsed)
+  const blob = JSON.stringify(out)
+
+  test('context metrics carry node status but NOT internal fields', () => {
+    expect(out.metrics.nodes.sw1).toEqual({ status: 'down' })
+    expect(out.metrics.warnings).toBeUndefined()
+  })
+  test('no monitoringError / SNMP text / parse-error blob leaks via /context', () => {
+    expect(blob).not.toContain('monitoringError')
+    expect(blob).not.toContain('SNMP timeout')
+    expect(blob).not.toContain('10.0.0.1')
+    expect(blob).not.toContain('internal config blob')
   })
 })


### PR DESCRIPTION
**Self-pentest finding.** `publicTopologyContext` shipped `metrics: parsed.metrics` raw; the live poll loop updates `parsed.metrics` in place with full `NodeMetrics`, so the share `/topologies/:token` and `/dashboards/:token/topologies/:id/context` endpoints leaked `monitoringError` (SNMP timeout text / internal addrs), `monitoring`, cpu/memory/lastSeen, and `warnings` to anonymous viewers. (Graph/alerts/layout/SSE were already projected in #414/#417; this context path predates P0 and slipped through.)

Fix: project context metrics through `publicMetrics()` (node → `{status}`, links keep traffic numbers, warnings dropped) — same projection the SSE uses. Regression test added.

Verified live under poll data: /context node metrics are `{status}` only; grep for monitoringError/monitoring/lastSeen/cpu/memory/warnings → all 0. Full pentest sweep otherwise clean (no IDOR, management 401, /ws 401, enumeration 404, abnormal-input safe). API 79/79; typecheck + biome clean. Part of #410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)