### PR TITLE
refactor(server): scope is a topology-level decision, not a per-source flag

### DIFF
--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -13,7 +13,7 @@ import { resolveCredentialsForAutoscan } from '../services/discovery-scheduler.j
 import { ObservationsService } from '../services/observations.js'
 import { type ParsedTopology, TopologyService } from '../services/topology.js'
 import { TopologySourcesService } from '../services/topology-sources.js'
-import type { MetricsMapping, TopologyInput } from '../types.js'
+import type { MetricsMapping, ScopeMode, TopologyInput } from '../types.js'
 
 /**
  * Overlay per-link bandwidth from the metrics mapping onto the graph.
@@ -360,6 +360,29 @@ export function createTopologiesApi(): Hono {
         return c.json({ error: 'Topology not found' }, 404)
       }
       return c.json(topology)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 400)
+    }
+  })
+
+  // Topology scope policy (composition). Scope is a single per-topology decision —
+  // which region set closes the world — so it lives on the topology, not per source.
+  app.get('/:id/composition', (c) => {
+    const id = c.req.param('id')
+    const topology = service.get(id)
+    if (!topology) return c.json({ error: 'Topology not found' }, 404)
+    return c.json({ scopeMode: topology.scopeMode, scopeSourceId: topology.scopeSourceId })
+  })
+
+  app.put('/:id/composition', async (c) => {
+    const id = c.req.param('id')
+    try {
+      const body = (await c.req.json()) as { scopeMode?: ScopeMode; scopeSourceId?: string | null }
+      const mode = body.scopeMode ?? 'auto'
+      const topology = service.setScope(id, mode, body.scopeSourceId ?? undefined)
+      if (!topology) return c.json({ error: 'Topology not found' }, 404)
+      return c.json({ scopeMode: topology.scopeMode, scopeSourceId: topology.scopeSourceId })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 400)

--- a/apps/server/api/src/api/topology-sources.ts
+++ b/apps/server/api/src/api/topology-sources.ts
@@ -13,7 +13,6 @@ import { TopologySourcesService } from '../services/topology-sources.js'
 import type {
   LinkContribution,
   NodeContribution,
-  ScopeRole,
   SyncMode,
   TopologyDataSourceInput,
 } from '../types.js'
@@ -46,7 +45,6 @@ function getDataSourceService() {
 function validateCompositionModes(body: {
   nodeContribution?: unknown
   linkContribution?: unknown
-  scopeRole?: unknown
 }): string | null {
   if (
     body.nodeContribution !== undefined &&
@@ -58,8 +56,6 @@ function validateCompositionModes(body: {
     !['add', 'update'].includes(String(body.linkContribution))
   )
     return "linkContribution must be 'add' or 'update'"
-  if (body.scopeRole !== undefined && body.scopeRole !== null && body.scopeRole !== 'scoping')
-    return "scopeRole must be 'scoping' or null"
   return null
 }
 
@@ -180,13 +176,11 @@ topologySourcesApi.put('/:topologyId/sources/:sourceId', async (c) => {
     optionsJson?: string
     nodeContribution?: NodeContribution
     linkContribution?: LinkContribution
-    scopeRole?: ScopeRole | null
   }>()
 
   const modeError = validateCompositionModes(body)
   if (modeError) return c.json({ error: modeError }, 400)
 
-  // scopeRole: 'scoping' sets it; explicit null clears it back to additive.
   const updated = getTopologySourcesService().update(sourceId, body)
   if (!updated) {
     return c.json({ error: 'Failed to update' }, 500)

--- a/apps/server/api/src/db/migrations/020_topology_scope.sql
+++ b/apps/server/api/src/db/migrations/020_topology_scope.sql
@@ -1,0 +1,18 @@
+-- Topology-level scope (composition-modes.md follow-up).
+--
+-- Scope is a SINGLE per-topology decision — "which region set closes the world" —
+-- not a per-source property. It moves off the per-source `scope_role` flag onto
+-- the topology row. Per-source contribution (node/link) stays per-attach, because
+-- "how THIS source behaves in THIS topology" is genuinely per (topology × source).
+--
+--   scope_mode:      'auto'   — the highest-priority topology source's regions are
+--                              the closed world (default; reproduces prior behavior)
+--                    'open'   — no scoping; pure union of all sources
+--                    'closed' — scope_source_id's regions are the closed world
+--   scope_source_id: the scoping source (data_sources.id) when scope_mode='closed'
+--
+-- No backcompat (server schema policy): scope_role is dropped. Existing topologies
+-- default to 'auto', which is what the old "top source defines scope" derivation did.
+ALTER TABLE topologies ADD COLUMN scope_mode TEXT NOT NULL DEFAULT 'auto';
+ALTER TABLE topologies ADD COLUMN scope_source_id TEXT;
+ALTER TABLE topology_data_sources DROP COLUMN scope_role;

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -24,6 +24,7 @@ import migration016 from './migrations/016_contribution_store.sql'
 import migration017 from './migrations/017_drop_dead_tables.sql'
 import migration018 from './migrations/018_composition_modes.sql'
 import migration019 from './migrations/019_fix_contribution_link_local_id_nullable.sql'
+import migration020 from './migrations/020_topology_scope.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -44,6 +45,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '017_drop_dead_tables.sql', sql: migration017 },
   { name: '018_composition_modes.sql', sql: migration018 },
   { name: '019_fix_contribution_link_local_id_nullable.sql', sql: migration019 },
+  { name: '020_topology_scope.sql', sql: migration020 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/topology-sources.ts
+++ b/apps/server/api/src/services/topology-sources.ts
@@ -11,7 +11,6 @@ import type {
   DataSourcePurpose,
   LinkContribution,
   NodeContribution,
-  ScopeRole,
   SyncMode,
   TopologyDataSource,
   TopologyDataSourceInput,
@@ -29,7 +28,6 @@ interface TopologyDataSourceRow {
   options_json: string | null
   node_contribution: string
   link_contribution: string
-  scope_role: string | null
   created_at: number
   updated_at: number
   // Joined columns from data_sources
@@ -56,7 +54,6 @@ function rowToTopologyDataSource(row: TopologyDataSourceRow): TopologyDataSource
     optionsJson: row.options_json || undefined,
     nodeContribution: (row.node_contribution as NodeContribution) || 'scoop',
     linkContribution: (row.link_contribution as LinkContribution) || 'add',
-    scopeRole: (row.scope_role as ScopeRole) || undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -224,7 +221,6 @@ export class TopologySourcesService {
       optionsJson,
       nodeContribution,
       linkContribution,
-      scopeRole,
     }: TopologyDataSourceInput,
   ): Promise<TopologyDataSource> {
     const id = await generateId()
@@ -245,7 +241,6 @@ export class TopologySourcesService {
       priority: priority ?? 0,
       nodeContribution: nodeContrib,
       linkContribution: linkContrib,
-      scopeRole: scopeRole ?? undefined,
       createdAt: now,
       updatedAt: now,
     }
@@ -253,8 +248,8 @@ export class TopologySourcesService {
     this.db
       .query(
         `INSERT INTO topology_data_sources
-        (id, topology_id, data_source_id, purpose, sync_mode, webhook_secret, priority, options_json, node_contribution, link_contribution, scope_role, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        (id, topology_id, data_source_id, purpose, sync_mode, webhook_secret, priority, options_json, node_contribution, link_contribution, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         id,
@@ -267,7 +262,6 @@ export class TopologySourcesService {
         optionsJson ?? null,
         nodeContrib,
         linkContrib,
-        scopeRole ?? null,
         now,
         now,
       )
@@ -285,10 +279,7 @@ export class TopologySourcesService {
         TopologyDataSourceInput,
         'syncMode' | 'priority' | 'optionsJson' | 'nodeContribution' | 'linkContribution'
       >
-    > & {
-      // null clears scopeRole back to additive; undefined leaves it unchanged.
-      scopeRole?: ScopeRole | null
-    },
+    >,
   ): TopologyDataSource | null {
     const existing = this.get(id)
     if (!existing) return null
@@ -327,11 +318,6 @@ export class TopologySourcesService {
     if (updates.linkContribution !== undefined) {
       updateParts.push('link_contribution = ?')
       values.push(updates.linkContribution)
-    }
-
-    if (updates.scopeRole !== undefined) {
-      updateParts.push('scope_role = ?')
-      values.push(updates.scopeRole ?? null)
     }
 
     if (updateParts.length === 0) return existing

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -56,7 +56,7 @@ import type {
   MetricsData,
   MetricsMapping,
   NodeContribution,
-  ScopeRole,
+  ScopeMode,
   Topology,
   TopologyInput,
 } from '../types.js'
@@ -85,6 +85,8 @@ interface TopologyRow {
   id: string
   name: string
   share_token: string | null
+  scope_mode: string | null
+  scope_source_id: string | null
   created_at: number
   updated_at: number
 }
@@ -96,6 +98,8 @@ function rowToTopology(row: TopologyRow): Topology {
     // Topology is just the shell. No content, no source pointers — sources live
     // in the m2m topology_data_sources table; mappingJson is derived from bindings.
     shareToken: row.share_token ?? undefined,
+    scopeMode: (row.scope_mode as Topology['scopeMode']) ?? 'auto',
+    scopeSourceId: row.scope_source_id ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -314,24 +318,28 @@ interface LinkBindingDesired {
   bandwidth?: number
 }
 
-/** A source's composition mode (topology-source-modes.md, Axis D). */
+/**
+ * A source's composition for one topology. node/link contribution are per-source
+ * (how THIS source behaves here); `closeScope` is derived from the TOPOLOGY's
+ * scope policy (which source's regions close the world) — see computeScopeSources.
+ */
 interface SourceMode {
   nodeContribution: NodeContribution
   linkContribution: LinkContribution
-  scopeRole?: ScopeRole
+  closeScope: boolean
 }
 
 /**
- * Apply a source's composition mode to its built contribution before it enters
+ * Apply a source's composition to its built contribution before it enters
  * resolve(): anchor its nodes (node_contribution='anchor'), anchor its links
- * (link_contribution='update'), and/or mark its regions closed
- * (scope_role='scoping'). Additive (the default) is a no-op. Never mutates input.
+ * (link_contribution='update'), and/or mark its regions `scope:'closed'` (this
+ * source is the topology's scope definer). All-default is a no-op. Never mutates
+ * input.
  */
 function applySourceMode(graph: NetworkGraph, mode: SourceMode): NetworkGraph {
   const anchorNodes = mode.nodeContribution === 'anchor'
   const anchorLinks = mode.linkContribution === 'update'
-  const closeScope = mode.scopeRole === 'scoping'
-  if (!anchorNodes && !anchorLinks && !closeScope) return graph
+  if (!anchorNodes && !anchorLinks && !mode.closeScope) return graph
   return {
     ...graph,
     nodes: anchorNodes
@@ -340,10 +348,32 @@ function applySourceMode(graph: NetworkGraph, mode: SourceMode): NetworkGraph {
     links: anchorLinks
       ? graph.links.map((l) => ({ ...l, presence: 'anchor' as const }))
       : graph.links,
-    ...(closeScope && graph.subgraphs
+    ...(mode.closeScope && graph.subgraphs
       ? { subgraphs: graph.subgraphs.map((s) => ({ ...s, scope: 'closed' as const })) }
       : {}),
   }
+}
+
+/**
+ * Resolve the topology's scope policy to the set of SOURCE ids whose regions
+ * close the world:
+ *   - 'open'   → none (pure union)
+ *   - 'closed' → just `scopeSourceId`
+ *   - 'auto'   → the highest-priority topology-purpose source(s)
+ * This is the scope POLICY; resolve() is pure mechanism (honors the `scope:'closed'`
+ * marks this drives). Empty set → no scoping.
+ */
+function computeScopeSources(
+  scopeMode: ScopeMode,
+  scopeSourceId: string | undefined,
+  topologySources: { dataSourceId: string; purpose: string; priority: number }[],
+): Set<string> {
+  if (scopeMode === 'open') return new Set()
+  if (scopeMode === 'closed') return new Set(scopeSourceId ? [scopeSourceId] : [])
+  const topo = topologySources.filter((s) => s.purpose === 'topology')
+  if (topo.length === 0) return new Set()
+  const maxPriority = topo.reduce((m, s) => Math.max(m, s.priority), Number.NEGATIVE_INFINITY)
+  return new Set(topo.filter((s) => s.priority === maxPriority).map((s) => s.dataSourceId))
 }
 
 /**
@@ -546,6 +576,24 @@ export class TopologyService {
 
     this.clearCacheEntry(id)
 
+    return this.get(id)
+  }
+
+  /**
+   * Set the topology's scope policy (composition). `scopeSourceId` is only
+   * meaningful for `scopeMode === 'closed'`; it's cleared otherwise. Bumps the
+   * composition revision (via clearCacheEntry) so the resolved graph re-resolves.
+   */
+  setScope(id: string, scopeMode: ScopeMode, scopeSourceId?: string): Topology | null {
+    const existing = this.get(id)
+    if (!existing) return null
+    const sourceId = scopeMode === 'closed' ? (scopeSourceId ?? null) : null
+    this.db
+      .query(
+        'UPDATE topologies SET scope_mode = ?, scope_source_id = ?, updated_at = ? WHERE id = ?',
+      )
+      .run(scopeMode, sourceId, timestamp(), id)
+    this.clearCacheEntry(id)
     return this.get(id)
   }
 
@@ -1071,26 +1119,43 @@ export class TopologyService {
     // the operator's curation — exclusions, overrides, metrics bindings, settings —
     // folded as resolve()'s top-priority contribution. Absent → empty. A hand-drawn
     // Manual source is NOT here; it's an ordinary source in `snapshots` below.
-    const authored: NetworkGraph = this.readProjectOverlay(topology.id) ?? {
+    const overlay: NetworkGraph = this.readProjectOverlay(topology.id) ?? {
       version: '1',
       name: topology.name,
       nodes: [],
       links: [],
     }
+    const topologySources = this.topologySources.listByTopology(topology.id)
+    // Scope POLICY → which sources' regions close the world (auto/open/closed).
+    // resolve() is pure mechanism: it honors `scope:'closed'` marks; we stamp them
+    // here per the topology's policy, on both the scope source(s) and the overlay
+    // (operator-curated regions also scope, unless the topology is 'open').
+    const scopeSourceIds = computeScopeSources(
+      topology.scopeMode,
+      topology.scopeSourceId,
+      topologySources,
+    )
+    const authored =
+      topology.scopeMode !== 'open' && overlay.subgraphs && overlay.subgraphs.length > 0
+        ? {
+            ...overlay,
+            subgraphs: overlay.subgraphs.map((s) => ({ ...s, scope: 'closed' as const })),
+          }
+        : overlay
     // Source priority feeds the resolver's field merge: when two sources
     // observe the same device, the higher-priority source wins each field it
     // holds. Mirrors `topology_data_sources.priority`. The project overlay
     // always outranks these (handled inside resolve() as the `authored` input).
     const priorityBySource = new Map<string, number>()
     const modeBySource = new Map<string, SourceMode>()
-    for (const tds of this.topologySources.listByTopology(topology.id)) {
+    for (const tds of topologySources) {
       priorityBySource.set(tds.dataSourceId, tds.priority)
       // Composition modes apply to the source's TOPOLOGY contribution only.
       if (tds.purpose === 'topology') {
         modeBySource.set(tds.dataSourceId, {
           nodeContribution: tds.nodeContribution,
           linkContribution: tds.linkContribution,
-          scopeRole: tds.scopeRole,
+          closeScope: scopeSourceIds.has(tds.dataSourceId),
         })
       }
     }

--- a/apps/server/api/src/types.ts
+++ b/apps/server/api/src/types.ts
@@ -87,9 +87,21 @@ export interface DataSourceInput {
  * The resolved project graph has its own endpoint:
  *   GET  /api/topologies/:tid/resolved
  */
+/**
+ * Topology-level scope (composition). A single decision per topology: which
+ * region set closes the world. `'auto'` = the highest-priority topology source's
+ * regions; `'open'` = no scoping (pure union); `'closed'` = `scopeSourceId`'s
+ * regions. The per-source `scope_role` flag was retired in favor of this.
+ */
+export type ScopeMode = 'auto' | 'open' | 'closed'
+
 export interface Topology {
   id: string
   name: string
+  /** Scope policy for this topology. Default 'auto'. */
+  scopeMode: ScopeMode
+  /** The scoping source (data_sources.id) when scopeMode === 'closed'. */
+  scopeSourceId?: string
   /**
    * Structure / metrics data source ids. No longer stored on the topology row
    * (sources live in `topology_data_sources`); the `/context` response derives
@@ -116,11 +128,12 @@ export type SyncMode = 'manual' | 'on_view' | 'webhook'
 export type DataSourcePurpose = 'topology' | 'metrics'
 
 // Per-source composition modes (topology-source-modes.md, Axis D). Two
-// independent knobs + a scope role. Defaults = Additive (scoop / add / no scope).
+// independent knobs describing how THIS source behaves in THIS topology.
+// Defaults = Additive (scoop / add). Scope is NOT here — it's a single
+// per-topology decision (see Topology.scopeMode).
 // NOT named `mode` — that collides with DiscoveryMode (auto|observe|disabled).
 export type NodeContribution = 'scoop' | 'anchor'
 export type LinkContribution = 'add' | 'update'
-export type ScopeRole = 'scoping'
 
 // Source merge is governed by `TopologyDataSource.priority` — the
 // higher-priority source wins each field in resolve() (see
@@ -141,8 +154,6 @@ export interface TopologyDataSource {
   nodeContribution: NodeContribution
   /** How this source's links participate. Default 'add'. */
   linkContribution: LinkContribution
-  /** When 'scoping', this source's regions are a closed world. Default undefined. */
-  scopeRole?: ScopeRole
   createdAt: number
   updatedAt: number
   // Joined data
@@ -157,7 +168,6 @@ export interface TopologyDataSourceInput {
   optionsJson?: string
   nodeContribution?: NodeContribution
   linkContribution?: LinkContribution
-  scopeRole?: ScopeRole
 }
 
 export interface Dashboard {

--- a/apps/server/api/test/db/composition-modes.test.ts
+++ b/apps/server/api/test/db/composition-modes.test.ts
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * Per-source composition modes (topology-source-modes.md, Axis D) — service
- * round-trip: defaults are Additive (scoop / add / no scope); roles persist;
- * scopeRole clears back to additive with an explicit null.
+ * Composition — service round-trips:
+ *  - Per-source modes (topology-source-modes.md, Axis D): defaults are Additive
+ *    (scoop / add); roles persist. Scope is NOT per-source anymore.
+ *  - Topology-level scope (020): scopeMode persists; scopeSourceId only sticks
+ *    for 'closed'.
  */
 import { afterAll, beforeAll, expect, test } from 'bun:test'
+import { TopologyService } from '../../src/services/topology.ts'
 import { TopologySourcesService } from '../../src/services/topology-sources.ts'
 import { getDatabase, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
 
@@ -22,57 +25,48 @@ function makeTopology(id: string): void {
     .run(id, id)
 }
 
-test('add() defaults to Additive (scoop / add / no scope)', async () => {
+test('add() defaults to Additive (scoop / add)', async () => {
   makeTopology('t_modes_1')
   const ds = insertDataSource('zabbix')
   const svc = new TopologySourcesService()
   const added = await svc.add('t_modes_1', { dataSourceId: ds, purpose: 'topology' })
   expect(added.nodeContribution).toBe('scoop')
   expect(added.linkContribution).toBe('add')
-  expect(added.scopeRole).toBeUndefined()
 
   const got = svc.get(added.id)
   expect(got?.nodeContribution).toBe('scoop')
   expect(got?.linkContribution).toBe('add')
-  expect(got?.scopeRole).toBeUndefined()
 })
 
-test('update() sets a role, and scopeRole clears with explicit null', async () => {
+test('update() sets per-source role (Enrichment)', async () => {
   makeTopology('t_modes_2')
   const ds = insertDataSource('netbox')
   const svc = new TopologySourcesService()
   const added = await svc.add('t_modes_2', { dataSourceId: ds, purpose: 'topology' })
 
-  // → Enrichment
   const enriched = svc.update(added.id, { nodeContribution: 'anchor', linkContribution: 'update' })
   expect(enriched?.nodeContribution).toBe('anchor')
   expect(enriched?.linkContribution).toBe('update')
 
-  // → Scoping
-  const scoped = svc.update(added.id, {
-    nodeContribution: 'scoop',
-    linkContribution: 'add',
-    scopeRole: 'scoping',
-  })
-  expect(scoped?.scopeRole).toBe('scoping')
-
-  // clear scope back to additive
-  const cleared = svc.update(added.id, { scopeRole: null })
-  expect(cleared?.scopeRole).toBeUndefined()
+  const additive = svc.update(added.id, { nodeContribution: 'scoop', linkContribution: 'add' })
+  expect(additive?.nodeContribution).toBe('scoop')
+  expect(additive?.linkContribution).toBe('add')
 })
 
-test('add() honors explicit modes', async () => {
-  makeTopology('t_modes_3')
-  const ds = insertDataSource('prometheus')
-  const svc = new TopologySourcesService()
-  const added = await svc.add('t_modes_3', {
-    dataSourceId: ds,
-    purpose: 'topology',
-    nodeContribution: 'anchor',
-    linkContribution: 'update',
-    scopeRole: 'scoping',
-  })
-  expect(added.nodeContribution).toBe('anchor')
-  expect(added.linkContribution).toBe('update')
-  expect(added.scopeRole).toBe('scoping')
+test('topology scope defaults to auto, and setScope round-trips', () => {
+  makeTopology('t_scope_1')
+  const ds = insertDataSource('zabbix', 'ds_scope_src')
+  const svc = new TopologyService()
+
+  expect(svc.get('t_scope_1')?.scopeMode).toBe('auto')
+  expect(svc.get('t_scope_1')?.scopeSourceId).toBeUndefined()
+
+  const closed = svc.setScope('t_scope_1', 'closed', ds)
+  expect(closed?.scopeMode).toBe('closed')
+  expect(closed?.scopeSourceId).toBe(ds)
+
+  // scopeSourceId is only meaningful for 'closed' — switching away clears it.
+  const open = svc.setScope('t_scope_1', 'open', ds)
+  expect(open?.scopeMode).toBe('open')
+  expect(open?.scopeSourceId).toBeUndefined()
 })

--- a/apps/server/api/test/db/schema.test.ts
+++ b/apps/server/api/test/db/schema.test.ts
@@ -57,9 +57,18 @@ describe('migration chain (001-014)', () => {
     }
   })
 
-  test('topology_data_sources has composition-mode columns (018)', () => {
+  test('topology_data_sources has per-source composition-mode columns (018)', () => {
     const cols = columns('topology_data_sources')
-    for (const c of ['node_contribution', 'link_contribution', 'scope_role']) {
+    for (const c of ['node_contribution', 'link_contribution']) {
+      expect(cols).toContain(c)
+    }
+    // scope_role was retired (020): scope is a topology-level decision now.
+    expect(cols).not.toContain('scope_role')
+  })
+
+  test('topologies has topology-level scope columns (020)', () => {
+    const cols = columns('topologies')
+    for (const c of ['scope_mode', 'scope_source_id']) {
       expect(cols).toContain(c)
     }
   })

--- a/apps/server/docs/design/topology-source-modes.md
+++ b/apps/server/docs/design/topology-source-modes.md
@@ -96,7 +96,10 @@ source can play different roles in different topologies):
 
 - `node_contribution`: `scoop` (default) | `anchor`
 - `link_contribution`: `add` (default) | `update`
-- `scope_role`: `NULL` (default) | `scoping`
+
+These two knobs describe "how THIS source behaves in THIS topology" — genuinely
+per (topology × source). Scope is NOT here: it's a single per-topology decision
+(see below).
 
 Node and link knobs are **independent** (decided): an Enrichment source can be
 `node_contribution=anchor` (adds no devices) yet `link_contribution=add` (asserts a
@@ -105,28 +108,41 @@ devices" case.
 
 UI presents **role presets** over these knobs; raw knobs are an advanced surface.
 
-| Preset | node | link | scope_role | meaning |
-|--------|------|------|-----------|---------|
-| **Additive** | scoop | add | NULL | adds nodes+links within the scope |
-| **Enrichment** | anchor | update | NULL | fills fields of existing entities only |
-| **Scoping** (override) | scoop | add | scoping | force this source to define the scope even when it isn't top-priority |
+| Preset | node | link | meaning |
+|--------|------|------|---------|
+| **Additive** | scoop | add | adds nodes+links within the scope |
+| **Enrichment** | anchor | update | fills fields of existing entities only |
 
-**Scope is ordering-driven (decided model 2).** The highest-priority topology
-SOURCE (the intrinsic overlay is excluded — it's curation, not coverage) defines
-the closed world: its regions confine every lower-priority source to within them.
-There is no per-source "is this the scope?" flag for the common case — priority
-already orders the sources, and the top one's coverage *is* the scope. `scope_role`
-is demoted to a manual **override** (force a non-top source to also define scope).
-Scope only activates when a scope-defining source actually contributes regions; a
-single source, or sources with no regions, resolve as an open-world union.
+### Scope is a topology-level decision (migration 020)
+
+Scope answers ONE question per topology — *which region set closes the world* — so
+it lives on the **topology row**, not as a per-source flag. The per-source
+`scope_role` was retired.
+
+- `topologies.scope_mode`: `auto` (default) | `open` | `closed`
+- `topologies.scope_source_id`: the scoping source, only for `closed`
+
+| scope_mode | closed world |
+|------------|--------------|
+| `auto` | the highest-priority topology source's regions (reproduces the old default) |
+| `open` | nothing — pure union of all sources |
+| `closed` | `scope_source_id`'s regions |
+
+**Policy lives in the service, mechanism in `resolve()`.** `resolve()` is pure
+mechanism: a region is the closed world iff one of its contributing subgraphs is
+marked `scope:'closed'`. The service (`topology.ts`) reads `scope_mode` and stamps
+that mark on the right contributions before calling resolve — on the chosen
+source(s) and, unless `open`, on the operator overlay's own regions. So there is no
+priority/source policy buried inside the resolver any more. Scope only activates
+when something is actually marked closed; otherwise it's an open-world union.
 
 The scope is **region-centric**: it is the scope source's REGIONS (e.g. a Zabbix
 host group), and "in scope" means being a member of such a region — NOT merely
 being emitted by the scope source. A cluster survives iff it (a) has an intrinsic
 member that makes a real topology claim (operator curation; a bare metrics-binding
 anchor does NOT count), (b) lands in a closed region by parent / ancestor, or
-(c) matches a closed region's membership predicate. Closed regions are those
-contributed by a scope-defining source OR the operator overlay.
+(c) matches a closed region's membership predicate. Closed regions are exactly the
+ones the service marked `scope:'closed'` per the topology's scope_mode.
 
 Critically this means the **scope source's own out-of-region nodes are dropped**,
 not just lower sources' — e.g. Zabbix LLDP external neighbors (synthesized for

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -15,7 +15,7 @@ import type {
   LinkContribution,
   MetricsMapping,
   NodeContribution,
-  ScopeRole,
+  ScopeMode,
   SyncMode,
   Topology,
   TopologyContext,
@@ -337,6 +337,18 @@ export const topologies = {
       method: 'DELETE',
     }),
 
+  // Topology-level scope policy (composition). Single per-topology decision.
+  composition: {
+    get: (id: string) =>
+      request<{ scopeMode: ScopeMode; scopeSourceId?: string }>(`/topologies/${id}/composition`),
+
+    set: (id: string, body: { scopeMode: ScopeMode; scopeSourceId?: string | null }) =>
+      request<{ scopeMode: ScopeMode; scopeSourceId?: string }>(`/topologies/${id}/composition`, {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      }),
+  },
+
   // Topology Data Sources (many-to-many)
   sources: {
     list: (topologyId: string) =>
@@ -357,7 +369,6 @@ export const topologies = {
         optionsJson?: string
         nodeContribution?: NodeContribution
         linkContribution?: LinkContribution
-        scopeRole?: ScopeRole | null
       },
     ) =>
       request<TopologyDataSource>(`/topologies/${topologyId}/sources/${sourceId}`, {

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -80,9 +80,14 @@ export interface DataSourceInput {
  * write a new one via api.topologies.sources.recordObservation(...).
  * The resolved project graph: api.topologies.getResolved(...).
  */
+/** Topology-level scope policy. See api ScopeMode. */
+export type ScopeMode = 'auto' | 'open' | 'closed'
+
 export interface Topology {
   id: string
   name: string
+  scopeMode: ScopeMode
+  scopeSourceId?: string
   topologySourceId?: string
   metricsSourceId?: string
   mappingJson?: string
@@ -132,10 +137,10 @@ export function serializeMultiFileContent(files: TopologyFile[]): string {
 export type SyncMode = 'manual' | 'on_view' | 'webhook'
 export type DataSourcePurpose = 'topology' | 'metrics'
 
-// Per-source composition modes (topology-source-modes.md, Axis D).
+// Per-source composition modes (topology-source-modes.md, Axis D). Scope is NOT
+// here — it's a single per-topology decision (Topology.scopeMode).
 export type NodeContribution = 'scoop' | 'anchor'
 export type LinkContribution = 'add' | 'update'
-export type ScopeRole = 'scoping'
 
 export interface TopologyDataSource {
   id: string
@@ -149,7 +154,6 @@ export interface TopologyDataSource {
   optionsJson?: string
   nodeContribution: NodeContribution
   linkContribution: LinkContribution
-  scopeRole?: ScopeRole
   createdAt: number
   updatedAt: number
   dataSource?: DataSource
@@ -163,7 +167,6 @@ export interface TopologyDataSourceInput {
   optionsJson?: string
   nodeContribution?: NodeContribution
   linkContribution?: LinkContribution
-  scopeRole?: ScopeRole | null
 }
 
 export interface ApiError {

--- a/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
@@ -33,7 +33,7 @@
     LinkContribution,
     NodeContribution,
     PluginConfigSchema,
-    ScopeRole,
+    ScopeMode,
     SyncMode,
     TopologyDataSource,
   } from '$lib/types'
@@ -216,25 +216,22 @@
     )
   }
 
-  // Composition role = a preset over the three per-source knobs
-  // (topology-source-modes.md). Default Additive (unconstrained union).
-  type CompositionRole = 'additive' | 'scoping' | 'enrichment'
+  // Composition role = how THIS source behaves in the topology. Two presets over
+  // the per-source knobs (scope is NOT here — it's a topology-level decision):
+  //   Additive   = scoop + add  (assert nodes & links)
+  //   Enrichment = anchor + update (fill fields only, claim nothing new)
+  type CompositionRole = 'additive' | 'enrichment'
   function roleOf(s: TopologyDataSource): CompositionRole {
-    if (s.scopeRole === 'scoping') return 'scoping'
-    if (s.nodeContribution === 'anchor') return 'enrichment'
-    return 'additive'
+    return s.nodeContribution === 'anchor' ? 'enrichment' : 'additive'
   }
   function setRole(source: TopologyDataSource, role: CompositionRole) {
     const updates: {
       nodeContribution: NodeContribution
       linkContribution: LinkContribution
-      scopeRole: ScopeRole | null
     } =
-      role === 'scoping'
-        ? { nodeContribution: 'scoop', linkContribution: 'add', scopeRole: 'scoping' }
-        : role === 'enrichment'
-          ? { nodeContribution: 'anchor', linkContribution: 'update', scopeRole: null }
-          : { nodeContribution: 'scoop', linkContribution: 'add', scopeRole: null }
+      role === 'enrichment'
+        ? { nodeContribution: 'anchor', linkContribution: 'update' }
+        : { nodeContribution: 'scoop', linkContribution: 'add' }
     void mutate(
       source.id,
       () => api.topologies.sources.update(ctx.topologyId, source.id, updates),
@@ -245,6 +242,39 @@
       },
       { reflect: true },
     )
+  }
+
+  // Topology-level scope (composition). Single decision: which region set closes
+  // the world. 'auto' = highest-priority topology source; 'open' = no scoping;
+  // 'closed' = the chosen scopeSourceId's regions.
+  let scopeMode = $state<ScopeMode>('auto')
+  let scopeSourceId = $state<string | undefined>(undefined)
+  $effect(() => {
+    scopeMode = ctx.topology?.scopeMode ?? 'auto'
+    scopeSourceId = ctx.topology?.scopeSourceId
+  })
+  // Topology-purpose sources, the candidates for 'closed-to'.
+  const topologySourceChoices = $derived(
+    ctx.currentSources
+      .filter((s) => s.purpose === 'topology')
+      .map((s) => ({
+        id: s.dataSourceId,
+        name: ctx.getDataSource(s.dataSourceId)?.name ?? s.dataSourceId,
+      })),
+  )
+  async function applyScope(mode: ScopeMode, sourceId?: string) {
+    scopeMode = mode
+    scopeSourceId = sourceId
+    try {
+      const res = await api.topologies.composition.set(ctx.topologyId, {
+        scopeMode: mode,
+        scopeSourceId: mode === 'closed' ? (sourceId ?? null) : null,
+      })
+      if (ctx.topology) ctx.topology = { ...ctx.topology, ...res }
+      ctx.bumpRevision()
+    } catch (e) {
+      localError = e instanceof Error ? e.message : String(e)
+    }
   }
 
   function changeDataSource(source: TopologyDataSource, newId: string) {
@@ -511,6 +541,46 @@
       </div>
     </div>
     <div class="card-body">
+      {#if topologySources.length > 0}
+        <!-- Topology-level scope: ONE decision for the whole topology — which
+             region set closes the world. Not a per-source property. -->
+        <div class="mb-4 flex flex-wrap items-center gap-2 rounded-lg bg-theme-bg-subtle p-3">
+          <span class="text-xs font-medium text-theme-text-emphasis">Scope</span>
+          <select
+            class="input"
+            style="width: 11rem;"
+            title="Which region set closes the world for this topology"
+            value={scopeMode}
+            onchange={(e) =>
+              applyScope(
+                e.currentTarget.value as ScopeMode,
+                e.currentTarget.value === 'closed' ? scopeSourceId : undefined,
+              )}
+          >
+            <option value="auto">Auto (top source)</option>
+            <option value="open">Open (union)</option>
+            <option value="closed">Closed to…</option>
+          </select>
+          {#if scopeMode === 'closed'}
+            <select
+              class="input"
+              style="width: 12rem;"
+              value={scopeSourceId ?? ''}
+              onchange={(e) => applyScope('closed', e.currentTarget.value || undefined)}
+            >
+              <option value="" disabled>Select a source…</option>
+              {#each topologySourceChoices as choice (choice.id)}
+                <option value={choice.id}>{choice.name}</option>
+              {/each}
+            </select>
+          {/if}
+          <span class="text-xs text-theme-text-muted">
+            {scopeMode === 'open'
+              ? 'all sources merged, nothing dropped'
+              : 'nodes outside the closed region are dropped'}
+          </span>
+        </div>
+      {/if}
       {#if topologySources.length === 0}
         <p class="text-sm text-theme-text-muted text-center py-4">
           No topology sources configured. Topology is defined manually.
@@ -626,12 +696,11 @@
                     <select
                       class="input"
                       style="width: 10rem;"
-                      title="How this source composes into the topology"
+                      title="How this source behaves in the topology"
                       value={roleOf(source)}
                       onchange={(e) => setRole(source, e.currentTarget.value as CompositionRole)}
                     >
                       <option value="additive">Additive</option>
-                      <option value="scoping">Scoping</option>
                       <option value="enrichment">Enrichment</option>
                     </select>
                   </div>

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -1033,7 +1033,8 @@ export interface Subgraph {
   /**
    * Scope marker (resolve input only). `'closed'` makes this region a closed
    * world: resolve() drops any node cluster that is not a member of some closed
-   * region. Set by a `scope_role: 'scoping'` source. Default (undefined) = open.
+   * region. Stamped by the caller per the topology's scope policy (auto / open /
+   * closed-to a chosen source). Default (undefined) = open.
    */
   scope?: 'closed'
 

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1838,11 +1838,11 @@ describe('resolve()', () => {
       expect(out.links[0]?.presence).toBeUndefined() // input-only, never emitted
     })
 
-    it('top-priority source defines the scope; a lower source is confined to it', () => {
-      // A (priority 1) is the highest-priority source → its region is the closed
-      // world (ordering-driven, no explicit flag). B (priority 0) is confined:
-      // its node that matches A's region membership is kept (fills the scope),
-      // the out-of-range one is dropped. A's own node is always kept.
+    it('a scope-marked region confines a lower source to it', () => {
+      // A's region is marked scope:'closed' (the caller's scope policy stamps this;
+      // resolve is pure mechanism). B (priority 0) is confined: its node that
+      // matches A's region membership is kept (fills the scope), the out-of-range
+      // one is dropped. A's own node is always kept.
       const scoping: SnapshotEntry = {
         sourceId: 'A',
         capturedAt: 1,
@@ -1852,7 +1852,12 @@ describe('resolve()', () => {
           ...emptyGraph(),
           nodes: [{ id: 'a1', label: 'in-region', identity: { mgmtIp: '10.0.0.1' }, parent: 'g' }],
           subgraphs: [
-            { id: 'g', label: 'Region', membership: [{ attr: 'subnet', value: '10.0.0.0/24' }] },
+            {
+              id: 'g',
+              label: 'Region',
+              scope: 'closed',
+              membership: [{ attr: 'subnet', value: '10.0.0.0/24' }],
+            },
           ],
         },
       }
@@ -1889,7 +1894,7 @@ describe('resolve()', () => {
             { id: 'in', label: 'in-region', identity: { mgmtIp: '10.0.0.1' }, parent: 'g' },
             { id: 'ext', label: 'external-neighbor', identity: { sysName: 'peer' } }, // no region
           ],
-          subgraphs: [{ id: 'g', label: 'Region' }],
+          subgraphs: [{ id: 'g', label: 'Region', scope: 'closed' }],
         },
       }
       const out = resolve(emptyGraph(), [scoping])
@@ -1910,7 +1915,7 @@ describe('resolve()', () => {
         graph: {
           ...emptyGraph(),
           nodes: [{ id: 'a1', label: 'a1', identity: { mgmtIp: '10.0.0.1' }, parent: 'g' }],
-          subgraphs: [{ id: 'g', label: 'Region' }],
+          subgraphs: [{ id: 'g', label: 'Region', scope: 'closed' }],
         },
       }
       const out = resolve(intrinsic, [scoping])

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -139,18 +139,17 @@ export function resolve(
     for (const m of cl.members) regionIdRemap.set(m.subgraph.id, cl.canonicalId)
   }
 
-  // 2d. Scope (ordering-driven, region-centric). The highest-priority topology
-  //     SOURCE (the intrinsic overlay is excluded as scope DEFINER — it's
-  //     curation, not coverage) makes its REGIONS the closed world. "In scope"
-  //     means being a member of a closed region — NOT merely being emitted by the
-  //     scope source — so even the scope source's own out-of-region nodes (e.g.
-  //     Zabbix LLDP external neighbors, outside the fetched host group) are
-  //     dropped. Closed regions = those from a scope-defining source OR the
-  //     overlay. Operator curation (a real intrinsic node) is always kept. No
-  //     closed region → no filtering (open-world union: a single source / sources
-  //     with no regions / no overlay regions). See clusterInClosedScope.
-  const scopeDefiningSourceIds = computeScopeDefiningSources(contributions)
-  const scope = buildScopeIndex(regions, regionIdRemap, scopeDefiningSourceIds)
+  // 2d. Scope (region-centric, MECHANISM only). A region is the closed world iff
+  //     one of its contributing subgraphs is marked `scope:'closed'`. resolve does
+  //     NOT decide WHICH source scopes — that policy (auto = top source / open /
+  //     closed-to a chosen source) lives in the caller, which stamps `scope:'closed'`
+  //     on the right contributions (incl. the overlay) before calling resolve.
+  //     "In scope" means being a member of a closed region — NOT merely being
+  //     emitted by the scope source — so even the scope source's own out-of-region
+  //     nodes (e.g. Zabbix LLDP external neighbors, outside the fetched host group)
+  //     are dropped. Operator curation (a real intrinsic node) is always kept. No
+  //     closed region → no filtering (open-world union). See clusterInClosedScope.
+  const scope = buildScopeIndex(regions, regionIdRemap)
   const nodeClusters =
     scope.closedRegionIds.size > 0
       ? afterExclusions.filter((c) => clusterInClosedScope(c, regions, regionIdRemap, scope))
@@ -990,42 +989,18 @@ interface ScopeIndex {
   inClosedScope: (regionId: string) => boolean
 }
 
-/**
- * The sources whose regions form the closed scope: the highest-priority
- * non-intrinsic source(s), PLUS any source that explicitly marks a region
- * `scope:'closed'` (manual override regardless of priority). The intrinsic
- * overlay (+∞) is excluded — it's curation, not coverage, so it never defines
- * the scope. Empty when there are no non-intrinsic sources.
- */
-function computeScopeDefiningSources(contributions: Contribution[]): Set<string> {
-  const sources = contributions.filter((c) => c.sourceId !== 'intrinsic')
-  const ids = new Set<string>()
-  if (sources.length === 0) return ids
-  const maxPriority = sources.reduce((m, c) => Math.max(m, c.priority), Number.NEGATIVE_INFINITY)
-  for (const c of sources) {
-    if (c.priority === maxPriority) ids.add(c.sourceId)
-    else if ((c.graph.subgraphs ?? []).some((s) => s.scope === 'closed')) ids.add(c.sourceId)
-  }
-  return ids
-}
-
 /** Index closed regions + the region parent chain for scope ancestry walks. */
 function buildScopeIndex(
   clusters: RegionCluster[],
   regionIdRemap: Map<string, string>,
-  scopeDefiningSourceIds: Set<string>,
 ): ScopeIndex {
   const closedRegionIds = new Set<string>()
   const regionParent = new Map<string, string>()
   for (const cl of clusters) {
-    // A region is part of the closed scope if a scope-defining source OR the
-    // operator overlay (intrinsic curation) contributed it. Scope-source regions
-    // (e.g. Zabbix host groups) come in automatically; operator-authored regions
-    // count too, so a node matching their membership is in scope.
-    if (
-      cl.members.some((m) => m.sourceId === 'intrinsic' || scopeDefiningSourceIds.has(m.sourceId))
-    )
-      closedRegionIds.add(cl.canonicalId)
+    // A region is part of the closed scope iff one of its contributing subgraphs
+    // is marked `scope:'closed'`. The caller decides which source(s) scope and
+    // stamps that mark — resolve is pure mechanism here (no priority/source policy).
+    if (cl.members.some((m) => m.subgraph.scope === 'closed')) closedRegionIds.add(cl.canonicalId)
     const ranked = [...cl.members].sort(
       (a, b) => b.priority - a.priority || b.capturedAt - a.capturedAt,
     )


### PR DESCRIPTION
## What

Scope (which region set closes the world) becomes a **single per-topology decision** instead of a per-source `scope_role` flag. Per-source contribution (node/link) stays per-attach.

## Why

Scope answers one question per topology, but it was expressed as a flag scattered across N source-attach rows, and the actual "which source scopes" decision was a `maxPriority` derivation **buried inside `resolve()`** — policy living in core. Following the discussion: scope is topology-owned; the per-source knob only made sense for "how this source behaves here" (add vs enrich).

## How

**Policy → service, mechanism → resolve (the clean split).**
- `resolve()` is now pure mechanism: a region is closed iff one of its contributing subgraphs is marked `scope:'closed'`. The `computeScopeDefiningSources` priority magic is deleted.
- `topology.ts` owns the policy: reads `topology.scope_mode` and stamps the mark on the right contributions before resolve — the chosen source(s), and (unless `open`) the operator overlay's own regions.

**Storage — relational, no JSON blob** (matches the DB-native contribution store):
- migration 020: `+ topologies.scope_mode` (`auto`|`open`|`closed`), `+ topologies.scope_source_id`; **DROP** `topology_data_sources.scope_role`. No backcompat — existing topologies default to `auto`, which reproduces the prior "top source defines scope".

**New capabilities**: `open` (pure union, no scoping) is expressible for the first time; `closed-to <source>` is an explicit choice instead of the awkward override.

**API**: `GET/PUT /topologies/:id/composition`.
**UI**: per-source Role is now `Additive | Enrichment` (Scoping removed); one topology-level Scope control (Auto / Open / Closed-to + source picker) sits atop the Sources list.

## Verify

- test6, `scope_mode='auto'` → Zabbix (priority 10) scopes → **63 nodes, all in "Backbone Routers", 0 floating** — identical to the prior ordering-driven result (also confirms #404 dedup live: 104 links).
- Core 317 + API 80 tests green (migration 020 incl. `DROP COLUMN` exercised by the temp-DB suite). Full monorepo build 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
