### PR TITLE
feat(core): ScopeFilter — common topology-level scope (Phase 1)

### DIFF
--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -1009,6 +1009,23 @@ export interface MembershipCriterion {
   key?: string
 }
 
+/**
+ * A topology-level scope: the SINGLE, plugin-independent definition of which
+ * nodes the topology covers, expressed as the same {@link MembershipCriterion}
+ * predicate the region machinery uses. A node is in scope when it matches an
+ * `include` criterion (or `include` is empty) AND no `exclude` criterion.
+ * Both empty → no scoping (open-world union).
+ *
+ * This is the common shape every topology source's "what to pull" filter folds
+ * into (Zabbix host groups, NetBox sites/tags/roles, subnets → criteria).
+ * Plugins MAY push it down to their upstream query for efficiency, but resolve()
+ * enforces it post-merge regardless, so coverage never depends on push-down.
+ */
+export interface ScopeFilter {
+  include?: MembershipCriterion[]
+  exclude?: MembershipCriterion[]
+}
+
 export interface Subgraph {
   id: string
 

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1948,6 +1948,67 @@ describe('resolve()', () => {
       expect(out.nodes.map((n) => n.label).sort()).toEqual(['a', 'b'])
     })
   })
+
+  describe('topology-level scope filter (options.scope)', () => {
+    const threeNodes = (sourceId: string): SnapshotEntry => ({
+      sourceId,
+      capturedAt: 1,
+      status: 'ok',
+      graph: {
+        ...emptyGraph(),
+        nodes: [
+          { id: 'in1', label: 'in-1', identity: { mgmtIp: '10.0.0.1' } },
+          { id: 'in2', label: 'in-2', identity: { mgmtIp: '10.0.0.2' } },
+          { id: 'out', label: 'out', identity: { mgmtIp: '10.9.0.9' } },
+        ],
+      },
+    })
+
+    it('no filter → open-world union (all kept)', () => {
+      const out = resolve(emptyGraph(), [threeNodes('A')])
+      expect(out.nodes).toHaveLength(3)
+    })
+
+    it('empty include/exclude → no scoping (all kept)', () => {
+      const out = resolve(emptyGraph(), [threeNodes('A')], { scope: { include: [], exclude: [] } })
+      expect(out.nodes).toHaveLength(3)
+    })
+
+    it('include by subnet keeps only matching clusters', () => {
+      const out = resolve(emptyGraph(), [threeNodes('A')], {
+        scope: { include: [{ attr: 'subnet', value: '10.0.0.0/24' }] },
+      })
+      expect(out.nodes.map((n) => n.label).sort()).toEqual(['in-1', 'in-2'])
+    })
+
+    it('exclude removes matching clusters even with no include', () => {
+      const out = resolve(emptyGraph(), [threeNodes('A')], {
+        scope: { exclude: [{ attr: 'name', value: '^out$' }] },
+      })
+      expect(out.nodes.map((n) => n.label).sort()).toEqual(['in-1', 'in-2'])
+    })
+
+    it('exclude wins over include', () => {
+      const out = resolve(emptyGraph(), [threeNodes('A')], {
+        scope: {
+          include: [{ attr: 'subnet', value: '10.0.0.0/24' }],
+          exclude: [{ attr: 'name', value: '^in-2$' }],
+        },
+      })
+      expect(out.nodes.map((n) => n.label)).toEqual(['in-1'])
+    })
+
+    it('an intrinsic (curated) node survives the scope filter', () => {
+      const intrinsic: NetworkGraph = {
+        ...emptyGraph(),
+        nodes: [{ id: 'op', label: 'operator-placed', identity: { mgmtIp: '10.9.0.1' } }],
+      }
+      const out = resolve(intrinsic, [threeNodes('A')], {
+        scope: { include: [{ attr: 'subnet', value: '10.0.0.0/24' }] },
+      })
+      expect(out.nodes.map((n) => n.label).sort()).toEqual(['in-1', 'in-2', 'operator-placed'])
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -15,6 +15,7 @@ import {
   type NodePort,
   type Provenance,
   type RegionIdentity,
+  type ScopeFilter,
   type Subgraph,
 } from '../models/types.js'
 import { keyHash, nodeIdentityKeys, portIdentityKeys } from './identity.js'
@@ -150,10 +151,22 @@ export function resolve(
   //     are dropped. Operator curation (a real intrinsic node) is always kept. No
   //     closed region → no filtering (open-world union). See clusterInClosedScope.
   const scope = buildScopeIndex(regions, regionIdRemap)
-  const nodeClusters =
+  const regionScoped =
     scope.closedRegionIds.size > 0
       ? afterExclusions.filter((c) => clusterInClosedScope(c, regions, regionIdRemap, scope))
       : afterExclusions
+
+  // 2e. Topology-level scope predicate (orthogonal to region scope). When the
+  //     caller supplies include/exclude criteria, drop clusters that don't match
+  //     — operator-curated intrinsic nodes are always kept. This is the common,
+  //     plugin-independent scope every source's "what to pull" filter folds into.
+  const scopeFilter = options.scope
+  const hasScopeFilter =
+    !!scopeFilter && (scopeFilter.include?.length ?? 0) + (scopeFilter.exclude?.length ?? 0) > 0
+  const nodeClusters =
+    hasScopeFilter && scopeFilter
+      ? regionScoped.filter((c) => clusterMatchesScopeFilter(c, scopeFilter))
+      : regionScoped
 
   // 3. For each cluster, fold into a single resolved Node
   const resolvedNodes: Node[] = []
@@ -918,6 +931,26 @@ function clusterRegions(contributions: Contribution[]): RegionCluster[] {
       claim({ sourceId: c.sourceId, priority: c.priority, capturedAt: c.capturedAt, subgraph: s })
   }
   return clusters
+}
+
+/**
+ * Whether a node cluster satisfies the topology-level scope filter: it matches an
+ * `include` criterion (or `include` is empty) AND no `exclude` criterion. A
+ * criterion is satisfied when ANY member node of the cluster matches it (so a
+ * cluster confirmed across sources stays in scope if any contributor matches).
+ * Operator-curated intrinsic nodes are always kept, mirroring region scope.
+ */
+function clusterMatchesScopeFilter(cluster: NodeCluster, scope: ScopeFilter): boolean {
+  for (const m of cluster.members) {
+    if (m.sourceId === 'intrinsic' && intrinsicAssertsTopology(m.node)) return true
+  }
+  const include = scope.include ?? []
+  const exclude = scope.exclude ?? []
+  const anyMemberMatches = (crit: MembershipCriterion): boolean =>
+    cluster.members.some((m) => criterionMatches(m.node, crit))
+  if (exclude.some(anyMemberMatches)) return false
+  if (include.length === 0) return true
+  return include.some(anyMemberMatches)
 }
 
 /** Whether a node satisfies any membership criterion of any member of a region. */

--- a/libs/@shumoku/core/src/observation/types.ts
+++ b/libs/@shumoku/core/src/observation/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // For commercial licensing, contact: contact@shumoku.dev
 
-import type { NetworkGraph } from '../models/types.js'
+import type { NetworkGraph, ScopeFilter } from '../models/types.js'
 
 /**
  * One source's observation at a point in time. The server's
@@ -51,6 +51,13 @@ export interface ResolveOptions {
    * detection. They still show in inspector history. Default 30 days.
    */
   staleThresholdMs?: number
+  /**
+   * Topology-level scope predicate. When it carries any `include`/`exclude`
+   * criterion, resolve drops every node cluster that doesn't satisfy it
+   * (operator-curated intrinsic nodes are always kept). Absent / empty → no
+   * topology-level scoping. Orthogonal to, and applied after, region scope.
+   */
+  scope?: ScopeFilter
 }
 
 /**


### PR DESCRIPTION
## Phase 1 of moving scope to the topology side

The first of three phases that make **scope a single, plugin-independent, topology-level thing** (so per-source Mode + Scope can live in one Composition surface). This phase is **core only** — the type + resolve mechanism — with **no live wiring**, so behavior is unchanged.

## What

- `ScopeFilter { include?: MembershipCriterion[]; exclude?: MembershipCriterion[] }` — reuses the existing region `MembershipCriterion` vocabulary (`name` / `subnet` / `metadata`), so no new matching language.
- `ResolveOptions.scope`: when it carries any include/exclude criterion, `resolve()` drops node clusters that don't satisfy it — **match an include (or include empty) AND no exclude**. Operator-curated intrinsic nodes are always kept (mirrors region scope). Empty/absent → no scoping.

## Why this shape

Every topology source's "what to pull" filter (Zabbix host groups, NetBox sites/tags/roles, subnets) folds into this one predicate. Crucially, `resolve()` enforces it **post-merge for every source**, so coverage never depends on a plugin being able to push the filter down to its upstream query — push-down stays a pure optimization (Phase 2).

## Scope of this PR

Pure capability addition. The service does **not** pass `options.scope` yet, so today's region scope still governs (test6 unchanged). Phase 2 = topology storage + plugin translation (split each plugin's optionsSchema into common scope criteria vs. behavior knobs); Phase 3 = the Composition UI (Mode + Scope together) and retiring the old per-source surfaces.

## Test

6 new resolve tests (open / empty / include-by-subnet / exclude / exclude-wins / intrinsic-survives). Core 323 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
