### PR TITLE
feat(server): topology scope criteria — storage + wiring (Phase 2a)

### DIFF
--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -3,7 +3,12 @@
  * CRUD endpoints for topology management
  */
 
-import { buildHierarchicalSheets, type NetworkGraph, specDeviceType } from '@shumoku/core'
+import {
+  buildHierarchicalSheets,
+  type NetworkGraph,
+  type ScopeFilter,
+  specDeviceType,
+} from '@shumoku/core'
 import { type EmbeddableRenderOutput, renderEmbeddable } from '@shumoku/renderer-svg'
 import { Hono } from 'hono'
 import { getLayoutEngine } from '../layout.js'
@@ -366,23 +371,42 @@ export function createTopologiesApi(): Hono {
     }
   })
 
-  // Topology scope policy (composition). Scope is a single per-topology decision —
-  // which region set closes the world — so it lives on the topology, not per source.
+  // Topology scope (composition). A single per-topology decision. `scope` is the
+  // common ScopeFilter (include/exclude criteria) the resolver enforces post-merge;
+  // scopeMode/scopeSourceId is the older region-mark path, kept during transition.
   app.get('/:id/composition', (c) => {
     const id = c.req.param('id')
     const topology = service.get(id)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
-    return c.json({ scopeMode: topology.scopeMode, scopeSourceId: topology.scopeSourceId })
+    return c.json({
+      scopeMode: topology.scopeMode,
+      scopeSourceId: topology.scopeSourceId,
+      scope: topology.scope,
+    })
   })
 
   app.put('/:id/composition', async (c) => {
     const id = c.req.param('id')
     try {
-      const body = (await c.req.json()) as { scopeMode?: ScopeMode; scopeSourceId?: string | null }
-      const mode = body.scopeMode ?? 'auto'
-      const topology = service.setScope(id, mode, body.scopeSourceId ?? undefined)
+      const body = (await c.req.json()) as {
+        scopeMode?: ScopeMode
+        scopeSourceId?: string | null
+        scope?: ScopeFilter
+      }
+      let topology = service.get(id)
       if (!topology) return c.json({ error: 'Topology not found' }, 404)
-      return c.json({ scopeMode: topology.scopeMode, scopeSourceId: topology.scopeSourceId })
+      if (body.scopeMode !== undefined || body.scopeSourceId !== undefined) {
+        topology = service.setScope(id, body.scopeMode ?? 'auto', body.scopeSourceId ?? undefined)
+      }
+      if (body.scope !== undefined) {
+        topology = service.setScopeCriteria(id, body.scope)
+      }
+      if (!topology) return c.json({ error: 'Topology not found' }, 404)
+      return c.json({
+        scopeMode: topology.scopeMode,
+        scopeSourceId: topology.scopeSourceId,
+        scope: topology.scope,
+      })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 400)

--- a/apps/server/api/src/db/migrations/021_topology_scope_criteria.sql
+++ b/apps/server/api/src/db/migrations/021_topology_scope_criteria.sql
@@ -1,0 +1,27 @@
+-- Topology-level scope criteria (common ScopeFilter, Phase 2).
+--
+-- The single, plugin-independent scope of a topology, stored relationally (not as
+-- a JSON blob — consistent with the DB-native contribution store). Each row is one
+-- include/exclude MembershipCriterion. A topology with no rows = no scope filter
+-- (open). This is what every source's plugin-shaped "what to pull" filter folds
+-- into; resolve() enforces it post-merge, plugins may push it down (Phase 2b/3).
+--
+--   kind:  'include' | 'exclude'
+--   attr:  'name' | 'subnet' | 'metadata'   (matches MembershipCriterion)
+--   key:   metadata key (only when attr='metadata')
+--   value: the criterion value
+--
+-- scope_mode / scope_source_id (020) stay for now; the region-mark scope still
+-- governs existing topologies until plugin translation + UI land (Phase 2b/3),
+-- so this addition is non-regressing.
+CREATE TABLE IF NOT EXISTS topology_scope_criteria (
+  id TEXT PRIMARY KEY,
+  topology_id TEXT NOT NULL REFERENCES topologies(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,
+  attr TEXT NOT NULL,
+  key TEXT,
+  value TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_scope_criteria_topology ON topology_scope_criteria (topology_id);

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -25,6 +25,7 @@ import migration017 from './migrations/017_drop_dead_tables.sql'
 import migration018 from './migrations/018_composition_modes.sql'
 import migration019 from './migrations/019_fix_contribution_link_local_id_nullable.sql'
 import migration020 from './migrations/020_topology_scope.sql'
+import migration021 from './migrations/021_topology_scope_criteria.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -46,6 +47,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '018_composition_modes.sql', sql: migration018 },
   { name: '019_fix_contribution_link_local_id_nullable.sql', sql: migration019 },
   { name: '020_topology_scope.sql', sql: migration020 },
+  { name: '021_topology_scope_criteria.sql', sql: migration021 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -25,16 +25,19 @@
  */
 
 import type { Database } from 'bun:sqlite'
+import crypto from 'node:crypto'
 import type {
   Attachment,
   IconDimensions,
   Identity,
   LayoutResult,
+  MembershipCriterion,
   MetricsBindingAttachment,
   NetworkGraph,
   Node,
   NodePort,
   ResolvedLayout,
+  ScopeFilter,
   SnapshotEntry,
   Subgraph,
   Termination,
@@ -100,9 +103,18 @@ function rowToTopology(row: TopologyRow): Topology {
     shareToken: row.share_token ?? undefined,
     scopeMode: (row.scope_mode as Topology['scopeMode']) ?? 'auto',
     scopeSourceId: row.scope_source_id ?? undefined,
+    // Filled by the service from topology_scope_criteria (rowToTopology has no db).
+    scope: { include: [], exclude: [] },
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
+}
+
+interface ScopeCriterionRow {
+  kind: string
+  attr: string
+  key: string | null
+  value: string
 }
 
 /**
@@ -503,7 +515,7 @@ export class TopologyService {
   /** Get all topologies from the database (shells only). */
   list(): Topology[] {
     const rows = this.db.query('SELECT * FROM topologies ORDER BY name ASC').all() as TopologyRow[]
-    return rows.map((row) => rowToTopology(row))
+    return rows.map((row) => this.withScope(rowToTopology(row)))
   }
 
   /** Get a single topology shell by ID. */
@@ -511,7 +523,7 @@ export class TopologyService {
     const row = this.db.query('SELECT * FROM topologies WHERE id = ?').get(id) as
       | TopologyRow
       | undefined
-    return row ? rowToTopology(row) : null
+    return row ? this.withScope(rowToTopology(row)) : null
   }
 
   /** Get a topology shell by name. */
@@ -519,7 +531,60 @@ export class TopologyService {
     const row = this.db.query('SELECT * FROM topologies WHERE name = ?').get(name) as
       | TopologyRow
       | undefined
-    return row ? rowToTopology(row) : null
+    return row ? this.withScope(rowToTopology(row)) : null
+  }
+
+  /** Read the topology's scope criteria into a ScopeFilter. */
+  readScopeCriteria(topologyId: string): ScopeFilter {
+    const rows = this.db
+      .query('SELECT kind, attr, key, value FROM topology_scope_criteria WHERE topology_id = ?')
+      .all(topologyId) as ScopeCriterionRow[]
+    const include: MembershipCriterion[] = []
+    const exclude: MembershipCriterion[] = []
+    for (const r of rows) {
+      const crit: MembershipCriterion = {
+        attr: r.attr as MembershipCriterion['attr'],
+        value: r.value,
+        ...(r.key ? { key: r.key } : {}),
+      }
+      ;(r.kind === 'exclude' ? exclude : include).push(crit)
+    }
+    return { include, exclude }
+  }
+
+  /** Fill a topology's `scope` from its criteria rows. */
+  private withScope(topology: Topology): Topology {
+    topology.scope = this.readScopeCriteria(topology.id)
+    return topology
+  }
+
+  /**
+   * Replace the topology's scope criteria wholesale. Bumps the composition
+   * revision so the resolved graph re-resolves under the new scope.
+   */
+  setScopeCriteria(topologyId: string, scope: ScopeFilter): Topology | null {
+    if (!this.get(topologyId)) return null
+    const now = timestamp()
+    this.db.query('DELETE FROM topology_scope_criteria WHERE topology_id = ?').run(topologyId)
+    const insert = this.db.query(
+      `INSERT INTO topology_scope_criteria (id, topology_id, kind, attr, key, value, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    const write = (kind: 'include' | 'exclude', crit: MembershipCriterion): void => {
+      insert.run(
+        crypto.randomUUID(),
+        topologyId,
+        kind,
+        crit.attr,
+        crit.key ?? null,
+        crit.value,
+        now,
+      )
+    }
+    for (const c of scope.include ?? []) write('include', c)
+    for (const c of scope.exclude ?? []) write('exclude', c)
+    this.clearCacheEntry(topologyId)
+    return this.get(topologyId)
   }
 
   /**
@@ -1013,7 +1078,7 @@ export class TopologyService {
     const row = this.db.query('SELECT * FROM topologies WHERE share_token = ?').get(token) as
       | TopologyRow
       | undefined
-    return row ? rowToTopology(row) : null
+    return row ? this.withScope(rowToTopology(row)) : null
   }
 
   /**
@@ -1160,7 +1225,9 @@ export class TopologyService {
       }
     }
     const snapshots = this.readObservedSnapshots(topology.id, priorityBySource, modeBySource)
-    const resolvedGraph = resolveObservations(authored, snapshots)
+    // Topology-level scope criteria (Phase 2): enforced post-merge by resolve, on
+    // top of the region-mark scope. Empty → no extra filtering.
+    const resolvedGraph = resolveObservations(authored, snapshots, { scope: topology.scope })
     // Post-resolve display filter (project-level pref on the overlay settings).
     // Runs on the fully-merged graph — never per-source.
     const graph = authored.settings?.hideDisconnected

--- a/apps/server/api/src/types.ts
+++ b/apps/server/api/src/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for the Shumoku real-time server
  */
 
-import type { LayoutResult, MetricsData, NetworkGraph } from '@shumoku/core'
+import type { LayoutResult, MetricsData, NetworkGraph, ScopeFilter } from '@shumoku/core'
 
 export type {
   LinkMetrics,
@@ -98,10 +98,16 @@ export type ScopeMode = 'auto' | 'open' | 'closed'
 export interface Topology {
   id: string
   name: string
-  /** Scope policy for this topology. Default 'auto'. */
+  /** Scope policy for this topology. Default 'auto'. (Region-mark scope; being
+   * superseded by `scope` criteria — kept during the Phase 2/3 transition.) */
   scopeMode: ScopeMode
   /** The scoping source (data_sources.id) when scopeMode === 'closed'. */
   scopeSourceId?: string
+  /**
+   * Topology-level scope criteria — the common, plugin-independent filter the
+   * resolver enforces post-merge. Empty include+exclude = no scope filter.
+   */
+  scope: ScopeFilter
   /**
    * Structure / metrics data source ids. No longer stored on the topology row
    * (sources live in `topology_data_sources`); the `/context` response derives

--- a/apps/server/api/test/db/composition-modes.test.ts
+++ b/apps/server/api/test/db/composition-modes.test.ts
@@ -70,3 +70,24 @@ test('topology scope defaults to auto, and setScope round-trips', () => {
   expect(open?.scopeMode).toBe('open')
   expect(open?.scopeSourceId).toBeUndefined()
 })
+
+test('topology scope criteria round-trip (setScopeCriteria / readScopeCriteria)', () => {
+  makeTopology('t_scope_2')
+  const svc = new TopologyService()
+
+  // Defaults: empty filter.
+  expect(svc.get('t_scope_2')?.scope).toEqual({ include: [], exclude: [] })
+
+  const set = svc.setScopeCriteria('t_scope_2', {
+    include: [{ attr: 'metadata', key: 'hostGroups', value: 'Backbone Routers' }],
+    exclude: [{ attr: 'name', value: '^mgmt-' }],
+  })
+  expect(set?.scope.include).toEqual([
+    { attr: 'metadata', key: 'hostGroups', value: 'Backbone Routers' },
+  ])
+  expect(set?.scope.exclude).toEqual([{ attr: 'name', value: '^mgmt-' }])
+
+  // Replace wholesale: empty clears.
+  const cleared = svc.setScopeCriteria('t_scope_2', { include: [], exclude: [] })
+  expect(cleared?.scope).toEqual({ include: [], exclude: [] })
+})

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -1998,6 +1998,35 @@ describe('resolve()', () => {
       expect(out.nodes.map((n) => n.label)).toEqual(['in-1'])
     })
 
+    it('include by array metadata (host groups) matches any element', () => {
+      const snap: SnapshotEntry = {
+        sourceId: 'A',
+        capturedAt: 1,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [
+            {
+              id: 'r1',
+              label: 'in-group',
+              identity: { mgmtIp: '10.0.0.1' },
+              metadata: { hostGroups: ['Backbone Routers', 'Core'] },
+            },
+            {
+              id: 'r2',
+              label: 'other',
+              identity: { mgmtIp: '10.0.0.2' },
+              metadata: { hostGroups: ['Access'] },
+            },
+          ],
+        },
+      }
+      const out = resolve(emptyGraph(), [snap], {
+        scope: { include: [{ attr: 'metadata', key: 'hostGroups', value: 'Backbone Routers' }] },
+      })
+      expect(out.nodes.map((n) => n.label)).toEqual(['in-group'])
+    })
+
     it('an intrinsic (curated) node survives the scope filter', () => {
       const intrinsic: NetworkGraph = {
         ...emptyGraph(),

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -978,7 +978,11 @@ function criterionMatches(node: Node, crit: MembershipCriterion): boolean {
   if (crit.attr === 'metadata') {
     if (!crit.key) return false
     const v = node.metadata?.[crit.key]
-    return v !== undefined && String(v) === crit.value
+    if (v === undefined) return false
+    // Array metadata (e.g. a node's `hostGroups`) matches if any element equals
+    // the value — so a host-group / tag / role criterion hits a multi-valued field.
+    if (Array.isArray(v)) return v.some((x) => String(x) === crit.value)
+    return String(v) === crit.value
   }
   return false
 }


### PR DESCRIPTION
## Phase 2a — topology scope criteria: storage + wiring

Wires the common `ScopeFilter` (Phase 1, #420) end to end: **storage → service → resolve**, plus the API. **Non-regressing** — no criteria are set yet, so the existing region-mark scope still governs (test6 unchanged at 63 nodes).

## What

- **migration 021**: `topology_scope_criteria` table — relational, **not a JSON blob** (consistent with the DB-native contribution store). One row per include/exclude `MembershipCriterion`; FK-cascades on topology delete.
- **TopologyService**: `readScopeCriteria` / `setScopeCriteria`; `Topology.scope` is filled on every read; `parseTopology` passes `{ scope }` to `resolve()`, enforced post-merge on top of region scope. Empty include+exclude → no-op.
- **core**: `criterionMatches` now handles **array metadata** (a host-group / tag / role criterion hits a multi-valued field).
- **API**: `GET/PUT /topologies/:id/composition` carries `scope`.

## Known follow-up baked into the plan (Phase 2b)

Topology-scoping plugins must **emit the dimension they key on**. Verified on test6: Zabbix nodes carry `hostname`/`zabbixHostId` but **not `hostGroups`** in node metadata — the host group lives on the region/subgraph parent — so a `hostGroups` criterion can't match a node *yet*. Emitting it is Phase 2b; this PR is the plumbing.

## Test

Service round-trip test (`setScopeCriteria`/`readScopeCriteria`) + core array-metadata match. Core 324 + API 81 green; migration 021 exercised by the temp-DB suite; 19/19 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
