### PR TITLE
feat(zabbix): emit host-group names on the node (Phase 2b)

### DIFF
--- a/libs/plugins/zabbix/src/topology.test.ts
+++ b/libs/plugins/zabbix/src/topology.test.ts
@@ -28,6 +28,8 @@ describe('convertZabbixToGraph', () => {
     expect(n?.identity?.mgmtIp).toBe('172.16.0.2')
     expect(n?.identity?.vendorIds?.['zabbix-hostid']).toBe('1')
     expect(n?.metadata?.['hostname']).toBe('ptxA.noc')
+    // Host-group names land on the node too (for topology ScopeFilter matching).
+    expect(n?.metadata?.['hostGroups']).toEqual(['016.000.seg'])
     expect(n?.parent).toBe('inst1:sg:016.000.seg')
     expect(g.subgraphs?.[0]?.label).toBe('016.000.seg')
   })

--- a/libs/plugins/zabbix/src/topology.ts
+++ b/libs/plugins/zabbix/src/topology.ts
@@ -92,6 +92,9 @@ export function convertZabbixToGraph(
         zabbixHostId: host.hostid,
         zabbixHost: host.host,
         zabbixStatus: host.status === '0' ? 'monitored' : 'unmonitored',
+        // Host-group names on the NODE (not just the region) so a topology
+        // ScopeFilter `{attr:'metadata', key:'hostGroups'}` can match it directly.
+        hostGroups: (host.hostgroups ?? []).map((g) => g.name),
       },
     }
     staged.push({ node, host })


### PR DESCRIPTION
## Phase 2b (step 1) — make scope-by-host-group actually match

The topology `ScopeFilter` (Phase 2a, #421) matches criteria against **node** fields, but Zabbix put host groups only on the region (subgraph parent), not the node — so `{attr:'metadata', key:'hostGroups'}` could never match a node (confirmed on test6: nodes carried `hostname`/`zabbixHostId` but no `hostGroups`).

## What

Emit `metadata.hostGroups` (host-group names, array) on each Zabbix host node. Combined with resolve's array-metadata matching (Phase 2a), a topology scope criterion **by host group now works end to end** — resolve enforces it post-merge, no push-down required.

## Not in this PR (later Phase 2b)

- Pushing the criterion down to the Zabbix API query (pure optimization).
- Splitting `optionsSchema` into scope criteria vs behavior knobs.
- NetBox.

## Test

Asserts `metadata.hostGroups` on the built node. Zabbix 10 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)