### PR TITLE
fix(web): scope fields only at topology level, not duplicated per source

### DIFF
--- a/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
@@ -111,6 +111,21 @@
     return type ? pluginTypes.find((p) => p.type === type)?.optionsSchema : undefined
   }
 
+  /**
+   * The per-source options form shows ONLY the non-scope fields (behavior knobs
+   * like groupBy / includeExternalNeighbors). The scope-marked fields (host
+   * groups, sites, …) moved up to the topology-level Scope, so we strip them here
+   * to avoid showing the same control in two places. Returns undefined when a
+   * source has no non-scope options left.
+   */
+  function behaviorSchemaFor(type?: string): PluginConfigSchema | undefined {
+    const schema = optionsSchemaFor(type)
+    if (!schema) return undefined
+    const entries = Object.entries(schema.properties).filter(([, p]) => !p.scope)
+    if (entries.length === 0) return undefined
+    return { ...schema, properties: Object.fromEntries(entries) }
+  }
+
   function formatAgo(ts: number): string {
     const diff = Date.now() - ts
     if (diff < 60_000) return 'just now'
@@ -702,7 +717,7 @@
 
               <!-- Expanded detail: config + scope + danger actions -->
               {#if isOpen}
-                {@const optSchema = optionsSchemaFor(dataSource?.type)}
+                {@const optSchema = behaviorSchemaFor(dataSource?.type)}
                 <div class="border-t border-theme-border p-3 space-y-3">
                   <div class="flex items-end gap-2">
                     <label class="flex-1 space-y-0.5">


### PR DESCRIPTION
Scope-marked options (Zabbix host groups / exclude groups) moved to the topology Scope but still rendered in each source's "Source options" form — duplicated. Strip scope-marked fields from the per-source form (`behaviorSchemaFor`); it now shows only behavior knobs (groupBy / includeExternalNeighbors / parentTag). Scope dimensions live solely in the topology Scope. The source's own optionsJson (fetch filter) is untouched, just hidden from that form. Mode stays per source by design. svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)