### PR TITLE
feat(server): Mode is topology-wide, not per-source

### DIFF
--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -18,7 +18,13 @@ import { resolveCredentialsForAutoscan } from '../services/discovery-scheduler.j
 import { ObservationsService } from '../services/observations.js'
 import { type ParsedTopology, TopologyService } from '../services/topology.js'
 import { TopologySourcesService } from '../services/topology-sources.js'
-import type { MetricsMapping, ScopeMode, TopologyInput } from '../types.js'
+import type {
+  CompositionMode,
+  MetricsMapping,
+  ScopeMode,
+  Topology,
+  TopologyInput,
+} from '../types.js'
 
 /**
  * Overlay per-link bandwidth from the metrics mapping onto the graph.
@@ -374,15 +380,18 @@ export function createTopologiesApi(): Hono {
   // Topology scope (composition). A single per-topology decision. `scope` is the
   // common ScopeFilter (include/exclude criteria) the resolver enforces post-merge;
   // scopeMode/scopeSourceId is the older region-mark path, kept during transition.
+  const compositionOf = (t: Topology) => ({
+    scopeMode: t.scopeMode,
+    scopeSourceId: t.scopeSourceId,
+    scope: t.scope,
+    compositionMode: t.compositionMode,
+  })
+
   app.get('/:id/composition', (c) => {
     const id = c.req.param('id')
     const topology = service.get(id)
     if (!topology) return c.json({ error: 'Topology not found' }, 404)
-    return c.json({
-      scopeMode: topology.scopeMode,
-      scopeSourceId: topology.scopeSourceId,
-      scope: topology.scope,
-    })
+    return c.json(compositionOf(topology))
   })
 
   app.put('/:id/composition', async (c) => {
@@ -392,6 +401,7 @@ export function createTopologiesApi(): Hono {
         scopeMode?: ScopeMode
         scopeSourceId?: string | null
         scope?: ScopeFilter
+        compositionMode?: CompositionMode
       }
       let topology = service.get(id)
       if (!topology) return c.json({ error: 'Topology not found' }, 404)
@@ -401,12 +411,11 @@ export function createTopologiesApi(): Hono {
       if (body.scope !== undefined) {
         topology = service.setScopeCriteria(id, body.scope)
       }
+      if (body.compositionMode !== undefined) {
+        topology = service.setCompositionMode(id, body.compositionMode)
+      }
       if (!topology) return c.json({ error: 'Topology not found' }, 404)
-      return c.json({
-        scopeMode: topology.scopeMode,
-        scopeSourceId: topology.scopeSourceId,
-        scope: topology.scope,
-      })
+      return c.json(compositionOf(topology))
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 400)

--- a/apps/server/api/src/db/migrations/022_topology_composition_mode.sql
+++ b/apps/server/api/src/db/migrations/022_topology_composition_mode.sql
@@ -1,0 +1,12 @@
+-- Topology-level composition Mode (the merge method for the whole topology).
+--
+-- Mode was per-source (topology_data_sources.node_contribution/link_contribution),
+-- but it's one decision per topology — HOW sources merge — so it moves onto the
+-- topology row. The per-source columns become vestigial (the service derives every
+-- source's contribution from this single value); they can be dropped in a later
+-- cleanup.
+--
+--   composition_mode: 'additive'   — every source adds nodes + links (union). default.
+--                     'enrichment' — sources only enrich existing nodes/links
+--                                    (anchor / update); they assert nothing new.
+ALTER TABLE topologies ADD COLUMN composition_mode TEXT NOT NULL DEFAULT 'additive';

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -26,6 +26,7 @@ import migration018 from './migrations/018_composition_modes.sql'
 import migration019 from './migrations/019_fix_contribution_link_local_id_nullable.sql'
 import migration020 from './migrations/020_topology_scope.sql'
 import migration021 from './migrations/021_topology_scope_criteria.sql'
+import migration022 from './migrations/022_topology_composition_mode.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -48,6 +49,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '019_fix_contribution_link_local_id_nullable.sql', sql: migration019 },
   { name: '020_topology_scope.sql', sql: migration020 },
   { name: '021_topology_scope_criteria.sql', sql: migration021 },
+  { name: '022_topology_composition_mode.sql', sql: migration022 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -90,6 +90,7 @@ interface TopologyRow {
   share_token: string | null
   scope_mode: string | null
   scope_source_id: string | null
+  composition_mode: string | null
   created_at: number
   updated_at: number
 }
@@ -103,6 +104,7 @@ function rowToTopology(row: TopologyRow): Topology {
     shareToken: row.share_token ?? undefined,
     scopeMode: (row.scope_mode as Topology['scopeMode']) ?? 'auto',
     scopeSourceId: row.scope_source_id ?? undefined,
+    compositionMode: (row.composition_mode as Topology['compositionMode']) ?? 'additive',
     // Filled by the service from topology_scope_criteria (rowToTopology has no db).
     scope: { include: [], exclude: [] },
     createdAt: row.created_at,
@@ -583,6 +585,16 @@ export class TopologyService {
     }
     for (const c of scope.include ?? []) write('include', c)
     for (const c of scope.exclude ?? []) write('exclude', c)
+    this.clearCacheEntry(topologyId)
+    return this.get(topologyId)
+  }
+
+  /** Set the topology-wide composition Mode (additive | enrichment). */
+  setCompositionMode(topologyId: string, mode: Topology['compositionMode']): Topology | null {
+    if (!this.get(topologyId)) return null
+    this.db
+      .query('UPDATE topologies SET composition_mode = ?, updated_at = ? WHERE id = ?')
+      .run(mode, timestamp(), topologyId)
     this.clearCacheEntry(topologyId)
     return this.get(topologyId)
   }
@@ -1213,13 +1225,17 @@ export class TopologyService {
     // always outranks these (handled inside resolve() as the `authored` input).
     const priorityBySource = new Map<string, number>()
     const modeBySource = new Map<string, SourceMode>()
+    // Mode is a TOPOLOGY-WIDE merge method (not per-source): every topology source
+    // gets the same node/link contribution derived from `topology.compositionMode`.
+    //   additive   → scoop / add  (sources assert nodes + links)
+    //   enrichment → anchor / update (sources only enrich; assert nothing new)
+    const enrich = topology.compositionMode === 'enrichment'
     for (const tds of topologySources) {
       priorityBySource.set(tds.dataSourceId, tds.priority)
-      // Composition modes apply to the source's TOPOLOGY contribution only.
       if (tds.purpose === 'topology') {
         modeBySource.set(tds.dataSourceId, {
-          nodeContribution: tds.nodeContribution,
-          linkContribution: tds.linkContribution,
+          nodeContribution: enrich ? 'anchor' : 'scoop',
+          linkContribution: enrich ? 'update' : 'add',
           closeScope: scopeSourceIds.has(tds.dataSourceId),
         })
       }

--- a/apps/server/api/src/types.ts
+++ b/apps/server/api/src/types.ts
@@ -95,9 +95,18 @@ export interface DataSourceInput {
  */
 export type ScopeMode = 'auto' | 'open' | 'closed'
 
+/**
+ * Topology-level composition Mode — the merge method for the whole topology.
+ * `'additive'` = every source adds nodes+links (union); `'enrichment'` = sources
+ * only enrich existing nodes/links, asserting nothing new.
+ */
+export type CompositionMode = 'additive' | 'enrichment'
+
 export interface Topology {
   id: string
   name: string
+  /** How sources merge into this topology. Default 'additive'. */
+  compositionMode: CompositionMode
   /** Scope policy for this topology. Default 'auto'. (Region-mark scope; being
    * superseded by `scope` criteria — kept during the Phase 2/3 transition.) */
   scopeMode: ScopeMode

--- a/apps/server/api/test/db/composition-modes.test.ts
+++ b/apps/server/api/test/db/composition-modes.test.ts
@@ -71,6 +71,16 @@ test('topology scope defaults to auto, and setScope round-trips', () => {
   expect(open?.scopeSourceId).toBeUndefined()
 })
 
+test('topology composition mode defaults to additive and round-trips', () => {
+  makeTopology('t_mode_topo')
+  const svc = new TopologyService()
+  expect(svc.get('t_mode_topo')?.compositionMode).toBe('additive')
+  const enriched = svc.setCompositionMode('t_mode_topo', 'enrichment')
+  expect(enriched?.compositionMode).toBe('enrichment')
+  const back = svc.setCompositionMode('t_mode_topo', 'additive')
+  expect(back?.compositionMode).toBe('additive')
+})
+
 test('topology scope criteria round-trip (setScopeCriteria / readScopeCriteria)', () => {
   makeTopology('t_scope_2')
   const svc = new TopologyService()

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   DashboardInput,
   DataSource,
   DataSourceInput,
+  CompositionMode,
   LinkContribution,
   MetricsMapping,
   NodeContribution,
@@ -342,21 +343,31 @@ export const topologies = {
   // the common include/exclude criteria the resolver enforces post-merge.
   composition: {
     get: (id: string) =>
-      request<{ scopeMode: ScopeMode; scopeSourceId?: string; scope: ScopeFilter }>(
-        `/topologies/${id}/composition`,
-      ),
+      request<{
+        scopeMode: ScopeMode
+        scopeSourceId?: string
+        scope: ScopeFilter
+        compositionMode: CompositionMode
+      }>(`/topologies/${id}/composition`),
 
     set: (
       id: string,
-      body: { scopeMode?: ScopeMode; scopeSourceId?: string | null; scope?: ScopeFilter },
+      body: {
+        scopeMode?: ScopeMode
+        scopeSourceId?: string | null
+        scope?: ScopeFilter
+        compositionMode?: CompositionMode
+      },
     ) =>
-      request<{ scopeMode: ScopeMode; scopeSourceId?: string; scope: ScopeFilter }>(
-        `/topologies/${id}/composition`,
-        {
-          method: 'PUT',
-          body: JSON.stringify(body),
-        },
-      ),
+      request<{
+        scopeMode: ScopeMode
+        scopeSourceId?: string
+        scope: ScopeFilter
+        compositionMode: CompositionMode
+      }>(`/topologies/${id}/composition`, {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      }),
   },
 
   // Topology Data Sources (many-to-many)

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -83,6 +83,9 @@ export interface DataSourceInput {
 /** Topology-level scope policy. See api ScopeMode. */
 export type ScopeMode = 'auto' | 'open' | 'closed'
 
+/** Topology-wide merge method. additive = sources add; enrichment = enrich only. */
+export type CompositionMode = 'additive' | 'enrichment'
+
 /** One membership/scope criterion — mirrors core MembershipCriterion. */
 export interface MembershipCriterion {
   attr: 'name' | 'subnet' | 'metadata'
@@ -104,6 +107,8 @@ export interface Topology {
   scopeSourceId?: string
   /** Common topology-level scope (include/exclude criteria). */
   scope?: ScopeFilter
+  /** Topology-wide merge method. */
+  compositionMode?: CompositionMode
   topologySourceId?: string
   metricsSourceId?: string
   mappingJson?: string

--- a/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
@@ -29,10 +29,9 @@
   import { Button } from '$lib/components/ui/button'
   import { topologies } from '$lib/stores'
   import type {
+    CompositionMode,
     DataSourcePluginInfo,
-    LinkContribution,
     MembershipCriterion,
-    NodeContribution,
     PluginConfigProperty,
     PluginConfigSchema,
     SyncMode,
@@ -232,32 +231,20 @@
     )
   }
 
-  // Composition role = how THIS source behaves in the topology. Two presets over
-  // the per-source knobs (scope is NOT here — it's a topology-level decision):
-  //   Additive   = scoop + add  (assert nodes & links)
-  //   Enrichment = anchor + update (fill fields only, claim nothing new)
-  type CompositionRole = 'additive' | 'enrichment'
-  function roleOf(s: TopologyDataSource): CompositionRole {
-    return s.nodeContribution === 'anchor' ? 'enrichment' : 'additive'
-  }
-  function setRole(source: TopologyDataSource, role: CompositionRole) {
-    const updates: {
-      nodeContribution: NodeContribution
-      linkContribution: LinkContribution
-    } =
-      role === 'enrichment'
-        ? { nodeContribution: 'anchor', linkContribution: 'update' }
-        : { nodeContribution: 'scoop', linkContribution: 'add' }
-    void mutate(
-      source.id,
-      () => api.topologies.sources.update(ctx.topologyId, source.id, updates),
-      (updated) => {
-        ctx.currentSources = ctx.currentSources.map((s) =>
-          s.id === source.id ? (updated as TopologyDataSource) : s,
-        )
-      },
-      { reflect: true },
-    )
+  // Composition Mode = the merge method for the WHOLE topology (not per source):
+  //   Additive   = every source adds nodes + links (union)
+  //   Enrichment = sources only enrich existing nodes/links, assert nothing new
+  function setCompositionMode(mode: CompositionMode) {
+    if (ctx.topology) ctx.topology = { ...ctx.topology, compositionMode: mode }
+    api.topologies.composition
+      .set(ctx.topologyId, { compositionMode: mode })
+      .then((res) => {
+        if (ctx.topology) ctx.topology = { ...ctx.topology, compositionMode: res.compositionMode }
+        ctx.bumpRevision()
+      })
+      .catch((e) => {
+        localError = e instanceof Error ? e.message : String(e)
+      })
   }
 
   // Topology-level Scope (composition): one common include/exclude criteria set
@@ -607,6 +594,25 @@
     </div>
     <div class="card-body">
       {#if topologySources.length > 0}
+        <!-- Topology-wide composition Mode: the merge method for the whole topology. -->
+        <div class="mb-4 flex flex-wrap items-center gap-2 rounded-lg bg-theme-bg-subtle p-3">
+          <span class="text-xs font-medium text-theme-text-emphasis">Mode</span>
+          <select
+            class="input"
+            style="width: 11rem;"
+            title="How sources merge into this topology"
+            value={ctx.topology?.compositionMode ?? 'additive'}
+            onchange={(e) => setCompositionMode(e.currentTarget.value as CompositionMode)}
+          >
+            <option value="additive">Additive</option>
+            <option value="enrichment">Enrichment</option>
+          </select>
+          <span class="text-xs text-theme-text-muted">
+            {(ctx.topology?.compositionMode ?? 'additive') === 'enrichment'
+              ? 'sources only enrich existing nodes/links'
+              : 'every source adds nodes + links (union)'}
+          </span>
+        </div>
         <!-- Topology-level Scope: ONE common filter for the whole topology, edited
              with the same form (and live value picker) as a source's options. The
              fields come from each topology source's scope-marked schema. Empty =
@@ -698,6 +704,8 @@
                 </div>
                 <!-- Composition controls (topology-side, always visible): Mode +
                      priority per source, alongside the shared Scope above. -->
+                <!-- Priority is per-source (resolve field-merge order). Mode is
+                     topology-wide (see the Composition control above). -->
                 {#if hasMultipleTopologySources}
                   <input
                     type="number"
@@ -709,16 +717,6 @@
                       patchSource(source, { priority: Number(e.currentTarget.value) || 0 }, true)}
                   >
                 {/if}
-                <select
-                  class="input shrink-0"
-                  style="width: 8.5rem;"
-                  title="Mode — how this source behaves in the topology"
-                  value={roleOf(source)}
-                  onchange={(e) => setRole(source, e.currentTarget.value as CompositionRole)}
-                >
-                  <option value="additive">Additive</option>
-                  <option value="enrichment">Enrichment</option>
-                </select>
                 <Button
                   variant="outline"
                   size="sm"


### PR DESCRIPTION
Mode (the merge method — decided options Additive/Enrichment) was per-source, but it's one decision for the whole topology (how sources merge). Move it onto the topology; remove the per-source Mode dropdown.

- migration 022: `topologies.composition_mode` (additive | enrichment, default additive). Per-source node/link_contribution columns become vestigial.
- service derives every topology source's contribution from the one `topology.compositionMode` (additive → scoop/add, enrichment → anchor/update); `setCompositionMode`; composition API carries `compositionMode`.
- web: one topology-level Mode select in the Composition area (next to Scope); removed per-source Mode + roleOf/setRole. Priority stays per-source (it IS the resolve field-merge order).

Composition now reads as: one Mode + one Scope at top; each source row carries only priority + Sync. Tests green; 19/19 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)