### PR TITLE
feat(core): layout invariant checks + bandwidth width modes (P0, #430)

### DIFF
--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -73,10 +73,29 @@ export {
   resolveNodePosition,
   resolvePosition,
 } from './interaction.js'
+// Layout invariant checks (containment / overlap / collinear tracks) —
+// standing verification fixture for every placement/routing pass.
+export {
+  type BoxSpec,
+  type CollinearOverlap,
+  type ContainerSpec,
+  type ContainmentViolation,
+  checkLayoutInvariants,
+  findCollinearOverlaps,
+  findContainmentViolations,
+  findNodeOverlaps,
+  type LayoutInvariantOptions,
+  type LayoutInvariantReport,
+  type NodeOverlap,
+  type PolylineSpec,
+} from './invariants.js'
 export {
   bpsToLinkWidth,
+  bpsToLinkWidthMode,
   getBandwidthWidth,
   getLinkWidth,
+  getLinkWidthForMode,
+  type LinkWidthMode,
   linkSpeedBps,
   resolveBandwidthBps,
 } from './link-utils.js'

--- a/libs/@shumoku/core/src/layout/invariants.test.ts
+++ b/libs/@shumoku/core/src/layout/invariants.test.ts
@@ -1,0 +1,187 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import {
+  type BoxSpec,
+  findCollinearOverlaps,
+  findContainmentViolations,
+  findNodeOverlaps,
+} from './invariants.js'
+
+const box = (id: string, x: number, y: number, width = 100, height = 26): BoxSpec => ({
+  id,
+  x,
+  y,
+  width,
+  height,
+})
+
+describe('findNodeOverlaps', () => {
+  it('reports overlapping boxes with penetration depth', () => {
+    // centers 80 apart, widths 100 → 20px x-penetration; same row → full y-penetration
+    const overlaps = findNodeOverlaps([box('a', 0, 0), box('b', 80, 0)])
+    expect(overlaps).toHaveLength(1)
+    const first = overlaps[0]
+    expect(first?.a).toBe('a')
+    expect(first?.b).toBe('b')
+    expect(first?.overlapX).toBeCloseTo(20)
+  })
+
+  it('accepts touching boxes and separated rows', () => {
+    expect(findNodeOverlaps([box('a', 0, 0), box('b', 100, 0)])).toHaveLength(0)
+    expect(findNodeOverlaps([box('a', 0, 0), box('b', 0, 26)])).toHaveLength(0)
+  })
+
+  it('enforces a clearance margin when given', () => {
+    expect(findNodeOverlaps([box('a', 0, 0), box('b', 110, 0)], 12)).toHaveLength(1)
+    expect(findNodeOverlaps([box('a', 0, 0), box('b', 113, 0)], 12)).toHaveLength(0)
+  })
+})
+
+describe('findContainmentViolations', () => {
+  const container = {
+    id: 'zone',
+    bounds: { x: 0, y: 0, width: 300, height: 100 },
+    memberIds: ['a', 'b'],
+  }
+
+  it('accepts members inside, flags protruding members', () => {
+    // a: fully inside; b: left edge at -39 → 39px protrusion (the thunder-1 bug class)
+    const violations = findContainmentViolations([box('a', 150, 50), box('b', 11, 50)], [container])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.nodeId).toBe('b')
+    expect(violations[0]?.protrusion).toBeCloseTo(39)
+  })
+
+  it('ignores members that are not laid out', () => {
+    expect(findContainmentViolations([box('a', 150, 50)], [container])).toHaveLength(0)
+  })
+})
+
+describe('findCollinearOverlaps', () => {
+  const line = (id: string, pts: [number, number][], halfWidth = 1) => ({
+    id,
+    points: pts.map(([x, y]) => ({ x, y })),
+    halfWidth,
+  })
+
+  it('flags two horizontals on the same track', () => {
+    const hits = findCollinearOverlaps([
+      line('a', [
+        [0, 100],
+        [200, 100],
+      ]),
+      line('b', [
+        [50, 101],
+        [250, 101],
+      ]),
+    ])
+    expect(hits).toHaveLength(1)
+    expect(hits[0]?.sharedLength).toBeCloseTo(150)
+  })
+
+  it('accepts parallel lines separated beyond their stroke widths', () => {
+    const hits = findCollinearOverlaps([
+      line(
+        'a',
+        [
+          [0, 100],
+          [200, 100],
+        ],
+        2,
+      ),
+      line(
+        'b',
+        [
+          [50, 110],
+          [250, 110],
+        ],
+        2,
+      ),
+    ])
+    expect(hits).toHaveLength(0)
+  })
+
+  it('accounts for stroke half-widths: wide ribbons need wider tracks', () => {
+    // 8px apart is fine for 1px strokes but a collision for 8px-half ribbons
+    const thin = findCollinearOverlaps([
+      line(
+        'a',
+        [
+          [0, 100],
+          [200, 100],
+        ],
+        1,
+      ),
+      line(
+        'b',
+        [
+          [0, 108],
+          [200, 108],
+        ],
+        1,
+      ),
+    ])
+    expect(thin).toHaveLength(0)
+    const wide = findCollinearOverlaps([
+      line(
+        'a',
+        [
+          [0, 100],
+          [200, 100],
+        ],
+        8,
+      ),
+      line(
+        'b',
+        [
+          [0, 108],
+          [200, 108],
+        ],
+        8,
+      ),
+    ])
+    expect(wide).toHaveLength(1)
+  })
+
+  it('ignores crossings and short shared runs', () => {
+    const crossing = findCollinearOverlaps([
+      line('a', [
+        [0, 0],
+        [100, 100],
+      ]),
+      line('b', [
+        [0, 100],
+        [100, 0],
+      ]),
+    ])
+    expect(crossing).toHaveLength(0)
+    const brief = findCollinearOverlaps([
+      line('a', [
+        [0, 100],
+        [200, 100],
+      ]),
+      line('b', [
+        [195, 100],
+        [400, 100],
+      ]),
+    ])
+    expect(brief).toHaveLength(0)
+  })
+
+  it('checks 45° diagonals too, not just axis-aligned segments', () => {
+    const hits = findCollinearOverlaps([
+      line('a', [
+        [0, 0],
+        [100, 100],
+      ]),
+      line('b', [
+        [20, 21],
+        [120, 121],
+      ]),
+    ])
+    expect(hits).toHaveLength(1)
+  })
+})

--- a/libs/@shumoku/core/src/layout/invariants.ts
+++ b/libs/@shumoku/core/src/layout/invariants.ts
@@ -1,0 +1,299 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Layout invariant checks (engine-v3-migration.md P0, #430).
+ *
+ * During the v3 prototype rounds, every visual defect the user spotted by
+ * eye ("thunder-1 sticks out of its box", "qfx5120 and nexus overlap")
+ * turned out to be a layout pass violating an invariant that nothing was
+ * checking. Lesson recorded in engine-v3-design.md §30-31: each new
+ * placement pass can silently break containment / overlap / track
+ * separation, so the checks must be a standing fixture — vitest in CI and
+ * cheap enough to assert in dev builds.
+ *
+ * Three invariants, all pure-geometry and engine-agnostic:
+ *   1. Node boxes never overlap.
+ *   2. A node stays inside its container's bounds (subgraph membership).
+ *   3. No two edge segments run collinear on the same track (parallel
+ *      within a small gap AND sharing more than a token length). Distinct
+ *      strands/lanes are separated by design, so any near-zero-gap pair is
+ *      a routing bug, not a style.
+ *
+ * `checkLayoutInvariants` adapts a ResolvedLayout; the `find*` functions
+ * are pure and unit-testable without an engine.
+ */
+
+import type { Bounds, Position } from '../models/types.js'
+import { resolveNodeSize } from './engine/index.js'
+import type { ResolvedLayout } from './resolved-types.js'
+
+// ============================================================================
+// Pure geometry inputs
+// ============================================================================
+
+/** Axis-aligned node box, position = CENTER (renderer semantics). */
+export interface BoxSpec {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** A container (subgraph/zone box) and the node ids it must enclose. */
+export interface ContainerSpec {
+  id: string
+  bounds: Bounds
+  memberIds: readonly string[]
+}
+
+/** An edge centerline as a polyline, with optional stroke half-width. */
+export interface PolylineSpec {
+  id: string
+  points: readonly Position[]
+  /** Half of the drawn stroke (or strand-bundle) width. Default 1. */
+  halfWidth?: number
+}
+
+// ============================================================================
+// 1. Node overlap
+// ============================================================================
+
+export interface NodeOverlap {
+  a: string
+  b: string
+  /** Penetration depth along x/y (both > 0 when overlapping). */
+  overlapX: number
+  overlapY: number
+}
+
+/**
+ * Find pairs of node boxes that overlap (optionally requiring `margin`
+ * clear space between boxes). O(n²) — layout-sized inputs only.
+ */
+export function findNodeOverlaps(boxes: readonly BoxSpec[], margin = 0): NodeOverlap[] {
+  const out: NodeOverlap[] = []
+  for (let i = 0; i < boxes.length; i++) {
+    const a = boxes[i]
+    if (!a) continue
+    for (let j = i + 1; j < boxes.length; j++) {
+      const b = boxes[j]
+      if (!b) continue
+      const overlapX = (a.width + b.width) / 2 + margin - Math.abs(a.x - b.x)
+      const overlapY = (a.height + b.height) / 2 + margin - Math.abs(a.y - b.y)
+      if (overlapX > 0 && overlapY > 0) out.push({ a: a.id, b: b.id, overlapX, overlapY })
+    }
+  }
+  return out
+}
+
+// ============================================================================
+// 2. Containment
+// ============================================================================
+
+export interface ContainmentViolation {
+  nodeId: string
+  containerId: string
+  /** How far the box protrudes beyond the container (px, > 0). */
+  protrusion: number
+}
+
+/**
+ * Find member nodes whose box is not fully inside their container's
+ * bounds (shrunk by `pad` on each side). Unknown member ids are ignored —
+ * membership resolution is the caller's concern.
+ */
+export function findContainmentViolations(
+  boxes: readonly BoxSpec[],
+  containers: readonly ContainerSpec[],
+  pad = 0,
+): ContainmentViolation[] {
+  const byId = new Map<string, BoxSpec>()
+  for (const box of boxes) byId.set(box.id, box)
+  const out: ContainmentViolation[] = []
+  for (const c of containers) {
+    for (const memberId of c.memberIds) {
+      const box = byId.get(memberId)
+      if (!box) continue
+      const left = c.bounds.x + pad - (box.x - box.width / 2)
+      const right = box.x + box.width / 2 - (c.bounds.x + c.bounds.width - pad)
+      const top = c.bounds.y + pad - (box.y - box.height / 2)
+      const bottom = box.y + box.height / 2 - (c.bounds.y + c.bounds.height - pad)
+      const protrusion = Math.max(left, right, top, bottom)
+      if (protrusion > 0.5) out.push({ nodeId: memberId, containerId: c.id, protrusion })
+    }
+  }
+  return out
+}
+
+// ============================================================================
+// 3. Collinear track sharing
+// ============================================================================
+
+export interface CollinearOverlap {
+  a: string
+  b: string
+  /** Length of the shared collinear run (px). */
+  sharedLength: number
+}
+
+export interface CollinearOptions {
+  /** Segments shorter than this are ignored (chamfers, stubs). */
+  minSegmentLength?: number
+  /** Shared runs shorter than this are tolerated. */
+  minSharedLength?: number
+  /** Extra clearance required between strokes beyond their half-widths. */
+  clearance?: number
+}
+
+/**
+ * Find pairs of edges with segments that run on the same track: parallel
+ * (within ~1°), closer than the sum of their half-widths + clearance, and
+ * sharing more than `minSharedLength` of extent. Reports each edge pair
+ * once with its longest shared run.
+ */
+export function findCollinearOverlaps(
+  lines: readonly PolylineSpec[],
+  options: CollinearOptions = {},
+): CollinearOverlap[] {
+  const minSeg = options.minSegmentLength ?? 13
+  const minShared = options.minSharedLength ?? 12
+  const clearance = options.clearance ?? 0.5
+  const out = new Map<string, CollinearOverlap>()
+  for (let i = 0; i < lines.length; i++) {
+    const la = lines[i]
+    if (!la) continue
+    for (let j = i + 1; j < lines.length; j++) {
+      const lb = lines[j]
+      if (!lb) continue
+      const gap = (la.halfWidth ?? 1) + (lb.halfWidth ?? 1) + clearance
+      const shared = maxSharedRun(la.points, lb.points, minSeg, gap)
+      if (shared <= minShared) continue
+      const key = `${la.id}|${lb.id}`
+      const prev = out.get(key)
+      if (!prev || shared > prev.sharedLength) {
+        out.set(key, { a: la.id, b: lb.id, sharedLength: shared })
+      }
+    }
+  }
+  return [...out.values()]
+}
+
+function maxSharedRun(
+  ptsA: readonly Position[],
+  ptsB: readonly Position[],
+  minSeg: number,
+  gap: number,
+): number {
+  let best = 0
+  for (let s = 1; s < ptsA.length; s++) {
+    const a1 = ptsA[s - 1]
+    const a2 = ptsA[s]
+    if (!a1 || !a2) continue
+    const vax = a2.x - a1.x
+    const vay = a2.y - a1.y
+    const lenA = Math.hypot(vax, vay)
+    if (lenA < minSeg) continue
+    for (let t = 1; t < ptsB.length; t++) {
+      const b1 = ptsB[t - 1]
+      const b2 = ptsB[t]
+      if (!b1 || !b2) continue
+      const vbx = b2.x - b1.x
+      const vby = b2.y - b1.y
+      const lenB = Math.hypot(vbx, vby)
+      if (lenB < minSeg) continue
+      // parallel check: normalized cross product ≈ sin(angle)
+      if (Math.abs(vax * vby - vay * vbx) / (lenA * lenB) > 0.02) continue
+      // perpendicular distance between the two lines
+      const dx = b1.x - a1.x
+      const dy = b1.y - a1.y
+      if (Math.abs(dx * vay - dy * vax) / lenA > gap) continue
+      // shared extent along A's direction
+      const t1 = (dx * vax + dy * vay) / lenA
+      const t2 = ((b2.x - a1.x) * vax + (b2.y - a1.y) * vay) / lenA
+      const lo = Math.max(0, Math.min(t1, t2))
+      const hi = Math.min(lenA, Math.max(t1, t2))
+      if (hi - lo > best) best = hi - lo
+    }
+  }
+  return best
+}
+
+// ============================================================================
+// ResolvedLayout adapter
+// ============================================================================
+
+export interface LayoutInvariantReport {
+  nodeOverlaps: NodeOverlap[]
+  containmentViolations: ContainmentViolation[]
+  collinearOverlaps: CollinearOverlap[]
+  ok: boolean
+}
+
+export interface LayoutInvariantOptions {
+  /** Required clear space between node boxes. Default 0 (touching is ok). */
+  nodeMargin?: number
+  /** Containment padding inside subgraph bounds. Default 0. */
+  containmentPad?: number
+  collinear?: CollinearOptions
+}
+
+/**
+ * Run all invariant checks against a ResolvedLayout. Containment uses
+ * `node.parent` → subgraph bounds (subgraphs without bounds are skipped).
+ * Edge tracks use `route.points` when present, else `points`.
+ */
+export function checkLayoutInvariants(
+  layout: ResolvedLayout,
+  options: LayoutInvariantOptions = {},
+): LayoutInvariantReport {
+  const boxes: BoxSpec[] = []
+  for (const [id, node] of layout.nodes) {
+    const pos = node.position
+    if (!pos) continue
+    const size = resolveNodeSize(node)
+    boxes.push({ id, x: pos.x, y: pos.y, width: size.width, height: size.height })
+  }
+
+  const members = new Map<string, string[]>()
+  for (const [id, node] of layout.nodes) {
+    const parent = node.parent
+    if (!parent) continue
+    const list = members.get(parent)
+    if (list) list.push(id)
+    else members.set(parent, [id])
+  }
+  const containers: ContainerSpec[] = []
+  for (const [id, sg] of layout.subgraphs) {
+    const bounds = sg.bounds
+    const memberIds = members.get(id)
+    if (!bounds || !memberIds || memberIds.length === 0) continue
+    containers.push({ id, bounds, memberIds })
+  }
+
+  const lines: PolylineSpec[] = []
+  for (const [id, edge] of layout.edges) {
+    const points = edge.route?.points ?? edge.points
+    if (points.length < 2) continue
+    lines.push({ id, points, halfWidth: Math.max(0.5, edge.width / 2) })
+  }
+
+  const nodeOverlaps = findNodeOverlaps(boxes, options.nodeMargin ?? 0)
+  const containmentViolations = findContainmentViolations(
+    boxes,
+    containers,
+    options.containmentPad ?? 0,
+  )
+  const collinearOverlaps = findCollinearOverlaps(lines, options.collinear)
+  return {
+    nodeOverlaps,
+    containmentViolations,
+    collinearOverlaps,
+    ok:
+      nodeOverlaps.length === 0 &&
+      containmentViolations.length === 0 &&
+      collinearOverlaps.length === 0,
+  }
+}

--- a/libs/@shumoku/core/src/layout/link-utils.test.ts
+++ b/libs/@shumoku/core/src/layout/link-utils.test.ts
@@ -1,0 +1,61 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import type { Link } from '../models/types.js'
+import { bpsToLinkWidthMode, getLinkWidthForMode } from './link-utils.js'
+
+describe('bpsToLinkWidthMode', () => {
+  it('log mode matches the legacy anchored curve', () => {
+    expect(bpsToLinkWidthMode(10e9, 'log')).toBeCloseTo(14)
+    expect(bpsToLinkWidthMode(100e9, 'log')).toBeCloseTo(34)
+  })
+
+  it('linear mode is proportional with a visibility floor and a cap', () => {
+    expect(bpsToLinkWidthMode(400e9, 'linear')).toBeCloseTo(16)
+    expect(bpsToLinkWidthMode(100e9, 'linear')).toBeCloseTo(4)
+    expect(bpsToLinkWidthMode(10e9, 'linear')).toBeCloseTo(0.4) // floored
+    // proportion holds where the floor doesn't bite: 400G is 4× 100G
+    expect(bpsToLinkWidthMode(400e9, 'linear') / bpsToLinkWidthMode(100e9, 'linear')).toBeCloseTo(4)
+    expect(bpsToLinkWidthMode(10e12, 'linear')).toBe(64) // capped
+  })
+
+  it('class mode snaps to discrete road classes', () => {
+    expect(bpsToLinkWidthMode(400e9, 'class')).toBe(6.5)
+    expect(bpsToLinkWidthMode(200e9, 'class')).toBe(4)
+    expect(bpsToLinkWidthMode(25e9, 'class')).toBe(2.6)
+    expect(bpsToLinkWidthMode(10e9, 'class')).toBe(1.7)
+    expect(bpsToLinkWidthMode(1e9, 'class')).toBe(1.1)
+  })
+
+  it('returns 0 for unknown bandwidth in every mode', () => {
+    expect(bpsToLinkWidthMode(undefined, 'log')).toBe(0)
+    expect(bpsToLinkWidthMode(undefined, 'linear')).toBe(0)
+    expect(bpsToLinkWidthMode(undefined, 'class')).toBe(0)
+  })
+})
+
+describe('getLinkWidthForMode', () => {
+  const link = (rateBps?: number): Link => ({
+    from: { node: 'a' },
+    to: { node: 'b' },
+    ...(rateBps !== undefined ? { rateBps } : {}),
+  })
+
+  it('explicit style overrides the mode', () => {
+    const styled: Link = { ...link(100e9), style: { strokeWidth: 9 } }
+    expect(getLinkWidthForMode(styled, 'linear')).toBe(9)
+  })
+
+  it('falls back to type/default when bandwidth is unknown', () => {
+    expect(getLinkWidthForMode({ ...link(), type: 'thick' }, 'linear')).toBe(4)
+    expect(getLinkWidthForMode(link(), 'log')).toBe(3)
+    expect(getLinkWidthForMode(link(), 'linear')).toBe(1.5)
+  })
+
+  it('uses the selected mode for bandwidth-derived widths', () => {
+    expect(getLinkWidthForMode(link(400e9), 'linear')).toBeCloseTo(16)
+    expect(getLinkWidthForMode(link(400e9), 'class')).toBe(6.5)
+  })
+})

--- a/libs/@shumoku/core/src/layout/link-utils.ts
+++ b/libs/@shumoku/core/src/layout/link-utils.ts
@@ -111,6 +111,73 @@ export function bpsToLinkWidth(bps: number | undefined): number {
   return bps === undefined ? 0 : bpsToWidth(bps)
 }
 
+// ============================================================================
+// Width modes (engine-v3-migration.md A1, #430)
+// ============================================================================
+
+/**
+ * How bandwidth maps to stroke width.
+ *
+ *   - `log`    — the legacy anchored log curve above. Compresses the range
+ *                so every link stays visible; the read is "fast vs slow",
+ *                not proportion.
+ *   - `linear` — width ∝ bandwidth (px per Gbps). Honest proportion: a
+ *                400G trunk is visibly 40× a 10G access link, like river
+ *                width on a map. Requires a width-aware layout (v3 router)
+ *                because trunk ribbons get genuinely wide; slow links
+ *                bottom out at `LINEAR_MIN_WIDTH`.
+ *   - `class`  — discrete road classes (motorway / trunk / regional /
+ *                local / lane). Rank is readable at a glance; differences
+ *                within a class are intentionally suppressed.
+ */
+export type LinkWidthMode = 'log' | 'linear' | 'class'
+
+/** px per Gbps for `linear` mode (v3 prototype calibration: 400G → 16px). */
+const LINEAR_PX_PER_GBPS = 0.04
+const LINEAR_MIN_WIDTH = 0.4
+const LINEAR_MAX_WIDTH = 64
+
+/** Discrete class widths for `class` mode, fastest first. */
+const CLASS_STEPS: readonly (readonly [number, number])[] = [
+  [400e9, 6.5],
+  [100e9, 4],
+  [25e9, 2.6],
+  [10e9, 1.7],
+]
+const CLASS_MIN_WIDTH = 1.1
+
+/**
+ * Map bits/sec to stroke width under the given mode. Unknown bandwidth
+ * returns 0 (caller decides the fallback), matching `bpsToLinkWidth`.
+ */
+export function bpsToLinkWidthMode(bps: number | undefined, mode: LinkWidthMode = 'log'): number {
+  if (bps === undefined || !Number.isFinite(bps) || bps <= 0) return 0
+  if (mode === 'log') return bpsToWidth(bps)
+  if (mode === 'linear') {
+    const width = (bps / 1e9) * LINEAR_PX_PER_GBPS
+    return Math.min(LINEAR_MAX_WIDTH, Math.max(LINEAR_MIN_WIDTH, width))
+  }
+  for (const [threshold, width] of CLASS_STEPS) {
+    if (bps >= threshold) return width
+  }
+  return CLASS_MIN_WIDTH
+}
+
+/**
+ * Visual line width for a link under a width mode. Same precedence as
+ * `getLinkWidth` (explicit style > bandwidth > type > default). Because a
+ * core `Link` is one physical link, this IS the per-strand width — a LAG
+ * renders as N parallel links each at its own width, never as one merged
+ * stroke (v3 "railway discipline": no two services share a drawn line).
+ */
+export function getLinkWidthForMode(link: Link, mode: LinkWidthMode = 'log'): number {
+  if (link.style?.strokeWidth) return link.style.strokeWidth
+  const bps = linkSpeedBps(link)
+  if (bps !== undefined) return bpsToLinkWidthMode(bps, mode)
+  if (link.type === 'thick') return 4
+  return mode === 'log' ? 3 : 1.5
+}
+
 /** Map a bandwidth label/number to the calibrated stroke width. */
 export function getBandwidthWidth(bw: LinkBandwidth | null | undefined): number {
   return bpsToLinkWidth(resolveBandwidthBps(bw))


### PR DESCRIPTION
Closes #430. P0 of the v3 layout migration (#429, `engine-v3-migration.md`).

## Summary
- `layout/invariants.ts` — standing verification for the three invariants every placement/routing pass must hold:
  1. node boxes never overlap
  2. members stay inside their container bounds
  3. no two edges share a collinear track (stroke-width aware)
  Pure geometry functions (`findNodeOverlaps` / `findContainmentViolations` / `findCollinearOverlaps`) + `checkLayoutInvariants(ResolvedLayout)` adapter. In the v3 prototype rounds, every user-spotted visual defect traced back to one of these going unchecked (engine-v3-design.md §30-31).
- `link-utils` — `LinkWidthMode`: `log` (legacy curve, unchanged) / `linear` (width ∝ bandwidth, the look adopted in v3) / `class` (discrete road classes). New `bpsToLinkWidthMode` / `getLinkWidthForMode`; existing `getLinkWidth` untouched.

## Test
- 14 new vitest cases (invariants + width modes); core suite 341 passed, typecheck/biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
