### PR TITLE
fix(core): composite apex sink-guard, side-port ramps, degenerate subgraph skip

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -431,6 +431,12 @@ export function layoutComposite(
     })
   }
   for (const original of graph.subgraphs ?? []) {
+    // Skip degenerate groupings that contain most of the graph (e.g. a
+    // monitoring host-group every device belongs to) — a box around
+    // everything carries no information and visually swallows the zones.
+    let memberCount = 0
+    for (const node of nodes.values()) if (node.parent === original.id) memberCount++
+    if (memberCount >= nodes.size * 0.6) continue
     subgraphs.set(original.id, { ...original, bounds: boundsOfMembers(original, nodes) })
   }
 
@@ -456,10 +462,28 @@ function computeDepths(
   nodes: Map<string, Node>,
   neighbors: Map<string, Map<string, LogicalEdge>>,
 ): Map<string, number> {
+  // Apex candidates must carry trunk-class bandwidth. This is the v3
+  // "default-route sink guard" (engine-v2-design.md §7.5): a shared
+  // firewall/last-resort node touches everything over thin links and a
+  // low device-tier (firewall=15), so without the bandwidth gate it
+  // out-ranks the actual border routers and the whole diagram hangs off
+  // the sink.
+  let globalMaxBw = 0
+  const maxBwOf = new Map<string, number>()
+  for (const id of ids) {
+    let best = 0
+    for (const edge of neighbors.get(id)?.values() ?? []) best = Math.max(best, edge.bw)
+    maxBwOf.set(id, best)
+    globalMaxBw = Math.max(globalMaxBw, best)
+  }
+  const trunkClass = (id: string): boolean =>
+    globalMaxBw <= 0 || (maxBwOf.get(id) ?? 0) >= globalMaxBw * 0.5
+
   let bestTier = Number.POSITIVE_INFINITY
   const tierOf = new Map<string, number>()
   for (const id of ids) {
     if ((neighbors.get(id)?.size ?? 0) === 0) continue
+    if (!trunkClass(id)) continue
     const hint = resolveTierFromSpec(nodes.get(id)?.spec)
     if (!hint) continue
     tierOf.set(id, hint.tier)

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -63,9 +63,24 @@ export function applyOctilinearRoutes(
   const chamfer = options.chamfer ?? 9
   const clearance = options.trackClearance ?? 3
 
-  // -- classify: only bottom→top vertical pairs are routed ----------------------
+  // -- classify ------------------------------------------------------------------
+  // bottom→top pairs route vertically; side-port peers (left/right at similar
+  // height) route as under-loops ("ramps" — the v3 redundancy/peer notation).
+  interface RampRoute {
+    id: string
+    x1: number
+    y1: number
+    dir1: number
+    x2: number
+    y2: number
+    dir2: number
+    half: number
+    busY: number
+  }
   const straights: OrthRoute[] = []
   const orths: OrthRoute[] = []
+  const ramps: RampRoute[] = []
+  const isSidePort = (side: string): boolean => side === 'left' || side === 'right'
   const sortedEdges = [...edges.values()].sort((a, b) => (a.id < b.id ? -1 : 1))
   for (const edge of sortedEdges) {
     const upper =
@@ -73,6 +88,25 @@ export function applyOctilinearRoutes(
         ? edge.fromPort
         : edge.toPort
     const lower = upper === edge.fromPort ? edge.toPort : edge.fromPort
+    const half = Math.max(0.5, edge.width / 2)
+    if (
+      isSidePort(upper.side) &&
+      isSidePort(lower.side) &&
+      Math.abs(lower.absolutePosition.y - upper.absolutePosition.y) <= 80
+    ) {
+      ramps.push({
+        id: edge.id,
+        x1: upper.absolutePosition.x,
+        y1: upper.absolutePosition.y,
+        dir1: upper.side === 'right' ? 1 : -1,
+        x2: lower.absolutePosition.x,
+        y2: lower.absolutePosition.y,
+        dir2: lower.side === 'right' ? 1 : -1,
+        half,
+        busY: 0,
+      })
+      continue
+    }
     if (upper.side !== 'bottom' || lower.side !== 'top') continue
     const x1 = upper.absolutePosition.x
     const y1 = upper.absolutePosition.y
@@ -85,7 +119,7 @@ export function applyOctilinearRoutes(
       y1,
       x2,
       y2,
-      half: Math.max(0.5, edge.width / 2),
+      half,
       trackY: 0,
       shiftX: 0,
     }
@@ -114,6 +148,31 @@ export function applyOctilinearRoutes(
       ceil: route.y2 - 10,
     })
   }
+  // ramp buses share the SAME allocator (separate allocators collide):
+  // the bus runs below the lower endpoint, unbounded downward.
+  const rampRequestOf = new Map<string, RampRoute>()
+  for (const ramp of ramps) {
+    const bottom = Math.max(ramp.y1, ramp.y2)
+    const probe: OrthRoute = {
+      id: `ramp:${ramp.id}`,
+      x1: ramp.x1,
+      y1: bottom,
+      x2: ramp.x2,
+      y2: bottom + 1000,
+      half: ramp.half,
+      trackY: 0,
+      shiftX: 0,
+    }
+    rampRequestOf.set(probe.id, ramp)
+    requests.push({
+      route: probe,
+      lo: Math.min(ramp.x1, ramp.x2) - 16,
+      hi: Math.max(ramp.x1, ramp.x2) + 16,
+      want: bottom + 30,
+      floor: bottom + 18,
+      ceil: bottom + 400,
+    })
+  }
   requests.sort((a, b) => a.want - b.want || (a.route.id < b.route.id ? -1 : 1))
   const placedTracks: { y: number; lo: number; hi: number; half: number }[] = []
   for (const request of requests) {
@@ -140,7 +199,9 @@ export function applyOctilinearRoutes(
       }
     }
     placedTracks.push({ y, lo: request.lo, hi: request.hi, half })
-    request.route.trackY = y
+    const ramp = rampRequestOf.get(request.route.id)
+    if (ramp) ramp.busY = y
+    else request.route.trackY = y
   }
 
   // -- vertical corridor separation (geometry-level, not a render nudge) --------
@@ -206,6 +267,23 @@ export function applyOctilinearRoutes(
       { x: route.x1 + route.shiftX, y: route.trackY },
       { x: route.x2 + route.shiftX, y: route.trackY },
       { x: route.x2 + route.shiftX, y: route.y2 },
+    ]
+    edge.route = { kind: 'polyline', points: chamferCorners(corner, chamfer) }
+    edge.points = corner
+    routed++
+  }
+  for (const ramp of ramps) {
+    const edge = edges.get(ramp.id)
+    if (!edge) continue
+    const out1 = ramp.x1 + ramp.dir1 * 14
+    const out2 = ramp.x2 + ramp.dir2 * 14
+    const corner: Position[] = [
+      { x: ramp.x1, y: ramp.y1 },
+      { x: out1, y: ramp.y1 },
+      { x: out1, y: ramp.busY },
+      { x: out2, y: ramp.busY },
+      { x: out2, y: ramp.y2 },
+      { x: ramp.x2, y: ramp.y2 },
     ]
     edge.route = { kind: 'polyline', points: chamferCorners(corner, chamfer) }
     edge.points = corner


### PR DESCRIPTION
Part of #429 / #432 / #433 — first live-render round of the composite layout against a discovered 53-node network, verified in the web viewer via devtools.

## Fixes
1. **Apex sink guard** — apex candidates now require trunk-class bandwidth (≥ half the graph max). Without it, a shared last-resort firewall (device tier 15, 17 thin links) outranked the border routers and the whole diagram hung off the sink.
2. **Side-port ramps** — left/right peer links at similar height route as orthogonal under-loops on the shared track allocator, instead of 16px Bezier sweeps across the page.
3. **Degenerate subgraph skip** — original subgraphs containing ≥60% of all nodes (e.g. a monitoring host-group everything belongs to) are skipped in composite mode.

Core suite: 349 passed; typecheck/biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
