### PR TITLE
fix(core,web): align ports to peers by geometry; weathermap follows routed polylines

### DIFF
--- a/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
+++ b/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
@@ -52,13 +52,19 @@
   // edges) we collapse to a single combined overlay — see template —
   // because there's no geometric anchor to split lanes from.
   const hasPorts = $derived(!!(context.fromPort && context.toPort))
+  // Routed (octilinear polyline) edges: the flow dashes must follow the
+  // routed path, not a port-to-port Bezier — otherwise every routed link
+  // grows a phantom diagonal dash line across the diagram. Polyline path
+  // data contains no 'C' command; both lanes share the path, and the
+  // opposite dash directions keep in/out distinguishable.
+  const isRoutedPolyline = $derived(!context.pathD.includes('C'))
   const inPathD = $derived(
-    hasPorts && context.fromPort && context.toPort
+    !isRoutedPolyline && hasPorts && context.fromPort && context.toPort
       ? bezierOffsetPath(context.fromPort, context.toPort, laneOffset)
       : context.pathD,
   )
   const outPathD = $derived(
-    hasPorts && context.fromPort && context.toPort
+    !isRoutedPolyline && hasPorts && context.fromPort && context.toPort
       ? bezierOffsetPath(context.fromPort, context.toPort, -laneOffset)
       : context.pathD,
   )

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -27,8 +27,87 @@
  * graceful fallback where it doesn't.
  */
 
-import type { Bounds, Position } from '../../models/types.js'
+import type { Bounds, Node, Position } from '../../models/types.js'
+import { resolveNodeSize } from '../engine/index.js'
 import type { ResolvedEdge } from '../resolved-types.js'
+
+/**
+ * Re-seat ports to face their peer, by GEOMETRY. The flat-tree side
+ * decision leans on link from/to direction, but discovered (LLDP) links
+ * point in arbitrary directions — on test6, 29 of 104 links ended up
+ * with both ports facing AWAY from each other (lower node's bottom port
+ * climbing to the upper node's top port), which forced Bezier wrap-around
+ * sweeps and made the dense bands look tangled. v3 lesson (§9): never
+ * trust from/to orientation; trust positions.
+ *
+ * Mutates the ResolvedPort objects in place (1 port = 1 link, so a flip
+ * never affects another edge). Returns the number of ports re-seated.
+ */
+export function alignPortsToPeers(
+  edges: Map<string, ResolvedEdge>,
+  nodes: Map<string, Node>,
+): number {
+  let flipped = 0
+  const seat = (
+    port: ResolvedEdge['fromPort'],
+    nodeId: string,
+    side: 'top' | 'bottom' | 'left' | 'right',
+  ): void => {
+    if (port.side === side) return
+    const node = nodes.get(nodeId)
+    const center = node?.position
+    if (!node || !center) return
+    const size = resolveNodeSize(node)
+    if (side === 'top' || side === 'bottom') {
+      port.absolutePosition = {
+        x: Math.max(
+          center.x - size.width / 2 + 6,
+          Math.min(center.x + size.width / 2 - 6, port.absolutePosition.x),
+        ),
+        y: side === 'top' ? center.y - size.height / 2 : center.y + size.height / 2,
+      }
+    } else {
+      port.absolutePosition = {
+        x: side === 'left' ? center.x - size.width / 2 : center.x + size.width / 2,
+        y: center.y,
+      }
+    }
+    port.side = side
+    flipped++
+  }
+  for (const edge of [...edges.values()].sort((a, b) => (a.id < b.id ? -1 : 1))) {
+    const fromCenter = nodes.get(edge.fromNodeId)?.position
+    const toCenter = nodes.get(edge.toNodeId)?.position
+    if (!fromCenter || !toCenter) continue
+    const dy = toCenter.y - fromCenter.y
+    if (Math.abs(dy) > 40) {
+      const upperIsFrom = dy > 0
+      seat(
+        upperIsFrom ? edge.fromPort : edge.toPort,
+        upperIsFrom ? edge.fromNodeId : edge.toNodeId,
+        'bottom',
+      )
+      seat(
+        upperIsFrom ? edge.toPort : edge.fromPort,
+        upperIsFrom ? edge.toNodeId : edge.fromNodeId,
+        'top',
+      )
+    } else {
+      const leftIsFrom = fromCenter.x <= toCenter.x
+      seat(
+        leftIsFrom ? edge.fromPort : edge.toPort,
+        leftIsFrom ? edge.fromNodeId : edge.toNodeId,
+        'right',
+      )
+      seat(
+        leftIsFrom ? edge.toPort : edge.fromPort,
+        leftIsFrom ? edge.toNodeId : edge.fromNodeId,
+        'left',
+      )
+    }
+  }
+  return flipped
+}
 
 /** A rectangle wires must not run through (zone box or node box). */
 export interface RoutingObstacle {

--- a/libs/@shumoku/core/src/layout/unified-engine.ts
+++ b/libs/@shumoku/core/src/layout/unified-engine.ts
@@ -24,7 +24,7 @@ import { autoLayoutFlatTree } from './auto-placement/flat-tree/auto-layout.js'
 import { layoutCompound } from './auto-placement/flat-tree/compound.js'
 import { placePorts } from './auto-placement/flat-tree/port-placement.js'
 import { layoutComposite, shouldUseComposite } from './composite/index.js'
-import { applyOctilinearRoutes } from './composite/router.js'
+import { alignPortsToPeers, applyOctilinearRoutes } from './composite/router.js'
 import { createEngine, resolveNodeSize } from './engine/index.js'
 import { getLinkWidth, getLinkWidthForMode } from './link-utils.js'
 import type { ResolvedLayout } from './resolved-types.js'
@@ -76,6 +76,9 @@ export async function computeNetworkLayout(
     for (const edge of edges.values()) {
       edge.width = Math.max(1, getLinkWidthForMode(edge.link, 'linear'))
     }
+    // ports must face their peers (discovered links have arbitrary
+    // from/to orientation — never trust it, trust geometry)
+    alignPortsToPeers(edges, comp.nodes)
     // zone boxes are routing obstacles: through-traffic takes the gutters
     const obstacles: { id: string; bounds: NonNullable<Subgraph['bounds']> }[] = []
     for (const [id, sg] of comp.subgraphs) {


### PR DESCRIPTION
Part of #429 / #433. Two tangle sources identified from the live test6 render:

1. **Port-side inversion (the main one)** — discovered (LLDP) links carry arbitrary from/to orientation, and the flat-tree port-side decision trusts it. 29/104 links had both ports facing AWAY from each other → Bezier wrap-around sweeps everywhere. `alignPortsToPeers` re-seats ports toward the peer from final geometry before routing. Result: **104/104 edges octilinear-routed** (was 74/104).
2. **Weathermap lanes ignored routes** — utilization in/out lanes were port-to-port Bezier offsets, drawing phantom diagonal dash lines for routed edges. Routed polylines now carry the dashes on the path itself.

Verified live in the web viewer. Core suite 349 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
