### PR TITLE
feat(core): place-and-route search for composite layout (P4)

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -34,6 +34,19 @@ export interface CompositeLayoutOptions {
   cellGapX?: number
   /** Zone box padding. */
   zonePad?: number
+  /**
+   * Pair unit ids (from `CompositeLayoutResult.pairs`) whose member
+   * order should be mirrored. Search move vocabulary: the left/right
+   * order inside a redundant pair is a real degree of freedom — the v3
+   * rounds found exactly the pair a human flagged by eye (§35).
+   */
+  pairFlips?: ReadonlySet<string>
+  /**
+   * Extra vertical space inserted BEFORE band index i — congestion
+   * feedback from routing (a channel overflowing with wire tracks
+   * widens its road bed on the next pass).
+   */
+  bandExtra?: ReadonlyMap<number, number>
 }
 
 export interface CompositeLayoutResult {
@@ -44,6 +57,12 @@ export interface CompositeLayoutResult {
   bounds: Bounds
   /** zone name → member node ids (for invariant checks / diagnostics). */
   zones: Map<string, string[]>
+  /** Redundant-pair unit ids (search flip candidates). */
+  pairs: string[]
+  /** Band y-ranges (top/bottom, final coordinates) for congestion measurement. */
+  bands: { top: number; bottom: number }[]
+  /** Node pair-keys (`a|b`, sorted) belonging to the primary dependency tree. */
+  primaryEdges: Set<string>
 }
 
 /** Synthetic zone subgraphs get this id prefix. */
@@ -308,7 +327,18 @@ export function layoutComposite(
 
   const zoneX = new Map<string, number>()
   const zoneY = new Map<string, number>()
-  placeZoneBands(zoneIds, zoneRank, zoneAdj, zoneParent, zoneBox, zoneX, zoneY, zoneGap, bandGap)
+  const bandRanges = placeZoneBands(
+    zoneIds,
+    zoneRank,
+    zoneAdj,
+    zoneParent,
+    zoneBox,
+    zoneX,
+    zoneY,
+    zoneGap,
+    bandGap,
+    options.bandExtra,
+  )
 
   // -- port refine: pull units toward their cross-zone neighbors ---------------
   const minSep = 24
@@ -378,8 +408,9 @@ export function layoutComposite(
       if (node) node.position = { x: gx, y: gy }
       continue
     }
+    const order = options.pairFlips?.has(unit.id) ? [...unit.members].reverse() : unit.members
     let x = gx - unit.width / 2
-    for (const member of unit.members) {
+    for (const member of order) {
       const node = nodes.get(member)
       if (!node) continue
       const size = resolveNodeSize(node)
@@ -440,6 +471,20 @@ export function layoutComposite(
     subgraphs.set(original.id, { ...original, bounds: boundsOfMembers(original, nodes) })
   }
 
+  // primary dependency edges at node level (for emphasis styling / search)
+  const primaryEdges = new Set<string>()
+  for (const unit of units) {
+    const parent = primaryParent.get(unit.id)
+    if (parent === undefined) continue
+    const parentUnit = unitById.get(parent)
+    if (!parentUnit) continue
+    for (const m of unit.members) {
+      for (const p of parentUnit.members) {
+        if (neighbors.get(m)?.has(p)) primaryEdges.add(pairKey(m, p))
+      }
+    }
+  }
+
   return {
     nodes,
     subgraphs,
@@ -450,6 +495,9 @@ export function layoutComposite(
       height: maxY - minY + PAD * 2,
     },
     zones: zoneMembers,
+    pairs: units.filter((u) => u.members.length === 2).map((u) => u.id),
+    bands: bandRanges.map((b) => ({ top: b.top + shiftY, bottom: b.bottom + shiftY })),
+    primaryEdges,
   }
 }
 
@@ -544,26 +592,42 @@ function detectPairs(
     if (zoneOf(edge.a) !== zoneOf(edge.b)) continue
     tryPair(edge.a, edge.b)
   }
-  // 2) naming + structure fallback: same zone, same depth, direct link,
-  //    and twin-style names (stem or host part match)
+  // 2) naming + structure fallback: same zone, twin-style names (stem or
+  //    host part match), similar depth, and structural evidence — a direct
+  //    interconnect OR a shared uplink. Jaccard/direct-only is wrong both
+  //    ways (v3 §24/§30): true HA pairs often uplink to DIFFERENT routers
+  //    on purpose, and some pairs have no direct heartbeat link at all.
+  const candidates: { a: string; b: string; direct: boolean }[] = []
   for (const a of ids) {
-    if (paired.has(a)) continue
     const nodeA = nodes.get(a)
     if (!nodeA) continue
     const labelA = labelOf(nodeA)
-    for (const [b] of [...(neighbors.get(a) ?? new Map())].sort()) {
-      if (b <= a || paired.has(b)) continue
+    for (const b of ids) {
+      if (b <= a) continue
       if (zoneOf(a) !== zoneOf(b)) continue
-      if (depth.get(a) !== depth.get(b)) continue
+      if (Math.abs((depth.get(a) ?? 0) - (depth.get(b) ?? 0)) > 1) continue
       const nodeB = nodes.get(b)
       if (!nodeB) continue
       const labelB = labelOf(nodeB)
-      if (stemOf(labelA) === stemOf(labelB) || hostOf(labelA) === hostOf(labelB)) {
-        tryPair(a, b)
-        break
+      if (stemOf(labelA) !== stemOf(labelB) && hostOf(labelA) !== hostOf(labelB)) continue
+      const direct = neighbors.get(a)?.has(b) ?? false
+      let shared = false
+      if (!direct) {
+        for (const n of neighbors.get(a)?.keys() ?? []) {
+          if (n !== b && neighbors.get(b)?.has(n)) {
+            shared = true
+            break
+          }
+        }
       }
+      if (direct || shared) candidates.push({ a, b, direct })
     }
   }
+  candidates.sort(
+    (x, y) =>
+      Number(y.direct) - Number(x.direct) || (pairKey(x.a, x.b) < pairKey(y.a, y.b) ? -1 : 1),
+  )
+  for (const candidate of candidates) tryPair(candidate.a, candidate.b)
   return paired
 }
 
@@ -577,14 +641,17 @@ function placeZoneBands(
   zoneY: Map<string, number>,
   zoneGap: number,
   bandGap: number,
-): void {
+  bandExtra?: ReadonlyMap<number, number>,
+): { top: number; bottom: number }[] {
   const ranks = [...new Set(zoneIds.map((z) => zoneRank.get(z) ?? 0))].sort((a, b) => a - b)
   const centerOf = new Map<string, number>()
   for (const zone of zoneIds) centerOf.set(zone, 0)
+  const bandRanges: { top: number; bottom: number }[] = []
 
   let y = 0
   const placed = new Set<string>()
-  for (const rank of ranks) {
+  for (const [bandIndex, rank] of ranks.entries()) {
+    y += bandExtra?.get(bandIndex) ?? 0
     const bandZones = zoneIds.filter((z) => (zoneRank.get(z) ?? 0) === rank)
     // group zones under their (already placed) feeder zone
     const groups = new Map<string, string[]>()
@@ -677,8 +744,10 @@ function placeZoneBands(
       }
       bandHeight = Math.max(bandHeight, block.h)
     }
+    bandRanges.push({ top: y, bottom: y + bandHeight })
     y += bandHeight + bandGap
   }
+  return bandRanges
 }
 
 function barycenter(

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -1,0 +1,287 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Place-and-route search for the composite layout (engine-v3-migration.md
+ * B3, #434; the 突き合わせ loop of engine-v3-design.md §32-35).
+ *
+ * Placement proposes a form, wiring routes it for real, and the score of
+ * the ROUTED geometry arbitrates — never a straight-line proxy (v3 §32:
+ * optimizing a proxy quietly diverges from what gets drawn). Three layers,
+ * all deterministic and bounded:
+ *
+ *   1. multi-start over a small parameter grid (gaps),
+ *   2. congestion feedback: a channel whose wire-track demand overflows
+ *      its band gap widens the road bed and the layout re-runs,
+ *   3. pair-flip hill-climb: the left/right order inside each redundant
+ *      pair is flipped if real routing gets cheaper (v3 §35 — the move
+ *      that reproduced a human reviewer's "these two look backwards").
+ */
+
+import type { NetworkGraph } from '../../models/types.js'
+import { placePorts } from '../auto-placement/flat-tree/port-placement.js'
+import { resolveNodeSize } from '../engine/index.js'
+import { findCollinearOverlaps, type PolylineSpec } from '../invariants.js'
+import { getLinkWidthForMode } from '../link-utils.js'
+import type { ResolvedEdge, ResolvedLayout, ResolvedPort } from '../resolved-types.js'
+import { routeEdges } from '../route-edges.js'
+import {
+  type CompositeLayoutOptions,
+  type CompositeLayoutResult,
+  layoutComposite,
+} from './index.js'
+import { alignPortsToPeers, applyOctilinearRoutes, type RoutingObstacle } from './router.js'
+
+export interface RoutedScore {
+  cost: number
+  crossings: number
+  collinear: number
+  pierce: number
+  bends: number
+  length: number
+}
+
+export interface CompositeSearchResult {
+  comp: CompositeLayoutResult
+  ports: Map<string, ResolvedPort>
+  edges: Map<string, ResolvedEdge>
+  score: RoutedScore
+}
+
+export interface CompositeSearchOptions {
+  /** Hard cap on layout+route evaluations. Default 16. */
+  maxEvaluations?: number
+}
+
+/** Lay out, port, route and score one composite variant. */
+async function evaluate(
+  graph: NetworkGraph,
+  layoutOptions: CompositeLayoutOptions,
+): Promise<CompositeSearchResult> {
+  const comp = layoutComposite(graph, layoutOptions)
+  const direction = graph.settings?.direction ?? 'TB'
+  const ports = placePorts(comp.nodes, graph.links, direction)
+  const edges = await routeEdges(comp.nodes, ports, graph.links, comp.subgraphs)
+  for (const edge of edges.values()) {
+    edge.width = Math.max(1, getLinkWidthForMode(edge.link, 'linear'))
+  }
+  alignPortsToPeers(edges, comp.nodes)
+  const obstacles: RoutingObstacle[] = []
+  for (const [id, sg] of comp.subgraphs) {
+    if (sg.bounds) obstacles.push({ id, bounds: sg.bounds })
+  }
+  applyOctilinearRoutes(edges, { obstacles })
+  return { comp, ports, edges, score: scoreRoutedEdges(edges, comp.nodes) }
+}
+
+/**
+ * Run the search: parameter multi-start → congestion pass → pair flips.
+ * Total evaluations stay within `maxEvaluations` (default 16); the
+ * result is always the best ROUTED variant seen.
+ */
+export async function searchCompositeLayout(
+  graph: NetworkGraph,
+  options: CompositeSearchOptions = {},
+): Promise<CompositeSearchResult> {
+  const maxEvaluations = options.maxEvaluations ?? 16
+  let evaluations = 0
+  const budgeted = async (
+    layoutOptions: CompositeLayoutOptions,
+  ): Promise<CompositeSearchResult | undefined> => {
+    if (evaluations >= maxEvaluations) return undefined
+    evaluations++
+    return evaluate(graph, layoutOptions)
+  }
+
+  // 1) multi-start over the gap grid
+  const variants: CompositeLayoutOptions[] = [
+    {},
+    { zoneGap: 70 },
+    { bandGap: 120 },
+    { cellGapX: 24 },
+    { zoneGap: 70, bandGap: 190 },
+  ]
+  let bestOptions: CompositeLayoutOptions = {}
+  let best = await evaluate(graph, bestOptions)
+  evaluations++
+  for (const variant of variants.slice(1)) {
+    const candidate = await budgeted(variant)
+    if (candidate && candidate.score.cost < best.score.cost) {
+      best = candidate
+      bestOptions = variant
+    }
+  }
+
+  // 2) congestion feedback: widen overflowing channels and retry once
+  const bandExtra = measureCongestion(best)
+  if (bandExtra.size > 0) {
+    const candidate = await budgeted({ ...bestOptions, bandExtra })
+    if (candidate && candidate.score.cost < best.score.cost) {
+      best = candidate
+      bestOptions = { ...bestOptions, bandExtra }
+    }
+  }
+
+  // 3) pair-flip hill-climb (each flip kept only if real routing improves)
+  const flips = new Set<string>()
+  for (const pair of [...best.comp.pairs].sort()) {
+    const trial = new Set(flips)
+    trial.add(pair)
+    const candidate = await budgeted({ ...bestOptions, pairFlips: trial })
+    if (candidate && candidate.score.cost < best.score.cost) {
+      best = candidate
+      flips.add(pair)
+    }
+  }
+
+  return best
+}
+
+/**
+ * Channel congestion: for each inter-band gap, the demand is the summed
+ * bundle height of horizontal runs wanting that gap; overflow becomes
+ * extra gap before the lower band (v3 §38-39 — measuring placed spans
+ * underestimates because allocators clamp into the channel).
+ */
+function measureCongestion(result: CompositeSearchResult): Map<number, number> {
+  const bands = result.comp.bands
+  const demand = new Map<number, number>()
+  const gapOf = (y: number): number => {
+    for (let i = 0; i + 1 < bands.length; i++) {
+      const lower = bands[i]
+      const upper = bands[i + 1]
+      if (!lower || !upper) continue
+      if (y >= lower.bottom - 4 && y <= upper.top + 4) return i
+    }
+    return -1
+  }
+  for (const edge of result.edges.values()) {
+    const points = edge.route?.points ?? edge.points
+    for (let i = 1; i < points.length; i++) {
+      const a = points[i - 1]
+      const b = points[i]
+      if (!a || !b || Math.abs(a.y - b.y) > 0.5 || Math.abs(a.x - b.x) < 14) continue
+      const gap = gapOf(a.y)
+      if (gap >= 0) demand.set(gap, (demand.get(gap) ?? 0) + edge.width + 4)
+    }
+  }
+  const extra = new Map<number, number>()
+  for (const [gap, need] of demand) {
+    const lower = bands[gap]
+    const upper = bands[gap + 1]
+    if (!lower || !upper) continue
+    const available = upper.top - lower.bottom - 24
+    if (need > available) extra.set(gap + 1, Math.ceil(need - available))
+  }
+  return extra
+}
+
+/** Score actually-routed geometry (no straight-line proxies). */
+export function scoreRoutedEdges(
+  edges: Map<string, ResolvedEdge>,
+  nodes: ResolvedLayout['nodes'],
+): RoutedScore {
+  interface Poly {
+    a: string
+    b: string
+    pts: { x: number; y: number }[]
+    half: number
+    id: string
+  }
+  const polys: Poly[] = []
+  for (const edge of edges.values()) {
+    const pts = edge.route?.points ?? edge.points
+    if (pts.length < 2) continue
+    polys.push({
+      a: edge.fromNodeId,
+      b: edge.toNodeId,
+      pts,
+      half: Math.max(0.5, edge.width / 2),
+      id: edge.id,
+    })
+  }
+  let crossings = 0
+  let bends = 0
+  let length = 0
+  for (const poly of polys) {
+    bends += Math.max(0, poly.pts.length - 2)
+    for (let i = 1; i < poly.pts.length; i++) {
+      const a = poly.pts[i - 1]
+      const b = poly.pts[i]
+      if (a && b) length += Math.hypot(b.x - a.x, b.y - a.y)
+    }
+  }
+  for (let i = 0; i < polys.length; i++) {
+    const pa = polys[i]
+    if (!pa) continue
+    for (let j = i + 1; j < polys.length; j++) {
+      const pb = polys[j]
+      if (!pb) continue
+      if (pa.a === pb.a || pa.a === pb.b || pa.b === pb.a || pa.b === pb.b) continue
+      for (let s = 1; s < pa.pts.length; s++) {
+        for (let t = 1; t < pb.pts.length; t++) {
+          const a1 = pa.pts[s - 1]
+          const a2 = pa.pts[s]
+          const b1 = pb.pts[t - 1]
+          const b2 = pb.pts[t]
+          if (a1 && a2 && b1 && b2 && segmentsIntersect(a1, a2, b1, b2)) crossings++
+        }
+      }
+    }
+  }
+  const lines: PolylineSpec[] = polys.map((p) => ({ id: p.id, points: p.pts, halfWidth: p.half }))
+  const collinear = findCollinearOverlaps(lines).length
+  // wires running through unrelated node boxes
+  let pierce = 0
+  const boxes: { id: string; x: number; y: number; w: number; h: number }[] = []
+  for (const [id, node] of nodes) {
+    if (!node.position) continue
+    const size = resolveNodeSize(node)
+    boxes.push({ id, x: node.position.x, y: node.position.y, w: size.width, h: size.height })
+  }
+  for (const poly of polys) {
+    for (const box of boxes) {
+      if (box.id === poly.a || box.id === poly.b) continue
+      const bx = box.x - box.w / 2 - 2
+      const by = box.y - box.h / 2 - 2
+      const bw = box.w + 4
+      const bh = box.h + 4
+      let hit = false
+      for (let s = 1; s < poly.pts.length && !hit; s++) {
+        const a = poly.pts[s - 1]
+        const b = poly.pts[s]
+        if (!a || !b) continue
+        if (Math.max(a.x, b.x) < bx || Math.min(a.x, b.x) > bx + bw) continue
+        if (Math.max(a.y, b.y) < by || Math.min(a.y, b.y) > by + bh) continue
+        hit =
+          segmentsIntersect(a, b, { x: bx, y: by }, { x: bx + bw, y: by }) ||
+          segmentsIntersect(a, b, { x: bx, y: by + bh }, { x: bx + bw, y: by + bh }) ||
+          segmentsIntersect(a, b, { x: bx, y: by }, { x: bx, y: by + bh }) ||
+          segmentsIntersect(a, b, { x: bx + bw, y: by }, { x: bx + bw, y: by + bh })
+      }
+      if (hit) pierce++
+    }
+  }
+  return {
+    cost: crossings + collinear * 8 + pierce * 2 + bends * 0.4 + length / 400,
+    crossings,
+    collinear,
+    pierce,
+    bends,
+    length,
+  }
+}
+
+function segmentsIntersect(
+  a1: { x: number; y: number },
+  a2: { x: number; y: number },
+  b1: { x: number; y: number },
+  b2: { x: number; y: number },
+): boolean {
+  const d1 = (a2.x - a1.x) * (b1.y - a1.y) - (a2.y - a1.y) * (b1.x - a1.x)
+  const d2 = (a2.x - a1.x) * (b2.y - a1.y) - (a2.y - a1.y) * (b2.x - a1.x)
+  const d3 = (b2.x - b1.x) * (a1.y - b1.y) - (b2.y - b1.y) * (a1.x - b1.x)
+  const d4 = (b2.x - b1.x) * (a2.y - b1.y) - (b2.y - b1.y) * (a2.x - b1.x)
+  return d1 > 0 !== d2 > 0 && d3 > 0 !== d4 > 0
+}

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -40,7 +40,14 @@ export {
   shouldUseComposite,
   ZONE_SUBGRAPH_PREFIX,
 } from './composite/index.js'
-export { applyOctilinearRoutes, chamferCorners } from './composite/router.js'
+export { alignPortsToPeers, applyOctilinearRoutes, chamferCorners } from './composite/router.js'
+export {
+  type CompositeSearchOptions,
+  type CompositeSearchResult,
+  type RoutedScore,
+  scoreRoutedEdges,
+  searchCompositeLayout,
+} from './composite/search.js'
 export type {
   LayoutEngine as ShumokuLayoutEngine,
   PortsBySide as EnginePortsBySide,

--- a/libs/@shumoku/core/src/layout/resolved-types.ts
+++ b/libs/@shumoku/core/src/layout/resolved-types.ts
@@ -110,6 +110,13 @@ export interface ResolvedEdge {
   route?:
     | { kind: 'bus'; points: Position[]; busId: string; branchIndex: number; branchCount: number }
     | { kind: 'polyline'; points: Position[] }
+  /**
+   * Semantic weight for renderers (v3 grammar): `primary` = the edge
+   * belongs to the primary dependency tree (each node's strongest
+   * uplink) and should read as the structural skeleton; `secondary` =
+   * redundancy / peering context, drawn subdued. Absent = no opinion.
+   */
+  emphasis?: 'primary' | 'secondary'
 }
 
 // ============================================================================

--- a/libs/@shumoku/core/src/layout/unified-engine.ts
+++ b/libs/@shumoku/core/src/layout/unified-engine.ts
@@ -19,14 +19,13 @@
  */
 
 import type { LayoutEngine } from '../hierarchical.js'
-import type { LayoutResult, NetworkGraph, Subgraph } from '../models/types.js'
+import type { LayoutResult, NetworkGraph } from '../models/types.js'
 import { autoLayoutFlatTree } from './auto-placement/flat-tree/auto-layout.js'
 import { layoutCompound } from './auto-placement/flat-tree/compound.js'
-import { placePorts } from './auto-placement/flat-tree/port-placement.js'
-import { layoutComposite, shouldUseComposite } from './composite/index.js'
-import { alignPortsToPeers, applyOctilinearRoutes } from './composite/router.js'
+import { shouldUseComposite } from './composite/index.js'
+import { searchCompositeLayout } from './composite/search.js'
 import { createEngine, resolveNodeSize } from './engine/index.js'
-import { getLinkWidth, getLinkWidthForMode } from './link-utils.js'
+import { getLinkWidth } from './link-utils.js'
 import type { ResolvedLayout } from './resolved-types.js'
 import { routeEdges } from './route-edges.js'
 
@@ -66,25 +65,18 @@ export async function computeNetworkLayout(
   // flat-tree/compound. Hand-drawn diagrams rarely qualify.
   const useComposite = options.composite ?? shouldUseComposite(graph)
   if (useComposite) {
-    const comp = layoutComposite(graph)
-    const ports = placePorts(comp.nodes, graph.links, direction)
-    const edges = await routeEdges(comp.nodes, ports, graph.links, comp.subgraphs)
-    // Composite pairs with the LINEAR width mode (v3 decision: width ∝
-    // bandwidth, like river width on a map). The legacy log widths
-    // (14-34px) are also physically incompatible with channel routing —
-    // bundles that wide cannot be separated between ports.
+    // Place-and-route search (v3 突き合わせ loop): placement variants are
+    // routed for real and the routed-geometry score arbitrates — gaps
+    // multi-start, congestion-widened channels, redundant-pair flips.
+    const { comp, ports, edges } = await searchCompositeLayout(graph)
+    // primary dependency tree emphasis for renderers
     for (const edge of edges.values()) {
-      edge.width = Math.max(1, getLinkWidthForMode(edge.link, 'linear'))
+      const key =
+        edge.fromNodeId < edge.toNodeId
+          ? `${edge.fromNodeId}|${edge.toNodeId}`
+          : `${edge.toNodeId}|${edge.fromNodeId}`
+      edge.emphasis = comp.primaryEdges.has(key) ? 'primary' : 'secondary'
     }
-    // ports must face their peers (discovered links have arbitrary
-    // from/to orientation — never trust it, trust geometry)
-    alignPortsToPeers(edges, comp.nodes)
-    // zone boxes are routing obstacles: through-traffic takes the gutters
-    const obstacles: { id: string; bounds: NonNullable<Subgraph['bounds']> }[] = []
-    for (const [id, sg] of comp.subgraphs) {
-      if (sg.bounds) obstacles.push({ id, bounds: sg.bounds })
-    }
-    applyOctilinearRoutes(edges, { obstacles })
     return buildResults({
       nodes: comp.nodes,
       ports,


### PR DESCRIPTION
Closes #434; finishes the congestion-widening remainder of #433. Part of #429.

## Summary
- `layout/composite/search.ts` — the v3 negotiation loop in core: placement proposes, wiring routes for real, the ROUTED-geometry score arbitrates. Three deterministic, evaluation-capped layers: parameter multi-start → congestion feedback (overflowing channels widen their band gap and re-layout) → pair-flip hill-climb. ~150ms on the 53-node reference graph.
- `layoutComposite` search hooks: `pairFlips`, `bandExtra`, result metadata (`pairs`, `bands`, `primaryEdges`).
- Pair-detection fix: structural evidence = direct interconnect OR shared uplink (was direct-only + exact-depth, detecting 1 of 4 known pairs; now 4/4).
- `ResolvedEdge.emphasis` (`primary`/`secondary`) so renderers can draw the primary dependency tree as the skeleton (P5 consumes this).

Core suite 349 passed; search measured on the live graph (cost 2001 → 1827 with correct pairs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
