### PR TITLE
feat(core,renderer): v3 semantic grammar — sink rail, HA glasses, primary emphasis (P5)

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -63,6 +63,8 @@ export interface CompositeLayoutResult {
   bands: { top: number; bottom: number }[]
   /** Node pair-keys (`a|b`, sorted) belonging to the primary dependency tree. */
   primaryEdges: Set<string>
+  /** Shared-service sink nodes placed on the bottom rail. */
+  sinks: string[]
 }
 
 /** Synthetic zone subgraphs get this id prefix. */
@@ -186,8 +188,28 @@ export function layoutComposite(
     return typeof loc === 'string' && loc !== '' ? loc : `__solo:${id}`
   }
 
+  // -- bandwidth classes + shared-service sinks --------------------------------
+  // A sink (default-route firewall, shared service) touches everything over
+  // thin links: high degree, no trunk-class bandwidth. It must not anchor
+  // the hierarchy (v2 §7.5 sink guard), must not shortcut BFS depths, and
+  // lives on its own rail below the zones instead of bloating one zone box.
+  let globalMaxBw = 0
+  const maxBwOf = new Map<string, number>()
+  for (const id of ids) {
+    let best = 0
+    for (const edge of neighbors.get(id)?.values() ?? []) best = Math.max(best, edge.bw)
+    maxBwOf.set(id, best)
+    globalMaxBw = Math.max(globalMaxBw, best)
+  }
+  const trunkClass = (id: string): boolean =>
+    globalMaxBw <= 0 || (maxBwOf.get(id) ?? 0) >= globalMaxBw * 0.5
+  const sinkSet = new Set<string>()
+  for (const id of ids) {
+    if ((neighbors.get(id)?.size ?? 0) >= 8 && !trunkClass(id)) sinkSet.add(id)
+  }
+
   // -- hierarchy depth: apex from role tiers, then undirected BFS -------------
-  const depth = computeDepths(ids, nodes, neighbors)
+  const depth = computeDepths(ids, nodes, neighbors, trunkClass, sinkSet)
 
   // -- redundant pairs ---------------------------------------------------------
   const pairedWith = detectPairs(ids, nodes, edges, neighbors, zoneOf, depth)
@@ -197,6 +219,7 @@ export function layoutComposite(
   const units: Unit[] = []
   const unitOf = new Map<string, string>()
   for (const id of ids) {
+    if (sinkSet.has(id)) continue // sinks live on their own rail, not in zones
     const partner = pairedWith.get(id)
     if (partner !== undefined && partner < id) continue
     const members = partner !== undefined ? [id, partner].sort() : [id]
@@ -442,6 +465,34 @@ export function layoutComposite(
     node.position = { x: node.position.x + shiftX, y: node.position.y + shiftY }
   }
 
+  // -- sink rail: shared-service sinks sit on their own row below the zones
+  //    (v3 collector rail) instead of dragging 15+ links into one zone box --
+  let railBottom = maxY - minY + PAD
+  if (sinkSet.size > 0) {
+    const railY = maxY - minY + PAD + 110
+    const sinkIds = [...sinkSet].sort()
+    let railWidth = 0
+    let railHeight = 0
+    for (const id of sinkIds) {
+      const node = nodes.get(id)
+      if (!node) continue
+      const size = resolveNodeSize(node)
+      railWidth += size.width + 40
+      railHeight = Math.max(railHeight, size.height)
+    }
+    railWidth -= 40
+    const contentWidth = maxX - minX
+    let x = PAD + Math.max(0, (contentWidth - railWidth) / 2)
+    for (const id of sinkIds) {
+      const node = nodes.get(id)
+      if (!node) continue
+      const size = resolveNodeSize(node)
+      node.position = { x: x + size.width / 2, y: railY + railHeight / 2 }
+      x += size.width + 40
+    }
+    railBottom = railY + railHeight
+  }
+
   // -- subgraphs: synthetic zone boxes + original subgraph bounds ------------------
   const subgraphs = new Map<string, Subgraph>()
   const zoneMembers = new Map<string, string[]>()
@@ -492,12 +543,13 @@ export function layoutComposite(
       x: 0,
       y: 0,
       width: maxX - minX + PAD * 2,
-      height: maxY - minY + PAD * 2,
+      height: railBottom + PAD,
     },
     zones: zoneMembers,
     pairs: units.filter((u) => u.members.length === 2).map((u) => u.id),
     bands: bandRanges.map((b) => ({ top: b.top + shiftY, bottom: b.bottom + shiftY })),
     primaryEdges,
+    sinks: [...sinkSet].sort(),
   }
 }
 
@@ -509,24 +561,12 @@ function computeDepths(
   ids: readonly string[],
   nodes: Map<string, Node>,
   neighbors: Map<string, Map<string, LogicalEdge>>,
+  trunkClass: (id: string) => boolean,
+  sinkSet: ReadonlySet<string>,
 ): Map<string, number> {
-  // Apex candidates must carry trunk-class bandwidth. This is the v3
-  // "default-route sink guard" (engine-v2-design.md §7.5): a shared
-  // firewall/last-resort node touches everything over thin links and a
-  // low device-tier (firewall=15), so without the bandwidth gate it
-  // out-ranks the actual border routers and the whole diagram hangs off
-  // the sink.
-  let globalMaxBw = 0
-  const maxBwOf = new Map<string, number>()
-  for (const id of ids) {
-    let best = 0
-    for (const edge of neighbors.get(id)?.values() ?? []) best = Math.max(best, edge.bw)
-    maxBwOf.set(id, best)
-    globalMaxBw = Math.max(globalMaxBw, best)
-  }
-  const trunkClass = (id: string): boolean =>
-    globalMaxBw <= 0 || (maxBwOf.get(id) ?? 0) >= globalMaxBw * 0.5
-
+  // Apex candidates must carry trunk-class bandwidth (v3 sink guard:
+  // a shared last-resort firewall has a low device tier and 17 thin
+  // links — without the gate it out-ranks the border routers).
   let bestTier = Number.POSITIVE_INFINITY
   const tierOf = new Map<string, number>()
   for (const id of ids) {
@@ -559,6 +599,9 @@ function computeDepths(
   while (queue.length > 0) {
     const current = queue.shift()
     if (current === undefined) break
+    // never traverse THROUGH a sink — it touches everything and would
+    // shortcut every depth to root+2
+    if (sinkSet.has(current)) continue
     const currentDepth = depth.get(current) ?? 0
     const adj = neighbors.get(current)
     if (!adj) continue

--- a/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
@@ -102,6 +102,29 @@
       : (link?.style?.stroke ?? getVlanStroke(link?.vlan) ?? colors.linkStroke),
   )
   const isDouble = $derived(linkType === 'double')
+  // v3 semantic grammar: redundancy links (HA/VC/vPC/MLAG/stack heartbeats)
+  // are a COUPLING, not a wire — drawn as a double "glasses" bridge between
+  // the two member devices instead of a routed stroke.
+  const isCoupling = $derived(link?.redundancy !== undefined)
+  const couplingLines = $derived(() => {
+    const a = edge.fromPort?.absolutePosition ?? edge.points[0]
+    const b = edge.toPort?.absolutePosition ?? edge.points[edge.points.length - 1]
+    if (!a || !b) return []
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const len = Math.hypot(dx, dy)
+    if (len < 1) return []
+    const px = (-dy / len) * 3.5
+    const py = (dx / len) * 3.5
+    return [
+      `M ${a.x + px} ${a.y + py} L ${b.x + px} ${b.y + py}`,
+      `M ${a.x - px} ${a.y - py} L ${b.x - px} ${b.y - py}`,
+    ]
+  })
+  // primary dependency tree reads as the skeleton; everything else is context
+  const strokeOpacity = $derived(
+    edge.emphasis === 'secondary' ? 0.45 : edge.emphasis === 'primary' ? 1 : 1,
+  )
 
   const linkLabel = $derived(() => {
     if (!link?.label) return []
@@ -149,7 +172,30 @@
 </script>
 
 <g class="link-group" data-link-id={edge.id} bind:this={groupElement}>
-  {#if isDouble}
+  {#if isCoupling && couplingLines().length === 2}
+    {@const lines = couplingLines()}
+    <path
+      bind:this={basePathElement}
+      class="link link-coupling"
+      d={lines[0]}
+      fill="none"
+      stroke={strokeColor}
+      stroke-width={2}
+      stroke-opacity={0.9}
+      stroke-linecap="round"
+      pointer-events="none"
+    />
+    <path
+      class="link link-coupling"
+      d={lines[1]}
+      fill="none"
+      stroke={strokeColor}
+      stroke-width={2}
+      stroke-opacity={0.9}
+      stroke-linecap="round"
+      pointer-events="none"
+    />
+  {:else if isDouble}
     {@const gap = Math.max(3, Math.round(edge.width * 0.9))}
     <path
       bind:this={basePathElement}
@@ -185,6 +231,7 @@
       fill="none"
       stroke={strokeColor}
       stroke-width={edge.width}
+      stroke-opacity={strokeOpacity}
       stroke-linecap="round"
       stroke-dasharray={dasharray() || undefined}
       pointer-events="none"


### PR DESCRIPTION
Closes #435. Part of #429.

## Summary
- **Sink rail (composite)** — shared-service sinks (high degree, no trunk-class bandwidth) are detected, excluded from BFS traversal (they shortcut every depth to root+2) and from zone membership, and placed on their own rail below the zones — the v3 collector. On the reference network this pulls the 17-link last-resort firewall out of its zone box; its links now run as quiet verticals to the bottom instead of converging mid-diagram.
- **HA glasses (renderer)** — links with `link.redundancy` draw as a double "glasses" bridge between the pair members (a coupling, not a wire).
- **Primary emphasis (renderer)** — `edge.emphasis === 'secondary'` dims context links (0.45) so the primary dependency tree reads as the structural skeleton.

Verified live on the web viewer. Core suite 349 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
