### PR TITLE
feat(layout): 帯間整列修正 + org-chart櫛形バス — スタブなしで交差-31%

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -934,10 +934,16 @@ function placeZoneBands(
         xs.push(x)
         cursor = x + block.w + zoneGap
       }
-      const firstX = xs[0] ?? 0
-      const lastBlock = rowBlocks[rowBlocks.length - 1]
-      const lastX = xs[xs.length - 1] ?? 0
-      const shift = -(firstX + lastX + (lastBlock?.w ?? 0)) / 2
+      // Preserve the desired-x frame: shift the row only by the average
+      // deviation the overlap resolution introduced. Re-centering every
+      // row at x=0 (the old behavior) destroyed cross-band alignment —
+      // a child band could never sit under its feeder when band content
+      // was asymmetric (test6: pods drifted 300-900px off their hub).
+      let deviation = 0
+      for (const [i, block] of rowBlocks.entries()) {
+        deviation += block.desired - ((xs[i] ?? 0) + block.w / 2)
+      }
+      const shift = rowBlocks.length > 0 ? deviation / rowBlocks.length : 0
       let rowHeight = 0
       for (const [i, block] of rowBlocks.entries()) {
         const blockX = (xs[i] ?? 0) + shift

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -175,6 +175,16 @@ export interface OctilinearOptions {
    * are exempt from that obstacle.
    */
   obstacles?: readonly RoutingObstacle[]
+  /**
+   * Primary fan-out groups drawn as ONE org-chart trunk (v3 §47⑤):
+   * comb id (parent node id) → edge ids. The parent drops a single
+   * trunk to a shared horizontal bus; each child rises from the bus.
+   * Collapses N parallel long risers into drop→bus→riser, which is the
+   * pre-attentive "org chart" reading and removes the riser-vs-riser
+   * crossings entirely. Edges that don't fit the clean vertical case
+   * fall back to normal classification.
+   */
+  combs?: ReadonlyMap<string, readonly string[]>
 }
 
 interface OrthRoute {
@@ -223,9 +233,69 @@ export function applyOctilinearRoutes(
   const ramps: RampRoute[] = []
   const isSidePort = (side: string): boolean => side === 'left' || side === 'right'
   const sortedEdges = [...edges.values()].sort((a, b) => (a.id < b.id ? -1 : 1))
+
+  // -- org-chart combs (v3 §47⑤): primary fan-outs share one trunk + bus ----
+  interface CombMember {
+    edgeId: string
+    px: number
+    py: number
+    cx: number
+    cy: number
+    half: number
+  }
+  interface CombRoute {
+    id: string
+    members: CombMember[]
+    trunkX: number
+    busY: number
+    half: number
+  }
+  const combRoutes: CombRoute[] = []
+  const combEdgeIds = new Set<string>()
+  if (options.combs) {
+    for (const [combId, edgeIds] of [...options.combs].sort((a, b) => (a[0] < b[0] ? -1 : 1))) {
+      const members: CombMember[] = []
+      for (const edgeId of [...edgeIds].sort()) {
+        const edge = edges.get(edgeId)
+        if (!edge || edge.coupling) continue
+        const parentPort =
+          edge.fromNodeId === combId
+            ? edge.fromPort
+            : edge.toNodeId === combId
+              ? edge.toPort
+              : undefined
+        if (!parentPort) continue
+        const childPort = parentPort === edge.fromPort ? edge.toPort : edge.fromPort
+        // only the clean vertical case rides the comb; everything else
+        // falls back to normal classification below
+        if (parentPort.side !== 'bottom' || childPort.side !== 'top') continue
+        if (childPort.absolutePosition.y - parentPort.absolutePosition.y < 48) continue
+        members.push({
+          edgeId,
+          px: parentPort.absolutePosition.x,
+          py: parentPort.absolutePosition.y,
+          cx: childPort.absolutePosition.x,
+          cy: childPort.absolutePosition.y,
+          half: Math.max(0.5, edge.width / 2),
+        })
+      }
+      if (members.length < 2) continue
+      const trunkX = members.reduce((sum, m) => sum + m.px, 0) / members.length
+      combRoutes.push({
+        id: combId,
+        members,
+        trunkX,
+        busY: 0,
+        half: Math.max(...members.map((m) => m.half)),
+      })
+      for (const m of members) combEdgeIds.add(m.edgeId)
+    }
+  }
+
   for (const edge of sortedEdges) {
     // couplings are drawn as the glasses bridge, never routed as a wire
     if (edge.coupling) continue
+    if (combEdgeIds.has(edge.id)) continue
     const upper =
       edge.fromPort.absolutePosition.y <= edge.toPort.absolutePosition.y
         ? edge.fromPort
@@ -389,6 +459,23 @@ export function applyOctilinearRoutes(
       },
     })
   }
+  // comb buses go through the SAME global allocator — one request per comb
+  for (const comb of combRoutes) {
+    const minChildY = Math.min(...comb.members.map((m) => m.cy))
+    const maxParentY = Math.max(...comb.members.map((m) => m.py))
+    requests.push({
+      id: `comb:${comb.id}`,
+      half: comb.half,
+      lo: Math.min(comb.trunkX, ...comb.members.map((m) => m.cx)) - 16,
+      hi: Math.max(comb.trunkX, ...comb.members.map((m) => m.cx)) + 16,
+      want: minChildY - 26,
+      floor: maxParentY + 10,
+      ceil: minChildY - 10,
+      assign: (y) => {
+        comb.busY = y
+      },
+    })
+  }
   // ramp buses share the SAME allocator (separate allocators collide)
   for (const ramp of ramps) {
     const bottom = Math.max(ramp.y1, ramp.y2)
@@ -436,6 +523,14 @@ export function applyOctilinearRoutes(
 
   // -- vertical corridor separation (geometry-level, not a render nudge) --------
   const placedVerticals: { x: number; y1: number; y2: number; half: number }[] = []
+  // comb trunks and risers are fixed corridors — register them first
+  for (const comb of combRoutes) {
+    const minParentY = Math.min(...comb.members.map((m) => m.py))
+    placedVerticals.push({ x: comb.trunkX, y1: minParentY, y2: comb.busY, half: comb.half })
+    for (const m of comb.members) {
+      placedVerticals.push({ x: m.cx, y1: comb.busY, y2: m.cy, half: m.half })
+    }
+  }
   // gutter columns are fixed corridors — register them first so others dodge
   for (const route of [...straights, ...orths]) {
     if (route.gutterX === undefined) continue
@@ -537,6 +632,31 @@ export function applyOctilinearRoutes(
     edge.route = { kind: 'polyline', points: chamferCorners(corner, chamfer) }
     edge.points = corner
     routed++
+  }
+  for (const comb of combRoutes) {
+    const n = comb.members.length
+    for (const [i, m] of comb.members.entries()) {
+      const edge = edges.get(m.edgeId)
+      if (!edge) continue
+      // collapse the parent port onto the shared trunk
+      const parentPort = edge.fromNodeId === comb.id ? edge.fromPort : edge.toPort
+      parentPort.absolutePosition = { ...parentPort.absolutePosition, x: comb.trunkX }
+      const corner: Position[] = [
+        { x: comb.trunkX, y: m.py },
+        { x: comb.trunkX, y: comb.busY },
+        { x: m.cx, y: comb.busY },
+        { x: m.cx, y: m.cy },
+      ]
+      edge.route = {
+        kind: 'bus',
+        points: chamferCorners(corner, chamfer),
+        busId: comb.id,
+        branchIndex: i,
+        branchCount: n,
+      }
+      edge.points = corner
+      routed++
+    }
   }
   for (const ramp of ramps) {
     const edge = edges.get(ramp.id)

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -83,7 +83,25 @@ async function evaluate(
   for (const [id, sg] of comp.subgraphs) {
     if (sg.bounds) obstacles.push({ id, bounds: sg.bounds })
   }
-  applyOctilinearRoutes(edges, { obstacles })
+  // org-chart combs (v3 §47⑤): group primary edges by their parent (the
+  // shallower endpoint) — a parent feeding ≥2 children draws one trunk
+  // to a shared bus instead of N independent risers.
+  const combs = new Map<string, string[]>()
+  for (const edge of edges.values()) {
+    if (edge.coupling) continue
+    if (!comp.primaryEdges.has(pairKey(edge.fromNodeId, edge.toNodeId))) continue
+    const da = comp.depths.get(edge.fromNodeId)
+    const db = comp.depths.get(edge.toNodeId)
+    if (da === undefined || db === undefined || da === db) continue
+    const parent = da < db ? edge.fromNodeId : edge.toNodeId
+    const list = combs.get(parent) ?? []
+    list.push(edge.id)
+    combs.set(parent, list)
+  }
+  for (const [parent, list] of combs) {
+    if (list.length < 2) combs.delete(parent)
+  }
+  applyOctilinearRoutes(edges, { obstacles, combs })
   return { comp, ports, edges, score: scoreRoutedEdges(edges, comp.nodes, comp.depths) }
 }
 
@@ -309,7 +327,16 @@ export function scoreRoutedEdges(
     }
   }
   const lines: PolylineSpec[] = polys.map((p) => ({ id: p.id, points: p.pts, halfWidth: p.half }))
-  const collinear = findCollinearOverlaps(lines).length
+  // comb siblings SHARE the trunk/bus by design — same-bus overlap is the
+  // org-chart grammar, not a violation
+  const busOf = new Map<string, string>()
+  for (const edge of edges.values()) {
+    if (edge.route?.kind === 'bus') busOf.set(edge.id, edge.route.busId)
+  }
+  const collinear = findCollinearOverlaps(lines).filter((o) => {
+    const ba = busOf.get(o.a)
+    return ba === undefined || ba !== busOf.get(o.b)
+  }).length
   // wires running through unrelated node boxes
   let pierce = 0
   const boxes: { id: string; x: number; y: number; w: number; h: number }[] = []


### PR DESCRIPTION
## 背景

ユーザー指摘「配線を見る感じ配置が最適化されきってないようにも見える」。計測で裏付け: 探索ムーブ（gap/±x/転置/flip）はcostを~4%しか動かせず、交差226本の主因はムーブ語彙の射程外にあった。スタブ化（v3 §47⑥）は使わず、構造側の2点で解消する。

## 1. 帯間整列の破壊バグ修正（placeZoneBands）

各サブ行を配置後に **必ず x=0 中心へ再センタリング**していた（`shift = -(firstX+lastX+w)/2`）。`desired`（フィーダー直下）を計算しても行ごとに原点へ引き戻されるため、バンド構成が非対称だと子バンドはフィーダーの下に来られない — test6ではpod群が集約ハブから dx 300-900px ズレていた。

修正: シフト量を「重なり解消が導入した desired からの平均偏差」に変更。整列意図を保存しつつ、apexバンド（全desired=0）では従来の中心化と等価。

**効果: 交差 226→192, pierce 30→23、podがハブ直下に整列**

## 2. org-chart櫛形バス（v3 §47⑤ の未移植分）

主依存ファンアウト（fsax9004g→pod×7、s9610-36d→pod×6 等、全辺PRIM）が N本の独立 V-H-V ライザーとして別トラックに引かれていた。v3確定形はこれを **trunk drop→共有横bus→riser の櫛形**で描く。

- ルータに comb ステージ追加: 主依存親ごとに辺をグループ化、trunk x 共有、bus y はグローバルアロケータに1リクエストで参加（v3鉄則「アロケータは1つ」維持）
- `route.kind = 'bus'`（既存variant）で emit、レンダラ変更不要
- comb内のトラック共有は文法そのものなので、routedScore の collinear 判定から同一bus対を除外

**効果: 交差 192→156, bends 604→488, 総延長 -9%**

## test6 合計

| | 前 | 後 |
|---|---|---|
| crossings | 226 | **156 (-31%)** |
| bends | 604 | 488 |
| 描画辺 | 104 | 104（スタブ化なし・全辺実線） |
| bezierフォールバック | 0 | 0 |
| 探索時間 | ~320ms | ~290ms |

ライブページ確認済み（pod帯が櫛形で整列、長距離平行ライザー消滅）。

残課題（次の議論ネタ）: svc族のバンド割れ（D-1/D-2に分散、dx 400-612の連絡線）、上段ピアリング帯の交差、upward 18本（構造的ピア辺）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
