### PR TITLE
fix(layout): スコープ枠と図boundsを実配線の外接矩形まで拡張

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -85,6 +85,12 @@ export interface CompositeLayoutResult {
   depths: Map<string, number>
   /** Block keys per band, in placed order (band-order search handles). */
   bandBlocks: string[][]
+  /**
+   * Ids of enclosing scope subgraphs (outer frames). Routing happens
+   * after layout, and gutters/ramps may run outside the node extents —
+   * the router pass stretches these frames to keep the wiring inside.
+   */
+  scopes: string[]
 }
 
 /** Synthetic zone subgraphs get this id prefix. */
@@ -670,6 +676,7 @@ export function layoutComposite(
     heartbeats: collectHeartbeats(units, neighbors),
     depths: depth,
     bandBlocks,
+    scopes: enclosing.map((e) => e.sg.id),
   }
 }
 

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -102,6 +102,42 @@ async function evaluate(
     if (list.length < 2) combs.delete(parent)
   }
   applyOctilinearRoutes(edges, { obstacles, combs })
+  // Routes may run outside the node/zone extents (gutter bypasses, ramp
+  // under-loops, vertical shifts) — stretch the enclosing scope frames
+  // and the figure bounds so no wiring sticks out of the outer box.
+  let rx1 = Number.POSITIVE_INFINITY
+  let ry1 = Number.POSITIVE_INFINITY
+  let rx2 = Number.NEGATIVE_INFINITY
+  let ry2 = Number.NEGATIVE_INFINITY
+  for (const edge of edges.values()) {
+    if (edge.coupling) continue
+    const pts = edge.route?.points ?? edge.points
+    const half = edge.width / 2 + 2
+    for (const p of pts) {
+      rx1 = Math.min(rx1, p.x - half)
+      ry1 = Math.min(ry1, p.y - half)
+      rx2 = Math.max(rx2, p.x + half)
+      ry2 = Math.max(ry2, p.y + half)
+    }
+  }
+  if (Number.isFinite(rx1)) {
+    for (const id of comp.scopes) {
+      const frame = comp.subgraphs.get(id)
+      const b = frame?.bounds
+      if (!frame || !b) continue
+      const nx1 = Math.min(b.x, rx1 - 14)
+      const ny1 = Math.min(b.y, ry1 - 14)
+      const nx2 = Math.max(b.x + b.width, rx2 + 14)
+      const ny2 = Math.max(b.y + b.height, ry2 + 14)
+      frame.bounds = { x: nx1, y: ny1, width: nx2 - nx1, height: ny2 - ny1 }
+    }
+    const bb = comp.bounds
+    const bx1 = Math.min(bb.x, rx1 - 28)
+    const by1 = Math.min(bb.y, ry1 - 28)
+    const bx2 = Math.max(bb.x + bb.width, rx2 + 28)
+    const by2 = Math.max(bb.y + bb.height, ry2 + 28)
+    comp.bounds = { x: bx1, y: by1, width: bx2 - bx1, height: by2 - by1 }
+  }
   return { comp, ports, edges, score: scoreRoutedEdges(edges, comp.nodes, comp.depths) }
 }
 


### PR DESCRIPTION
## 背景

ユーザー指摘「配線が大枠からはみ出てる」。#447 の外周スコープ枠はノード箱・ゾーン箱の union で計算しているが、枠は**レイアウト時**に決まり配線は**その後**に走る。ガター迂回・ランプ下回り・縦シフトは正当にノード領域の外を通るため、test6 では 400G トランクの右側ガターが枠を突き抜けていた。

## 実装

- `CompositeLayoutResult.scopes`（外周フレームの id 一覧）を追加
- evaluate() で `applyOctilinearRoutes` 後に、全ルートポリライン（線半幅込み、coupling 除く）の外接矩形を計算し、各スコープ枠（+14px）と図全体 bounds（+28px）をそこまで拡張

## 確認

- test6 ライブページで白トランクのガターがフレーム内に収まることを確認
- スコア不変・349テストパス・typecheck クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
