### PR TITLE
refactor(layout): サブグラフは内部完結配線を所有する（#448の一般化）

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -31,6 +31,7 @@ import {
   type CompositeLayoutResult,
   layoutComposite,
   pairKey,
+  ZONE_SUBGRAPH_PREFIX,
 } from './index.js'
 import { alignPortsToPeers, applyOctilinearRoutes, type RoutingObstacle } from './router.js'
 
@@ -102,40 +103,67 @@ async function evaluate(
     if (list.length < 2) combs.delete(parent)
   }
   applyOctilinearRoutes(edges, { obstacles, combs })
-  // Routes may run outside the node/zone extents (gutter bypasses, ramp
-  // under-loops, vertical shifts) — stretch the enclosing scope frames
-  // and the figure bounds so no wiring sticks out of the outer box.
-  let rx1 = Number.POSITIVE_INFINITY
-  let ry1 = Number.POSITIVE_INFINITY
-  let rx2 = Number.NEGATIVE_INFINITY
-  let ry2 = Number.NEGATIVE_INFINITY
+  // A subgraph OWNS the wiring that completes inside it (both endpoints
+  // are members), and routes legally run outside the member boxes
+  // (gutter bypasses, ramp under-loops, vertical shifts). Container
+  // bounds therefore settle bottom-up AFTER routing: every subgraph
+  // stretches to its internal routes, and the figure bounds to all of
+  // them. Cross-boundary wiring belongs to the enclosing level, not to
+  // the zone it happens to pass.
+  const memberSets = new Map<string, Set<string>>()
+  for (const id of comp.subgraphs.keys()) {
+    if (id.startsWith(ZONE_SUBGRAPH_PREFIX)) {
+      const zoneMembers = comp.zones.get(id.slice(ZONE_SUBGRAPH_PREFIX.length))
+      if (zoneMembers) memberSets.set(id, new Set(zoneMembers))
+    } else {
+      const set = new Set<string>()
+      for (const [nodeId, node] of comp.nodes) if (node.parent === id) set.add(nodeId)
+      if (set.size > 0) memberSets.set(id, set)
+    }
+  }
+  interface Extent {
+    x1: number
+    y1: number
+    x2: number
+    y2: number
+  }
+  const grow = (extent: Extent | undefined, x: number, y: number, half: number): Extent => ({
+    x1: Math.min(extent?.x1 ?? Number.POSITIVE_INFINITY, x - half),
+    y1: Math.min(extent?.y1 ?? Number.POSITIVE_INFINITY, y - half),
+    x2: Math.max(extent?.x2 ?? Number.NEGATIVE_INFINITY, x + half),
+    y2: Math.max(extent?.y2 ?? Number.NEGATIVE_INFINITY, y + half),
+  })
+  let figure: Extent | undefined
+  const internal = new Map<string, Extent>()
   for (const edge of edges.values()) {
     if (edge.coupling) continue
     const pts = edge.route?.points ?? edge.points
     const half = edge.width / 2 + 2
+    const owners: string[] = []
+    for (const [id, members] of memberSets) {
+      if (members.has(edge.fromNodeId) && members.has(edge.toNodeId)) owners.push(id)
+    }
     for (const p of pts) {
-      rx1 = Math.min(rx1, p.x - half)
-      ry1 = Math.min(ry1, p.y - half)
-      rx2 = Math.max(rx2, p.x + half)
-      ry2 = Math.max(ry2, p.y + half)
+      figure = grow(figure, p.x, p.y, half)
+      for (const id of owners) internal.set(id, grow(internal.get(id), p.x, p.y, half))
     }
   }
-  if (Number.isFinite(rx1)) {
-    for (const id of comp.scopes) {
-      const frame = comp.subgraphs.get(id)
-      const b = frame?.bounds
-      if (!frame || !b) continue
-      const nx1 = Math.min(b.x, rx1 - 14)
-      const ny1 = Math.min(b.y, ry1 - 14)
-      const nx2 = Math.max(b.x + b.width, rx2 + 14)
-      const ny2 = Math.max(b.y + b.height, ry2 + 14)
-      frame.bounds = { x: nx1, y: ny1, width: nx2 - nx1, height: ny2 - ny1 }
-    }
+  for (const [id, extent] of internal) {
+    const sg = comp.subgraphs.get(id)
+    const b = sg?.bounds
+    if (!sg || !b) continue
+    const nx1 = Math.min(b.x, extent.x1 - 12)
+    const ny1 = Math.min(b.y, extent.y1 - 12)
+    const nx2 = Math.max(b.x + b.width, extent.x2 + 12)
+    const ny2 = Math.max(b.y + b.height, extent.y2 + 12)
+    sg.bounds = { x: nx1, y: ny1, width: nx2 - nx1, height: ny2 - ny1 }
+  }
+  if (figure) {
     const bb = comp.bounds
-    const bx1 = Math.min(bb.x, rx1 - 28)
-    const by1 = Math.min(bb.y, ry1 - 28)
-    const bx2 = Math.max(bb.x + bb.width, rx2 + 28)
-    const by2 = Math.max(bb.y + bb.height, ry2 + 28)
+    const bx1 = Math.min(bb.x, figure.x1 - 28)
+    const by1 = Math.min(bb.y, figure.y1 - 28)
+    const bx2 = Math.max(bb.x + bb.width, figure.x2 + 28)
+    const by2 = Math.max(bb.y + bb.height, figure.y2 + 28)
     comp.bounds = { x: bx1, y: by1, width: bx2 - bx1, height: by2 - by1 }
   }
   return { comp, ports, edges, score: scoreRoutedEdges(edges, comp.nodes, comp.depths) }


### PR DESCRIPTION
## 背景

ユーザー指摘: 「（サブグラフ内で完結する配線は）配線もサブグラフの持っている要素のはず」→ その通りで、#448 はスコープ枠だけを特別扱いした対症療法だった。

## 原則化

**サブグラフは、両端がメンバーである配線をメンバーノードと同様に所有する。** したがってコンテナの bounds は配線確定後にボトムアップで締まる — スコープ枠に限らず全サブグラフが対象。

- 各サブグラフ（ゾーン箱含む）: 内部完結ルートの外接矩形 +12px まで拡張
  - ゾーンのメンバーは `comp.zones`、元サブグラフ/スコープは `node.parent` から
- 図全体 bounds: 全ルート +28px
- **越境配線は通過先のゾーンではなく上位レベルの所有物** — ゾーン箱は膨らまない
- ゾーン内ペアのランプ下回りが箱の下にはみ出すケースも同じ規則で自動的にカバー（スコープ専用コードは削除）

## 確認

- test6: スコア・描画とも不変（フレームの内部配線=全配線なので #448 と同値になるのが正しい）
- 349テストパス、typecheck/lint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
