### PR TITLE
feat(layout,renderer): 密な面のポートラベルを配線沿いに回転

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -150,6 +150,13 @@ export function alignPortsToPeers(
       entry.port.absolutePosition = { ...entry.port.absolutePosition, x: cursor + w / 2 }
       cursor += w
     }
+    // Horizontal port labels are ~40-70px wide; when the face pitch is
+    // tighter than that, they physically cannot clear each other — tell
+    // the renderer to run the labels along the wires instead.
+    const pitch = (total * scale) / group.length
+    if (pitch < 44) {
+      for (const entry of group) entry.port.labelOrientation = 'vertical'
+    }
   }
   return flipped
 }

--- a/libs/@shumoku/core/src/layout/resolved-types.ts
+++ b/libs/@shumoku/core/src/layout/resolved-types.ts
@@ -41,6 +41,13 @@ export interface ResolvedPort {
   side: 'top' | 'bottom' | 'left' | 'right'
   /** Port visual size */
   size: Size
+  /**
+   * Label drawing hint set by the layout (which knows the slot pitch):
+   * `vertical` = rotate the label to run along the wire because the
+   * face is too dense for horizontal labels to clear each other.
+   * Absent = horizontal (today's default).
+   */
+  labelOrientation?: 'horizontal' | 'vertical'
 }
 
 // ============================================================================

--- a/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
@@ -55,6 +55,9 @@
   const labelPos = $derived(computePortLabelPosition(port))
 
   const hasLabel = $derived(port.label.trim().length > 0)
+  const verticalLabel = $derived(
+    port.labelOrientation === 'vertical' && (port.side === 'top' || port.side === 'bottom'),
+  )
   const labelWidth = $derived(engine.text.measure(port.label, 'port') + 4)
   const labelHeight = 12
   const bgX = $derived(() => {
@@ -177,31 +180,58 @@
   {@render overlay?.(port, overlayContext)}
 
   {#if !hideLabel && hasLabel}
-    <rect
-      class="port-label-bg"
-      x={bgX()}
-      y={bgY}
-      width={labelWidth}
-      height={labelHeight}
-      rx="2"
-      fill={colors.portLabelBg}
-      pointer-events="none"
-    />
-    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-    <text
-      class="port-label-text"
-      x={labelPos.x}
-      y={labelPos.y}
-      text-anchor={labelPos.textAnchor}
-      font-size="9"
-      fill={colors.portLabelColor}
-      onclick={(e: MouseEvent) => {
-        if (!interactive) return
-        e.stopPropagation()
-        onlabeledit?.(port.id, port.label, e.clientX, e.clientY)
-      }}
-    >
-      {port.label}
-    </text>
+    {#if verticalLabel}
+      <!-- Dense face (layout hint): run the label along the wire so
+           neighbors can't overlap — drawn like a right-side label,
+           rotated 90° around the port (up for top, down for bottom). -->
+      <g transform={`rotate(${port.side === 'top' ? -90 : 90} ${px} ${py})`} pointer-events="none">
+        <rect
+          class="port-label-bg"
+          x={px + 10}
+          y={py - labelHeight + 3}
+          width={labelWidth}
+          height={labelHeight}
+          rx="2"
+          fill={colors.portLabelBg}
+        />
+        <text
+          class="port-label-text"
+          x={px + 12}
+          y={py}
+          text-anchor="start"
+          font-size="9"
+          fill={colors.portLabelColor}
+        >
+          {port.label}
+        </text>
+      </g>
+    {:else}
+      <rect
+        class="port-label-bg"
+        x={bgX()}
+        y={bgY}
+        width={labelWidth}
+        height={labelHeight}
+        rx="2"
+        fill={colors.portLabelBg}
+        pointer-events="none"
+      />
+      <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+      <text
+        class="port-label-text"
+        x={labelPos.x}
+        y={labelPos.y}
+        text-anchor={labelPos.textAnchor}
+        font-size="9"
+        fill={colors.portLabelColor}
+        onclick={(e: MouseEvent) => {
+          if (!interactive) return
+          e.stopPropagation()
+          onlabeledit?.(port.id, port.label, e.clientX, e.clientY)
+        }}
+      >
+        {port.label}
+      </text>
+    {/if}
   {/if}
 </g>


### PR DESCRIPTION
## 背景

ユーザー指摘「ポートラベル同士が被さってるの結構ある。対策できてない？」→ できていなかった。#451 のスロットは**配線の落ち口の間隔**（16pxピッチ）を確保しただけで、40〜70px幅の水平ラベルはそのピッチでは物理的に重なる。ピッチをラベル幅まで広げる案は検証済みで図が爆発する（#451のPR本文参照）ため、**間隔ではなく向き**で解く。

## 実装（ラック図・ネットワーク図の慣習: 密なポート番号は配線沿いに書く）

- `ResolvedPort.labelOrientation`（'horizontal' | 'vertical'）を追加 — **判断はピッチを知っているレイアウト側**（ルータの幅対応スロットパス）が行う: ピッチ < 44px の面のポートに vertical を立てる。レンダラ側に密度ヒューリスティックは置かない
- SvgPort は vertical のとき右側面スタイルのラベルをポート中心に90°回転して描画（top面は上向き、bottom面は下向き、背景ピル付き）。疎な面は従来どおり水平
- ラベルのクリック編集は水平パスのみ（vertical は discovered の密グラフ用で手編集対象外）

## 確認

- test6 ズーム確認: 隣接する櫛ライザーのラベル（ehg-0/0/0:0 / ehg-0/0/0:1）が並んで重ならない。疎な面（hg-1/51 等）は水平のまま
- 349テストパス、typecheck/lint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)
