### PR TITLE
feat(layout): ポート/ラベルを第一級幾何に — 所有モデルで重なり254→9

### DIFF
--- a/libs/@shumoku/core/src/layout/auto-placement/flat-tree/port-placement.ts
+++ b/libs/@shumoku/core/src/layout/auto-placement/flat-tree/port-placement.ts
@@ -32,6 +32,7 @@
 
 import type { Direction, Link, Node, Position } from '../../../models/types.js'
 import { resolveNodeSize } from '../../engine/index.js'
+import { shortIfName } from '../../port-geometry.js'
 import type { ResolvedPort } from '../../resolved-types.js'
 
 /** Default port visual size */
@@ -52,7 +53,9 @@ export interface PortAssignment {
 
 function getNodePortLabel(node: Node | undefined, portId: string): string {
   const port = node?.ports?.find((p) => p.id === portId)
-  return port?.label ?? portId
+  // Vendor-canonical short form (HundredGigE → Hu …) — lossless to a
+  // network engineer, a third of the drawn width.
+  return shortIfName(port?.label ?? portId)
 }
 
 function getPortPlacement(

--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -20,6 +20,7 @@
 import type { Bounds, Direction, NetworkGraph, Node, Subgraph } from '../../models/types.js'
 import { resolveNodeSize } from '../engine/index.js'
 import { getLinkWidthForMode, linkSpeedBps } from '../link-utils.js'
+import { PORT_LABEL_BOX_OFFSET, portLabelLength } from '../port-geometry.js'
 import { resolveTierFromSpec } from '../role-tiers.js'
 
 export interface CompositeLayoutOptions {
@@ -61,6 +62,15 @@ export interface CompositeLayoutOptions {
   nudges?: ReadonlyMap<string, number>
   /** Bands wider than this wrap into sub-rows (v3 §24). */
   maxBandW?: number
+  /**
+   * Per-node width floors fed back from the previous routing round
+   * (alignPortsToPeers reports faces that had to compress their port
+   * slots). Growing the node is the correct resolution for an
+   * over-subscribed face; this closes that feedback loop.
+   */
+  minNodeWidths?: ReadonlyMap<string, number>
+  /** Same feedback for side faces (left/right port slots). */
+  minNodeHeights?: ReadonlyMap<string, number>
 }
 
 export interface CompositeLayoutResult {
@@ -169,8 +179,6 @@ export function layoutComposite(
   const wireClear = Math.round(maxLinkWidth)
   const zoneGap = Math.max(options.zoneGap ?? 90, wireClear + 16)
   const bandGap = Math.max(options.bandGap ?? 150, wireClear + 24)
-  const rowGap = Math.max(options.rowGap ?? 56, wireClear + 16)
-  const cellGapX = Math.max(options.cellGapX ?? 32, wireClear + 12)
   const zonePad = options.zonePad ?? 26
 
   // -- nodes (copies; we set position) + deterministic jitter source --------
@@ -286,11 +294,66 @@ export function layoutComposite(
       const node = nodes.get(id)
       if (!node || node.size) continue
       const body = resolveNodeSize(node)
-      const width = Math.max(body.width, faces.top + 16, faces.bottom + 16)
-      const height = Math.max(body.height, faces.left + 12, faces.right + 12)
+      const width = Math.max(
+        body.width,
+        faces.top + 16,
+        faces.bottom + 16,
+        options.minNodeWidths?.get(id) ?? 0,
+      )
+      const height = Math.max(
+        body.height,
+        faces.left + 12,
+        faces.right + 12,
+        options.minNodeHeights?.get(id) ?? 0,
+      )
       if (width > body.width || height > body.height) node.size = { width, height }
     }
   }
+
+  // -- label-aware corridors ----------------------------------------------------
+  // Ports own labels, and labels are geometry: the corridor between two
+  // facing rows must hold BOTH rows' label lanes (vertical labels run
+  // along the wire), and the gap between side-by-side units must hold a
+  // side label. Derived from the actual longest names per direction —
+  // pathological data (machine-id port names) makes the figure larger,
+  // never overlapping; clean data tightens it automatically.
+  // Resolve the DISPLAY label exactly like port placement does (port id
+  // → NodePort.label); link endpoints carry port IDs, which can be long
+  // machine identifiers that are never rendered.
+  const displayPortLabel = (nodeId: string, portRef: unknown): string | undefined => {
+    if (typeof portRef !== 'string' || portRef.length === 0) return undefined
+    const owner = nodes.get(nodeId)
+    const port = owner?.ports?.find((p) => p.id === portRef)
+    return port?.label ?? portRef
+  }
+  const verticalReachOf = new Map<string, number>()
+  const lateralReachOf = new Map<string, number>()
+  let crossZoneReach = 0
+  for (const link of graph.links) {
+    const sameDepth = (depth.get(link.from.node) ?? 0) === (depth.get(link.to.node) ?? 0)
+    const crossZone = zoneOf(link.from.node) !== zoneOf(link.to.node)
+    for (const [nodeId, portRef] of [
+      [link.from.node, link.from.port],
+      [link.to.node, link.to.port],
+    ] as const) {
+      const label = displayPortLabel(nodeId, portRef)
+      if (label === undefined) continue
+      const reach = PORT_LABEL_BOX_OFFSET + portLabelLength(label)
+      if (sameDepth) {
+        lateralReachOf.set(nodeId, Math.max(lateralReachOf.get(nodeId) ?? 0, reach))
+      } else {
+        verticalReachOf.set(nodeId, Math.max(verticalReachOf.get(nodeId) ?? 0, reach))
+      }
+      if (crossZone) crossZoneReach = Math.max(crossZoneReach, reach)
+    }
+  }
+  // Bases; the zone-local layout raises them per zone from that zone's
+  // own longest labels, so one verbose vendor naming scheme doesn't
+  // inflate every zone in the figure.
+  const rowGapBase = Math.max(options.rowGap ?? 56, wireClear + 16)
+  const cellGapXBase = Math.max(options.cellGapX ?? 32, wireClear + 12)
+  // Inter-band corridors carry cross-zone wiring labels from both sides.
+  const bandGapEff = Math.max(bandGap, crossZoneReach * 2 + 8)
 
   // -- redundant pairs ---------------------------------------------------------
   const pairedWith = detectPairs(ids, nodes, edges, neighbors, zoneOf, depth)
@@ -359,6 +422,17 @@ export function layoutComposite(
   const localY = new Map<string, number>()
   const zoneBox = new Map<string, { w: number; h: number }>()
   const zoneRows = new Map<string, Unit[][]>()
+  // Label-aware corridors are PER ADJACENT PAIR, not per zone: the gap
+  // between two specific units (or rows) holds exactly the labels that
+  // actually face each other. A single verbose name pays only where it
+  // sits instead of inflating the whole zone.
+  const unitLReach = (unit: Unit): number =>
+    Math.max(0, ...unit.members.map((m) => lateralReachOf.get(m) ?? 0))
+  const unitVReach = (unit: Unit): number =>
+    Math.max(0, ...unit.members.map((m) => verticalReachOf.get(m) ?? 0))
+  const pairGap = (a: Unit, b: Unit): number =>
+    Math.max(cellGapXBase, unitLReach(a) + unitLReach(b) + 8)
+  const rowVReach = (row: Unit[]): number => Math.max(0, ...row.map(unitVReach))
   for (const zone of zoneIds) {
     const members = zoneUnits.get(zone) ?? []
     const minDepth = Math.min(...members.map((u) => u.depth))
@@ -370,29 +444,36 @@ export function layoutComposite(
       else rowMap.set(row, [unit])
     }
     const rowKeys = [...rowMap.keys()].sort((a, b) => a - b)
-    const rows: Unit[][] = []
+    const rows: Unit[][] = rowKeys.map((key) => rowMap.get(key) ?? [])
     let maxRowWidth = 0
     let y = zonePad
     const placeRow = (row: Unit[], rowY: number, rowHeight: number): void => {
       let x = zonePad
-      for (const unit of row) {
+      for (const [i, unit] of row.entries()) {
         localX.set(unit.id, x + unit.width / 2 + jitter(unit.members[0] ?? unit.id, 3) * 8)
         localY.set(unit.id, rowY + rowHeight / 2 + jitter(unit.members[0] ?? unit.id, 7) * 6)
-        x += unit.width + cellGapX
+        x += unit.width
+        const next = row[i + 1]
+        if (next) x += pairGap(unit, next)
       }
     }
     const rowYs: number[] = []
     const rowHeights: number[] = []
-    for (const key of rowKeys) {
-      const row = rowMap.get(key) ?? []
-      rows.push(row)
-      const rowWidth = row.reduce((sum, u) => sum + u.width, 0) + cellGapX * (row.length - 1)
+    for (const [rowIndex, row] of rows.entries()) {
+      let rowWidth = 0
+      for (const [i, unit] of row.entries()) {
+        rowWidth += unit.width
+        const next = row[i + 1]
+        if (next) rowWidth += pairGap(unit, next)
+      }
       maxRowWidth = Math.max(maxRowWidth, rowWidth)
       const rowHeight = Math.max(...row.map((u) => u.height))
       rowYs.push(y)
       rowHeights.push(rowHeight)
       placeRow(row, y, rowHeight)
-      y += rowHeight + rowGap
+      const nextRow = rows[rowIndex + 1]
+      y += rowHeight
+      if (nextRow) y += Math.max(rowGapBase, rowVReach(row) + rowVReach(nextRow) + 8)
     }
     // intra-zone barycenter ordering (v3 §24): two sweeps pulling each
     // unit next to its in-zone neighbors before global refinement
@@ -417,7 +498,7 @@ export function layoutComposite(
       }
     }
     zoneRows.set(zone, rows)
-    zoneBox.set(zone, { w: maxRowWidth + zonePad * 2, h: y - rowGap + zonePad })
+    zoneBox.set(zone, { w: maxRowWidth + zonePad * 2, h: y + zonePad })
   }
 
   // -- quotient: bands by zone rank, child-block packing under feeders ---------
@@ -469,14 +550,14 @@ export function layoutComposite(
     zoneX,
     zoneY,
     zoneGap,
-    bandGap,
+    bandGapEff,
     options.maxBandW ?? 1700,
     options.bandExtra,
     options.bandOrder,
   )
 
   // -- port refine: pull units toward their cross-zone neighbors ---------------
-  const minSep = 24
+
   for (let pass = 0; pass < 2; pass++) {
     for (const zone of zoneIds) {
       const rows = zoneRows.get(zone) ?? []
@@ -505,7 +586,7 @@ export function layoutComposite(
           const current = localX.get(unit.id) ?? lo
           localX.set(unit.id, Math.max(lo, Math.min(hi, current + (target - current) * 0.6)))
         }
-        resolveRow(row, localX, box.w, minSep)
+        resolveRow(row, localX, box.w, pairGap)
       }
     }
   }
@@ -524,7 +605,7 @@ export function layoutComposite(
     for (const zone of zoneIds) {
       const box = zoneBox.get(zone)
       if (!box) continue
-      for (const row of zoneRows.get(zone) ?? []) resolveRow(row, localX, box.w, minSep)
+      for (const row of zoneRows.get(zone) ?? []) resolveRow(row, localX, box.w, pairGap)
     }
   }
 
@@ -548,7 +629,7 @@ export function layoutComposite(
   for (const zone of zoneIds) {
     const box = zoneBox.get(zone)
     if (!box) continue
-    for (const row of zoneRows.get(zone) ?? []) resolveRow(row, localX, box.w, minSep)
+    for (const row of zoneRows.get(zone) ?? []) resolveRow(row, localX, box.w, pairGap)
   }
 
   // -- compose to absolute centers ----------------------------------------------
@@ -1224,13 +1305,15 @@ function barycenter(
   return weight > 0 ? sum / weight : 0
 }
 
-/** Sort a row by x and enforce minimum separation inside the zone box. */
+/** Sort a row by x and enforce minimum separation inside the zone box.
+ *  `minSep` may be a per-pair function (label-aware corridors). */
 function resolveRow(
   row: Unit[],
   localX: Map<string, number>,
   boxWidth: number,
-  minSep: number,
+  minSep: number | ((a: Unit, b: Unit) => number),
 ): void {
+  const sepOf = typeof minSep === 'number' ? () => minSep : minSep
   const sorted = [...row].sort(
     (a, b) => (localX.get(a.id) ?? 0) - (localX.get(b.id) ?? 0) || (a.id < b.id ? -1 : 1),
   )
@@ -1238,7 +1321,7 @@ function resolveRow(
     const prev = sorted[i - 1]
     const curr = sorted[i]
     if (!prev || !curr) continue
-    const minX = (localX.get(prev.id) ?? 0) + prev.width / 2 + minSep + curr.width / 2
+    const minX = (localX.get(prev.id) ?? 0) + prev.width / 2 + sepOf(prev, curr) + curr.width / 2
     if ((localX.get(curr.id) ?? 0) < minX) localX.set(curr.id, minX)
   }
   const last = sorted[sorted.length - 1]

--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -328,10 +328,8 @@ export function layoutComposite(
   }
   const verticalReachOf = new Map<string, number>()
   const lateralReachOf = new Map<string, number>()
-  let crossZoneReach = 0
   for (const link of graph.links) {
     const sameDepth = (depth.get(link.from.node) ?? 0) === (depth.get(link.to.node) ?? 0)
-    const crossZone = zoneOf(link.from.node) !== zoneOf(link.to.node)
     for (const [nodeId, portRef] of [
       [link.from.node, link.from.port],
       [link.to.node, link.to.port],
@@ -344,7 +342,6 @@ export function layoutComposite(
       } else {
         verticalReachOf.set(nodeId, Math.max(verticalReachOf.get(nodeId) ?? 0, reach))
       }
-      if (crossZone) crossZoneReach = Math.max(crossZoneReach, reach)
     }
   }
   // Bases; the zone-local layout raises them per zone from that zone's
@@ -352,8 +349,6 @@ export function layoutComposite(
   // inflate every zone in the figure.
   const rowGapBase = Math.max(options.rowGap ?? 56, wireClear + 16)
   const cellGapXBase = Math.max(options.cellGapX ?? 32, wireClear + 12)
-  // Inter-band corridors carry cross-zone wiring labels from both sides.
-  const bandGapEff = Math.max(bandGap, crossZoneReach * 2 + 8)
 
   // -- redundant pairs ---------------------------------------------------------
   const pairedWith = detectPairs(ids, nodes, edges, neighbors, zoneOf, depth)
@@ -539,6 +534,48 @@ export function layoutComposite(
     zoneParent.set(zone, best)
   }
 
+  // Label corridors at band boundaries are PER BOUNDARY: only the links
+  // that actually cross boundary i pay for it (the global-max version
+  // inflated every band gap to the single worst label in the graph —
+  // the "giant whitespace" defect). Down-labels from the upper band and
+  // up-labels from the lower band share the corridor, so reserve their
+  // sum where it exceeds the base gap. Goes through the same bandExtra
+  // channel as routing congestion feedback.
+  const rankValues = [...new Set([...zoneRank.values()])].sort((a, b) => a - b)
+  const bandIndexOfRank = new Map(rankValues.map((rank, i) => [rank, i]))
+  const bandOfZone = (zone: string): number => bandIndexOfRank.get(zoneRank.get(zone) ?? 0) ?? 0
+  const downNeed = new Map<number, number>() // boundary above band i
+  const upNeed = new Map<number, number>()
+  for (const link of graph.links) {
+    const za = zoneOf(link.from.node)
+    const zb = zoneOf(link.to.node)
+    if (za === zb || sinkSet.has(link.from.node) || sinkSet.has(link.to.node)) continue
+    const ba = bandOfZone(za)
+    const bb = bandOfZone(zb)
+    if (ba === bb) continue
+    const upperNode = ba < bb ? link.from.node : link.to.node
+    const lowerNode = ba < bb ? link.to.node : link.from.node
+    const upperBand = Math.min(ba, bb)
+    const lowerBand = Math.max(ba, bb)
+    const upperReach = verticalReachOf.get(upperNode) ?? 0
+    const lowerReach = verticalReachOf.get(lowerNode) ?? 0
+    downNeed.set(upperBand + 1, Math.max(downNeed.get(upperBand + 1) ?? 0, upperReach))
+    upNeed.set(lowerBand, Math.max(upNeed.get(lowerBand) ?? 0, lowerReach))
+  }
+  const labelBandExtra = new Map<number, number>(options.bandExtra ?? [])
+  for (const i of new Set([...downNeed.keys(), ...upNeed.keys()])) {
+    const need = (downNeed.get(i) ?? 0) + (upNeed.get(i) ?? 0) + 8 - bandGap
+    if (need > 0) labelBandExtra.set(i, (labelBandExtra.get(i) ?? 0) + Math.ceil(need))
+  }
+  // per-zone vertical label reach, so compaction can't squeeze the
+  // corridor the band extras just reserved
+  const zoneVReachMap = new Map<string, number>()
+  for (const zone of zoneIds) {
+    let reach = 0
+    for (const unit of zoneUnits.get(zone) ?? []) reach = Math.max(reach, unitVReach(unit))
+    zoneVReachMap.set(zone, reach)
+  }
+
   const zoneX = new Map<string, number>()
   const zoneY = new Map<string, number>()
   const { bandRanges, bandBlocks } = placeZoneBands(
@@ -550,10 +587,11 @@ export function layoutComposite(
     zoneX,
     zoneY,
     zoneGap,
-    bandGapEff,
+    bandGap,
     options.maxBandW ?? 1700,
-    options.bandExtra,
+    labelBandExtra,
     options.bandOrder,
+    zoneVReachMap,
   )
 
   // -- port refine: pull units toward their cross-zone neighbors ---------------
@@ -1011,6 +1049,7 @@ function placeZoneBands(
   maxBandW: number,
   bandExtra?: ReadonlyMap<number, number>,
   bandOrder?: ReadonlyMap<number, readonly string[]>,
+  zoneVReach?: ReadonlyMap<string, number>,
 ): { bandRanges: { top: number; bottom: number }[]; bandBlocks: string[][] } {
   const ranks = [...new Set(zoneIds.map((z) => zoneRank.get(z) ?? 0))].sort((a, b) => a - b)
   const centerOf = new Map<string, number>()
@@ -1250,12 +1289,18 @@ function placeZoneBands(
   // shape — until it would collide with an x-overlapping block above it.
   // Blocks with nothing overlapping above keep their band y, so the rank
   // discipline survives where it matters.
-  const vGap = bandGap
+  const reachOfZones = (zones: readonly string[]): number =>
+    Math.max(0, ...zones.map((z) => zoneVReach?.get(z) ?? 0))
   placedBlocks.sort((a, b) => a.y - b.y || a.x - b.x)
   const settled: typeof placedBlocks = []
   for (const block of placedBlocks) {
+    // the corridor between two stacked blocks must hold both blocks'
+    // vertical label lanes — compaction must not squeeze what the band
+    // extras reserved
+    const moverReach = reachOfZones(block.zones)
     let target: number | undefined
     for (const other of settled) {
+      const vGap = Math.max(bandGap, reachOfZones(other.zones) + moverReach + 8)
       for (const obstacle of other.rects) {
         const obstacleBottom = other.y + obstacle.relY + obstacle.h
         for (const mover of block.rects) {

--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -20,7 +20,7 @@
 import type { Bounds, Direction, NetworkGraph, Node, Subgraph } from '../../models/types.js'
 import { resolveNodeSize } from '../engine/index.js'
 import { getLinkWidthForMode, linkSpeedBps } from '../link-utils.js'
-import { PORT_LABEL_BOX_OFFSET, portLabelLength } from '../port-geometry.js'
+import { PORT_LABEL_BOX_OFFSET, portLabelLength, shortIfName } from '../port-geometry.js'
 import { resolveTierFromSpec } from '../role-tiers.js'
 
 export interface CompositeLayoutOptions {
@@ -324,23 +324,31 @@ export function layoutComposite(
     if (typeof portRef !== 'string' || portRef.length === 0) return undefined
     const owner = nodes.get(nodeId)
     const port = owner?.ports?.find((p) => p.id === portRef)
-    return port?.label ?? portRef
+    return shortIfName(port?.label ?? portRef)
   }
-  const verticalReachOf = new Map<string, number>()
+  // DIRECTIONAL reach: a label occupies space only on the face it sits
+  // on. A leaf whose links all go UP has top labels only — reserving
+  // room below it would put whitespace where no label can ever exist
+  // (that exact defect shipped once: every row paid for both directions).
+  const reachUpOf = new Map<string, number>() // top-face labels (links to shallower peers)
+  const reachDownOf = new Map<string, number>() // bottom-face labels (links to deeper peers)
   const lateralReachOf = new Map<string, number>()
   for (const link of graph.links) {
-    const sameDepth = (depth.get(link.from.node) ?? 0) === (depth.get(link.to.node) ?? 0)
-    for (const [nodeId, portRef] of [
-      [link.from.node, link.from.port],
-      [link.to.node, link.to.port],
+    const dFrom = depth.get(link.from.node) ?? 0
+    const dTo = depth.get(link.to.node) ?? 0
+    for (const [nodeId, portRef, dSelf, dPeer] of [
+      [link.from.node, link.from.port, dFrom, dTo],
+      [link.to.node, link.to.port, dTo, dFrom],
     ] as const) {
       const label = displayPortLabel(nodeId, portRef)
       if (label === undefined) continue
       const reach = PORT_LABEL_BOX_OFFSET + portLabelLength(label)
-      if (sameDepth) {
+      if (dSelf === dPeer) {
         lateralReachOf.set(nodeId, Math.max(lateralReachOf.get(nodeId) ?? 0, reach))
+      } else if (dPeer < dSelf) {
+        reachUpOf.set(nodeId, Math.max(reachUpOf.get(nodeId) ?? 0, reach))
       } else {
-        verticalReachOf.set(nodeId, Math.max(verticalReachOf.get(nodeId) ?? 0, reach))
+        reachDownOf.set(nodeId, Math.max(reachDownOf.get(nodeId) ?? 0, reach))
       }
     }
   }
@@ -423,11 +431,14 @@ export function layoutComposite(
   // sits instead of inflating the whole zone.
   const unitLReach = (unit: Unit): number =>
     Math.max(0, ...unit.members.map((m) => lateralReachOf.get(m) ?? 0))
-  const unitVReach = (unit: Unit): number =>
-    Math.max(0, ...unit.members.map((m) => verticalReachOf.get(m) ?? 0))
+  const unitUpReach = (unit: Unit): number =>
+    Math.max(0, ...unit.members.map((m) => reachUpOf.get(m) ?? 0))
+  const unitDownReach = (unit: Unit): number =>
+    Math.max(0, ...unit.members.map((m) => reachDownOf.get(m) ?? 0))
   const pairGap = (a: Unit, b: Unit): number =>
     Math.max(cellGapXBase, unitLReach(a) + unitLReach(b) + 8)
-  const rowVReach = (row: Unit[]): number => Math.max(0, ...row.map(unitVReach))
+  const rowDownReach = (row: Unit[]): number => Math.max(0, ...row.map(unitDownReach))
+  const rowUpReach = (row: Unit[]): number => Math.max(0, ...row.map(unitUpReach))
   for (const zone of zoneIds) {
     const members = zoneUnits.get(zone) ?? []
     const minDepth = Math.min(...members.map((u) => u.depth))
@@ -468,7 +479,9 @@ export function layoutComposite(
       placeRow(row, y, rowHeight)
       const nextRow = rows[rowIndex + 1]
       y += rowHeight
-      if (nextRow) y += Math.max(rowGapBase, rowVReach(row) + rowVReach(nextRow) + 8)
+      // only the labels that actually FACE this gap pay for it: the
+      // upper row's bottom labels + the lower row's top labels
+      if (nextRow) y += Math.max(rowGapBase, rowDownReach(row) + rowUpReach(nextRow) + 8)
     }
     // intra-zone barycenter ordering (v3 §24): two sweeps pulling each
     // unit next to its in-zone neighbors before global refinement
@@ -557,8 +570,8 @@ export function layoutComposite(
     const lowerNode = ba < bb ? link.to.node : link.from.node
     const upperBand = Math.min(ba, bb)
     const lowerBand = Math.max(ba, bb)
-    const upperReach = verticalReachOf.get(upperNode) ?? 0
-    const lowerReach = verticalReachOf.get(lowerNode) ?? 0
+    const upperReach = reachDownOf.get(upperNode) ?? 0
+    const lowerReach = reachUpOf.get(lowerNode) ?? 0
     downNeed.set(upperBand + 1, Math.max(downNeed.get(upperBand + 1) ?? 0, upperReach))
     upNeed.set(lowerBand, Math.max(upNeed.get(lowerBand) ?? 0, lowerReach))
   }
@@ -567,14 +580,30 @@ export function layoutComposite(
     const need = (downNeed.get(i) ?? 0) + (upNeed.get(i) ?? 0) + 8 - bandGap
     if (need > 0) labelBandExtra.set(i, (labelBandExtra.get(i) ?? 0) + Math.ceil(need))
   }
-  // per-zone vertical label reach, so compaction can't squeeze the
-  // corridor the band extras just reserved
-  const zoneVReachMap = new Map<string, number>()
+  // per-zone DIRECTIONAL label reach, so compaction can't squeeze the
+  // corridor the band extras just reserved (down-labels of the upper
+  // block + up-labels of the lower block)
+  const zoneDownReach = new Map<string, number>()
+  const zoneUpReach = new Map<string, number>()
   for (const zone of zoneIds) {
-    let reach = 0
-    for (const unit of zoneUnits.get(zone) ?? []) reach = Math.max(reach, unitVReach(unit))
-    zoneVReachMap.set(zone, reach)
+    let down = 0
+    let up = 0
+    for (const unit of zoneUnits.get(zone) ?? []) {
+      down = Math.max(down, unitDownReach(unit))
+      up = Math.max(up, unitUpReach(unit))
+    }
+    zoneDownReach.set(zone, down)
+    zoneUpReach.set(zone, up)
   }
+
+  // Band width budget scales with CONTENT: zones widened (port slots,
+  // label corridors) while a fixed 1700px budget stayed — bands wrapped
+  // into ever more stacked sub-rows and the figure exploded vertically
+  // (5000px tall, 1:2.7 aspect). Target a landscape-ish aspect instead:
+  // budget = sqrt(total packed zone area × aspect), floored at 1700.
+  let zoneArea = 0
+  for (const [, box] of zoneBox) zoneArea += (box.w + zoneGap) * (box.h + bandGap)
+  const maxBandW = options.maxBandW ?? Math.max(1700, Math.round(Math.sqrt(zoneArea * 1.5)))
 
   const zoneX = new Map<string, number>()
   const zoneY = new Map<string, number>()
@@ -588,10 +617,11 @@ export function layoutComposite(
     zoneY,
     zoneGap,
     bandGap,
-    options.maxBandW ?? 1700,
+    maxBandW,
     labelBandExtra,
     options.bandOrder,
-    zoneVReachMap,
+    zoneDownReach,
+    zoneUpReach,
   )
 
   // -- port refine: pull units toward their cross-zone neighbors ---------------
@@ -1049,7 +1079,8 @@ function placeZoneBands(
   maxBandW: number,
   bandExtra?: ReadonlyMap<number, number>,
   bandOrder?: ReadonlyMap<number, readonly string[]>,
-  zoneVReach?: ReadonlyMap<string, number>,
+  zoneDownReach?: ReadonlyMap<string, number>,
+  zoneUpReach?: ReadonlyMap<string, number>,
 ): { bandRanges: { top: number; bottom: number }[]; bandBlocks: string[][] } {
   const ranks = [...new Set(zoneIds.map((z) => zoneRank.get(z) ?? 0))].sort((a, b) => a - b)
   const centerOf = new Map<string, number>()
@@ -1289,18 +1320,20 @@ function placeZoneBands(
   // shape — until it would collide with an x-overlapping block above it.
   // Blocks with nothing overlapping above keep their band y, so the rank
   // discipline survives where it matters.
-  const reachOfZones = (zones: readonly string[]): number =>
-    Math.max(0, ...zones.map((z) => zoneVReach?.get(z) ?? 0))
+  const downOfZones = (zones: readonly string[]): number =>
+    Math.max(0, ...zones.map((z) => zoneDownReach?.get(z) ?? 0))
+  const upOfZones = (zones: readonly string[]): number =>
+    Math.max(0, ...zones.map((z) => zoneUpReach?.get(z) ?? 0))
   placedBlocks.sort((a, b) => a.y - b.y || a.x - b.x)
   const settled: typeof placedBlocks = []
   for (const block of placedBlocks) {
-    // the corridor between two stacked blocks must hold both blocks'
-    // vertical label lanes — compaction must not squeeze what the band
-    // extras reserved
-    const moverReach = reachOfZones(block.zones)
+    // the corridor between two stacked blocks holds the upper block's
+    // DOWN labels and the lower (moving) block's UP labels — direction
+    // matters, or whitespace appears where no label can exist
+    const moverUp = upOfZones(block.zones)
     let target: number | undefined
     for (const other of settled) {
-      const vGap = Math.max(bandGap, reachOfZones(other.zones) + moverReach + 8)
+      const vGap = Math.max(bandGap, downOfZones(other.zones) + moverUp + 8)
       for (const obstacle of other.rects) {
         const obstacleBottom = other.y + obstacle.relY + obstacle.h
         for (const mover of block.rects) {

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -43,16 +43,52 @@ import type { ResolvedEdge } from '../resolved-types.js'
  * Mutates the ResolvedPort objects in place (1 port = 1 link, so a flip
  * never affects another edge). Returns the number of ports re-seated.
  */
+export interface AlignResult {
+  /** Number of ports re-seated to face their peer. */
+  flipped: number
+  /**
+   * Nodes whose busiest face could not seat its ports at full slot
+   * width (the pass had to compress). Value = the full width/height
+   * the node NEEDS. Feed back into the next layout round as
+   * `minNodeWidths` / `minNodeHeights` — growing the node is the
+   * correct resolution; compression is only the within-round fallback.
+   */
+  minWidths: Map<string, number>
+  minHeights: Map<string, number>
+}
+
+/** Slot a port claims along its face: stroke width + air, floored so a
+ *  12px label strip plus breathing room always fits. Keep in sync with
+ *  the face-demand estimate in `layoutComposite`. */
+export const PORT_SLOT = (edgeWidth: number): number => Math.max(14, edgeWidth + 4)
+
 export function alignPortsToPeers(
   edges: Map<string, ResolvedEdge>,
   nodes: Map<string, Node>,
-): number {
+  options: {
+    /**
+     * For collapsed redundant pairs: each member's OUTWARD lateral side
+     * (left member → 'left', right member → 'right'). A member's
+     * side-seated ports always use the outward face — seating them
+     * toward the partner puts ports, labels and wires inside the 16px
+     * pair gap, on top of the partner.
+     */
+    outwardSide?: ReadonlyMap<string, 'left' | 'right'>
+  } = {},
+): AlignResult {
   let flipped = 0
+  const minWidths = new Map<string, number>()
+  const minHeights = new Map<string, number>()
   const seat = (
     port: ResolvedEdge['fromPort'],
     nodeId: string,
     side: 'top' | 'bottom' | 'left' | 'right',
   ): void => {
+    // Uniform label policy for the composite schematic: top/bottom port
+    // labels ALWAYS run along the wire (vertical), side ports stay
+    // horizontal. Mixed orientations on one face read as clutter, and
+    // horizontal labels can never clear each other at schematic pitch.
+    port.labelOrientation = side === 'top' || side === 'bottom' ? 'vertical' : 'horizontal'
     if (port.side === side) return
     const node = nodes.get(nodeId)
     const center = node?.position
@@ -96,16 +132,12 @@ export function alignPortsToPeers(
       )
     } else {
       const leftIsFrom = fromCenter.x <= toCenter.x
-      seat(
-        leftIsFrom ? edge.fromPort : edge.toPort,
-        leftIsFrom ? edge.fromNodeId : edge.toNodeId,
-        'right',
-      )
-      seat(
-        leftIsFrom ? edge.toPort : edge.fromPort,
-        leftIsFrom ? edge.toNodeId : edge.fromNodeId,
-        'left',
-      )
+      const rightSidePort = leftIsFrom ? edge.fromPort : edge.toPort
+      const rightSideNode = leftIsFrom ? edge.fromNodeId : edge.toNodeId
+      const leftSidePort = leftIsFrom ? edge.toPort : edge.fromPort
+      const leftSideNode = leftIsFrom ? edge.toNodeId : edge.fromNodeId
+      seat(rightSidePort, rightSideNode, options.outwardSide?.get(rightSideNode) ?? 'right')
+      seat(leftSidePort, leftSideNode, options.outwardSide?.get(leftSideNode) ?? 'left')
     }
   }
 
@@ -118,6 +150,10 @@ export function alignPortsToPeers(
     string,
     { port: ResolvedEdge['fromPort']; peerX: number; width: number; edgeId: string }[]
   >()
+  const sideGroups = new Map<
+    string,
+    { port: ResolvedEdge['fromPort']; peerY: number; width: number; edgeId: string }[]
+  >()
   for (const edge of sortedForSeat) {
     if (edge.coupling) continue
     const ends: [ResolvedEdge['fromPort'], ResolvedEdge['fromPort']][] = [
@@ -125,11 +161,17 @@ export function alignPortsToPeers(
       [edge.toPort, edge.fromPort],
     ]
     for (const [port, peer] of ends) {
-      if (port.side !== 'top' && port.side !== 'bottom') continue
-      const key = `${port.nodeId}|${port.side}`
-      const group = faceGroups.get(key) ?? []
-      group.push({ port, peerX: peer.absolutePosition.x, width: edge.width, edgeId: edge.id })
-      faceGroups.set(key, group)
+      if (port.side === 'top' || port.side === 'bottom') {
+        const key = `${port.nodeId}|${port.side}`
+        const group = faceGroups.get(key) ?? []
+        group.push({ port, peerX: peer.absolutePosition.x, width: edge.width, edgeId: edge.id })
+        faceGroups.set(key, group)
+      } else {
+        const key = `${port.nodeId}|${port.side}`
+        const group = sideGroups.get(key) ?? []
+        group.push({ port, peerY: peer.absolutePosition.y, width: edge.width, edgeId: edge.id })
+        sideGroups.set(key, group)
+      }
     }
   }
   for (const [key, group] of [...faceGroups].sort((a, b) => (a[0] < b[0] ? -1 : 1))) {
@@ -140,25 +182,46 @@ export function alignPortsToPeers(
     if (!node || !center) continue
     const size = resolveNodeSize(node)
     group.sort((a, b) => a.peerX - b.peerX || (a.edgeId < b.edgeId ? -1 : 1))
-    const slots = group.map((entry) => Math.max(8, entry.width + 4))
+    const slots = group.map((entry) => PORT_SLOT(entry.width))
     const total = slots.reduce((sum, w) => sum + w, 0)
     const faceWidth = Math.max(12, size.width - 8)
     const scale = total > faceWidth ? faceWidth / total : 1
+    if (scale < 1) {
+      // under-provisioned face: report the width the node actually needs
+      minWidths.set(nodeId, Math.max(minWidths.get(nodeId) ?? 0, total + 8))
+    }
     let cursor = center.x - (total * scale) / 2
     for (const [i, entry] of group.entries()) {
-      const w = (slots[i] ?? 8) * scale
+      const w = (slots[i] ?? 14) * scale
       entry.port.absolutePosition = { ...entry.port.absolutePosition, x: cursor + w / 2 }
       cursor += w
     }
-    // Horizontal port labels are ~40-70px wide; when the face pitch is
-    // tighter than that, they physically cannot clear each other — tell
-    // the renderer to run the labels along the wires instead.
-    const pitch = (total * scale) / group.length
-    if (pitch < 44) {
-      for (const entry of group) entry.port.labelOrientation = 'vertical'
+  }
+  // Same discipline for the side faces — without this every left/right
+  // port of a node sat on the exact same point (test6: 106 port-port
+  // collisions, all on side faces of same-depth peer routers).
+  for (const [key, group] of [...sideGroups].sort((a, b) => (a[0] < b[0] ? -1 : 1))) {
+    const nodeId = key.slice(0, key.lastIndexOf('|'))
+    const node = nodes.get(nodeId)
+    const center = node?.position
+    if (!node || !center) continue
+    const size = resolveNodeSize(node)
+    group.sort((a, b) => a.peerY - b.peerY || (a.edgeId < b.edgeId ? -1 : 1))
+    const slots = group.map((entry) => PORT_SLOT(entry.width))
+    const total = slots.reduce((sum, h) => sum + h, 0)
+    const faceHeight = Math.max(12, size.height - 8)
+    const scale = total > faceHeight ? faceHeight / total : 1
+    if (scale < 1) {
+      minHeights.set(nodeId, Math.max(minHeights.get(nodeId) ?? 0, total + 8))
+    }
+    let cursor = center.y - (total * scale) / 2
+    for (const [i, entry] of group.entries()) {
+      const h = (slots[i] ?? 14) * scale
+      entry.port.absolutePosition = { ...entry.port.absolutePosition, y: cursor + h / 2 }
+      cursor += h
     }
   }
-  return flipped
+  return { flipped, minWidths, minHeights }
 }
 
 /** A rectangle wires must not run through (zone box or node box). */
@@ -642,18 +705,28 @@ export function applyOctilinearRoutes(
   }
   for (const comb of combRoutes) {
     const n = comb.members.length
+    // Ports keep their own slots on the face (each is a real interface
+    // with its own label); the drops GATHER into the shared trunk via a
+    // short 45° merge just below the face — the harness reading.
+    const gatherY = Math.max(...comb.members.map((m) => m.py)) + 6
     for (const [i, m] of comb.members.entries()) {
       const edge = edges.get(m.edgeId)
       if (!edge) continue
-      // collapse the parent port onto the shared trunk
-      const parentPort = edge.fromNodeId === comb.id ? edge.fromPort : edge.toPort
-      parentPort.absolutePosition = { ...parentPort.absolutePosition, x: comb.trunkX }
-      const corner: Position[] = [
-        { x: comb.trunkX, y: m.py },
+      const dx = Math.abs(m.px - comb.trunkX)
+      const raw: Position[] = [
+        { x: m.px, y: m.py },
+        { x: m.px, y: gatherY },
+        { x: comb.trunkX, y: gatherY + dx },
         { x: comb.trunkX, y: comb.busY },
         { x: m.cx, y: comb.busY },
         { x: m.cx, y: m.cy },
       ]
+      // drop zero-length segments (member sitting exactly on the trunk)
+      const corner = raw.filter(
+        (p, idx) =>
+          idx === 0 ||
+          Math.hypot(p.x - (raw[idx - 1]?.x ?? p.x), p.y - (raw[idx - 1]?.y ?? p.y)) > 0.5,
+      )
       edge.route = {
         kind: 'bus',
         points: chamferCorners(corner, chamfer),

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -576,13 +576,15 @@ export function applyOctilinearRoutes(
       },
     })
   }
-  // comb buses go through the SAME global allocator — one request per comb
+  // comb buses go through the SAME global allocator — one request per
+  // comb, sized for the whole parallel-strand corridor
   for (const comb of combRoutes) {
     const minChildY = Math.min(...comb.members.map((m) => m.cy))
     const maxParentY = Math.max(...comb.members.map((m) => m.py))
+    const pitch = Math.max(3, comb.half * 2 + 1.5)
     requests.push({
       id: `comb:${comb.id}`,
-      half: comb.half,
+      half: (comb.members.length * pitch) / 2 + comb.half,
       lo: Math.min(comb.trunkX, ...comb.members.map((m) => m.cx)) - 16,
       hi: Math.max(comb.trunkX, ...comb.members.map((m) => m.cx)) + 16,
       want: minChildY - 26,
@@ -640,10 +642,12 @@ export function applyOctilinearRoutes(
 
   // -- vertical corridor separation (geometry-level, not a render nudge) --------
   const placedVerticals: { x: number; y1: number; y2: number; half: number }[] = []
-  // comb trunks and risers are fixed corridors — register them first
+  // comb trunk corridors and risers are fixed — register them first
   for (const comb of combRoutes) {
     const minParentY = Math.min(...comb.members.map((m) => m.py))
-    placedVerticals.push({ x: comb.trunkX, y1: minParentY, y2: comb.busY, half: comb.half })
+    const pitch = Math.max(3, comb.half * 2 + 1.5)
+    const corridorHalf = (comb.members.length * pitch) / 2 + comb.half
+    placedVerticals.push({ x: comb.trunkX, y1: minParentY, y2: comb.busY, half: corridorHalf })
     for (const m of comb.members) {
       placedVerticals.push({ x: m.cx, y1: comb.busY, y2: m.cy, half: m.half })
     }
@@ -752,20 +756,28 @@ export function applyOctilinearRoutes(
   }
   for (const comb of combRoutes) {
     const n = comb.members.length
-    // Ports keep their own slots on the face (each is a real interface
-    // with its own label); the drops GATHER into the shared trunk via a
-    // short 45° merge just below the face — the harness reading.
+    // Metro discipline (v3 §27-33: ONE STRAND PER PHYSICAL LINK, no
+    // merged trunk): members run as PARALLEL strands in a shared
+    // corridor — each line stays individually traceable from port to
+    // child (the dependency reading), while the corridor itself reads
+    // as one harness. Lane order follows child x so strands never
+    // cross each other inside the corridor.
+    const pitch = Math.max(3, Math.max(...comb.members.map((m) => m.half)) * 2 + 1.5)
+    const ordered = [...comb.members].sort((a, b) => a.cx - b.cx || (a.edgeId < b.edgeId ? -1 : 1))
     const gatherY = Math.max(...comb.members.map((m) => m.py)) + 6
-    for (const [i, m] of comb.members.entries()) {
+    for (const [i, m] of ordered.entries()) {
       const edge = edges.get(m.edgeId)
       if (!edge) continue
-      const dx = Math.abs(m.px - comb.trunkX)
+      const lane = (i - (n - 1) / 2) * pitch
+      const trunkLaneX = comb.trunkX + lane
+      const busLaneY = comb.busY + lane
+      const dx = Math.abs(m.px - trunkLaneX)
       const raw: Position[] = [
         { x: m.px, y: m.py },
         { x: m.px, y: gatherY },
-        { x: comb.trunkX, y: gatherY + dx },
-        { x: comb.trunkX, y: comb.busY },
-        { x: m.cx, y: comb.busY },
+        { x: trunkLaneX, y: gatherY + dx },
+        { x: trunkLaneX, y: busLaneY },
+        { x: m.cx, y: busLaneY },
         { x: m.cx, y: m.cy },
       ]
       // drop zero-length segments (member sitting exactly on the trunk)

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -29,6 +29,7 @@
 
 import type { Bounds, Node, Position } from '../../models/types.js'
 import { resolveNodeSize } from '../engine/index.js'
+import { portLabelBox } from '../port-geometry.js'
 import type { ResolvedEdge } from '../resolved-types.js'
 
 /**
@@ -220,6 +221,52 @@ export function alignPortsToPeers(
       entry.port.absolutePosition = { ...entry.port.absolutePosition, y: cursor + h / 2 }
       cursor += h
     }
+  }
+
+  // -- strip de-aliasing (slot allocation extended to LABELS) -----------------
+  // Vertical label strips are 12px wide at their port's x; strips from
+  // FACING faces collide only when x-aligned. Same discipline as the
+  // track allocator: on collision, shift one occupant to the next free
+  // lane (half a slot sideways, clamped to its own face) instead of
+  // paying corridor space for the whole row.
+  const strips: { port: ResolvedEdge['fromPort']; nodeId: string }[] = []
+  for (const edge of sortedForSeat) {
+    if (edge.coupling) continue
+    for (const port of [edge.fromPort, edge.toPort]) {
+      if (port.labelOrientation !== 'vertical' || port.label.trim() === '') continue
+      strips.push({ port, nodeId: port.nodeId })
+    }
+  }
+  strips.sort((a, b) => (a.port.id < b.port.id ? -1 : 1))
+  const overlaps = (a: Bounds, b: Bounds): boolean =>
+    a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+  for (let pass = 0; pass < 2; pass++) {
+    let moved = 0
+    for (let i = 0; i < strips.length; i++) {
+      const a = strips[i]
+      if (!a) continue
+      const boxA = portLabelBox(a.port)
+      if (!boxA) continue
+      for (let j = i + 1; j < strips.length; j++) {
+        const b = strips[j]
+        if (!b || b.nodeId === a.nodeId) continue // same-face pairs are slot-spaced already
+        const boxB = portLabelBox(b.port)
+        if (!boxB || !overlaps(boxA, boxB)) continue
+        const node = nodes.get(b.nodeId)
+        const center = node?.position
+        if (!node || !center) continue
+        const size = resolveNodeSize(node)
+        const need = boxA.x + boxA.width - boxB.x + 3
+        const lo = center.x - size.width / 2 + 6
+        const hi = center.x + size.width / 2 - 6
+        const shifted = Math.max(lo, Math.min(hi, b.port.absolutePosition.x + need))
+        if (shifted !== b.port.absolutePosition.x) {
+          b.port.absolutePosition = { ...b.port.absolutePosition, x: shifted }
+          moved++
+        }
+      }
+    }
+    if (moved === 0) break
   }
   return { flipped, minWidths, minHeights }
 }

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -22,8 +22,9 @@
 import type { NetworkGraph } from '../../models/types.js'
 import { placePorts } from '../auto-placement/flat-tree/port-placement.js'
 import { resolveNodeSize } from '../engine/index.js'
-import { findCollinearOverlaps, type PolylineSpec } from '../invariants.js'
+import { findCollinearOverlaps, findPortClutter, type PolylineSpec } from '../invariants.js'
 import { getLinkWidthForMode } from '../link-utils.js'
+import { portLabelBox } from '../port-geometry.js'
 import type { ResolvedEdge, ResolvedLayout, ResolvedPort } from '../resolved-types.js'
 import { routeEdges } from '../route-edges.js'
 import {
@@ -44,6 +45,8 @@ export interface RoutedScore {
   length: number
   /** Wires that climb against the hierarchy (deeper node drawn above its shallower peer). */
   upward: number
+  /** Port-box / label-box collisions (first-class geometry, #430 lesson). */
+  clutter: number
 }
 
 export interface CompositeSearchResult {
@@ -51,6 +54,13 @@ export interface CompositeSearchResult {
   ports: Map<string, ResolvedPort>
   edges: Map<string, ResolvedEdge>
   score: RoutedScore
+  /**
+   * Faces that had to compress their port slots this round: node id →
+   * width/height the node needs. Non-empty means the layout should
+   * re-run with these as `minNodeWidths`/`minNodeHeights`
+   * (port-demand feedback).
+   */
+  portDeficits: { widths: Map<string, number>; heights: Map<string, number> }
 }
 
 export interface CompositeSearchOptions {
@@ -77,9 +87,26 @@ async function evaluate(
       comp.heartbeats.has(pairKey(edge.fromNodeId, edge.toNodeId))
     ) {
       edge.coupling = true
+      // the glasses bridge spans a 16px pair gap — port labels there can
+      // only ever collide with the partner, so they don't render
+      edge.fromPort.label = ''
+      edge.toPort.label = ''
     }
   }
-  alignPortsToPeers(edges, comp.nodes)
+  // pair members seat lateral ports on their OUTWARD face, never into
+  // the 16px gap toward the partner
+  const outwardSide = new Map<string, 'left' | 'right'>()
+  for (const pair of comp.pairs) {
+    const members = pair.split('+')
+    const a = members[0]
+    const b = members[1]
+    if (a === undefined || b === undefined) continue
+    const ax = comp.nodes.get(a)?.position?.x ?? 0
+    const bx = comp.nodes.get(b)?.position?.x ?? 0
+    outwardSide.set(ax <= bx ? a : b, 'left')
+    outwardSide.set(ax <= bx ? b : a, 'right')
+  }
+  const align = alignPortsToPeers(edges, comp.nodes, { outwardSide })
   const obstacles: RoutingObstacle[] = []
   for (const [id, sg] of comp.subgraphs) {
     if (sg.bounds) obstacles.push({ id, bounds: sg.bounds })
@@ -147,6 +174,18 @@ async function evaluate(
       figure = grow(figure, p.x, p.y, half)
       for (const id of owners) internal.set(id, grow(internal.get(id), p.x, p.y, half))
     }
+    // Port labels are owned geometry — their boxes are footprint too.
+    for (const port of [edge.fromPort, edge.toPort]) {
+      const labelRect = portLabelBox(port)
+      if (!labelRect) continue
+      for (const [x, y] of [
+        [labelRect.x, labelRect.y],
+        [labelRect.x + labelRect.width, labelRect.y + labelRect.height],
+      ] as const) {
+        figure = grow(figure, x, y, 2)
+        for (const id of owners) internal.set(id, grow(internal.get(id), x, y, 2))
+      }
+    }
     // Labels are part of the edge's rendered footprint too. Mirror the
     // renderer's placement (midpoint of the routed points, 10px mono,
     // centered, one 12px line per label) with a conservative width
@@ -196,7 +235,13 @@ async function evaluate(
     const by2 = Math.max(bb.y + bb.height, figure.y2 + 28)
     comp.bounds = { x: bx1, y: by1, width: bx2 - bx1, height: by2 - by1 }
   }
-  return { comp, ports, edges, score: scoreRoutedEdges(edges, comp.nodes, comp.depths) }
+  return {
+    comp,
+    ports,
+    edges,
+    score: scoreRoutedEdges(edges, comp.nodes, comp.depths),
+    portDeficits: { widths: align.minWidths, heights: align.minHeights },
+  }
 }
 
 /**
@@ -218,22 +263,55 @@ export async function searchCompositeLayout(
     return evaluate(graph, layoutOptions)
   }
 
-  // 1) multi-start over the gap grid
+  let bestOptions: CompositeLayoutOptions = {}
+  let best = await evaluate(graph, bestOptions)
+  evaluations++
+
+  // 0) port-demand feedback: a face that had to compress its port slots
+  //    reports the width its node needs. Re-layout with those floors —
+  //    adopted unconditionally, because compressed ports are a geometric
+  //    violation (overlapping port/label boxes), not a style preference.
+  //    Faces can shift after resizing, so iterate (bounded).
+  let widthFloors: ReadonlyMap<string, number> | undefined
+  let heightFloors: ReadonlyMap<string, number> | undefined
+  for (
+    let round = 0;
+    round < 3 && (best.portDeficits.widths.size > 0 || best.portDeficits.heights.size > 0);
+    round++
+  ) {
+    const mergedW = new Map(widthFloors ?? [])
+    for (const [id, w] of best.portDeficits.widths) {
+      mergedW.set(id, Math.max(mergedW.get(id) ?? 0, w))
+    }
+    const mergedH = new Map(heightFloors ?? [])
+    for (const [id, h] of best.portDeficits.heights) {
+      mergedH.set(id, Math.max(mergedH.get(id) ?? 0, h))
+    }
+    widthFloors = mergedW
+    heightFloors = mergedH
+    const candidate = await budgeted({
+      ...bestOptions,
+      minNodeWidths: widthFloors,
+      minNodeHeights: heightFloors,
+    })
+    if (!candidate) break
+    best = candidate
+    bestOptions = { ...bestOptions, minNodeWidths: widthFloors, minNodeHeights: heightFloors }
+  }
+
+  // 1) multi-start over the gap grid (floors ride along)
   const variants: CompositeLayoutOptions[] = [
-    {},
     { zoneGap: 70 },
     { bandGap: 120 },
     { cellGapX: 24 },
     { zoneGap: 70, bandGap: 190 },
   ]
-  let bestOptions: CompositeLayoutOptions = {}
-  let best = await evaluate(graph, bestOptions)
-  evaluations++
-  for (const variant of variants.slice(1)) {
-    const candidate = await budgeted(variant)
+  for (const variant of variants) {
+    const trial = { ...variant, minNodeWidths: widthFloors, minNodeHeights: heightFloors }
+    const candidate = await budgeted(trial)
     if (candidate && candidate.score.cost < best.score.cost) {
       best = candidate
-      bestOptions = variant
+      bestOptions = trial
     }
   }
 
@@ -462,6 +540,29 @@ export function scoreRoutedEdges(
       if (hit) pierce++
     }
   }
+  // port/label clutter: collisions among owned geometry (port boxes,
+  // label boxes, labels vs foreign nodes). With the demand feedback
+  // this should be zero; the term makes any residual visible to the
+  // search instead of invisible to it.
+  const seenPorts = new Map<string, ResolvedPort>()
+  for (const edge of edges.values()) {
+    seenPorts.set(edge.fromPort.id, edge.fromPort)
+    seenPorts.set(edge.toPort.id, edge.toPort)
+  }
+  const nodeBoxSpecs = [...nodes]
+    .filter(([, node]) => node.position)
+    .map(([id, node]) => {
+      const size = resolveNodeSize(node)
+      return {
+        id,
+        x: node.position?.x ?? 0,
+        y: node.position?.y ?? 0,
+        width: size.width,
+        height: size.height,
+      }
+    })
+  const clutter = findPortClutter([...seenPorts.values()], nodeBoxSpecs).length
+
   // upward penalty (v3 §31): 基本上流>下流 — a wire whose deeper endpoint
   // sits ABOVE its shallower endpoint reads as the hierarchy inverting.
   let upward = 0
@@ -479,13 +580,21 @@ export function scoreRoutedEdges(
     }
   }
   return {
-    cost: crossings + collinear * 8 + pierce * 2 + bends * 0.4 + length / 400 + upward * 12,
+    cost:
+      crossings +
+      collinear * 8 +
+      pierce * 2 +
+      bends * 0.4 +
+      length / 400 +
+      upward * 12 +
+      clutter * 6,
     crossings,
     collinear,
     pierce,
     bends,
     length,
     upward,
+    clutter,
   }
 }
 

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -130,6 +130,7 @@ async function evaluate(
     if (list.length < 2) combs.delete(parent)
   }
   applyOctilinearRoutes(edges, { obstacles, combs })
+  placeLinkLabels(edges, comp.nodes)
   // A subgraph OWNS the wiring that completes inside it (both endpoints
   // are members), and routes legally run outside the member boxes
   // (gutter bypasses, ramp under-loops, vertical shifts). Container
@@ -202,8 +203,8 @@ async function evaluate(
       const a = pts[midIdx - 1]
       const b = pts[midIdx]
       if (a && b) {
-        const mx = (a.x + b.x) / 2
-        const my = (a.y + b.y) / 2
+        const mx = edge.labelAnchor?.x ?? (a.x + b.x) / 2
+        const my = edge.labelAnchor?.y ?? (a.y + b.y) / 2
         const halfWidth = (Math.max(...labelLines.map((t) => t.length)) * 6.5) / 2
         const top = my - 8 - 12
         const bottom = my - 8 + labelLines.length * 12
@@ -441,6 +442,97 @@ function measureCongestion(result: CompositeSearchResult): Map<number, number> {
     if (need > available) extra.set(gap + 1, Math.ceil(need - available))
   }
   return extra
+}
+
+/**
+ * Link-label placement as a routing stage (the same mutual-awareness
+ * model as ports/labels/nodes): each edge's label slides ALONG its own
+ * routed polyline to a spot that collides with nothing already known —
+ * node boxes, port-label strips, and labels placed before it. The
+ * renderer's fixed-midpoint is only the fallback.
+ */
+function placeLinkLabels(edges: Map<string, ResolvedEdge>, nodes: ResolvedLayout['nodes']): void {
+  interface Box {
+    x1: number
+    y1: number
+    x2: number
+    y2: number
+  }
+  const obstacles: Box[] = []
+  for (const [, node] of nodes) {
+    if (!node.position) continue
+    const size = resolveNodeSize(node)
+    obstacles.push({
+      x1: node.position.x - size.width / 2,
+      y1: node.position.y - size.height / 2,
+      x2: node.position.x + size.width / 2,
+      y2: node.position.y + size.height / 2,
+    })
+  }
+  for (const edge of edges.values()) {
+    for (const port of [edge.fromPort, edge.toPort]) {
+      const strip = portLabelBox(port)
+      if (strip) {
+        obstacles.push({
+          x1: strip.x,
+          y1: strip.y,
+          x2: strip.x + strip.width,
+          y2: strip.y + strip.height,
+        })
+      }
+    }
+  }
+  const hits = (box: Box): number => {
+    let n = 0
+    for (const o of obstacles) {
+      if (box.x1 < o.x2 && box.x2 > o.x1 && box.y1 < o.y2 && box.y2 > o.y1) n++
+    }
+    return n
+  }
+  for (const edge of [...edges.values()].sort((a, b) => (a.id < b.id ? -1 : 1))) {
+    if (edge.coupling) continue
+    const lines: string[] = []
+    const linkLabel = edge.link.label
+    if (linkLabel !== undefined) {
+      lines.push(Array.isArray(linkLabel) ? linkLabel.join(' / ') : linkLabel)
+    }
+    const vlan = edge.link.vlan
+    if (vlan && vlan.length > 0) lines.push(`VLAN ${vlan.join(', ')}`)
+    if (lines.length === 0) continue
+    const pts = edge.route?.points ?? edge.points
+    if (pts.length < 2) continue
+    const halfW = (Math.max(...lines.map((t) => t.length)) * 6) / 2
+    const boxAt = (x: number, y: number): Box => ({
+      x1: x - halfW,
+      y1: y - 20,
+      x2: x + halfW,
+      y2: y - 8 + lines.length * 12,
+    })
+    let best: { x: number; y: number } | undefined
+    let bestCost = Number.POSITIVE_INFINITY
+    for (let s = 1; s < pts.length; s++) {
+      const a = pts[s - 1]
+      const b = pts[s]
+      if (!a || !b) continue
+      const len = Math.hypot(b.x - a.x, b.y - a.y)
+      if (len < 24 && pts.length > 2) continue
+      for (const t of [0.5, 0.3, 0.7]) {
+        const x = a.x + (b.x - a.x) * t
+        const y = a.y + (b.y - a.y) * t
+        // prefer the path's middle and segment centers, but a clean
+        // spot anywhere on the wire beats a cluttered midpoint
+        const cost = hits(boxAt(x, y)) * 10 + Math.abs(s - pts.length / 2) + (t === 0.5 ? 0 : 0.5)
+        if (cost < bestCost) {
+          bestCost = cost
+          best = { x, y }
+        }
+      }
+    }
+    if (best) {
+      edge.labelAnchor = best
+      obstacles.push(boxAt(best.x, best.y))
+    }
+  }
 }
 
 /** Score actually-routed geometry (no straight-line proxies). */

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -61,10 +61,19 @@ export interface CompositeSearchResult {
    * (port-demand feedback).
    */
   portDeficits: { widths: Map<string, number>; heights: Map<string, number> }
+  /** Search telemetry: how much of the budget ran and what it bought. */
+  stats?: {
+    evaluations: number
+    accepted: number
+    initialCost: number
+    finalCost: number
+  }
 }
 
 export interface CompositeSearchOptions {
-  /** Hard cap on layout+route evaluations. Default 48. */
+  /** Hard cap on layout+route evaluations. Default 160 (~2s on a
+   *  60-node graph — the v3 norm; the move vocabulary saturates near
+   *  190, so larger budgets buy nothing). */
   maxEvaluations?: number
 }
 
@@ -254,7 +263,7 @@ export async function searchCompositeLayout(
   graph: NetworkGraph,
   options: CompositeSearchOptions = {},
 ): Promise<CompositeSearchResult> {
-  const maxEvaluations = options.maxEvaluations ?? 48
+  const maxEvaluations = options.maxEvaluations ?? 160
   let evaluations = 0
   const budgeted = async (
     layoutOptions: CompositeLayoutOptions,
@@ -267,6 +276,8 @@ export async function searchCompositeLayout(
   let bestOptions: CompositeLayoutOptions = {}
   let best = await evaluate(graph, bestOptions)
   evaluations++
+  let accepted = 0
+  const initialCost = best.score.cost
 
   // 0) port-demand feedback: a face that had to compress its port slots
   //    reports the width its node needs. Re-layout with those floors —
@@ -297,6 +308,7 @@ export async function searchCompositeLayout(
     })
     if (!candidate) break
     best = candidate
+    accepted++
     bestOptions = { ...bestOptions, minNodeWidths: widthFloors, minNodeHeights: heightFloors }
   }
 
@@ -306,12 +318,17 @@ export async function searchCompositeLayout(
     { bandGap: 120 },
     { cellGapX: 24 },
     { zoneGap: 70, bandGap: 190 },
+    { zoneGap: 60, bandGap: 130 },
+    { zoneGap: 110 },
+    { maxBandW: 2600 },
+    { maxBandW: 3200 },
   ]
   for (const variant of variants) {
     const trial = { ...variant, minNodeWidths: widthFloors, minNodeHeights: heightFloors }
     const candidate = await budgeted(trial)
     if (candidate && candidate.score.cost < best.score.cost) {
       best = candidate
+      accepted++
       bestOptions = trial
     }
   }
@@ -322,6 +339,7 @@ export async function searchCompositeLayout(
     const candidate = await budgeted({ ...bestOptions, bandExtra })
     if (candidate && candidate.score.cost < best.score.cost) {
       best = candidate
+      accepted++
       bestOptions = { ...bestOptions, bandExtra }
     }
   }
@@ -333,7 +351,7 @@ export async function searchCompositeLayout(
   for (const [bandIndex, blocks] of best.comp.bandBlocks.entries()) {
     if (blocks.length < 2) continue
     const current = [...(acceptedOrders.get(bandIndex) ?? blocks)]
-    const maxSwaps = Math.min(3, current.length - 1)
+    const maxSwaps = Math.min(5, current.length - 1)
     for (let i = 0; i < maxSwaps; i++) {
       const swapped = [...current]
       const a = swapped[i]
@@ -346,6 +364,7 @@ export async function searchCompositeLayout(
       const candidate = await budgeted({ ...bestOptions, bandOrder: trial })
       if (candidate && candidate.score.cost < best.score.cost) {
         best = candidate
+        accepted++
         acceptedOrders.set(bandIndex, swapped)
         current.splice(0, current.length, ...swapped)
       }
@@ -361,6 +380,7 @@ export async function searchCompositeLayout(
     const candidate = await budgeted({ ...bestOptions, pairFlips: trial })
     if (candidate && candidate.score.cost < best.score.cost) {
       best = candidate
+      accepted++
       flips.add(pair)
     }
   }
@@ -386,22 +406,36 @@ export async function searchCompositeLayout(
   }
   const busiest = [...unitDegree.entries()]
     .sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1))
-    .slice(0, 6)
+    .slice(0, 16)
     .map(([id]) => id)
   const nudges = new Map<string, number>()
-  for (const unitId of busiest) {
-    for (const dx of [24, -24]) {
-      const trial = new Map(nudges)
-      trial.set(unitId, dx)
-      const candidate = await budgeted({ ...bestOptions, nudges: trial })
-      if (candidate && candidate.score.cost < best.score.cost) {
-        best = candidate
-        nudges.set(unitId, dx)
-        break
+  // wider amplitude grid + second round while budget remains: the ±24
+  // single shot left obvious slack on the table
+  for (let round = 0; round < 2; round++) {
+    let improvedThisRound = false
+    for (const unitId of busiest) {
+      for (const dx of [24, -24, 48, -48, 96, -96]) {
+        const trial = new Map(nudges)
+        trial.set(unitId, (nudges.get(unitId) ?? 0) + dx)
+        const candidate = await budgeted({ ...bestOptions, nudges: trial })
+        if (candidate && candidate.score.cost < best.score.cost) {
+          best = candidate
+          accepted++
+          nudges.set(unitId, trial.get(unitId) ?? dx)
+          improvedThisRound = true
+          break
+        }
       }
     }
+    if (!improvedThisRound) break
   }
 
+  best.stats = {
+    evaluations,
+    accepted,
+    initialCost,
+    finalCost: best.score.cost,
+  }
   return best
 }
 
@@ -679,7 +713,9 @@ export function scoreRoutedEdges(
       bends * 0.4 +
       length / 400 +
       upward * 12 +
-      clutter * 6,
+      // overlap-free is a REQUIREMENT, not a preference — weight high
+      // enough that no crossing/length win can buy a collision
+      clutter * 40,
     crossings,
     collinear,
     pierce,

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -709,7 +709,9 @@ export function scoreRoutedEdges(
     cost:
       crossings +
       collinear * 8 +
-      pierce * 2 +
+      // a wire under a node is a defect, not a trade-off (90° crossings
+      // are the grammar; piercing is not)
+      pierce * 20 +
       bends * 0.4 +
       length / 400 +
       upward * 12 +

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -100,10 +100,12 @@ export {
   findCollinearOverlaps,
   findContainmentViolations,
   findNodeOverlaps,
+  findPortClutter,
   type LayoutInvariantOptions,
   type LayoutInvariantReport,
   type NodeOverlap,
   type PolylineSpec,
+  type PortClutter,
 } from './invariants.js'
 export {
   bpsToLinkWidth,
@@ -115,6 +117,17 @@ export {
   linkSpeedBps,
   resolveBandwidthBps,
 } from './link-utils.js'
+// Port / port-label geometry — single source of truth shared by the
+// renderer, the invariant checker and the routed score.
+export {
+  PORT_LABEL_BOX_OFFSET,
+  PORT_LABEL_FONT,
+  PORT_LABEL_H,
+  portBox,
+  portLabelBox,
+  portLabelLength,
+  portLabelReach,
+} from './port-geometry.js'
 // Conversion utilities (for backward compatibility with legacy LayoutResult)
 export { resolveLayout, unresolveLayout } from './resolve.js'
 // Resolved layout model (Port/Edge as computed objects, Node/Subgraph used directly)

--- a/libs/@shumoku/core/src/layout/invariants.ts
+++ b/libs/@shumoku/core/src/layout/invariants.ts
@@ -27,7 +27,8 @@
 
 import type { Bounds, Position } from '../models/types.js'
 import { resolveNodeSize } from './engine/index.js'
-import type { ResolvedLayout } from './resolved-types.js'
+import { portBox, portLabelBox } from './port-geometry.js'
+import type { ResolvedLayout, ResolvedPort } from './resolved-types.js'
 
 // ============================================================================
 // Pure geometry inputs
@@ -222,6 +223,70 @@ function maxSharedRun(
 }
 
 // ============================================================================
+// 4. Port / port-label clutter
+// ============================================================================
+
+/**
+ * A geometric collision among the elements a node OWNS: its port
+ * markers and their labels. The ownership chain (node → port → label)
+ * only means something if these boxes are first-class geometry — v3
+ * lesson re-learned: what isn't measured silently regresses.
+ */
+export interface PortClutter {
+  kind: 'port-port' | 'label-label' | 'label-node'
+  a: string
+  b: string
+}
+
+const rectsOverlap = (a: Bounds, b: Bounds, margin = 0): boolean =>
+  a.x < b.x + b.width + margin &&
+  a.x + a.width > b.x - margin &&
+  a.y < b.y + b.height + margin &&
+  a.y + a.height > b.y - margin
+
+/**
+ * Find collisions among port boxes, among label boxes, and between a
+ * label and a FOREIGN node box (a label may touch its own node).
+ * O(n²) on layout-sized inputs.
+ */
+export function findPortClutter(
+  ports: readonly ResolvedPort[],
+  nodeBoxes: readonly BoxSpec[] = [],
+): PortClutter[] {
+  const out: PortClutter[] = []
+  const boxes = ports.map((p) => ({ port: p, box: portBox(p), label: portLabelBox(p) }))
+  for (let i = 0; i < boxes.length; i++) {
+    const a = boxes[i]
+    if (!a) continue
+    for (let j = i + 1; j < boxes.length; j++) {
+      const b = boxes[j]
+      if (!b) continue
+      if (rectsOverlap(a.box, b.box)) {
+        out.push({ kind: 'port-port', a: a.port.id, b: b.port.id })
+      }
+      if (a.label && b.label && rectsOverlap(a.label, b.label)) {
+        out.push({ kind: 'label-label', a: a.port.id, b: b.port.id })
+      }
+    }
+    if (a.label) {
+      for (const node of nodeBoxes) {
+        if (node.id === a.port.nodeId) continue
+        const rect: Bounds = {
+          x: node.x - node.width / 2,
+          y: node.y - node.height / 2,
+          width: node.width,
+          height: node.height,
+        }
+        if (rectsOverlap(a.label, rect)) {
+          out.push({ kind: 'label-node', a: a.port.id, b: node.id })
+        }
+      }
+    }
+  }
+  return out
+}
+
+// ============================================================================
 // ResolvedLayout adapter
 // ============================================================================
 
@@ -229,6 +294,7 @@ export interface LayoutInvariantReport {
   nodeOverlaps: NodeOverlap[]
   containmentViolations: ContainmentViolation[]
   collinearOverlaps: CollinearOverlap[]
+  portClutter: PortClutter[]
   ok: boolean
 }
 
@@ -287,13 +353,16 @@ export function checkLayoutInvariants(
     options.containmentPad ?? 0,
   )
   const collinearOverlaps = findCollinearOverlaps(lines, options.collinear)
+  const portClutter = findPortClutter([...layout.ports.values()], boxes)
   return {
     nodeOverlaps,
     containmentViolations,
     collinearOverlaps,
+    portClutter,
     ok:
       nodeOverlaps.length === 0 &&
       containmentViolations.length === 0 &&
-      collinearOverlaps.length === 0,
+      collinearOverlaps.length === 0 &&
+      portClutter.length === 0,
   }
 }

--- a/libs/@shumoku/core/src/layout/port-geometry.ts
+++ b/libs/@shumoku/core/src/layout/port-geometry.ts
@@ -28,6 +28,40 @@ export const PORT_LABEL_H = 12
 /** Distance from the port center to where the label box starts. */
 export const PORT_LABEL_BOX_OFFSET = 10
 
+/**
+ * Canonical interface-name abbreviations — the same short forms the
+ * vendor CLIs themselves print (`show ip int brief`), so the rendered
+ * label stays losslessly readable to a network engineer while taking a
+ * third of the space. NOT truncation: every mapping is the established
+ * notation for that interface type.
+ */
+const IF_SHORT_FORMS: readonly [RegExp, string][] = [
+  [/^FourHundredGigE(?=\d|$)/, 'FH'],
+  [/^TwoHundredGigE(?=\d|$)/, 'TH'],
+  [/^HundredGigE(?=\d|$)/, 'Hu'],
+  [/^FortyGigE(?=\d|$)/, 'Fo'],
+  [/^TwentyFiveGigE(?=\d|$)/, 'Twe'],
+  [/^TenGigabitEthernet(?=\d|$)/, 'Te'],
+  [/^TenGigE(?=\d|$)/, 'Te'],
+  [/^GigabitEthernet(?=\d|$)/, 'Gi'],
+  [/^FastEthernet(?=\d|$)/, 'Fa'],
+  [/^TwentyFiveGigabitEthernet(?=\d|$)/, 'Twe'],
+  [/^Port-channel(?=\d|$)/i, 'Po'],
+  [/^Bundle-Ether(?=\d|$)/i, 'BE'],
+  [/^Loopback(?=\d|$)/i, 'Lo'],
+  [/^Management(?=\d|$)/i, 'Mgmt'],
+  [/^MgmtEth(?=\d|$)/, 'Mg'],
+]
+
+/** Vendor-canonical short form of an interface name (identity for
+ *  anything that doesn't match a known long prefix). */
+export function shortIfName(label: string): string {
+  for (const [pattern, short] of IF_SHORT_FORMS) {
+    if (pattern.test(label)) return label.replace(pattern, short)
+  }
+  return label
+}
+
 /** Estimated label box length along the reading direction. */
 export function portLabelLength(label: string): number {
   return label.length * PORT_LABEL_CHAR_W + 4

--- a/libs/@shumoku/core/src/layout/port-geometry.ts
+++ b/libs/@shumoku/core/src/layout/port-geometry.ts
@@ -1,0 +1,98 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Port and port-label geometry — the single source of truth.
+ *
+ * A node OWNS its ports, a port OWNS its label. For that ownership to
+ * mean anything geometrically, every consumer (renderer, invariant
+ * checker, routed-geometry score, container bounds) must agree on the
+ * boxes those elements occupy. This module is that agreement; the
+ * renderer's drawing code mirrors these formulas.
+ *
+ * Label width uses a conservative character estimate (no font
+ * measurement — layout must stay deterministic across environments).
+ * The renderer's actual text is guaranteed to fit inside the estimate.
+ */
+
+import type { Bounds } from '../models/types.js'
+import type { ResolvedPort } from './resolved-types.js'
+
+/** Port label font size used by the renderer (px). */
+export const PORT_LABEL_FONT = 9
+/** Conservative per-character width at PORT_LABEL_FONT, monospace. */
+export const PORT_LABEL_CHAR_W = 5.6
+/** Label box height (one line incl. padding). */
+export const PORT_LABEL_H = 12
+/** Distance from the port center to where the label box starts. */
+export const PORT_LABEL_BOX_OFFSET = 10
+
+/** Estimated label box length along the reading direction. */
+export function portLabelLength(label: string): number {
+  return label.length * PORT_LABEL_CHAR_W + 4
+}
+
+/** Axis-aligned box of the port marker itself. */
+export function portBox(port: ResolvedPort): Bounds {
+  return {
+    x: port.absolutePosition.x - port.size.width / 2,
+    y: port.absolutePosition.y - port.size.height / 2,
+    width: port.size.width,
+    height: port.size.height,
+  }
+}
+
+/**
+ * Axis-aligned box of the port's label, or undefined when the port has
+ * no label. Mirrors the renderer:
+ *   - vertical (composite top/bottom): the label runs along the wire,
+ *     away from the node face, in a 12px-wide strip.
+ *   - horizontal: classic placement per side (above / below / beside).
+ */
+export function portLabelBox(port: ResolvedPort): Bounds | undefined {
+  const label = port.label.trim()
+  if (label.length === 0) return undefined
+  const w = portLabelLength(label)
+  const px = port.absolutePosition.x
+  const py = port.absolutePosition.y
+
+  if (port.labelOrientation === 'vertical' && (port.side === 'top' || port.side === 'bottom')) {
+    // rotated strip along the wire: 12px across, w long, starting
+    // PORT_LABEL_BOX_OFFSET from the port center
+    if (port.side === 'top') {
+      return { x: px - 9, y: py - PORT_LABEL_BOX_OFFSET - w, width: PORT_LABEL_H, height: w }
+    }
+    return { x: px - 3, y: py + PORT_LABEL_BOX_OFFSET, width: PORT_LABEL_H, height: w }
+  }
+
+  switch (port.side) {
+    case 'left':
+      return { x: px - PORT_LABEL_BOX_OFFSET - 2 - w, y: py - 9, width: w, height: PORT_LABEL_H }
+    case 'right':
+      return { x: px + PORT_LABEL_BOX_OFFSET + 2, y: py - 9, width: w, height: PORT_LABEL_H }
+    case 'top':
+      return {
+        x: px - w / 2,
+        y: py - PORT_LABEL_BOX_OFFSET - 2 - PORT_LABEL_H,
+        width: w,
+        height: PORT_LABEL_H,
+      }
+    default:
+      return { x: px - w / 2, y: py + PORT_LABEL_BOX_OFFSET + 4, width: w, height: PORT_LABEL_H }
+  }
+}
+
+/**
+ * Reach of a port's label measured from the node face outward, along
+ * the wire (vertical labels) — how much corridor the label needs
+ * between this row and the next. Horizontal labels reach PORT_LABEL_H.
+ */
+export function portLabelReach(port: ResolvedPort): number {
+  const box = portLabelBox(port)
+  if (!box) return 0
+  if (port.labelOrientation === 'vertical' && (port.side === 'top' || port.side === 'bottom')) {
+    return PORT_LABEL_BOX_OFFSET + box.height
+  }
+  return PORT_LABEL_BOX_OFFSET + PORT_LABEL_H
+}

--- a/libs/@shumoku/core/src/layout/resolved-types.ts
+++ b/libs/@shumoku/core/src/layout/resolved-types.ts
@@ -133,6 +133,13 @@ export interface ResolvedEdge {
    * between detected pair members).
    */
   coupling?: boolean
+  /**
+   * Where to draw the link/VLAN label, chosen by the label-placement
+   * routing stage from candidate points ALONG the routed polyline so it
+   * collides with nothing it knows about (nodes, port labels, other
+   * link labels). Absent = renderer's midpoint fallback.
+   */
+  labelAnchor?: Position
 }
 
 // ============================================================================

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -199,6 +199,10 @@
     .node-icon { color: ${colors.nodeTextSecondary}; }
     .subgraph-label { font-family: system-ui, -apple-system, sans-serif; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
     .link-label { font-family: ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace; font-size: 10px; fill: ${colors.textSecondary}; }
+    /* Port labels MUST render in the same monospace metric the layout
+       uses for collision boxes (port-geometry PORT_LABEL_CHAR_W) — an
+       unstyled font here silently breaks the size contract. */
+    .port-label-text { font-family: ui-monospace, "JetBrains Mono", Menlo, Consolas, monospace; }
 
     /* All elements: clickable for selection in any mode */
     .node[data-id] { cursor: pointer; }

--- a/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
@@ -136,6 +136,9 @@
     return link.vlan.length === 1 ? `VLAN ${link.vlan[0]}` : `VLAN ${link.vlan.join(', ')}`
   })
   const midpoint = $derived(() => {
+    // layout-chosen anchor (label-placement routing stage) wins; the
+    // geometric midpoint is only the fallback
+    if (edge.labelAnchor) return edge.labelAnchor
     if (edge.points.length < 2) return null
     const midIdx = Math.floor(edge.points.length / 2)
     const a = edge.points[midIdx - 1]

--- a/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
@@ -58,6 +58,8 @@
   const verticalLabel = $derived(
     port.labelOrientation === 'vertical' && (port.side === 'top' || port.side === 'bottom'),
   )
+  // Full label, never truncated — the layout reserves the corridor for
+  // the longest port name (port-geometry lane) instead of hiding text.
   const labelWidth = $derived(engine.text.measure(port.label, 'port') + 4)
   const labelHeight = 12
   const bgX = $derived(() => {

--- a/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  import { createEngine, type ResolvedPort } from '@shumoku/core'
-
-  /** Shared sizing engine for label-width measurement. */
-  const engine = createEngine()
+  import { portLabelLength, type ResolvedPort } from '@shumoku/core'
 
   import type { PortOverlaySnippet } from '../../lib/overlays'
   import type { RenderColors } from '../../lib/render-colors'
@@ -58,9 +55,10 @@
   const verticalLabel = $derived(
     port.labelOrientation === 'vertical' && (port.side === 'top' || port.side === 'bottom'),
   )
-  // Full label, never truncated — the layout reserves the corridor for
-  // the longest port name (port-geometry lane) instead of hiding text.
-  const labelWidth = $derived(engine.text.measure(port.label, 'port') + 4)
+  // Full label, never truncated. The width comes from the SAME
+  // deterministic metric the layout used for collision boxes and
+  // corridors (port-geometry) — one size authority, no canvas drift.
+  const labelWidth = $derived(portLabelLength(port.label))
   const labelHeight = 12
   const bgX = $derived(() => {
     if (labelPos.textAnchor === 'middle') return labelPos.x - labelWidth / 2


### PR DESCRIPTION
## 概要（16コミットの最終形）

「ポート・ポートラベル・リンク・ノードは相互認知している幾何であり、ラベルも配置配線アルゴリズムの正式な語彙」という所有モデルへの根本改修。

### 幾何モデル
- `layout/port-geometry.ts`: ポート箱・ラベル箱の単一の真実（決定論計量）。レンダラはサイズ権威としてこれに従う（monospace明示+`portLabelLength`、canvas実測とCSS未指定フォントの3重権威を解消）
- `findPortClutter`（port-port/label-label/label-node）を invariants 常設＋routedScore（×40=準ハード制約）に
- ベンダー正準略記 `shortIfName`（HundredGigE→Hu 等、CLI互換・可逆）

### 配置
- 圧縮フォールバック廃止→需要フィードバック（minNodeWidths/Heights、side面スロット新設）
- 方向別ラベルリーチ（reachUp/Down）— 上向きラベルしか無い行の下に幻の予約をしない
- ラベル回廊は隣接ペア単位・バンド境界単位（グローバルmax廃止）
- **maxBandW をコンテンツ量から導出**（sqrt(ゾーン総面積×1.5)）— wrap爆発（高さ5387px・交差218）の真因修正

### 配線
- comb は**並走ストランド**（v3メトロ規律: 1物理リンク=1ストランド、回廊共有・レーン個別・子x順で回廊内無交差）
- リンクラベル配置＝ルーティングの一段（自分のポリライン上で無衝突位置を選択、`ResolvedEdge.labelAnchor`）
- 短冊de-alias（同x衝突→半スロット横ずれ）、ペア外向き面固定、coupling ポートラベル非表示
- pierce重み2→20（貫通は欠陥、90°交差は文法）

### 探索
- テレメトリ（stats: evaluations/accepted/cost推移）— 「予算でなく語彙が81評価で飽和」を可視化
- 語彙拡張: variants+4（maxBandWも探索）、nudge top16×±24/48/96×2round、転置5/band
- 既定予算 48→160評価（test6で約2秒、飽和点~190）

## test6 実測（リワーク開始時→現在）

| | 開始時 | 現在 |
|---|---|---|
| ポート/ラベル衝突 | 254（不可視だった） | **5** |
| crossings | 96 | 100 |
| pierce | 27 | 17 |
| collinear | 6 | 6 |
| 図の高さ | ~3100 | 3584 |

## 残課題（マージ後 issue 化）

1. pierce/collinear ゼロ化（ノード箱をガター障害物に昇格、並走回廊クリアランス）
2. 列粒度コンパクション（N-6下の comb 回廊 600px→200px 目標）
3. svc 族のバンド割れ（location忠実 vs 接続性）
4. apex location-family 則の構造検証（ハードコード監査①）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
