### PR TITLE
feat(layout): 貫通ゼロ達成 — combトランクは子も障害物、無理ならcombしない（#454 第2弾）

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -430,32 +430,36 @@ export function applyOctilinearRoutes(
       }
       const half = Math.max(...members.map((m) => m.half))
       const corridorHalf = (members.length * Math.max(3, half * 2 + 1.5)) / 2 + half
-      const memberNodes = new Set<string>([combId])
-      for (const m of members) {
-        const edge = edges.get(m.edgeId)
-        if (edge) {
-          memberNodes.add(edge.fromNodeId)
-          memberNodes.add(edge.toNodeId)
-        }
-      }
+      // The trunk corridor runs from the parent past EVERY child row
+      // down to the deepest bus — member children are obstacles for it
+      // too (a child may only be touched by its own riser at its own
+      // x). Only the parent's box is exempt.
       const yLo = Math.max(...members.map((m) => m.py)) + 6
-      const yHi = Math.min(...members.map((m) => m.cy)) - 10
+      const yHi = Math.max(...members.map((m) => m.cy)) - 10
       const blocked = (x: number): boolean =>
         nodeBoxes.some(
           (b) =>
-            !memberNodes.has(b.id) &&
+            b.id !== combId &&
             x + corridorHalf > b.x1 - 2 &&
             x - corridorHalf < b.x2 + 2 &&
             yHi > b.y1 + 4 &&
             yLo < b.y2 - 4,
         )
       let trunkX = members.reduce((sum, m) => sum + m.px, 0) / members.length
-      for (const off of [0, 8, -8, 16, -16, 24, -24, 32, -32, 48, -48, 64, -64]) {
+      for (const off of [
+        0, 8, -8, 16, -16, 24, -24, 32, -32, 48, -48, 64, -64, 80, -80, 96, -96, 112, -112, 128,
+        -128,
+      ]) {
         if (!blocked(trunkX + off)) {
           trunkX += off
           break
         }
       }
+      // No clear column for the corridor (heterogeneous fan-outs that
+      // span several zones can't share one trunk) → don't comb at all;
+      // members fall back to normal orth routing, which has the full
+      // dodge machinery. A wire under a node loses to a missing bundle.
+      if (blocked(trunkX)) continue
       // One bus PER CHILD ROW (shared trunk): a single bus above the
       // topmost child sends risers straight through every intermediate
       // row — the dominant pierce source. Per-row buses keep each riser


### PR DESCRIPTION
## 概要

#454 第2弾。第1弾で残った貫通12本は全部 **comb のトランク縦区間**が原因だった:

1. **メンバーの子もトランクの障害物** — 回廊は親から最深行まで走るので、中間行の子ノードは（自分の riser が自分の x で触れる以外）障害物。除外を親の箱のみに絞り、ブロック判定範囲を最深の子まで拡張、回避オフセットを ±128 に拡大
2. **逃げ場がなければ comb しない** — 複数ゾーンを横断する異質なファンアウト（ptx10002 → dc+stage+noc 同時給電）はそもそも1本のトランクを共有すべきでない。回廊が確保できない親は comb を諦め、メンバーは完全な回避機構を持つ通常ルートにフォールバック。「束ねの欠落」より「ノード下の配線」のほうが重い欠陥

## test6 実測（#454 全体）

| | #454前 | 第1弾後 | 第2弾後 |
|---|---|---|---|
| pierce | 17 | 12 | **0** |
| collinear | 6 | 8 | **3** |
| crossings | 100 | 105 | 102 |
| clutter | 5 | 5 | 5 |

349テストパス、ライブページ確認済み。#454 の残りは collinear 3本のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
