### PR TITLE
fix(web): 共有トポロジ画面が更新を反映するように

### DIFF
--- a/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
+++ b/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
@@ -7,12 +7,41 @@
   let name = $state('')
   let loading = $state(true)
   let error = $state('')
+  let graphVersion = $state(0)
+  let lastGraphJson = ''
 
   const token = $derived($page.params.token)
   const loadShared = $derived(async () => {
     const res = await fetch(`/api/share/topologies/${token}/graph`)
     if (!res.ok) throw new Error(`Failed to load shared topology: ${res.status}`)
-    return res.json()
+    const text = await res.text()
+    lastGraphJson = text
+    return JSON.parse(text)
+  })
+
+  // The share view has no live channel for STRUCTURE (only metrics
+  // stream) — a wall-display tab kept the first graph forever. Poll the
+  // token-scoped graph and re-key the diagram only when it actually
+  // changed, so updates propagate without flashing on every tick.
+  $effect(() => {
+    const currentToken = token
+    if (!currentToken) return
+    const timer = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/share/topologies/${currentToken}/graph`)
+        if (!res.ok) return
+        const text = await res.text()
+        if (lastGraphJson !== '' && text !== lastGraphJson) {
+          lastGraphJson = text
+          graphVersion++
+        } else {
+          lastGraphJson = text
+        }
+      } catch {
+        // transient network failure — keep showing the current graph
+      }
+    }, 30_000)
+    return () => clearInterval(timer)
   })
 
   $effect(() => {
@@ -80,7 +109,9 @@
       </div>
     {:else}
       <div class="absolute inset-0">
-        <InteractiveSvgDiagram graphLoader={loadShared} readOnly={true} />
+        {#key graphVersion}
+          <InteractiveSvgDiagram graphLoader={loadShared} readOnly={true} />
+        {/key}
       </div>
     {/if}
   </div>


### PR DESCRIPTION
## 問題

共有リンクの画面は graph を最初に1回ロードしたきりで、その後は**メトリクスしかストリームしていなかった**。壁掛け表示などで開きっぱなしのタブは、トポロジが変わっても初回の図を表示し続ける。サーバ側は常に新鮮（getParsed は composition revision で無効化）なので、ページが再取得しないのが原因。

## 修正

- 30秒ごとにトークンスコープの graph をポーリング
- **ペイロードが実際に変わったときだけ**ダイアグラムを re-key（毎tickの再描画・チラつきなし）
- 一時的なフェッチ失敗は現状維持

svelte-check 0 errors。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
