### PR TITLE
fix(server): datasource update/delete invalidates attached topologies' parsed cache

### DIFF
--- a/apps/server/api/src/api/datasources.ts
+++ b/apps/server/api/src/api/datasources.ts
@@ -10,6 +10,7 @@ import type { AlertQueryOptions } from '../plugins/types.js'
 import { hasNativeApi } from '../plugins/types.js'
 import { DataSourceService } from '../services/datasource.js'
 import type { DataSourceInput } from '../types.js'
+import { getTopologyService, getTopologySourcesService } from './topologies.js'
 
 /**
  * Mask sensitive fields in config JSON
@@ -55,6 +56,18 @@ function validateConfigForType(type: string, configJson: string): string | null 
   const result = validateAgainstSchema(schema, parsed)
   if (result.ok) return null
   return result.errors.map((e) => `${e.path}: ${e.message}`).join('; ')
+}
+
+/**
+ * Drop the parsed-topology cache of every topology this source is attached
+ * to. Mirrors the invalidation the observation / sync / discovery-policy
+ * endpoints already do — without it, `getParsed()` keeps serving the
+ * pre-change resolved graph to /topologies/:id/graph and the share endpoints.
+ */
+function invalidateAttachedTopologies(dataSourceId: string): void {
+  for (const { topologyId } of getTopologySourcesService().listAttachedTopologies(dataSourceId)) {
+    getTopologyService().clearCacheEntry(topologyId)
+  }
 }
 
 export function createDataSourcesApi(): Hono {
@@ -172,17 +185,7 @@ export function createDataSourcesApi(): Hono {
   app.get('/:id/topologies', (c) => {
     const id = c.req.param('id')
     if (!service.get(id)) return c.json({ error: 'Data source not found' }, 404)
-    const db = (service as unknown as { db: import('bun:sqlite').Database }).db
-    const rows = db
-      .query(
-        `SELECT t.id AS topology_id, t.name
-         FROM topology_data_sources tds
-         JOIN topologies t ON t.id = tds.topology_id
-         WHERE tds.data_source_id = ?
-         ORDER BY t.name ASC`,
-      )
-      .all(id) as { topology_id: string; name: string }[]
-    return c.json(rows.map((r) => ({ topologyId: r.topology_id, name: r.name })))
+    return c.json(getTopologySourcesService().listAttachedTopologies(id))
   })
 
   // Get single data source
@@ -248,6 +251,11 @@ export function createDataSourcesApi(): Hono {
       if (!dataSource) {
         return c.json({ error: 'Data source not found' }, 404)
       }
+      // A config change can change what parseTopology resolves (a Manual
+      // source's graph lives in config_json), so drop the parsed cache of
+      // every attached topology — otherwise share/graph views serve the
+      // pre-edit graph until the process restarts.
+      invalidateAttachedTopologies(id)
       return c.json({
         ...dataSource,
         configJson: maskConfigSecrets(dataSource.configJson),
@@ -261,9 +269,16 @@ export function createDataSourcesApi(): Hono {
   // Delete data source
   app.delete('/:id', (c) => {
     const id = c.req.param('id')
+    // Resolve attachments BEFORE the delete — the junction rows go away
+    // with it (ON DELETE CASCADE), and the parents' resolved graphs must
+    // be recomputed without this source's contribution.
+    const attached = getTopologySourcesService().listAttachedTopologies(id)
     const deleted = service.delete(id)
     if (!deleted) {
       return c.json({ error: 'Data source not found' }, 404)
+    }
+    for (const { topologyId } of attached) {
+      getTopologyService().clearCacheEntry(topologyId)
     }
     return c.json({ success: true })
   })

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -189,7 +189,7 @@ export function getDataSourceService(): DataSourceService {
   return _dataSourceService
 }
 
-function getTopologySourcesService(): TopologySourcesService {
+export function getTopologySourcesService(): TopologySourcesService {
   if (!_topologySourcesService) {
     _topologySourcesService = new TopologySourcesService()
   }

--- a/apps/server/api/src/services/topology-sources.ts
+++ b/apps/server/api/src/services/topology-sources.ts
@@ -102,6 +102,25 @@ export class TopologySourcesService {
   }
 
   /**
+   * Reverse lookup: topologies a data source is attached to. Used to
+   * invalidate each parent topology's parsed cache when the source's
+   * config changes (a Manual source's graph lives in config_json), and
+   * by the Manual datasource page to render "edit in <topology>" links.
+   */
+  listAttachedTopologies(dataSourceId: string): { topologyId: string; name: string }[] {
+    const rows = this.db
+      .query(
+        `SELECT t.id AS topology_id, t.name
+         FROM topology_data_sources tds
+         JOIN topologies t ON t.id = tds.topology_id
+         WHERE tds.data_source_id = ?
+         ORDER BY t.name ASC`,
+      )
+      .all(dataSourceId) as { topology_id: string; name: string }[]
+    return rows.map((r) => ({ topologyId: r.topology_id, name: r.name }))
+  }
+
+  /**
    * List data sources by purpose (topology or metrics)
    */
   listByPurpose(topologyId: string, purpose: DataSourcePurpose): TopologyDataSource[] {


### PR DESCRIPTION
## 概要

Manual ソースのグラフ編集は `PUT /api/datasources/:id` を通る(migration 011 以降、グラフは `config_json` に保存される)が、このハンドラだけが observation / sync / discovery-policy の各経路と違って、attach 先トポロジーのパース済みキャッシュを無効化していなかった。そのため `TopologyService.getParsed()` が編集前の解決済みグラフを返し続け、`/api/topologies/:id/graph` と公開共有エンドポイント(`/api/share/topologies/:token/*`)はプロセス再起動まで古い内容を配信していた。

- `PUT /api/datasources/:id` の更新成功後に、attach されている全トポロジーのパース済みキャッシュを破棄するように修正
- `DELETE /api/datasources/:id` も同様に修正 — `topology_data_sources` の行はソース削除と同時に CASCADE で消えるため、attach 先の解決は削除の**前**に行う
- 逆引き用に `TopologySourcesService.listAttachedTopologies()` を追加し、`GET /api/datasources/:id/topologies` もこれを使うように変更(`(service as unknown as { db })` キャストハックを排除)

## テスト計画

- [x] `bun run typecheck`(server-api)
- [x] `bun run test`(server-api、16 件パス)
- [x] 変更ファイルに `bun x biome check`
- [ ] 手動確認: Manual ソースのグラフを編集し、サーバー再起動なしで `/api/topologies/:id/graph` と共有ページに編集が反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)