### PR TITLE
fix(server): 共有グラフに metadata.location を許可 — 共有画面が本体と同じ図に

### DIFF
--- a/apps/server/api/src/api/share-projections.ts
+++ b/apps/server/api/src/api/share-projections.ts
@@ -86,16 +86,24 @@ function shareSafeGraph(graph: NetworkGraph): NetworkGraph {
   return {
     ...rest,
     nodes: graph.nodes.map((n) => {
-      const { identity: _i, attachments: _a, metadata: _m, ports, ...node } = n
+      const { identity: _i, attachments: _a, metadata, ports, ...node } = n
+      // metadata is stripped EXCEPT the layout-bearing zone name: the
+      // composite layout derives its zones from `metadata.location`, and
+      // the zone label is drawn on the shared diagram anyway — without
+      // it the share view silently renders a completely different
+      // (flat-tree) layout than the one the owner shared.
+      const location = metadata?.['location']
+      const kept = typeof location === 'string' && location !== '' ? { metadata: { location } } : {}
       return ports
         ? {
             ...node,
+            ...kept,
             ports: ports.map((p) => {
               const { identity: _pi, attachments: _pa, ...port } = p
               return port
             }),
           }
-        : node
+        : { ...node, ...kept }
     }),
     links: graph.links.map((l) => {
       const { metadata: _lm, ...link } = l as typeof l & { metadata?: unknown }

--- a/apps/server/api/test/share-projections.test.ts
+++ b/apps/server/api/test/share-projections.test.ts
@@ -24,7 +24,7 @@ describe('publicTopologyGraph — strips sensitive carriers from the shared grap
         id: 'sw1',
         label: 'core-sw',
         identity: { mgmtIp: '10.0.0.1', chassisId: 'aa:bb', sysName: 'core-sw.local' },
-        metadata: { rack: 'R1' },
+        metadata: { rack: 'R1', location: 'NOC#N-1' },
         attachments: [{ kind: 'access', community: 'SUPERSECRET' }], // SNMP community → must drop
         ports: [
           {
@@ -55,15 +55,19 @@ describe('publicTopologyGraph — strips sensitive carriers from the shared grap
     expect(blob).not.toContain('PORTSECRET')
     expect(blob.toLowerCase()).not.toContain('community')
   })
-  test('no node/port identity, metadata, or endpoint ip', () => {
+  test('no node/port identity, metadata (except location), or endpoint ip', () => {
     expect(blob).not.toContain('mgmtIp')
     expect(blob).not.toContain('chassisId')
     expect(blob).not.toContain('sysName')
     expect(blob).not.toContain('10.0.0.1/30')
     expect(out.nodes[0]).not.toHaveProperty('identity')
-    expect(out.nodes[0]).not.toHaveProperty('metadata')
     expect(out.nodes[0]).not.toHaveProperty('attachments')
     expect(out.nodes[0]?.ports?.[0]).not.toHaveProperty('attachments')
+    // metadata is allow-listed down to the layout-bearing zone name:
+    // the composite layout needs `location`, and the zone label is
+    // drawn on the shared diagram anyway. Everything else must drop.
+    expect(blob).not.toContain('R1')
+    expect(out.nodes[0]?.metadata).toEqual({ location: 'NOC#N-1' })
   })
   test('no graph-level attachments or exclusions', () => {
     expect(out).not.toHaveProperty('attachments')


### PR DESCRIPTION
## 真因（「共有画面で図が更新されてない」の正体）

鮮度ではなくレイアウト経路の分岐だった。`shareSafeGraph()` が node の metadata を全部剥ぐため `metadata.location` も消え、**composite レイアウトの発動条件（location 付与率 ≥50%）を共有グラフだけ満たさず、旧 flat-tree 描画にフォールバック**していた。所有者が見ている図と共有先の図が別物になる。

## 修正

- `location` のみ許可リストで通す（ゾーン名は共有図のゾーンラベルとして既に描画されるもの＝新規の情報露出なし）。rack 等それ以外の metadata は引き続き全部落とす
- projection テストを「metadata === { location } のみ」で固定（rack は blob に出ないことも検証）

## 確認

- 共有ページ http://localhost:5173/share/topologies/EE1Q… が本体と同一の composite 図を描画することをライブ確認
- API テスト 19+63 パス、typecheck クリーン
- 注意: dev API プロセスが2日前のコードで動いていたため再起動済み（共有系の修正は API 再起動が必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
