### PR TITLE
feat(share): 構造同期をイベント駆動に — composition revision を SSE に相乗り

### DIFF
--- a/apps/server/api/src/api/share.ts
+++ b/apps/server/api/src/api/share.ts
@@ -45,8 +45,21 @@ function streamTopologyMetrics(c: Context, topologyId: string) {
       aborted = true
       unsub()
     })
+    // Composition revision rides the same stream: when the topology's
+    // structure changes, viewers get a `revision` event and refetch the
+    // graph — no timer polling on the client. The revision is a plain
+    // counter (nothing sensitive) and the read is an in-process SQLite
+    // point query, cheap at 1Hz per stream.
+    const topologyService = getTopologyService()
+    let lastRevision = topologyService.compositionRevisionOf(topologyId)
+    await stream.writeSSE({ event: 'revision', data: String(lastRevision) })
     let idleTicks = 0
     while (!aborted) {
+      const revision = topologyService.compositionRevisionOf(topologyId)
+      if (revision !== lastRevision) {
+        lastRevision = revision
+        await stream.writeSSE({ event: 'revision', data: String(revision) })
+      }
       if (pending) {
         const next = pending
         pending = null

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -1419,7 +1419,12 @@ export class TopologyService {
   }
 
   /** Current composition revision for a topology (0 if column/row missing). */
-  private compositionRevisionOf(id: string): number {
+  /**
+   * Current composition revision (bumped on every invalidation). Public:
+   * the share SSE stream sends it so viewers can refetch the graph on
+   * real changes instead of polling on a timer.
+   */
+  compositionRevisionOf(id: string): number {
     try {
       const row = this.db
         .query('SELECT composition_revision AS r FROM topologies WHERE id = ?')

--- a/apps/server/web/src/lib/stores/metrics.ts
+++ b/apps/server/web/src/lib/stores/metrics.ts
@@ -250,12 +250,21 @@ function createMetricsStore() {
     set(initialState)
   }
 
-  function connectShareStream(token: string): void {
+  function connectShareStream(token: string, onRevision?: (revision: number) => void): void {
     disconnectShareStream()
     try {
       const es = new EventSource(getShareStreamUrl(token))
       g.sse = es
       es.onopen = () => update((s) => ({ ...s, connected: true, error: null }))
+      if (onRevision) {
+        // The server pushes the topology's composition revision on the
+        // same stream — structure changed → the viewer refetches the
+        // graph. No timer polling.
+        es.addEventListener('revision', (event) => {
+          const revision = Number((event as MessageEvent).data)
+          if (Number.isFinite(revision)) onRevision(revision)
+        })
+      }
       es.onmessage = (event) => {
         if (!event.data) return // ignore keep-alive pings
         try {

--- a/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
+++ b/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
@@ -19,30 +19,25 @@
     return JSON.parse(text)
   })
 
-  // The share view has no live channel for STRUCTURE (only metrics
-  // stream) — a wall-display tab kept the first graph forever. Poll the
-  // token-scoped graph and re-key the diagram only when it actually
-  // changed, so updates propagate without flashing on every tick.
-  $effect(() => {
-    const currentToken = token
-    if (!currentToken) return
-    const timer = setInterval(async () => {
-      try {
-        const res = await fetch(`/api/share/topologies/${currentToken}/graph`)
-        if (!res.ok) return
-        const text = await res.text()
-        if (lastGraphJson !== '' && text !== lastGraphJson) {
-          lastGraphJson = text
-          graphVersion++
-        } else {
-          lastGraphJson = text
-        }
-      } catch {
-        // transient network failure — keep showing the current graph
+  // Structure updates are EVENT-driven: the metrics SSE stream carries
+  // the topology's composition revision, and a change triggers a graph
+  // refetch (re-keyed only when the payload really differs, so a
+  // revision bump without visual impact doesn't flash the diagram).
+  async function refetchGraph(currentToken: string): Promise<void> {
+    try {
+      const res = await fetch(`/api/share/topologies/${currentToken}/graph`)
+      if (!res.ok) return
+      const text = await res.text()
+      if (lastGraphJson !== '' && text !== lastGraphJson) {
+        lastGraphJson = text
+        graphVersion++
+      } else {
+        lastGraphJson = text
       }
-    }, 30_000)
-    return () => clearInterval(timer)
-  })
+    } catch {
+      // transient network failure — keep showing the current graph
+    }
+  }
 
   $effect(() => {
     const currentToken = token
@@ -64,8 +59,16 @@
         const data = await res.json()
         if (cancelled) return
         name = data.name || 'Shared Topology'
-        // Stream token-scoped live metrics (projected) into the diagram.
-        metricsStore.connectShareStream(currentToken)
+        // Stream token-scoped live metrics (projected) into the diagram;
+        // the same stream pushes composition-revision changes, which
+        // trigger a graph refetch (structure stays in sync, no polling).
+        let lastRevision: number | undefined
+        metricsStore.connectShareStream(currentToken, (revision) => {
+          if (lastRevision !== undefined && revision !== lastRevision) {
+            void refetchGraph(currentToken)
+          }
+          lastRevision = revision
+        })
       } catch {
         if (cancelled) return
         error = 'Failed to load topology'


### PR DESCRIPTION
## 概要

#461 のハードコード30秒ポーリングを撤廃し、プッシュ型に置き換え:

- **サーバ**: 共有メトリクス SSE ストリームが接続時と変更時に `revision` イベント（topology の composition revision。ただのカウンタで機微情報なし。読み取りはストリーム毎1HzのインプロセスSQLiteポイントクエリ）を送出
- **クライアント**: `metricsStore.connectShareStream(token, onRevision)` — revision が動いたら graph を再取得し、**ペイロードが実際に変わったときだけ** re-key（無意味なバンプでチラつかない）
- 新規エンドポイントなし・認証面の追加なし・タイマーなし。ダッシュボード側の widget ストリームも同じハンドラを通るので次段で同様に対応可能

## 確認

- ライブ: SSE が接続直後に `event: revision / data: 321` を送出、共有ページは本体と同一の composite 図を表示
- API テスト 19+63 パス、web svelte-check 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
