### PR TITLE
feat(server): resolve+layout bake in a Worker — serving never blocks (stale-while-revalidate)

### DIFF
--- a/apps/server/api/src/api/share.ts
+++ b/apps/server/api/src/api/share.ts
@@ -45,17 +45,20 @@ function streamTopologyMetrics(c: Context, topologyId: string) {
       aborted = true
       unsub()
     })
-    // Composition revision rides the same stream: when the topology's
-    // structure changes, viewers get a `revision` event and refetch the
-    // graph — no timer polling on the client. The revision is a plain
-    // counter (nothing sensitive) and the read is an in-process SQLite
-    // point query, cheap at 1Hz per stream.
+    // The SERVED revision rides the same stream: when the content a viewer
+    // would fetch actually changes (a background bake landing), they get a
+    // `revision` event and refetch — no timer polling on the client. This is
+    // deliberately NOT the composition revision: an input change kicks a bake
+    // but the serve stays on the stale artifact until the bake lands, so
+    // refetching on input change would just re-download the same diagram.
+    // The revision is a plain counter (nothing sensitive) and the read is an
+    // in-process SQLite point query, cheap at 1Hz per stream.
     const topologyService = getTopologyService()
-    let lastRevision = topologyService.compositionRevisionOf(topologyId)
+    let lastRevision = topologyService.servedRevisionOf(topologyId)
     await stream.writeSSE({ event: 'revision', data: String(lastRevision) })
     let idleTicks = 0
     while (!aborted) {
-      const revision = topologyService.compositionRevisionOf(topologyId)
+      const revision = topologyService.servedRevisionOf(topologyId)
       if (revision !== lastRevision) {
         lastRevision = revision
         await stream.writeSSE({ event: 'revision', data: String(revision) })

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -233,6 +233,11 @@ export function createTopologiesApi(): Hono {
         if (parseError) {
           return c.json({ error: parseError.message, errorPhase: parseError.phase }, 422)
         }
+        // First-ever bake still running — nothing to serve yet. 202 tells the
+        // client to keep its loading state and poll.
+        if (service.deriving(id)) {
+          return c.json({ deriving: true }, 202)
+        }
         return c.json({ error: 'Topology not found' }, 404)
       }
 
@@ -258,6 +263,7 @@ export function createTopologiesApi(): Hono {
         topologySourceId: parsed.topologySourceId,
         metricsSourceId: parsed.metricsSourceId,
         mapping: parsed.mapping,
+        stale: parsed.stale ?? false,
       })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -277,12 +283,16 @@ export function createTopologiesApi(): Hono {
         if (parseError) {
           return c.json({ error: parseError.message, errorPhase: parseError.phase }, 422)
         }
+        if (service.deriving(id)) {
+          return c.json({ deriving: true }, 202)
+        }
         return c.json({ error: 'Topology not found' }, 404)
       }
       return c.json({
         id: parsed.id,
         name: parsed.name,
         graph: applyMappingBandwidth(parsed.graph, parsed.mapping),
+        stale: parsed.stale ?? false,
       })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -305,6 +315,9 @@ export function createTopologiesApi(): Hono {
         if (parseError) {
           return c.json({ error: parseError.message, errorPhase: parseError.phase }, 422)
         }
+        if (service.deriving(id)) {
+          return c.json({ deriving: true }, 202)
+        }
         return c.json({ error: 'Topology not found' }, 404)
       }
       const output = await buildRenderOutput(parsed)
@@ -322,6 +335,9 @@ export function createTopologiesApi(): Hono {
     try {
       const parsed = await service.getParsed(id)
       if (!parsed) {
+        if (service.deriving(id)) {
+          return c.json({ deriving: true }, 202)
+        }
         return c.json({ error: 'Topology not found' }, 404)
       }
 
@@ -633,9 +649,11 @@ export function createTopologiesApi(): Hono {
         }
       }
 
-      // Invalidate parsed-topology cache so the next /render / /graph
-      // call re-runs resolve() across the newly-recorded observations.
+      // Invalidate parsed-topology cache, then bake the fresh artifact in the
+      // background NOW — the next /render / /graph serves the previous diagram
+      // (stale) instantly and swaps when the bake lands, instead of blocking.
       service.clearCacheEntry(id)
+      service.precompute(id)
 
       return c.json({
         success: true,

--- a/apps/server/api/src/api/topology-sources.ts
+++ b/apps/server/api/src/api/topology-sources.ts
@@ -504,6 +504,8 @@ topologySourcesApi.post('/:topologyId/sources/:sourceId/sync', async (c) => {
     capturedAt,
   )
   getTopologyService().clearCacheEntry(topologyId)
+  // Bake the fresh artifact in the background now (stale-while-revalidate).
+  getTopologyService().precompute(topologyId)
   // Stamp the legacy lastSyncedAt for UI surfaces that read it.
   getTopologySourcesService().updateLastSynced(attached.id)
 

--- a/apps/server/api/src/services/derivation.ts
+++ b/apps/server/api/src/services/derivation.ts
@@ -1,0 +1,134 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Derivation queue — one background bake (resolve + layout, in a Worker) per
+ * topology. The serving layer (`getParsed`) never computes in-request anymore:
+ * it serves the last-good artifact (possibly stale) and kicks a bake here;
+ * when the bake lands, the artifact + RAM cache are refreshed and viewers
+ * pick it up (share SSE watches the served revision; the app polls while
+ * `stale`).
+ *
+ * Module-level state on purpose: TopologyService is instantiated ad hoc in
+ * several places, but there must never be two Workers baking the same
+ * topology.
+ */
+
+import type { DeriveResult, TopologyService } from './topology.js'
+
+/** Hard ceiling — a runaway layout must not pin a core forever. */
+const DERIVE_TIMEOUT_MS = 30 * 60_000
+
+export type DeriveStage = 'resolve' | 'icons' | 'layout'
+
+interface DeriveJob {
+  promise: Promise<void>
+  stage: DeriveStage
+  startedAt: number
+  startedRevision: number
+  worker: Worker
+  /** Settle the promise and tear down (used by cancel + completion). */
+  settle: () => void
+}
+
+const jobs = new Map<string, DeriveJob>()
+
+/** Whether a bake is currently in flight for this topology. */
+export function isDeriving(topologyId: string): boolean {
+  return jobs.has(topologyId)
+}
+
+/** Current stage of the in-flight bake, if any (progress surface for the UI). */
+export function derivationStatus(
+  topologyId: string,
+): { stage: DeriveStage; startedAt: number } | null {
+  const job = jobs.get(topologyId)
+  return job ? { stage: job.stage, startedAt: job.startedAt } : null
+}
+
+/** Terminate an in-flight bake. Returns whether one was running. */
+export function cancelDerivation(topologyId: string): boolean {
+  const job = jobs.get(topologyId)
+  if (!job) return false
+  job.settle()
+  return true
+}
+
+/**
+ * Ensure a bake is running for the topology; returns a promise that settles
+ * when it finishes (success, error, cancel, or timeout). Deduped — kicking
+ * while one is in flight returns the in-flight promise. If the composition
+ * revision moved while baking, a follow-up bake is kicked automatically so
+ * the artifact converges without waiting for the next request.
+ */
+export function kickDerivation(topologyId: string, svc: TopologyService): Promise<void> {
+  const existing = jobs.get(topologyId)
+  if (existing) return existing.promise
+
+  const inputs = svc.collectDeriveInputs(topologyId)
+  if (!inputs) return Promise.resolve()
+  const startedRevision = svc.compositionRevisionOf(topologyId)
+
+  const worker = new Worker(new URL('./derive-worker.ts', import.meta.url).href)
+  let settle: () => void = () => {}
+  const promise = new Promise<void>((done) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      svc.recordDeriveError(
+        topologyId,
+        startedRevision,
+        `layout did not finish within ${DERIVE_TIMEOUT_MS / 60_000} minutes`,
+      )
+      settle()
+    }, DERIVE_TIMEOUT_MS)
+    settle = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      worker.terminate()
+      jobs.delete(topologyId)
+      done()
+    }
+    worker.onmessage = (event: MessageEvent) => {
+      const msg = event.data as
+        | { type: 'progress'; stage: DeriveStage }
+        | ({ type: 'result' } & DeriveResult)
+        | { type: 'error'; message: string }
+      if (msg.type === 'progress') {
+        const job = jobs.get(topologyId)
+        if (job) job.stage = msg.stage
+        return
+      }
+      if (msg.type === 'result') {
+        try {
+          svc.completeDerivation(topologyId, startedRevision, msg)
+        } catch (err) {
+          console.error(`[derivation] Failed to persist bake for ${topologyId}:`, err)
+        }
+      } else {
+        svc.recordDeriveError(topologyId, startedRevision, msg.message)
+      }
+      settle()
+      // Inputs changed mid-bake → what we just wrote is already stale; bake
+      // again immediately so viewers converge.
+      if (svc.compositionRevisionOf(topologyId) !== startedRevision) {
+        void kickDerivation(topologyId, svc)
+      }
+    }
+    worker.onerror = (event: ErrorEvent) => {
+      svc.recordDeriveError(topologyId, startedRevision, event.message || 'derive worker crashed')
+      settle()
+    }
+  })
+
+  jobs.set(topologyId, {
+    promise,
+    stage: 'resolve',
+    startedAt: Date.now(),
+    startedRevision,
+    worker,
+    settle,
+  })
+  worker.postMessage(inputs)
+  return promise
+}

--- a/apps/server/api/src/services/derive-worker.ts
+++ b/apps/server/api/src/services/derive-worker.ts
@@ -1,0 +1,67 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Derivation worker — runs the CPU-heavy half of a topology parse
+ * (resolve → display filter → icon dimensions → layout) in a Bun Worker so
+ * the serving event loop stays responsive. A large layout can take minutes;
+ * on the main thread that froze every API request (the "Loading topology..."
+ * hang after a big Sync).
+ *
+ * Pure compute: all inputs arrive via postMessage (no DB access here), the
+ * result goes back the same way. Maps survive the structured clone.
+ *
+ * Protocol (worker → host):
+ *   { type: 'progress', stage: 'resolve' | 'icons' | 'layout' }
+ *   { type: 'result', graph, layout, resolved, iconDimensions }
+ *   { type: 'error', message }
+ */
+
+import {
+  computeNetworkLayout,
+  type NetworkGraph,
+  resolve as resolveObservations,
+  type ScopeFilter,
+  type SnapshotEntry,
+} from '@shumoku/core'
+import { collectIconUrls, resolveAllIconDimensions } from '@shumoku/renderer-svg'
+import { filterDisconnected } from './display-filter.js'
+
+export interface DeriveRequest {
+  authored: NetworkGraph
+  snapshots: SnapshotEntry[]
+  scope?: ScopeFilter
+  hideDisconnected: boolean
+}
+
+declare var self: Worker
+
+self.onmessage = async (event: MessageEvent) => {
+  const req = event.data as DeriveRequest
+  try {
+    self.postMessage({ type: 'progress', stage: 'resolve' })
+    const resolvedGraph = resolveObservations(req.authored, req.snapshots, { scope: req.scope })
+    const graph = req.hideDisconnected ? filterDisconnected(resolvedGraph) : resolvedGraph
+
+    self.postMessage({ type: 'progress', stage: 'icons' })
+    let iconDimensions = new Map<string, { width: number; height: number }>()
+    const iconUrls = collectIconUrls(graph)
+    if (iconUrls.length > 0) {
+      try {
+        iconDimensions = await resolveAllIconDimensions(iconUrls)
+      } catch (err) {
+        console.warn('[derive-worker] Failed to resolve icon dimensions:', err)
+      }
+    }
+
+    self.postMessage({ type: 'progress', stage: 'layout' })
+    const { resolved, layout } = await computeNetworkLayout(graph)
+
+    self.postMessage({ type: 'result', graph, layout, resolved, iconDimensions })
+  } catch (err) {
+    self.postMessage({
+      type: 'error',
+      message: err instanceof Error ? err.message : String(err),
+    })
+  }
+}

--- a/apps/server/api/src/services/discovery-scheduler.ts
+++ b/apps/server/api/src/services/discovery-scheduler.ts
@@ -132,6 +132,10 @@ export async function syncSource(
     capturedAt,
   )
   deps.topologyService.clearCacheEntry(topologyId)
+  // Bake the fresh artifact in the background now — without this, the first
+  // viewer after a scheduled refresh would eat the (potentially minutes-long)
+  // layout wait instead of getting the stale diagram + a hot swap.
+  deps.topologyService.precompute(topologyId)
   deps.topologySourcesService.updateLastSynced(attached.id)
 
   return {

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -44,15 +44,12 @@ import type {
 } from '@shumoku/core'
 import {
   attachmentKey,
-  computeNetworkLayout,
   createMemoryFileResolver,
   deriveMappingFromGraph,
   HierarchicalParser,
-  resolve as resolveObservations,
   sampleNetwork,
   YamlParser,
 } from '@shumoku/core'
-import { collectIconUrls, resolveAllIconDimensions } from '@shumoku/renderer-svg'
 import { generateId, getDatabase, timestamp } from '../db/index.js'
 import type {
   LinkContribution,
@@ -64,7 +61,14 @@ import type {
   TopologyInput,
 } from '../types.js'
 import { buildGraph, ingestGraph } from './contribution-store.js'
-import { filterDisconnected } from './display-filter.js'
+import { isDeriving, kickDerivation } from './derivation.js'
+
+/**
+ * How long `getParsed` waits for an in-flight bake before falling back to
+ * stale-serving. Small topologies finish inside this window, so the common
+ * case still returns fresh data in one request.
+ */
+const DERIVE_WAIT_MS = 3_000
 
 /**
  * Sentinel `source_id` of the **project overlay** — the project's own
@@ -420,6 +424,17 @@ export interface ParsedTopology {
   topologySourceId?: string
   metricsSourceId?: string
   mapping?: MetricsMapping
+  /** Served from an artifact older than the current composition revision —
+   *  a background bake is (re)building the fresh one. */
+  stale?: boolean
+}
+
+/** What the derive worker sends back (apps/server/api/src/services/derive-worker.ts). */
+export interface DeriveResult {
+  graph: NetworkGraph
+  layout: LayoutResult
+  resolved?: ResolvedLayout
+  iconDimensions: ResolvedIconDimensions
 }
 
 /**
@@ -1094,8 +1109,14 @@ export class TopologyService {
   }
 
   /**
-   * Get a parsed topology ready for rendering
-   * Uses cache if available
+   * Get a parsed topology ready for rendering — WITHOUT computing in-request.
+   *
+   * Order: RAM cache → fresh artifact → (kick a background bake, wait briefly
+   * so small topologies still feel synchronous) → STALE artifact marked
+   * `stale: true` → null (first-ever bake, nothing to serve yet; the route
+   * reports `deriving`). The heavy resolve+layout always runs in the
+   * derivation Worker (see services/derivation.ts) — a minutes-long layout
+   * must never block the serving event loop.
    */
   async getParsed(id: string): Promise<ParsedTopology | null> {
     // Check cache first
@@ -1114,11 +1135,8 @@ export class TopologyService {
       return null
     }
 
-    // L2: a persisted resolved-graph artifact (survives restart / RAM eviction).
-    // Serve it only when it was built from the CURRENT composition revision and
-    // resolver version — otherwise it's stale and we recompute. Fully guarded:
-    // any read/parse failure falls through to a fresh resolve, so the artifact
-    // can never break a read (worst case = current behaviour).
+    // L2: a persisted resolved-graph artifact (survives restart / RAM eviction),
+    // fresh = built from the CURRENT composition revision + resolver version.
     const fromArtifact = this.tryHydrateArtifact(topology)
     if (fromArtifact) {
       this.cache.set(id, fromArtifact)
@@ -1126,44 +1144,104 @@ export class TopologyService {
       return fromArtifact
     }
 
-    // Capture the revision BEFORE the async resolve. If an input changes during
-    // parse (a concurrent bump), this captured value won't match the new
-    // current revision, so the artifact we persist is immediately considered
-    // stale rather than served as falsely-fresh.
-    const revisionAtStart = this.compositionRevisionOf(id)
-    try {
-      const parsed = await this.parseTopology(topology)
-      this.errorCache.delete(id)
-      // If an input changed DURING the async resolve, this result is already
-      // stale: don't poison the RAM cache or persist it as fresh. Return it to
-      // the current caller (it asked for "now"), but the next read re-resolves.
-      if (this.compositionRevisionOf(id) === revisionAtStart) {
-        this.cache.set(id, parsed)
-        this.writeResolvedArtifact(topology, parsed, revisionAtStart)
-      }
-      return parsed
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      const phase = message.includes('Invalid NetworkGraph') ? 'parse' : 'layout'
-      // Only cache the failure if the inputs haven't changed since the parse
-      // started. A concurrent edit (revision bump) may have already fixed the
-      // cause; caching a stale error would make later reads short-circuit to
-      // null until the next invalidation.
-      if (this.compositionRevisionOf(id) === revisionAtStart) {
-        this.errorCache.set(id, {
-          id,
-          name: topology.name,
-          phase,
-          message,
-          timestamp: Date.now(),
-        })
-      }
-      console.error(
-        `[TopologyService] Failed to parse topology "${topology.name}" (${id}):`,
-        message,
-      )
-      return null
+    // Bake in the Worker. Wait a short grace period so small topologies return
+    // their fresh result in this request (tests + snappy UX); a big layout
+    // overshoots it and we fall through to stale-serving below.
+    await Promise.race([
+      kickDerivation(id, this),
+      new Promise((resolveSleep) => setTimeout(resolveSleep, DERIVE_WAIT_MS)),
+    ])
+    const baked = this.cache.get(id)
+    if (baked) return baked
+    if (this.errorCache.has(id)) return null
+
+    // Still baking (or the bake landed for an already-moved revision): serve
+    // the last-good artifact, stale. Viewers refresh when the bake lands.
+    const staleParsed = this.tryHydrateArtifact(topology, { allowStale: true })
+    if (staleParsed) {
+      staleParsed.stale = true
+      return staleParsed
     }
+    return null
+  }
+
+  /** Whether a background bake is in flight for this topology. */
+  deriving(id: string): boolean {
+    return isDeriving(id)
+  }
+
+  /** Fire-and-forget bake — call after a sync so the artifact is ready before the next view. */
+  precompute(id: string): void {
+    void kickDerivation(id, this)
+  }
+
+  /**
+   * The revision of the CONTENT currently served (the artifact's
+   * built_revision, falling back to the composition revision when no artifact
+   * exists). The share SSE stream sends this — viewers must refetch when the
+   * served content changes (a bake landing), not when an input changes (the
+   * stale artifact they already have would just be refetched).
+   */
+  servedRevisionOf(id: string): number {
+    try {
+      const row = this.db
+        .query('SELECT built_revision AS r FROM topology_resolved_graph WHERE topology_id = ?')
+        .get(id) as { r: number } | undefined
+      if (row && typeof row.r === 'number') return row.r
+    } catch {
+      // fall through
+    }
+    return this.compositionRevisionOf(id)
+  }
+
+  /**
+   * Finalize a Worker bake: compose the ParsedTopology (DB-backed bits — mapping,
+   * source ids — happen here, not in the Worker), persist the artifact stamped
+   * with the revision the bake STARTED from, and refresh the RAM caches when
+   * that revision is still current.
+   */
+  completeDerivation(id: string, builtRevision: number, result: DeriveResult): void {
+    const topology = this.get(id)
+    if (!topology) return
+    const parsed: ParsedTopology = {
+      id: topology.id,
+      name: topology.name,
+      graph: result.graph,
+      layout: result.layout,
+      resolved: result.resolved,
+      iconDimensions: result.iconDimensions,
+      metrics: this.createEmptyMetrics(result.graph),
+      topologySourceId: this.topologySourceIdFor(topology.id),
+      metricsSourceId: this.metricsSourceIdFor(topology.id),
+      mapping: this.buildMapping(topology.id, result.graph),
+    }
+    // Persist even if the revision moved mid-bake: built_revision marks it
+    // stale, and stale-but-newer beats the previous artifact for stale-serving.
+    this.writeResolvedArtifact(topology, parsed, builtRevision)
+    if (this.compositionRevisionOf(id) === builtRevision) {
+      this.cache.set(id, parsed)
+      this.renderCache.delete(id)
+      this.errorCache.delete(id)
+    }
+  }
+
+  /** Record a bake failure (only when the inputs haven't changed since it started). */
+  recordDeriveError(id: string, builtRevision: number, message: string): void {
+    const topology = this.get(id)
+    if (!topology) return
+    if (this.compositionRevisionOf(id) !== builtRevision) return
+    const phase = message.includes('Invalid NetworkGraph') ? 'parse' : 'layout'
+    this.errorCache.set(id, {
+      id,
+      name: topology.name,
+      phase,
+      message,
+      timestamp: Date.now(),
+    })
+    console.error(
+      `[TopologyService] Failed to derive topology "${topology.name}" (${id}):`,
+      message,
+    )
   }
 
   /**
@@ -1178,9 +1256,12 @@ export class TopologyService {
   }
 
   /**
-   * Parse a topology and generate layout.
+   * Gather the resolver inputs for a derivation bake — the DB-read half of the
+   * old in-request parse. The compute half (resolve → display filter → icons →
+   * layout) runs in the derive Worker (services/derive-worker.ts) so it never
+   * blocks the serving event loop.
    *
-   * The resolver runs here over two DB-native pools, both read from the
+   * The resolver consumes two DB-native pools, both read from the
    * contribution store (`contribution_*`):
    *   - the PROJECT OVERLAY (attachment_id NULL) — the operator's curation —
    *     fills the `authored` slot (top priority);
@@ -1191,7 +1272,14 @@ export class TopologyService {
    * With no overlay, `authored` is an empty graph — the diagram is whatever the
    * attached sources produced.
    */
-  private async parseTopology(topology: Topology): Promise<ParsedTopology> {
+  collectDeriveInputs(topologyId: string): {
+    authored: NetworkGraph
+    snapshots: SnapshotEntry[]
+    scope?: ScopeFilter
+    hideDisconnected: boolean
+  } | null {
+    const topology = this.get(topologyId)
+    if (!topology) return null
     // The `authored` slot is the PROJECT OVERLAY (DB-native, attachment_id NULL):
     // the operator's curation — exclusions, overrides, metrics bindings, settings —
     // folded as resolve()'s top-priority contribution. Absent → empty. A hand-drawn
@@ -1241,42 +1329,14 @@ export class TopologyService {
       }
     }
     const snapshots = this.readObservedSnapshots(topology.id, priorityBySource, modeBySource)
-    // Topology-level scope criteria (Phase 2): enforced post-merge by resolve, on
-    // top of the region-mark scope. Empty → no extra filtering.
-    const resolvedGraph = resolveObservations(authored, snapshots, { scope: topology.scope })
-    // Post-resolve display filter (project-level pref on the overlay settings).
-    // Runs on the fully-merged graph — never per-source.
-    const graph = authored.settings?.hideDisconnected
-      ? filterDisconnected(resolvedGraph)
-      : resolvedGraph
-
-    // Resolve icon dimensions for URL icons (used by renderer for
-    // aspect-preserving sizing).
-    let iconDimensions: ResolvedIconDimensions = new Map()
-    const iconUrls = collectIconUrls(graph)
-    if (iconUrls.length > 0) {
-      try {
-        iconDimensions = await resolveAllIconDimensions(iconUrls)
-      } catch (err) {
-        console.warn('Failed to resolve icon dimensions:', err)
-      }
-    }
-
-    const { resolved, layout: layoutResult } = await computeNetworkLayout(graph)
-    const metrics = this.createEmptyMetrics(graph)
-    const mapping = this.buildMapping(topology.id, graph)
-
+    // Topology-level scope criteria + the display filter run in the Worker:
+    // scope is enforced post-merge by resolve; hideDisconnected runs on the
+    // fully-merged graph — never per-source.
     return {
-      id: topology.id,
-      name: topology.name,
-      graph,
-      layout: layoutResult,
-      resolved,
-      iconDimensions,
-      metrics,
-      topologySourceId: this.topologySourceIdFor(topology.id),
-      metricsSourceId: this.metricsSourceIdFor(topology.id),
-      mapping,
+      authored,
+      snapshots,
+      scope: topology.scope,
+      hideDisconnected: authored.settings?.hideDisconnected === true,
     }
   }
 
@@ -1438,18 +1498,25 @@ export class TopologyService {
   /**
    * Hydrate a ParsedTopology from the persisted resolved-graph artifact, if one
    * exists and is current (matching composition revision + resolver version).
+   * With `allowStale`, the revision check is skipped — the serving layer uses
+   * this to keep showing the last-good diagram while a bake is in flight (the
+   * resolver-version check still applies; a wrong-shape artifact never serves).
    * Returns null on any miss/staleness/parse error so the caller recomputes.
    * Metrics are always rebuilt empty (live values come per-poll); mapping is
    * re-derived from the stored graph so it tracks binding/residual edits.
    */
-  private tryHydrateArtifact(topology: Topology): ParsedTopology | null {
+  private tryHydrateArtifact(
+    topology: Topology,
+    opts?: { allowStale?: boolean },
+  ): ParsedTopology | null {
     try {
       const row = this.db
         .query('SELECT * FROM topology_resolved_graph WHERE topology_id = ?')
         .get(topology.id) as ResolvedGraphRow | undefined
       if (!row?.layout_json) return null
       if (row.resolver_version !== RESOLVER_VERSION) return null
-      if (row.built_revision !== this.compositionRevisionOf(topology.id)) return null
+      if (!opts?.allowStale && row.built_revision !== this.compositionRevisionOf(topology.id))
+        return null
 
       const graph = JSON.parse(row.graph_json) as NetworkGraph
       const { layout, resolved } = parseWithMaps<{

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -7,12 +7,12 @@ import type { NetworkGraph } from '@shumoku/core'
 import type {
   Alert,
   AlertQueryOptions,
+  CompositionMode,
   ConnectionResult,
   Dashboard,
   DashboardInput,
   DataSource,
   DataSourceInput,
-  CompositionMode,
   LinkContribution,
   MetricsMapping,
   NodeContribution,
@@ -279,9 +279,15 @@ export const topologies = {
   },
 
   getGraph: (id: string) =>
-    request<{ id: string; name: string; graph: NetworkGraph }>(
-      scoped(`/topologies/${id}/graph`, `/topologies/${id}/graph`),
-    ),
+    request<{
+      id?: string
+      name?: string
+      graph?: NetworkGraph
+      /** Last-good diagram served while a background bake runs. */
+      stale?: boolean
+      /** 202 — first bake still running, nothing to serve yet. */
+      deriving?: boolean
+    }>(scoped(`/topologies/${id}/graph`, `/topologies/${id}/graph`)),
 
   /** Resolved graph = project overlay folded with each attached source's contribution. */
   getResolved: (id: string) =>

--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -78,6 +78,7 @@
     MagnifyingGlassMinusIcon,
     MagnifyingGlassPlusIcon,
   } from 'phosphor-svelte'
+  import { onDestroy } from 'svelte'
   import { api } from '$lib/api'
   import {
     HighlightOverlay,
@@ -112,9 +113,12 @@
     /**
      * Override how the underlying NetworkGraph is fetched. Detail page
      * uses `topologyId` and the default fetcher. Share page passes a
-     * token-scoped fetcher via this prop.
+     * token-scoped fetcher via this prop. The response may instead signal
+     * `deriving` (server is still baking the first layout) or carry
+     * `stale: true` (last-good diagram served while a re-bake runs) — both
+     * make this component poll until the fresh bake lands.
      */
-    graphLoader?: () => Promise<{ graph: NetworkGraph }>
+    graphLoader?: () => Promise<{ graph?: NetworkGraph; stale?: boolean; deriving?: boolean }>
   }
   let {
     topologyId = '',
@@ -131,6 +135,10 @@
   let graph = $state<NetworkGraph | undefined>(undefined)
   let loading = $state(true)
   let error = $state('')
+  // Server is baking the layout in the background (large topology). While a
+  // previous diagram exists we keep showing it; otherwise the loading state
+  // says what's happening instead of a bare spinner.
+  let building = $state(false)
 
   // Drill-down navigation stack. `currentSheetId === null` means root.
   let currentSheetId = $state<string | null>(null)
@@ -142,16 +150,35 @@
 
   // --- Data loading ---
 
+  // Poll timer for server-side bakes: short interval while the first layout
+  // is being built (no diagram yet), longer while a stale diagram is shown.
+  let refreshTimer: ReturnType<typeof setTimeout> | undefined
+  function scheduleRefresh(ms: number) {
+    clearTimeout(refreshTimer)
+    refreshTimer = setTimeout(() => void loadGraph(), ms)
+  }
+  onDestroy(() => clearTimeout(refreshTimer))
+
   async function loadGraph() {
-    loading = true
+    // Keep the current diagram visible during a stale-refresh poll — only
+    // show the loading state when there is nothing on screen yet.
+    loading = graph === undefined
     error = ''
     try {
       const loader = graphLoader ?? (() => api.topologies.getGraph(topologyId))
       const res = await loader()
-      graph = res.graph
+      if (res.deriving) {
+        building = true
+        loading = graph === undefined
+        scheduleRefresh(3000)
+        return
+      }
+      if (res.graph) graph = res.graph
+      building = res.stale === true
+      if (res.stale) scheduleRefresh(5000)
+      loading = false
     } catch (e) {
       error = e instanceof Error ? e.message : 'Unknown error'
-    } finally {
       loading = false
     }
   }
@@ -358,7 +385,7 @@
   {#if loading}
     <div class="loading">
       <div class="spinner"></div>
-      <span>Loading topology...</span>
+      <span>{building ? 'Computing layout… (large topology)' : 'Loading topology...'}</span>
     </div>
   {:else if error}
     <div class="error">

--- a/apps/server/web/src/lib/widgets/TopologyWidget.svelte
+++ b/apps/server/web/src/lib/widgets/TopologyWidget.svelte
@@ -120,6 +120,11 @@
         }
       }
       const { graph } = await api.topologies.getGraph(config.topologyId)
+      if (!graph) {
+        // Server is still baking the first layout for this topology.
+        error = 'Topology is being prepared — try again shortly'
+        return
+      }
       rootGraph = graph
 
       const topLevel = (graph.subgraphs ?? []).filter((sg) => !sg.parent)

--- a/apps/server/web/src/routes/(app)/topologies/[id]/composition/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/composition/+page.svelte
@@ -140,7 +140,7 @@
       // gauge and grid so the counts mean what they appear to.
       const counts = { stable: 0, weak: 0, unbound: 0, total: 0 }
       const cards: DiscoveredCard[] = []
-      for (const node of graphResp.graph.nodes ?? []) {
+      for (const node of graphResp.graph?.nodes ?? []) {
         const isSegment =
           node.spec?.kind === 'hardware' && (node.spec as { type?: string }).type === 'segment'
         if (isSegment) continue


### PR DESCRIPTION
## 問題

test6規模（マージ後563ノード）のフルresolve+レイアウトは**約8分の同期CPU処理**で、無効化後の最初のリクエストの中で実行されていた。Sync（手動・スケジューラ）のたびにサーバー全体が無応答になり、「Loading topology...」のままリロードも固まる。実測の内訳: snapshots 24ms / resolve 70ms / filter 1ms / **layout 489s**。

## 変更（配信層と計算層の分離）

- **derive-worker.ts** — resolve → 表示フィルタ → アイコン寸法 → layout を Bun Worker で実行（純計算、postMessage往復。Mapはstructured cloneで生存）
- **derivation.ts** — モジュールレベルのジョブキュー：トポロジーごとに1ベイク、kickは重複合流、30分タイムアウト、ベイク中にrevisionが動いたら自動再ベイク。進捗ステージ（resolve/icons/layout）を追跡（次PRの進捗UIの土台）
- **getParsed はリクエスト内で計算しない** — RAMキャッシュ → 新鮮なアーティファクト → （ベイクをkickし3秒だけ待つ＝小規模はこれまで通り即返る）→ **旧アーティファクトを `stale:true` で返す** → 初回のみ 202 `{deriving:true}`
- Syncエンドポイント＋スケジューラは無効化直後に `precompute()` — ビューアを待たずに裏で焼き始める
- share SSE は composition revision ではなく**配信中コンテンツのrevision**（artifact built_revision）を流す — 入力が変わった時ではなく中身が実際に変わった時（ベイク完了時）だけ再フェッチ
- web: `deriving`（3秒ポーリング+「Computing layout…」表示）と `stale`（前の図を出し続けて5秒ポーリング、焼き上がりで差し替え）に対応

## 挙動

- Sync中・ベイク中もUIは固まらない（直前の図が出続け、完成で自動差し替え）
- スケジューラの定期Syncも同様（従来は5分ごとに8分の無応答が再生産されていた）

## Tests
- server API 85 pass（getParsed系テストはWorker経由で通過）/ typecheck 緑 / svelte-check 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)