### PR TITLE
fix(web): viewer uses the SERVER-BAKED layout — no more browser-thread freeze

### DIFF
--- a/apps/server/api/src/api/share.ts
+++ b/apps/server/api/src/api/share.ts
@@ -8,6 +8,7 @@
  * `resolveDashboardGrant` middleware, not re-checked per handler).
  */
 
+import { stringifyWithMaps } from '@shumoku/core'
 import { type Context, Hono } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import type { AlertQueryOptions } from '../plugins/types.js'
@@ -164,6 +165,43 @@ export function createShareApi(): Hono<{ Variables: ShareVars }> {
         return c.json({ error: 'Failed to parse topology' }, 500)
       }
       return c.json(publicTopologyGraph(parsed))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
+  })
+
+  // Shared topology view payload: share-safe graph + the server-baked
+  // ResolvedLayout (positions only — nothing sensitive) so the anonymous
+  // viewer never recomputes a large layout on its main thread. Maps are
+  // tagged (stringifyWithMaps); the client parses with parseWithMaps.
+  app.get('/topologies/:token/view', async (c) => {
+    const token = c.req.param('token')
+    const service = getTopologyService()
+    const topology = service.getByShareToken(token)
+    if (!topology) {
+      return c.json({ error: 'Not found' }, 404)
+    }
+    try {
+      const parsed = await service.getParsed(topology.id)
+      if (!parsed) {
+        const parseError = service.getParseError(topology.id)
+        if (parseError) {
+          // Generic message: never surface internal parse/connection detail to an
+          // anonymous viewer (it can carry config text / upstream errors).
+          return c.json({ error: 'Topology is currently unavailable' }, 422)
+        }
+        if (service.deriving(topology.id)) {
+          return c.json({ deriving: true }, 202)
+        }
+        return c.json({ error: 'Failed to parse topology' }, 500)
+      }
+      const body = stringifyWithMaps({
+        ...publicTopologyGraph(parsed),
+        resolved: parsed.resolved,
+        stale: parsed.stale ?? false,
+      })
+      return c.body(body, 200, { 'Content-Type': 'application/json' })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 500)

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -8,6 +8,7 @@ import {
   type NetworkGraph,
   type ScopeFilter,
   specDeviceType,
+  stringifyWithMaps,
 } from '@shumoku/core'
 import { type EmbeddableRenderOutput, renderEmbeddable } from '@shumoku/renderer-svg'
 import { Hono } from 'hono'
@@ -292,6 +293,39 @@ export function createTopologiesApi(): Hono {
         graph: applyMappingBandwidth(parsed.graph, parsed.mapping),
         stale: parsed.stale ?? false,
       })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
+  })
+
+  // Full client-view payload: graph + the SERVER-BAKED ResolvedLayout in one
+  // consistent snapshot (Maps tagged via stringifyWithMaps; the client parses
+  // with parseWithMaps). The interactive viewer uses this to skip its own
+  // computeNetworkLayout for the root sheet — a large layout re-run on the
+  // browser main thread froze the tab for minutes.
+  app.get('/:id/view', async (c) => {
+    const id = c.req.param('id')
+    try {
+      const parsed = await service.getParsed(id)
+      if (!parsed) {
+        const parseError = service.getParseError(id)
+        if (parseError) {
+          return c.json({ error: parseError.message, errorPhase: parseError.phase }, 422)
+        }
+        if (service.deriving(id)) {
+          return c.json({ deriving: true }, 202)
+        }
+        return c.json({ error: 'Topology not found' }, 404)
+      }
+      const body = stringifyWithMaps({
+        id: parsed.id,
+        name: parsed.name,
+        graph: applyMappingBandwidth(parsed.graph, parsed.mapping),
+        resolved: parsed.resolved,
+        stale: parsed.stale ?? false,
+      })
+      return c.body(body, 200, { 'Content-Type': 'application/json' })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 500)

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -47,7 +47,9 @@ import {
   createMemoryFileResolver,
   deriveMappingFromGraph,
   HierarchicalParser,
+  parseWithMaps,
   sampleNetwork,
+  stringifyWithMaps,
   YamlParser,
 } from '@shumoku/core'
 import { generateId, getDatabase, timestamp } from '../db/index.js'
@@ -129,37 +131,6 @@ interface ScopeCriterionRow {
  * stale and recomputed without a manual purge.
  */
 const RESOLVER_VERSION = 2
-
-/**
- * Map-aware JSON round-trip. `LayoutResult` / `ResolvedLayout` are Map-heavy
- * (nodes/links/ports/subgraphs are `Map`s) and `JSON.stringify` silently turns a
- * Map into `{}`, so the persisted artifact would be corrupt. These encode a Map
- * as `{__map__: [...entries]}` recursively (the replacer/reviver visit every
- * value), so arbitrarily-nested Maps survive the round-trip.
- */
-const MAP_TAG = '__map__'
-function stringifyWithMaps(value: unknown): string {
-  return JSON.stringify(value, (_k, v) =>
-    v instanceof Map ? { [MAP_TAG]: Array.from(v.entries()) } : v,
-  )
-}
-function parseWithMaps<T>(text: string): T {
-  return JSON.parse(text, (_k, v) => {
-    // Only the encoder's exact shape `{ __map__: [...] }` (a single key) is a
-    // tagged Map — so a real object that merely *has* a `__map__` array property
-    // is not misread as a Map.
-    if (
-      v &&
-      typeof v === 'object' &&
-      !Array.isArray(v) &&
-      Object.keys(v).length === 1 &&
-      Array.isArray((v as Record<string, unknown>)[MAP_TAG])
-    ) {
-      return new Map((v as Record<string, [unknown, unknown][]>)[MAP_TAG])
-    }
-    return v
-  }) as T
-}
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -3,7 +3,8 @@
  * Handles all communication with the Shumoku server API
  */
 
-import type { NetworkGraph } from '@shumoku/core'
+import type { NetworkGraph, ResolvedLayout } from '@shumoku/core'
+import { parseWithMaps } from '@shumoku/core'
 import type {
   Alert,
   AlertQueryOptions,
@@ -283,6 +284,37 @@ export const topologies = {
       /** 202 — first bake still running, nothing to serve yet. */
       deriving?: boolean
     }>(scoped(`/topologies/${id}/graph`, `/topologies/${id}/graph`)),
+
+  /**
+   * Graph + the SERVER-BAKED ResolvedLayout in one consistent snapshot.
+   * The interactive viewer uses this so it never recomputes a large layout
+   * on the browser main thread. Maps arrive tagged — parsed here.
+   */
+  getView: async (
+    id: string,
+  ): Promise<{
+    id?: string
+    name?: string
+    graph?: NetworkGraph
+    resolved?: ResolvedLayout
+    stale?: boolean
+    deriving?: boolean
+  }> => {
+    const path = scoped(`/topologies/${id}/view`, `/topologies/${id}/view`)
+    const response = await fetch(`${BASE_URL}${path}`)
+    if (response.status === 202) return { deriving: true }
+    if (!response.ok) {
+      let message = `HTTP error ${response.status}`
+      try {
+        const data = (await response.json()) as { error?: string }
+        if (data.error) message = data.error
+      } catch {
+        // Ignore JSON parsing error
+      }
+      throw new ApiError(message, response.status)
+    }
+    return parseWithMaps(await response.text())
+  },
 
   /** Resolved graph = project overlay folded with each attached source's contribution. */
   getResolved: (id: string) =>

--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -69,7 +69,7 @@
    * `getSvgElement`) used by the search palette and drill-down flows
    * continue to work without refactoring callers.
    */
-  import { darkTheme, lightTheme, type NetworkGraph } from '@shumoku/core'
+  import { darkTheme, lightTheme, type NetworkGraph, type ResolvedLayout } from '@shumoku/core'
   import {
     ArrowLeftIcon,
     CornersOutIcon,
@@ -118,7 +118,13 @@
      * `stale: true` (last-good diagram served while a re-bake runs) — both
      * make this component poll until the fresh bake lands.
      */
-    graphLoader?: () => Promise<{ graph?: NetworkGraph; stale?: boolean; deriving?: boolean }>
+    graphLoader?: () => Promise<{
+      graph?: NetworkGraph
+      /** Server-baked layout for the root sheet — skips client computation. */
+      resolved?: ResolvedLayout
+      stale?: boolean
+      deriving?: boolean
+    }>
   }
   let {
     topologyId = '',
@@ -133,6 +139,11 @@
 
   // --- State ---
   let graph = $state<NetworkGraph | undefined>(undefined)
+  // Server-baked root layout. When present, TopologyViewer skips its own
+  // computeNetworkLayout for the root sheet — a large layout recomputed on
+  // the browser main thread froze the tab for minutes. Sheet drill-downs
+  // still compute locally (child sheets are much smaller).
+  let serverLayout = $state<ResolvedLayout | undefined>(undefined)
   let loading = $state(true)
   let error = $state('')
   // Server is baking the layout in the background (large topology). While a
@@ -165,7 +176,7 @@
     loading = graph === undefined
     error = ''
     try {
-      const loader = graphLoader ?? (() => api.topologies.getGraph(topologyId))
+      const loader = graphLoader ?? (() => api.topologies.getView(topologyId))
       const res = await loader()
       if (res.deriving) {
         building = true
@@ -173,7 +184,10 @@
         scheduleRefresh(3000)
         return
       }
-      if (res.graph) graph = res.graph
+      if (res.graph) {
+        graph = res.graph
+        serverLayout = res.resolved
+      }
       building = res.stale === true
       if (res.stale) scheduleRefresh(5000)
       loading = false
@@ -414,9 +428,10 @@
       bind:this={viewer}
       {graph}
       sheetId={currentSheetId}
+      layout={currentSheetId ? undefined : serverLayout}
       theme={currentTheme}
       mode="view"
-      sheetCacheStrategy="eager"
+      sheetCacheStrategy="lazy"
       onselect={handleSelect}
     >
       {#snippet linkOverlay(edge, context)}

--- a/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
+++ b/apps/server/web/src/routes/share/topologies/[token]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { parseWithMaps } from '@shumoku/core'
   import { page } from '$app/stores'
   import InteractiveSvgDiagram from '$lib/components/InteractiveSvgDiagram.svelte'
   import Logo from '$lib/components/Logo.svelte'
@@ -11,12 +12,15 @@
   let lastGraphJson = ''
 
   const token = $derived($page.params.token)
+  // /view carries the SERVER-BAKED ResolvedLayout alongside the graph, so the
+  // shared viewer never recomputes a large layout on its main thread.
   const loadShared = $derived(async () => {
-    const res = await fetch(`/api/share/topologies/${token}/graph`)
+    const res = await fetch(`/api/share/topologies/${token}/view`)
+    if (res.status === 202) return { deriving: true }
     if (!res.ok) throw new Error(`Failed to load shared topology: ${res.status}`)
     const text = await res.text()
     lastGraphJson = text
-    return JSON.parse(text)
+    return parseWithMaps<Record<string, unknown>>(text)
   })
 
   // Structure updates are EVENT-driven: the metrics SSE stream carries
@@ -25,7 +29,7 @@
   // revision bump without visual impact doesn't flash the diagram).
   async function refetchGraph(currentToken: string): Promise<void> {
     try {
-      const res = await fetch(`/api/share/topologies/${currentToken}/graph`)
+      const res = await fetch(`/api/share/topologies/${currentToken}/view`)
       if (!res.ok) return
       const text = await res.text()
       if (lastGraphJson !== '' && text !== lastGraphJson) {

--- a/libs/@shumoku/core/src/index.ts
+++ b/libs/@shumoku/core/src/index.ts
@@ -18,6 +18,8 @@ export * from './icons/index.js'
 export * from './ids.js'
 // Layout
 export * from './layout/index.js'
+// Map-aware JSON (layout artifacts hold Maps)
+export * from './map-json.js'
 // Models
 export * from './models/index.js'
 // Observation (discovery / resolve)

--- a/libs/@shumoku/core/src/map-json.ts
+++ b/libs/@shumoku/core/src/map-json.ts
@@ -1,0 +1,32 @@
+/**
+ * JSON (de)serialization that round-trips `Map` values, used to ship layout
+ * artifacts (ResolvedLayout holds Maps) between the server's persisted
+ * artifact, its HTTP responses, and the web client. Maps are tagged as
+ * `{ "__map__": [[k, v], ...] }`; everything else is plain JSON.
+ */
+
+const MAP_TAG = '__map__'
+
+export function stringifyWithMaps(value: unknown): string {
+  return JSON.stringify(value, (_k, v) =>
+    v instanceof Map ? { [MAP_TAG]: Array.from(v.entries()) } : v,
+  )
+}
+
+export function parseWithMaps<T>(text: string): T {
+  return JSON.parse(text, (_k, v) => {
+    // Only the encoder's exact shape `{ __map__: [...] }` (a single key) is a
+    // tagged Map — so a real object that merely *has* a `__map__` array
+    // property is not misread as a Map.
+    if (
+      v &&
+      typeof v === 'object' &&
+      !Array.isArray(v) &&
+      Object.keys(v).length === 1 &&
+      Array.isArray((v as Record<string, unknown>)[MAP_TAG])
+    ) {
+      return new Map((v as Record<string, [unknown, unknown][]>)[MAP_TAG])
+    }
+    return v
+  }) as T
+}


### PR DESCRIPTION
## 問題

「ページが固まる」の正体：詳細ページ（とshareページ）の `TopologyViewer` が、サーバーが既にWorkerで焼いたのと**同じ約8分のレイアウト計算を、ブラウザのメインスレッドでやり直していた**。しかも `sheetCacheStrategy='eager'` でトップレベルsubgraph全部のレイアウトまで先回り計算 → タブが完全に固まる。APIは全部200/0.2秒で返っていた（サーバー側はPR #466で解決済み）。

## 変更

- **core**: `stringifyWithMaps` / `parseWithMaps` を `@shumoku/core`（map-json.ts）へ移動 — サーバーとWebで同一のMapタグ付きJSONコーデックを共有
- **api**: `GET /topologies/:id/view`（+ share token版 `/share/topologies/:token/view`）— graph + 焼き上がった完全な `ResolvedLayout` を**一貫したスナップショット**で返す（stale/derivingの意味は /graph と同じ。share版は share-safe projection を通す）
- **web**: `InteractiveSvgDiagram` は `/view` をロードし、ルートシートでは `layoutOverride` としてサーバーレイアウトを渡す — **オープン時のクライアント側レイアウト計算ゼロ**。シートのドリルダウンは子グラフが小さいのでローカル計算のまま、ただし 'eager' → 'lazy' に変更（巨大グラフでの全シート先回り計算をやめる）

## Tests
- core build / api typecheck+85 pass / svelte-check 0 errors / web build 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)