### PR TITLE
fix(web): break the /view refetch loop — zoom works again

### DIFF
--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -170,23 +170,30 @@
   }
   onDestroy(() => clearTimeout(refreshTimer))
 
+  // Non-reactive mirror of "a graph has been shown at least once". loadGraph
+  // is invoked from a $effect; reading the `graph` $state there would register
+  // it as a dependency, and since loadGraph also WRITES `graph`, that loops
+  // forever (refetch → new graph → effect refires → refetch …).
+  let hasGraph = false
+
   async function loadGraph() {
     // Keep the current diagram visible during a stale-refresh poll — only
     // show the loading state when there is nothing on screen yet.
-    loading = graph === undefined
+    loading = !hasGraph
     error = ''
     try {
       const loader = graphLoader ?? (() => api.topologies.getView(topologyId))
       const res = await loader()
       if (res.deriving) {
         building = true
-        loading = graph === undefined
+        loading = !hasGraph
         scheduleRefresh(3000)
         return
       }
       if (res.graph) {
         graph = res.graph
         serverLayout = res.resolved
+        hasGraph = true
       }
       building = res.stale === true
       if (res.stale) scheduleRefresh(5000)
@@ -369,6 +376,7 @@
   $effect(() => {
     // Track topologyId so the effect re-runs when the route id changes.
     topologyId
+    hasGraph = false
     loadGraph()
   })
 


### PR DESCRIPTION
## 問題

「ズームできない」の正体：`loadGraph()` が `$effect` から呼ばれる際に `loading = graph === undefined` で **`graph` $state を同期的に読んでいた**ため、effect の依存に `graph` が登録され、フェッチ完了の `graph` 代入で effect が再発火 → **無限リフェッチループ**。DevToolsで /view への**1200回超のリクエスト**（毎秒約3.5回、1回3MB）を確認。サイクルごとに図が再レンダリングされカメラがリセットされるので、ズームが一切効かないように見えていた。

（このループ自体はPR #466のweb変更で混入。当時はレスポンス処理が重くフリーズに紛れていて、#468でレスポンスが軽くなった結果「ズーム死」として顕在化した）

## 修正

「一度でもグラフを表示したか」を **非リアクティブなプレーン変数** `hasGraph` で追跡（topologyId変更でリセット）。effectの依存から `graph` が消え、ループ停止。

## 検証
- svelte-check 0 errors / build 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)