### PR TITLE
fix(server): ship the derive Worker in the production bundle

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -72,8 +72,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
 RUN getent group 1000 || groupadd --gid 1000 shumoku \
     && (getent passwd 1000 || useradd --uid 1000 --gid 1000 --shell /bin/sh --create-home shumoku)
 
-# Copy bundled server
+# Copy bundled server + the derivation Worker (spawned at runtime via
+# `new Worker(url)`, so it ships as a sibling bundle, not inlined)
 COPY --from=builder /app/apps/server/api/dist/bundle.js ./server.js
+COPY --from=builder /app/apps/server/api/dist/derive-worker.js ./derive-worker.js
 
 # Copy web UI build
 COPY --from=builder /app/apps/server/web/build ./web/build

--- a/apps/server/api/esbuild.config.js
+++ b/apps/server/api/esbuild.config.js
@@ -21,4 +21,18 @@ await esbuild.build({
   },
 })
 
-console.log('Bundle created: dist/bundle.js')
+// The derivation Worker is its OWN entry point: it is spawned at runtime via
+// `new Worker(url)`, so the main bundle never imports it and esbuild won't
+// pick it up. Ship it as a sibling bundle — derivation.ts resolves
+// `./derive-worker.js` next to the running entry in production.
+await esbuild.build({
+  entryPoints: ['dist/api/src/services/derive-worker.js'],
+  bundle: true,
+  platform: 'node',
+  target: 'esnext',
+  format: 'esm',
+  outfile: 'dist/derive-worker.js',
+  external: ['bun:sqlite', 'bun'],
+})
+
+console.log('Bundles created: dist/bundle.js, dist/derive-worker.js')

--- a/apps/server/api/src/services/derivation.ts
+++ b/apps/server/api/src/services/derivation.ts
@@ -14,10 +14,27 @@
  * topology.
  */
 
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import type { DeriveResult, TopologyService } from './topology.js'
 
 /** Hard ceiling — a runaway layout must not pin a core forever. */
 const DERIVE_TIMEOUT_MS = 30 * 60_000
+
+/**
+ * Worker entry path. In the bundled production image the worker ships as a
+ * sibling bundle of the server entry (`/app/derive-worker.js`, see
+ * esbuild.config.js + Dockerfile); in dev we run the TS source directly.
+ */
+function deriveWorkerUrl(): URL {
+  const bundled = new URL('./derive-worker.js', import.meta.url)
+  try {
+    if (existsSync(fileURLToPath(bundled))) return bundled
+  } catch {
+    // non-file URL (unlikely) — fall through to the TS source
+  }
+  return new URL('./derive-worker.ts', import.meta.url)
+}
 
 export type DeriveStage = 'resolve' | 'icons' | 'layout'
 
@@ -69,7 +86,7 @@ export function kickDerivation(topologyId: string, svc: TopologyService): Promis
   if (!inputs) return Promise.resolve()
   const startedRevision = svc.compositionRevisionOf(topologyId)
 
-  const worker = new Worker(new URL('./derive-worker.ts', import.meta.url).href)
+  const worker = new Worker(deriveWorkerUrl().href)
   let settle: () => void = () => {}
   const promise = new Promise<void>((done) => {
     let settled = false


### PR DESCRIPTION
## 問題

本番（Docker）でSyncすると `ModuleNotFound resolving "/app/derive-worker.ts"`。本番はesbuildの単一バンドル（/app/server.js）で動くが、導出Workerは実行時に `new Worker(url)` で起動するためesbuildの依存グラフに乗らず、バンドルにも同梱されていなかった。

## 修正

- **esbuild.config.js** — Workerを独立エントリとしてバンドル（`dist/derive-worker.js`）
- **Dockerfile** — `server.js` の隣に `derive-worker.js` をコピー
- **derivation.ts** — 実行エントリの隣に `./derive-worker.js` があればそれを使用（本番）、なければTSソースにフォールバック（dev）

## 検証

- tsc + esbuild をローカルで実行 → `dist/derive-worker.js`（380KB）生成
- バンドル版Workerを直接スポーンするスモークテスト → resolve+layout完走（`OK nodes: 2 layout nodes: 2`）

マージ後、**イメージの再ビルドが必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)