### PR TITLE
feat(sync): no-change gate — an unchanged re-sync never re-bakes the layout

### DIFF
--- a/apps/server/api/src/api/observations.ts
+++ b/apps/server/api/src/api/observations.ts
@@ -68,8 +68,12 @@ export function createScanRoute(): Hono {
           snapshot.capturedAt,
         )
         // Invalidate the parsed-topology cache so the next /render / /graph
-        // call re-runs resolve() with the new snapshot.
-        getTopologyService().clearCacheEntry(topologyId)
+        // call re-runs resolve() with the new snapshot — only when the
+        // contribution actually changed (no-change gate).
+        if (observation.contributionChanged) {
+          getTopologyService().clearCacheEntry(topologyId)
+          getTopologyService().precompute(topologyId)
+        }
         return c.json({ snapshot, observation })
       }
 
@@ -181,8 +185,13 @@ export function createObservationsRoute(): Hono {
         graph,
       })
       // Invalidate parsed-topology cache so the next /render runs
-      // resolve() against the new observation.
-      getTopologyService().clearCacheEntry(topologyId)
+      // resolve() against the new observation — only when the contribution
+      // actually changed (no-change gate; an identical editor re-save keeps
+      // the current artifact).
+      if (observation.contributionChanged) {
+        getTopologyService().clearCacheEntry(topologyId)
+        getTopologyService().precompute(topologyId)
+      }
       return c.json({ observation }, 201)
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)

--- a/apps/server/api/src/api/topology-sources.ts
+++ b/apps/server/api/src/api/topology-sources.ts
@@ -415,7 +415,12 @@ topologySourcesApi.post('/:topologyId/sources/:sourceId/probe', async (c) => {
       snapshot.status === 'failed' ? 'failed' : 'ok',
       capturedAt,
     )
-    getTopologyService().clearCacheEntry(topologyId)
+    // No-change gate: only invalidate + re-bake when the merged contribution
+    // actually changed.
+    if (observation.contributionChanged) {
+      getTopologyService().clearCacheEntry(topologyId)
+      getTopologyService().precompute(topologyId)
+    }
     getTopologySourcesService().updateLastSynced(attached.id)
     return c.json({
       observation,
@@ -503,9 +508,13 @@ topologySourcesApi.post('/:topologyId/sources/:sourceId/sync', async (c) => {
     status === 'failed' ? 'failed' : 'ok',
     capturedAt,
   )
-  getTopologyService().clearCacheEntry(topologyId)
-  // Bake the fresh artifact in the background now (stale-while-revalidate).
-  getTopologyService().precompute(topologyId)
+  // No-change gate: only invalidate + re-bake when the contribution actually
+  // changed; a re-sync of an unchanged source keeps the current artifact.
+  if (observation.contributionChanged) {
+    getTopologyService().clearCacheEntry(topologyId)
+    // Bake the fresh artifact in the background now (stale-while-revalidate).
+    getTopologyService().precompute(topologyId)
+  }
   // Stamp the legacy lastSyncedAt for UI surfaces that read it.
   getTopologySourcesService().updateLastSynced(attached.id)
 

--- a/apps/server/api/src/api/webhooks.ts
+++ b/apps/server/api/src/api/webhooks.ts
@@ -91,14 +91,18 @@ async function handleTopologyWebhook(c: Context, id: string, secret: string) {
 
     const { ObservationsService } = await import('../services/observations.js')
     const observations = new ObservationsService()
-    await observations.record({
+    const recorded = await observations.record({
       topologyId: source.topologyId,
       sourceId: source.dataSourceId,
       capturedAt: Date.now(),
       status: graph.nodes && graph.nodes.length > 0 ? 'ok' : 'empty',
       graph,
     })
-    getTopologyService().clearCacheEntry(source.topologyId)
+    // No-change gate: an unchanged webhook push keeps the current artifact.
+    if (recorded.contributionChanged) {
+      getTopologyService().clearCacheEntry(source.topologyId)
+      getTopologyService().precompute(source.topologyId)
+    }
     getTopologySourcesService().updateLastSynced(source.id)
 
     if (broadcastTopologyUpdate) {

--- a/apps/server/api/src/db/migrations/023_contribution_content_hash.sql
+++ b/apps/server/api/src/db/migrations/023_contribution_content_hash.sql
@@ -1,0 +1,5 @@
+-- No-change gate: hash of the contribution's STRUCTURAL content (volatile
+-- fields like observedAt stripped). A re-sync whose hash matches the stored
+-- one skips the composition-revision bump — and with it the multi-minute
+-- layout re-bake — because nothing the diagram shows has changed.
+ALTER TABLE contribution_source ADD COLUMN content_hash TEXT;

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -27,6 +27,7 @@ import migration019 from './migrations/019_fix_contribution_link_local_id_nullab
 import migration020 from './migrations/020_topology_scope.sql'
 import migration021 from './migrations/021_topology_scope_criteria.sql'
 import migration022 from './migrations/022_topology_composition_mode.sql'
+import migration023 from './migrations/023_contribution_content_hash.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -50,6 +51,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '020_topology_scope.sql', sql: migration020 },
   { name: '021_topology_scope_criteria.sql', sql: migration021 },
   { name: '022_topology_composition_mode.sql', sql: migration022 },
+  { name: '023_contribution_content_hash.sql', sql: migration023 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/contribution-store.ts
+++ b/apps/server/api/src/services/contribution-store.ts
@@ -126,6 +126,8 @@ export interface IngestOptions {
   attachmentId?: string | null
   lastStatus?: string
   lastOkAt?: number
+  /** Structural content hash (volatile fields stripped) for the no-change gate. */
+  contentHash?: string | null
 }
 
 /**
@@ -156,8 +158,8 @@ export function ingestGraph(
       'exclusions',
     ])
     db.query(
-      `INSERT INTO contribution_source (topology_id, source_id, attachment_id, last_status, last_ok_at, graph_payload_json)
-       VALUES (?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO contribution_source (topology_id, source_id, attachment_id, last_status, last_ok_at, graph_payload_json, content_hash)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       topologyId,
       sourceId,
@@ -165,6 +167,7 @@ export function ingestGraph(
       opts.lastStatus ?? null,
       opts.lastOkAt ?? null,
       j(graphPayload),
+      opts.contentHash ?? null,
     )
 
     const insElement = db.query(

--- a/apps/server/api/src/services/discovery-scheduler.ts
+++ b/apps/server/api/src/services/discovery-scheduler.ts
@@ -117,7 +117,7 @@ export async function syncSource(
     graph = null
   }
 
-  await deps.observationsService.record({
+  const recorded = await deps.observationsService.record({
     topologyId,
     sourceId,
     capturedAt,
@@ -131,11 +131,16 @@ export async function syncSource(
     status === 'failed' ? 'failed' : 'ok',
     capturedAt,
   )
-  deps.topologyService.clearCacheEntry(topologyId)
-  // Bake the fresh artifact in the background now — without this, the first
-  // viewer after a scheduled refresh would eat the (potentially minutes-long)
-  // layout wait instead of getting the stale diagram + a hot swap.
-  deps.topologyService.precompute(topologyId)
+  // No-change gate: a scheduled re-scan of an unchanged network must NOT bump
+  // the revision — that would re-run the (potentially minutes-long) layout
+  // bake every tick for nothing.
+  if (recorded.contributionChanged) {
+    deps.topologyService.clearCacheEntry(topologyId)
+    // Bake the fresh artifact in the background now — without this, the first
+    // viewer after a scheduled refresh would eat the layout wait instead of
+    // getting the stale diagram + a hot swap.
+    deps.topologyService.precompute(topologyId)
+  }
   deps.topologySourcesService.updateLastSynced(attached.id)
 
   return {

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -21,9 +21,35 @@
  */
 
 import type { Database } from 'bun:sqlite'
+import { createHash } from 'node:crypto'
 import type { NetworkGraph } from '@shumoku/core'
 import { generateId, getDatabase, timestamp } from '../db/index.js'
 import { ingestGraph } from './contribution-store.js'
+
+/**
+ * Hash of a contribution's STRUCTURAL content: volatile per-scan fields
+ * (`observedAt` timestamps stamped on every node/provenance by plugins) are
+ * stripped so two scans of an unchanged network hash identically. Key order
+ * is whatever the plugin produced — deterministic for identical upstream
+ * data, which is exactly the case the gate exists for.
+ */
+export function contributionContentHash(graph: NetworkGraph): string {
+  const strip = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(strip)
+    if (v && typeof v === 'object') {
+      const out: Record<string, unknown> = {}
+      for (const [k, val] of Object.entries(v)) {
+        if (k === 'observedAt') continue
+        out[k] = strip(val)
+      }
+      return out
+    }
+    return v
+  }
+  return createHash('sha256')
+    .update(JSON.stringify(strip(graph)))
+    .digest('hex')
+}
 
 export type ObservationStatus = 'ok' | 'partial' | 'failed' | 'empty'
 
@@ -40,6 +66,15 @@ export interface TopologyObservation {
   linkCount: number
   portCount: number
   createdAt: number
+  /**
+   * Whether this snapshot CHANGED the source's canonical contribution
+   * (structural hash differs from the stored one). False for failed scans,
+   * out-of-order arrivals, unattached sources — and, crucially, for re-scans
+   * of an unchanged network. Callers use this as the no-change gate: skip the
+   * composition-revision bump (and the multi-minute layout re-bake) when
+   * nothing the diagram shows has changed.
+   */
+  contributionChanged?: boolean
 }
 
 export interface RecordObservationInput {
@@ -123,8 +158,9 @@ export class ObservationsService {
     // source of truth; the audit row is its history twin. (ingestGraph runs its own
     // transaction — bun:sqlite nests it as a SAVEPOINT, so a failure here rolls back
     // both writes together.)
+    let contributionChanged = false
     const persist = this.db.transaction(() => {
-      this.materializeContribution(input)
+      contributionChanged = this.materializeContribution(input)
       this.db
         .query(
           `INSERT INTO topology_observations (
@@ -169,6 +205,7 @@ export class ObservationsService {
       linkCount,
       portCount,
       createdAt: now,
+      contributionChanged,
     }
   }
 
@@ -191,8 +228,8 @@ export class ObservationsService {
    * to an empty graph so a successful empty scan still retracts the source's prior
    * nodes (successful absence is real evidence).
    */
-  private materializeContribution(input: RecordObservationInput): void {
-    if (input.status === 'failed') return
+  private materializeContribution(input: RecordObservationInput): boolean {
+    if (input.status === 'failed') return false
     const attach = this.db
       .query(
         `SELECT tds.id AS attach_id
@@ -200,26 +237,48 @@ export class ObservationsService {
          WHERE tds.topology_id = ? AND tds.data_source_id = ? AND tds.purpose = 'topology'`,
       )
       .get(input.topologyId, input.sourceId) as { attach_id: string } | undefined
-    if (!attach) return
+    if (!attach) return false
     // Out-of-order guard: never let a strictly older scan replace newer canonical
     // state (re-applying the same capturedAt is fine — idempotent replace).
     const existing = this.db
-      .query('SELECT last_ok_at FROM contribution_source WHERE topology_id = ? AND source_id = ?')
-      .get(input.topologyId, input.sourceId) as { last_ok_at: number | null } | undefined
-    if (existing?.last_ok_at != null && input.capturedAt < existing.last_ok_at) return
+      .query(
+        'SELECT last_ok_at, content_hash FROM contribution_source WHERE topology_id = ? AND source_id = ?',
+      )
+      .get(input.topologyId, input.sourceId) as
+      | { last_ok_at: number | null; content_hash: string | null }
+      | undefined
+    if (existing?.last_ok_at != null && input.capturedAt < existing.last_ok_at) return false
     const graph: NetworkGraph = input.graph ?? {
       version: '1',
       name: '',
       nodes: [],
       links: [],
     }
+    const contentHash = contributionContentHash(graph)
+    // No-change gate: identical structural content → only refresh the
+    // freshness columns; the decomposed rows are already correct, and the
+    // caller can skip the revision bump (no re-resolve, no re-layout).
+    if (existing && existing.content_hash != null && existing.content_hash === contentHash) {
+      this.db
+        .query(
+          'UPDATE contribution_source SET last_status = ?, last_ok_at = ? WHERE topology_id = ? AND source_id = ?',
+        )
+        .run(input.status, input.capturedAt, input.topologyId, input.sourceId)
+      return false
+    }
     ingestGraph(
       input.topologyId,
       input.sourceId,
       graph,
-      { attachmentId: attach.attach_id, lastStatus: input.status, lastOkAt: input.capturedAt },
+      {
+        attachmentId: attach.attach_id,
+        lastStatus: input.status,
+        lastOkAt: input.capturedAt,
+        contentHash,
+      },
       this.db,
     )
+    return true
   }
 
   /**

--- a/apps/server/api/src/services/sync-job.ts
+++ b/apps/server/api/src/services/sync-job.ts
@@ -131,6 +131,7 @@ async function runSyncJob(
   deps: SyncJobDeps,
 ): Promise<void> {
   const { topologyId } = job
+  let anyChanged = false
   // Drive every source in parallel — slow netbox shouldn't block fast snmp.
   await Promise.allSettled(
     sources.map(async (source, i) => {
@@ -168,7 +169,7 @@ async function runSyncJob(
           return
         }
 
-        await deps.observationsService.record({
+        const recorded = await deps.observationsService.record({
           topologyId,
           sourceId: source.dataSourceId,
           capturedAt,
@@ -176,6 +177,7 @@ async function runSyncJob(
           statusMessage,
           graph,
         })
+        if (recorded.contributionChanged) anyChanged = true
         deps.observationsService.updateHysteresis(
           topologyId,
           source.dataSourceId,
@@ -200,6 +202,19 @@ async function runSyncJob(
   if (job.cancelRequested) {
     if (deriveStep) deriveStep.status = 'skipped'
     finish(job, 'cancelled')
+    return
+  }
+
+  // No-change gate: every source re-scanned to the same structural content →
+  // the diagram cannot have changed, so skip the invalidation AND the
+  // multi-minute layout re-bake entirely.
+  if (!anyChanged) {
+    if (deriveStep) {
+      deriveStep.status = 'skipped'
+      deriveStep.message = 'No changes since last sync'
+    }
+    const anyFetchOkUnchanged = job.steps.some((s) => s.key !== 'derive' && s.status === 'done')
+    finish(job, anyFetchOkUnchanged ? 'done' : 'failed')
     return
   }
 

--- a/apps/server/api/test/db/no-change-gate.test.ts
+++ b/apps/server/api/test/db/no-change-gate.test.ts
@@ -1,0 +1,120 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * No-change gate (migration 023): `record()` reports whether the snapshot
+ * CHANGED the source's canonical contribution. Re-scans of an unchanged
+ * network (even with fresh `observedAt` stamps) must report false so callers
+ * skip the revision bump — and with it the multi-minute layout re-bake.
+ */
+
+import { afterAll, beforeAll, expect, test } from 'bun:test'
+import type { NetworkGraph } from '@shumoku/core'
+import { ObservationsService } from '../../src/services/observations.ts'
+import { attachSource, getDatabase, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+let obs: ObservationsService
+beforeAll(() => {
+  db_ = setupTempDb()
+  obs = new ObservationsService()
+})
+afterAll(() => db_.teardown())
+
+function makeTopology(id: string): void {
+  getDatabase()
+    .query('INSERT INTO topologies (id, name, created_at, updated_at) VALUES (?, ?, 0, 0)')
+    .run(id, id)
+}
+
+const graphWith = (observedAt: number, ...nodeIds: string[]): NetworkGraph =>
+  ({
+    version: '1',
+    name: 't',
+    nodes: nodeIds.map((id) => ({
+      id,
+      label: id,
+      shape: 'rect',
+      identity: { sysName: id },
+      provenance: { source: 's', observedAt },
+    })),
+    links: [],
+  }) as NetworkGraph
+
+test('identical re-scan (fresh observedAt) does NOT change the contribution', async () => {
+  makeTopology('t_gate_1')
+  const ds = insertDataSource('zabbix', 'ds_gate_1')
+  attachSource('t_gate_1', ds, 'topology')
+
+  const first = await obs.record({
+    topologyId: 't_gate_1',
+    sourceId: ds,
+    capturedAt: 1000,
+    status: 'ok',
+    graph: graphWith(1000, 'a', 'b'),
+  })
+  expect(first.contributionChanged).toBe(true)
+
+  // Same structure, NEW observedAt stamps — the volatile field is stripped.
+  const second = await obs.record({
+    topologyId: 't_gate_1',
+    sourceId: ds,
+    capturedAt: 2000,
+    status: 'ok',
+    graph: graphWith(2000, 'a', 'b'),
+  })
+  expect(second.contributionChanged).toBe(false)
+
+  // Freshness columns still advance even when gated.
+  const row = getDatabase()
+    .query('SELECT last_ok_at FROM contribution_source WHERE topology_id = ? AND source_id = ?')
+    .get('t_gate_1', ds) as { last_ok_at: number }
+  expect(row.last_ok_at).toBe(2000)
+})
+
+test('a structural change DOES change the contribution', async () => {
+  makeTopology('t_gate_2')
+  const ds = insertDataSource('zabbix', 'ds_gate_2')
+  attachSource('t_gate_2', ds, 'topology')
+
+  await obs.record({
+    topologyId: 't_gate_2',
+    sourceId: ds,
+    capturedAt: 1000,
+    status: 'ok',
+    graph: graphWith(1000, 'a'),
+  })
+  const changed = await obs.record({
+    topologyId: 't_gate_2',
+    sourceId: ds,
+    capturedAt: 2000,
+    status: 'ok',
+    graph: graphWith(2000, 'a', 'b'),
+  })
+  expect(changed.contributionChanged).toBe(true)
+})
+
+test('failed scans and unattached sources never report a change', async () => {
+  makeTopology('t_gate_3')
+  const attached = insertDataSource('zabbix', 'ds_gate_3a')
+  attachSource('t_gate_3', attached, 'topology')
+  const unattached = insertDataSource('zabbix', 'ds_gate_3b')
+
+  const failed = await obs.record({
+    topologyId: 't_gate_3',
+    sourceId: attached,
+    capturedAt: 1000,
+    status: 'failed',
+    graph: null,
+  })
+  expect(failed.contributionChanged).toBe(false)
+
+  const noAttach = await obs.record({
+    topologyId: 't_gate_3',
+    sourceId: unattached,
+    capturedAt: 1000,
+    status: 'ok',
+    graph: graphWith(1000, 'x'),
+  })
+  expect(noAttach.contributionChanged).toBe(false)
+})


### PR DESCRIPTION
## 問題

Syncは「全置換 + フル再ベイク」で、**ネットワークが変わっていなくても**revisionが上がり数分のレイアウトを焼き直していた。スケジューラ（5分間隔）の定期Syncごとに無駄な8分ベイクが再生産される構造。

## 変更（差分更新の第一歩 = 無変化判定）

- **migration 023**: `contribution_source.content_hash` — 揮発フィールド（プラグインが毎スキャン刻む `observedAt`）を除外した構造ハッシュ(sha256)。無変化の再スキャンは同一ハッシュになる
- **record()** が `contributionChanged` を返す。ハッシュ一致時は鮮度カラム（last_status / last_ok_at）だけ前進させ、分解行は触らない
- **全Sync経路**（Sync-allジョブ / スケジューラ / per-source sync / probeマージ / webhook / エディタ保存）が `clearCacheEntry + precompute` をこのフラグでゲート。Sync-allモーダルではLayoutステップが「skipped — No changes since last sync」になる

Rebuild（クリアして再Sync）は従来どおり：クリアでcontribution（とハッシュ）ごと消えるので必ず再取り込みされる。

## 効果

- スケジューラの定期Sync：変化なし → **再ベイクゼロ**（従来は毎回8分）
- 手動Sync all：変化なしなら数十秒（フェッチのみ）で「変更なし」と表示されて完了

## Tests
- 新規 no-change-gate.test.ts（同一再スキャン=false・構造変化=true・failed/未アタッチ=false・鮮度前進）
- server API 88 pass / typecheck 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)