### PR TITLE
perf(layout): spatial-grid scoring + prefiltered track conflicts — 2.9x, bit-identical output

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -729,22 +729,24 @@ export function applyOctilinearRoutes(
   const placedTracks: { y: number; lo: number; hi: number; half: number }[] = []
   for (const request of requests) {
     const half = request.half
-    const conflicts = (y: number): boolean =>
-      placedTracks.some(
-        (p) =>
-          Math.abs(p.y - y) < p.half + half + clearance &&
-          request.lo < p.hi + 12 &&
-          request.hi > p.lo - 12,
-      ) ||
+    // The x-overlap halves of both conflict conditions don't depend on the
+    // candidate y, and placedTracks doesn't change during this request's
+    // step probing — prefilter once instead of rescanning every track and
+    // every node box per probe (same predicate, same result).
+    const candTracks = placedTracks.filter((p) => request.lo < p.hi + 12 && request.hi > p.lo - 12)
+    const candBoxes = nodeBoxes.filter(
+      (b) => !request.exempt?.has(b.id) && request.lo < b.x2 + 4 && request.hi > b.x1 - 4,
+    )
+    const conflicts = (y: number): boolean => {
+      for (const p of candTracks) {
+        if (Math.abs(p.y - y) < p.half + half + clearance) return true
+      }
       // never run a horizontal track THROUGH a foreign node box
-      nodeBoxes.some(
-        (b) =>
-          !request.exempt?.has(b.id) &&
-          y > b.y1 - half - 2 &&
-          y < b.y2 + half + 2 &&
-          request.lo < b.x2 + 4 &&
-          request.hi > b.x1 - 4,
-      )
+      for (const b of candBoxes) {
+        if (y > b.y1 - half - 2 && y < b.y2 + half + 2) return true
+      }
+      return false
+    }
     const clamp = (y: number): number => Math.max(request.floor, Math.min(request.ceil, y))
     let y = clamp(request.want)
     for (let step = 6; step <= 240 && conflicts(y); step += 6) {

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -27,6 +27,7 @@ import { getLinkWidthForMode } from '../link-utils.js'
 import { portLabelBox } from '../port-geometry.js'
 import type { ResolvedEdge, ResolvedLayout, ResolvedPort } from '../resolved-types.js'
 import { routeEdges } from '../route-edges.js'
+import { BBoxGrid } from '../spatial-grid.js'
 import {
   type CompositeLayoutOptions,
   type CompositeLayoutResult,
@@ -612,32 +613,52 @@ export function scoreRoutedEdges(
   let crossings = 0
   let bends = 0
   let length = 0
-  for (const poly of polys) {
+  // Flat segment list + grid index: intersecting segments always share a
+  // cell (their bboxes overlap), so testing only co-celled pairs counts
+  // exactly the same crossings as the old all-pairs scan — without the
+  // O((P·S)²) blowup that dominated large layouts.
+  interface Seg {
+    x1: number
+    y1: number
+    x2: number
+    y2: number
+    poly: number
+  }
+  const segs: Seg[] = []
+  const segGrid = new BBoxGrid(160)
+  for (let p = 0; p < polys.length; p++) {
+    const poly = polys[p]
+    if (!poly) continue
     bends += Math.max(0, poly.pts.length - 2)
     for (let i = 1; i < poly.pts.length; i++) {
       const a = poly.pts[i - 1]
       const b = poly.pts[i]
-      if (a && b) length += Math.hypot(b.x - a.x, b.y - a.y)
+      if (!a || !b) continue
+      length += Math.hypot(b.x - a.x, b.y - a.y)
+      const idx = segs.length
+      segs.push({ x1: a.x, y1: a.y, x2: b.x, y2: b.y, poly: p })
+      segGrid.insert(idx, a.x, a.y, b.x, b.y)
     }
   }
-  for (let i = 0; i < polys.length; i++) {
-    const pa = polys[i]
-    if (!pa) continue
-    for (let j = i + 1; j < polys.length; j++) {
-      const pb = polys[j]
-      if (!pb) continue
-      if (pa.a === pb.a || pa.a === pb.b || pa.b === pb.a || pa.b === pb.b) continue
-      for (let s = 1; s < pa.pts.length; s++) {
-        for (let t = 1; t < pb.pts.length; t++) {
-          const a1 = pa.pts[s - 1]
-          const a2 = pa.pts[s]
-          const b1 = pb.pts[t - 1]
-          const b2 = pb.pts[t]
-          if (a1 && a2 && b1 && b2 && segmentsIntersect(a1, a2, b1, b2)) crossings++
-        }
-      }
+  segGrid.forEachCandidatePair((i, j) => {
+    const sa = segs[i]
+    const sb = segs[j]
+    if (!sa || !sb || sa.poly === sb.poly) return
+    const pa = polys[sa.poly]
+    const pb = polys[sb.poly]
+    if (!pa || !pb) return
+    if (pa.a === pb.a || pa.a === pb.b || pa.b === pb.a || pa.b === pb.b) return
+    if (
+      segmentsIntersect(
+        { x: sa.x1, y: sa.y1 },
+        { x: sa.x2, y: sa.y2 },
+        { x: sb.x1, y: sb.y1 },
+        { x: sb.x2, y: sb.y2 },
+      )
+    ) {
+      crossings++
     }
-  }
+  })
   const lines: PolylineSpec[] = polys.map((p) => ({ id: p.id, points: p.pts, halfWidth: p.half }))
   // comb siblings SHARE the trunk/bus by design — same-bus overlap is the
   // org-chart grammar, not a violation
@@ -649,7 +670,9 @@ export function scoreRoutedEdges(
     const ba = busOf.get(o.a)
     return ba === undefined || ba !== busOf.get(o.b)
   }).length
-  // wires running through unrelated node boxes
+  // wires running through unrelated node boxes — box grid + per-segment
+  // queries; a segment can only pierce a box whose inflated bbox its own
+  // bbox overlaps, so the candidate sweep counts exactly the same pairs.
   let pierce = 0
   const boxes: { id: string; x: number; y: number; w: number; h: number }[] = []
   for (const [id, node] of nodes) {
@@ -657,28 +680,41 @@ export function scoreRoutedEdges(
     const size = resolveNodeSize(node)
     boxes.push({ id, x: node.position.x, y: node.position.y, w: size.width, h: size.height })
   }
+  const boxGrid = new BBoxGrid(320)
+  for (const [idx, box] of boxes.entries()) {
+    boxGrid.insert(
+      idx,
+      box.x - box.w / 2 - 2,
+      box.y - box.h / 2 - 2,
+      box.x + box.w / 2 + 2,
+      box.y + box.h / 2 + 2,
+    )
+  }
   for (const poly of polys) {
-    for (const box of boxes) {
-      if (box.id === poly.a || box.id === poly.b) continue
-      const bx = box.x - box.w / 2 - 2
-      const by = box.y - box.h / 2 - 2
-      const bw = box.w + 4
-      const bh = box.h + 4
-      let hit = false
-      for (let s = 1; s < poly.pts.length && !hit; s++) {
-        const a = poly.pts[s - 1]
-        const b = poly.pts[s]
-        if (!a || !b) continue
-        if (Math.max(a.x, b.x) < bx || Math.min(a.x, b.x) > bx + bw) continue
-        if (Math.max(a.y, b.y) < by || Math.min(a.y, b.y) > by + bh) continue
-        hit =
+    const hitBoxes = new Set<number>()
+    for (let s = 1; s < poly.pts.length; s++) {
+      const a = poly.pts[s - 1]
+      const b = poly.pts[s]
+      if (!a || !b) continue
+      boxGrid.query(a.x, a.y, b.x, b.y, (bi) => {
+        if (hitBoxes.has(bi)) return
+        const box = boxes[bi]
+        if (!box || box.id === poly.a || box.id === poly.b) return
+        const bx = box.x - box.w / 2 - 2
+        const by = box.y - box.h / 2 - 2
+        const bw = box.w + 4
+        const bh = box.h + 4
+        if (Math.max(a.x, b.x) < bx || Math.min(a.x, b.x) > bx + bw) return
+        if (Math.max(a.y, b.y) < by || Math.min(a.y, b.y) > by + bh) return
+        const hit =
           segmentsIntersect(a, b, { x: bx, y: by }, { x: bx + bw, y: by }) ||
           segmentsIntersect(a, b, { x: bx, y: by + bh }, { x: bx + bw, y: by + bh }) ||
           segmentsIntersect(a, b, { x: bx, y: by }, { x: bx, y: by + bh }) ||
           segmentsIntersect(a, b, { x: bx + bw, y: by }, { x: bx + bw, y: by + bh })
-      }
-      if (hit) pierce++
+        if (hit) hitBoxes.add(bi)
+      })
     }
+    pierce += hitBoxes.size
   }
   // port/label clutter: collisions among owned geometry (port boxes,
   // label boxes, labels vs foreign nodes). With the demand feedback

--- a/libs/@shumoku/core/src/layout/invariants.ts
+++ b/libs/@shumoku/core/src/layout/invariants.ts
@@ -29,6 +29,7 @@ import type { Bounds, Position } from '../models/types.js'
 import { resolveNodeSize } from './engine/index.js'
 import { portBox, portLabelBox } from './port-geometry.js'
 import type { ResolvedLayout, ResolvedPort } from './resolved-types.js'
+import { BBoxGrid } from './spatial-grid.js'
 
 // ============================================================================
 // Pure geometry inputs
@@ -162,64 +163,105 @@ export function findCollinearOverlaps(
   const minSeg = options.minSegmentLength ?? 13
   const minShared = options.minSharedLength ?? 12
   const clearance = options.clearance ?? 0.5
-  const out = new Map<string, CollinearOverlap>()
-  for (let i = 0; i < lines.length; i++) {
-    const la = lines[i]
-    if (!la) continue
-    for (let j = i + 1; j < lines.length; j++) {
-      const lb = lines[j]
-      if (!lb) continue
-      const gap = (la.halfWidth ?? 1) + (lb.halfWidth ?? 1) + clearance
-      const shared = maxSharedRun(la.points, lb.points, minSeg, gap)
-      if (shared <= minShared) continue
-      const key = `${la.id}|${lb.id}`
-      const prev = out.get(key)
-      if (!prev || shared > prev.sharedLength) {
-        out.set(key, { a: la.id, b: lb.id, sharedLength: shared })
-      }
+
+  // Segment grid: a contributing pair must be parallel within the pair gap
+  // AND overlap in extent, so the two segments sit within `gap` of each
+  // other — inflating every segment bbox by the LARGEST possible gap means
+  // any such pair shares a cell. Far pairs the old scan visited were all
+  // rejected by the gap/extent tests anyway, so the candidate sweep
+  // produces identical shared-run results.
+  let maxHalf = 1
+  for (const l of lines) maxHalf = Math.max(maxHalf, l.halfWidth ?? 1)
+  const inflate = maxHalf * 2 + clearance
+
+  interface Seg {
+    a1: Position
+    a2: Position
+    vax: number
+    vay: number
+    len: number
+    line: number
+  }
+  const segs: Seg[] = []
+  const grid = new BBoxGrid(180)
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li]
+    if (!line) continue
+    for (let s = 1; s < line.points.length; s++) {
+      const a1 = line.points[s - 1]
+      const a2 = line.points[s]
+      if (!a1 || !a2) continue
+      const vax = a2.x - a1.x
+      const vay = a2.y - a1.y
+      const len = Math.hypot(vax, vay)
+      if (len < minSeg) continue
+      const idx = segs.length
+      segs.push({ a1, a2, vax, vay, len, line: li })
+      grid.insert(
+        idx,
+        Math.min(a1.x, a2.x) - inflate,
+        Math.min(a1.y, a2.y) - inflate,
+        Math.max(a1.x, a2.x) + inflate,
+        Math.max(a1.y, a2.y) + inflate,
+      )
     }
   }
-  return [...out.values()]
+
+  // Best shared run per line pair — same math as the old maxSharedRun inner
+  // loop: for the (lower, higher) line pair the original always projected
+  // the higher line's segment onto the LOWER line's segment, so keep that
+  // exact orientation regardless of candidate arrival order.
+  const bestByPair = new Map<number, number>()
+  grid.forEachCandidatePair((i, j) => {
+    const sa = segs[i]
+    const sb = segs[j]
+    if (!sa || !sb || sa.line === sb.line) return
+    // parallel check: normalized cross product ≈ sin(angle)
+    if (Math.abs(sa.vax * sb.vay - sa.vay * sb.vax) / (sa.len * sb.len) > 0.02) return
+    const la = lines[sa.line]
+    const lb = lines[sb.line]
+    if (!la || !lb) return
+    const gap = (la.halfWidth ?? 1) + (lb.halfWidth ?? 1) + clearance
+    const first = sa.line < sb.line ? sa : sb
+    const second = sa.line < sb.line ? sb : sa
+    const run = sharedRun(first, second, gap)
+    if (run <= 0) return
+    const key = sa.line < sb.line ? sa.line * 1048576 + sb.line : sb.line * 1048576 + sa.line
+    const prev = bestByPair.get(key)
+    if (prev === undefined || run > prev) bestByPair.set(key, run)
+  })
+
+  const out: CollinearOverlap[] = []
+  for (const [key, shared] of bestByPair) {
+    if (shared <= minShared) continue
+    const la = lines[Math.floor(key / 1048576)]
+    const lb = lines[key % 1048576]
+    if (!la || !lb) continue
+    out.push({ a: la.id, b: lb.id, sharedLength: shared })
+  }
+  return out
 }
 
-function maxSharedRun(
-  ptsA: readonly Position[],
-  ptsB: readonly Position[],
-  minSeg: number,
-  gap: number,
-): number {
-  let best = 0
-  for (let s = 1; s < ptsA.length; s++) {
-    const a1 = ptsA[s - 1]
-    const a2 = ptsA[s]
-    if (!a1 || !a2) continue
-    const vax = a2.x - a1.x
-    const vay = a2.y - a1.y
-    const lenA = Math.hypot(vax, vay)
-    if (lenA < minSeg) continue
-    for (let t = 1; t < ptsB.length; t++) {
-      const b1 = ptsB[t - 1]
-      const b2 = ptsB[t]
-      if (!b1 || !b2) continue
-      const vbx = b2.x - b1.x
-      const vby = b2.y - b1.y
-      const lenB = Math.hypot(vbx, vby)
-      if (lenB < minSeg) continue
-      // parallel check: normalized cross product ≈ sin(angle)
-      if (Math.abs(vax * vby - vay * vbx) / (lenA * lenB) > 0.02) continue
-      // perpendicular distance between the two lines
-      const dx = b1.x - a1.x
-      const dy = b1.y - a1.y
-      if (Math.abs(dx * vay - dy * vax) / lenA > gap) continue
-      // shared extent along A's direction
-      const t1 = (dx * vax + dy * vay) / lenA
-      const t2 = ((b2.x - a1.x) * vax + (b2.y - a1.y) * vay) / lenA
-      const lo = Math.max(0, Math.min(t1, t2))
-      const hi = Math.min(lenA, Math.max(t1, t2))
-      if (hi - lo > best) best = hi - lo
-    }
-  }
-  return best
+interface RunSeg {
+  a1: Position
+  a2: Position
+  vax: number
+  vay: number
+  len: number
+}
+
+/** Shared extent of `b` projected onto `a` — the old maxSharedRun pair body. */
+function sharedRun(a: RunSeg, b: RunSeg, gap: number): number {
+  // perpendicular distance between the two lines
+  const dx = b.a1.x - a.a1.x
+  const dy = b.a1.y - a.a1.y
+  if (Math.abs(dx * a.vay - dy * a.vax) / a.len > gap) return 0
+  // shared extent along A's direction
+  const t1 = (dx * a.vax + dy * a.vay) / a.len
+  const t2 = ((b.a2.x - a.a1.x) * a.vax + (b.a2.y - a.a1.y) * a.vay) / a.len
+  const lo = Math.max(0, Math.min(t1, t2))
+  const hi = Math.min(a.len, Math.max(t1, t2))
+  return hi - lo
 }
 
 // ============================================================================
@@ -253,35 +295,65 @@ export function findPortClutter(
   ports: readonly ResolvedPort[],
   nodeBoxes: readonly BoxSpec[] = [],
 ): PortClutter[] {
-  const out: PortClutter[] = []
   const boxes = ports.map((p) => ({ port: p, box: portBox(p), label: portLabelBox(p) }))
-  for (let i = 0; i < boxes.length; i++) {
-    const a = boxes[i]
-    if (!a) continue
-    for (let j = i + 1; j < boxes.length; j++) {
+
+  // `rectsOverlap` at margin 0 IS bbox overlap, so grid candidates + the
+  // same predicate find the identical collision set as the old O(n²) scan;
+  // only the (unobservable to callers, who count) emit order differs —
+  // kept deterministic by sorting on indices.
+  const collect = (
+    kind: PortClutter['kind'],
+    rectOf: (b: (typeof boxes)[number]) => Bounds | null | undefined,
+  ): PortClutter[] => {
+    const grid = new BBoxGrid(96)
+    for (const [i, b] of boxes.entries()) {
+      const r = rectOf(b)
+      if (r) grid.insert(i, r.x, r.y, r.x + r.width, r.y + r.height)
+    }
+    const pairs: Array<[number, number]> = []
+    grid.forEachCandidatePair((i, j) => {
+      const a = boxes[i]
       const b = boxes[j]
-      if (!b) continue
-      if (rectsOverlap(a.box, b.box)) {
-        out.push({ kind: 'port-port', a: a.port.id, b: b.port.id })
+      if (!a || !b) return
+      const ra = rectOf(a)
+      const rb = rectOf(b)
+      if (ra && rb && rectsOverlap(ra, rb)) pairs.push([i, j])
+    })
+    pairs.sort((p, q) => p[0] - q[0] || p[1] - q[1])
+    return pairs.map(([i, j]) => {
+      const a = boxes[i]
+      const b = boxes[j]
+      return { kind, a: a?.port.id ?? '', b: b?.port.id ?? '' }
+    })
+  }
+
+  const out: PortClutter[] = [
+    ...collect('port-port', (b) => b.box),
+    ...collect('label-label', (b) => b.label),
+  ]
+
+  // label vs FOREIGN node box — node grid, queried per label.
+  const nodeGrid = new BBoxGrid(256)
+  const nodeRects: Bounds[] = nodeBoxes.map((node) => ({
+    x: node.x - node.width / 2,
+    y: node.y - node.height / 2,
+    width: node.width,
+    height: node.height,
+  }))
+  for (const [ni, rect] of nodeRects.entries()) {
+    nodeGrid.insert(ni, rect.x, rect.y, rect.x + rect.width, rect.y + rect.height)
+  }
+  for (const a of boxes) {
+    if (!a.label) continue
+    const label = a.label
+    nodeGrid.query(label.x, label.y, label.x + label.width, label.y + label.height, (ni) => {
+      const node = nodeBoxes[ni]
+      const rect = nodeRects[ni]
+      if (!node || !rect || node.id === a.port.nodeId) return
+      if (rectsOverlap(label, rect)) {
+        out.push({ kind: 'label-node', a: a.port.id, b: node.id })
       }
-      if (a.label && b.label && rectsOverlap(a.label, b.label)) {
-        out.push({ kind: 'label-label', a: a.port.id, b: b.port.id })
-      }
-    }
-    if (a.label) {
-      for (const node of nodeBoxes) {
-        if (node.id === a.port.nodeId) continue
-        const rect: Bounds = {
-          x: node.x - node.width / 2,
-          y: node.y - node.height / 2,
-          width: node.width,
-          height: node.height,
-        }
-        if (rectsOverlap(a.label, rect)) {
-          out.push({ kind: 'label-node', a: a.port.id, b: node.id })
-        }
-      }
-    }
+    })
   }
   return out
 }

--- a/libs/@shumoku/core/src/layout/spatial-grid.test.ts
+++ b/libs/@shumoku/core/src/layout/spatial-grid.test.ts
@@ -1,0 +1,229 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Exact-equivalence guards for the spatial-grid acceleration (the layout
+ * scoring optimization must NOT change any result — speed only).
+ *
+ * - BBoxGrid: candidate pairs are a SUPERSET of every bbox-overlapping pair
+ *   and each pair is reported once.
+ * - findCollinearOverlaps / findPortClutter: grid-accelerated results equal
+ *   the original O(n²) reference (copied verbatim below) on seeded-random
+ *   inputs shaped like real routed layouts.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import type { Bounds, Position } from '../models/types.js'
+import {
+  type CollinearOverlap,
+  findCollinearOverlaps,
+  findPortClutter,
+  type PolylineSpec,
+} from './invariants.js'
+import { portBox, portLabelBox } from './port-geometry.js'
+import type { ResolvedPort } from './resolved-types.js'
+import { BBoxGrid } from './spatial-grid.js'
+
+/** Deterministic PRNG (mulberry32) — property tests must be reproducible. */
+function rng(seed: number): () => number {
+  let s = seed
+  return () => {
+    s = (s + 0x6d2b79f5) | 0
+    let t = Math.imul(s ^ (s >>> 15), 1 | s)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+describe('BBoxGrid', () => {
+  test('candidate pairs cover every overlapping pair, each reported once', () => {
+    const rand = rng(42)
+    const rects: Array<{ x1: number; y1: number; x2: number; y2: number }> = []
+    for (let i = 0; i < 300; i++) {
+      const x = rand() * 4000 - 2000
+      const y = rand() * 2000 - 1000
+      const w = rand() * 300
+      const h = rand() * 120
+      rects.push({ x1: x, y1: y, x2: x + w, y2: y + h })
+    }
+    const grid = new BBoxGrid(160)
+    for (const [i, r] of rects.entries()) grid.insert(i, r.x1, r.y1, r.x2, r.y2)
+    const seen = new Set<string>()
+    grid.forEachCandidatePair((i, j) => {
+      const key = `${i}|${j}`
+      expect(seen.has(key)).toBe(false)
+      seen.add(key)
+    })
+    for (let i = 0; i < rects.length; i++) {
+      for (let j = i + 1; j < rects.length; j++) {
+        const a = rects[i]
+        const b = rects[j]
+        if (!a || !b) continue
+        const overlap = a.x1 <= b.x2 && a.x2 >= b.x1 && a.y1 <= b.y2 && a.y2 >= b.y1
+        if (overlap) expect(seen.has(`${i}|${j}`)).toBe(true)
+      }
+    }
+  })
+})
+
+// --- original O(n²) reference implementations (pre-optimization, verbatim) ---
+
+function referenceCollinear(
+  lines: readonly PolylineSpec[],
+  minSeg = 13,
+  minShared = 12,
+  clearance = 0.5,
+): CollinearOverlap[] {
+  const maxSharedRun = (
+    ptsA: readonly Position[],
+    ptsB: readonly Position[],
+    gap: number,
+  ): number => {
+    let best = 0
+    for (let s = 1; s < ptsA.length; s++) {
+      const a1 = ptsA[s - 1]
+      const a2 = ptsA[s]
+      if (!a1 || !a2) continue
+      const vax = a2.x - a1.x
+      const vay = a2.y - a1.y
+      const lenA = Math.hypot(vax, vay)
+      if (lenA < minSeg) continue
+      for (let t = 1; t < ptsB.length; t++) {
+        const b1 = ptsB[t - 1]
+        const b2 = ptsB[t]
+        if (!b1 || !b2) continue
+        const vbx = b2.x - b1.x
+        const vby = b2.y - b1.y
+        const lenB = Math.hypot(vbx, vby)
+        if (lenB < minSeg) continue
+        if (Math.abs(vax * vby - vay * vbx) / (lenA * lenB) > 0.02) continue
+        const dx = b1.x - a1.x
+        const dy = b1.y - a1.y
+        if (Math.abs(dx * vay - dy * vax) / lenA > gap) continue
+        const t1 = (dx * vax + dy * vay) / lenA
+        const t2 = ((b2.x - a1.x) * vax + (b2.y - a1.y) * vay) / lenA
+        const lo = Math.max(0, Math.min(t1, t2))
+        const hi = Math.min(lenA, Math.max(t1, t2))
+        if (hi - lo > best) best = hi - lo
+      }
+    }
+    return best
+  }
+  const out: CollinearOverlap[] = []
+  for (let i = 0; i < lines.length; i++) {
+    const la = lines[i]
+    if (!la) continue
+    for (let j = i + 1; j < lines.length; j++) {
+      const lb = lines[j]
+      if (!lb) continue
+      const gap = (la.halfWidth ?? 1) + (lb.halfWidth ?? 1) + clearance
+      const shared = maxSharedRun(la.points, lb.points, gap)
+      if (shared <= minShared) continue
+      out.push({ a: la.id, b: lb.id, sharedLength: shared })
+    }
+  }
+  return out
+}
+
+function referencePortClutter(
+  ports: readonly ResolvedPort[],
+  nodeBoxes: readonly { id: string; x: number; y: number; width: number; height: number }[],
+) {
+  const rectsOverlap = (a: Bounds, b: Bounds): boolean =>
+    a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+  const out: Array<{ kind: string; a: string; b: string }> = []
+  const boxes = ports.map((p) => ({ port: p, box: portBox(p), label: portLabelBox(p) }))
+  for (let i = 0; i < boxes.length; i++) {
+    const a = boxes[i]
+    if (!a) continue
+    for (let j = i + 1; j < boxes.length; j++) {
+      const b = boxes[j]
+      if (!b) continue
+      if (rectsOverlap(a.box, b.box)) out.push({ kind: 'port-port', a: a.port.id, b: b.port.id })
+      if (a.label && b.label && rectsOverlap(a.label, b.label)) {
+        out.push({ kind: 'label-label', a: a.port.id, b: b.port.id })
+      }
+    }
+    if (a.label) {
+      for (const node of nodeBoxes) {
+        if (node.id === a.port.nodeId) continue
+        const rect: Bounds = {
+          x: node.x - node.width / 2,
+          y: node.y - node.height / 2,
+          width: node.width,
+          height: node.height,
+        }
+        if (rectsOverlap(a.label, rect)) out.push({ kind: 'label-node', a: a.port.id, b: node.id })
+      }
+    }
+  }
+  return out
+}
+
+const sortKey = (e: { kind?: string; a: string; b: string; sharedLength?: number }) =>
+  `${e.kind ?? ''}|${e.a}|${e.b}`
+
+describe('grid-accelerated invariants equal the O(n²) reference', () => {
+  test('findCollinearOverlaps — random octilinear polylines', () => {
+    const rand = rng(7)
+    for (let round = 0; round < 5; round++) {
+      const lines: PolylineSpec[] = []
+      for (let i = 0; i < 120; i++) {
+        // octilinear-ish 2-4 segment polylines on a coarse lattice so
+        // parallel near-tracks actually occur
+        const pts: Position[] = []
+        let x = Math.round(rand() * 60) * 20
+        let y = Math.round(rand() * 30) * 20
+        pts.push({ x, y })
+        const segCount = 2 + Math.floor(rand() * 3)
+        for (let s = 0; s < segCount; s++) {
+          const dir = Math.floor(rand() * 4)
+          const len = 20 + Math.round(rand() * 8) * 20
+          if (dir === 0) x += len
+          else if (dir === 1) x -= len
+          else if (dir === 2) y += len
+          else y -= len
+          // a small fraction of tracks land 1px off to exercise the gap test
+          pts.push({ x: x + (rand() < 0.2 ? 1 : 0), y })
+        }
+        lines.push({ id: `e${i}`, points: pts, halfWidth: 0.5 + rand() * 3 })
+      }
+      const expected = referenceCollinear(lines)
+      const actual = findCollinearOverlaps(lines)
+      const norm = (list: CollinearOverlap[]) =>
+        [...list]
+          .sort((p, q) => (sortKey(p) < sortKey(q) ? -1 : 1))
+          .map((e) => `${e.a}|${e.b}|${e.sharedLength.toFixed(6)}`)
+      expect(norm(actual)).toEqual(norm(expected))
+    }
+  })
+
+  test('findPortClutter — random dense ports', () => {
+    const rand = rng(13)
+    for (let round = 0; round < 5; round++) {
+      const ports: ResolvedPort[] = []
+      for (let i = 0; i < 150; i++) {
+        const sides = ['top', 'bottom', 'left', 'right'] as const
+        ports.push({
+          id: `p${i}`,
+          nodeId: `n${i % 40}`,
+          label: rand() < 0.7 ? `Gi0/${i}` : '',
+          absolutePosition: { x: rand() * 1500, y: rand() * 800 },
+          side: sides[Math.floor(rand() * 4)] ?? 'top',
+          size: { width: 8, height: 8 },
+        })
+      }
+      const nodeBoxes = Array.from({ length: 40 }, (_, i) => ({
+        id: `n${i}`,
+        x: rand() * 1500,
+        y: rand() * 800,
+        width: 60 + rand() * 100,
+        height: 40 + rand() * 40,
+      }))
+      const expected = referencePortClutter(ports, nodeBoxes)
+      const actual = findPortClutter(ports, nodeBoxes)
+      const norm = (list: Array<{ kind: string; a: string; b: string }>) => list.map(sortKey).sort()
+      expect(norm(actual)).toEqual(norm(expected))
+    }
+  })
+})

--- a/libs/@shumoku/core/src/layout/spatial-grid.ts
+++ b/libs/@shumoku/core/src/layout/spatial-grid.ts
@@ -1,0 +1,96 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Uniform-grid candidate-pair index for geometric proximity queries.
+ *
+ * EXACT-equivalence accelerator: callers re-test every candidate with the
+ * precise predicate they used before; the grid only prunes pairs whose
+ * (inflated) bounding boxes cannot overlap. Two geometries that satisfy any
+ * overlap/intersection/within-distance-d predicate have overlapping bounding
+ * boxes (inflated by d/2 each), and overlapping bounding boxes always share
+ * at least one grid cell — so the candidate set is a superset of every true
+ * pair and the caller's counts come out identical to the O(n²) scan.
+ *
+ * Cell-key hash collisions merely merge unrelated cells (extra candidates,
+ * never missing ones), so correctness is collision-proof.
+ */
+export class BBoxGrid {
+  private cells = new Map<number, number[]>()
+  private readonly cellSize: number
+
+  constructor(cellSize: number) {
+    this.cellSize = Math.max(1, cellSize)
+  }
+
+  private cellKey(cx: number, cy: number): number {
+    // Bounded coordinates (layout space / cellSize) keep this collision-free
+    // in practice; a collision would only add candidates.
+    return cx * 131072 + cy
+  }
+
+  /** Register item `idx` as covering the bbox [x1,y1]-[x2,y2]. */
+  insert(idx: number, x1: number, y1: number, x2: number, y2: number): void {
+    const cx1 = Math.floor(Math.min(x1, x2) / this.cellSize)
+    const cy1 = Math.floor(Math.min(y1, y2) / this.cellSize)
+    const cx2 = Math.floor(Math.max(x1, x2) / this.cellSize)
+    const cy2 = Math.floor(Math.max(y1, y2) / this.cellSize)
+    for (let cx = cx1; cx <= cx2; cx++) {
+      for (let cy = cy1; cy <= cy2; cy++) {
+        const key = this.cellKey(cx, cy)
+        const list = this.cells.get(key)
+        if (list) list.push(idx)
+        else this.cells.set(key, [idx])
+      }
+    }
+  }
+
+  /**
+   * Invoke `cb` exactly once per unordered candidate pair (i < j) that
+   * shares at least one cell.
+   */
+  forEachCandidatePair(cb: (i: number, j: number) => void): void {
+    const seen = new Set<number>()
+    for (const list of this.cells.values()) {
+      for (let a = 0; a < list.length; a++) {
+        const ia = list[a]
+        if (ia === undefined) continue
+        for (let b = a + 1; b < list.length; b++) {
+          const ib = list[b]
+          if (ib === undefined || ia === ib) continue
+          const i = ia < ib ? ia : ib
+          const j = ia < ib ? ib : ia
+          // Items stay well under 2^21, so the packed key is collision-free.
+          const key = i * 2097152 + j
+          if (seen.has(key)) continue
+          seen.add(key)
+          cb(i, j)
+        }
+      }
+    }
+  }
+
+  /**
+   * Invoke `cb` once per registered item whose cells overlap the bbox
+   * (deduped per query).
+   */
+  query(x1: number, y1: number, x2: number, y2: number, cb: (idx: number) => void): void {
+    const cx1 = Math.floor(Math.min(x1, x2) / this.cellSize)
+    const cy1 = Math.floor(Math.min(y1, y2) / this.cellSize)
+    const cx2 = Math.floor(Math.max(x1, x2) / this.cellSize)
+    const cy2 = Math.floor(Math.max(y1, y2) / this.cellSize)
+    const seen = new Set<number>()
+    for (let cx = cx1; cx <= cx2; cx++) {
+      for (let cy = cy1; cy <= cy2; cy++) {
+        const list = this.cells.get(this.cellKey(cx, cy))
+        if (!list) continue
+        for (const idx of list) {
+          if (seen.has(idx)) continue
+          seen.add(idx)
+          cb(idx)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 調査結果（test6 = 460ノード/764リンク実データ）

フルベイク489秒の正体は composite探索（160評価×約1.2秒）。1評価の内訳は配置92ms / ポート11ms / ベジェ3ms に対し、**残り約840msが採点とルーターのO(n²)総当たり**だった：

| ホットスポット | self time |
|---|---|
| scoreRoutedEdges（交差・pierce ほか全ペア走査） | ~26% |
| router conflicts（全track×全ノード箱を毎プローブ再走査） | ~13% |
| findCollinearOverlaps / findPortClutter | ~15% |

## 変更（**出力は1ビットも変えない**等価アクセラレーション）

- **spatial-grid.ts**: `BBoxGrid` — 均一グリッドの候補ペア列挙/クエリ。重なり・距離述語を満たすペアは（膨張）bboxが重なり必ず同一セルを共有するので、候補は真ペアの**上位集合**。呼び出し側は元の述語で再判定するため計数は完全一致
- scoreRoutedEdges: 交差=セグメントグリッド、pierce=箱グリッド
- findCollinearOverlaps: 最大ギャップで膨張したセグメントグリッド。shared-runの数式は旧内側ループそのまま、**射影方向も旧実装の非対称性（ペアの先ライン基準）を維持**
- findPortClutter: rectsOverlap はbbox重なりそのもの → 種別ごとのグリッド
- router conflicts(): 両条件のx重なり半分はリクエスト内で不変 → プローブごとの全走査をやめ1回だけ前計算

## 等価性の証拠

- **プロパティテスト**: 旧O(n²)実装をverbatimで参照実装としてテスト内に保持し、シード乱数入力で結果集合の完全一致を検証（spatial-grid.test.ts、870 assertions）
- **実データ**: test6のフル探索（160評価）のコスト軌跡が**17桁まで一致** — `205530.24349912527 → 122111.04658803789`、採用20回も同一
- layoutテスト183本すべて緑（スナップショット含む）

## 速度

- フル探索: **191.7s → 65.5s（2.9倍）**、1評価 945ms → 434ms
- 残りのホットスポット（forEachCandidatePairオーバーヘッド、portLabelBox等）は次段候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)