### PR TITLE
chore(server): RESOLVER_VERSION 3 — invalidate pre-#474 layout artifacts

### DIFF
--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -130,7 +130,8 @@ interface ScopeCriterionRow {
  * `topology_resolved_graph` artifacts built by an older version are treated as
  * stale and recomputed without a manual purge.
  */
-const RESOLVER_VERSION = 2
+// v3: composite zones follow the parent subgraph + zone rows wrap (#474).
+const RESOLVER_VERSION = 3
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {


### PR DESCRIPTION
#474 でレイアウトアルゴリズムが変わったため、旧バージョンで焼かれた resolved_graph アーティファクトを stale 扱いにして自動再ベイクさせる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)