### PR TITLE
fix(layout): subgraph boxes stop overlapping — bounds expansion needs geometric containment

### DIFF
--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -130,8 +130,10 @@ interface ScopeCriterionRow {
  * `topology_resolved_graph` artifacts built by an older version are treated as
  * stale and recomputed without a manual purge.
  */
-// v3: composite zones follow the parent subgraph + zone rows wrap (#474).
-const RESOLVER_VERSION = 3
+// v4: subgraph bounds expansion requires geometric containment of both wire
+// endpoints — boxes no longer stretch to rail-seated sinks / cross-zone pair
+// halves (was: 116 overlapping subgraph pairs on test6).
+const RESOLVER_VERSION = 4
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -19,7 +19,7 @@
  *      that reproduced a human reviewer's "these two look backwards").
  */
 
-import type { NetworkGraph } from '../../models/types.js'
+import type { NetworkGraph, Subgraph } from '../../models/types.js'
 import { placePorts } from '../auto-placement/flat-tree/port-placement.js'
 import { resolveNodeSize } from '../engine/index.js'
 import { findCollinearOverlaps, findPortClutter, type PolylineSpec } from '../invariants.js'
@@ -187,13 +187,34 @@ async function evaluate(
   })
   let figure: Extent | undefined
   const internal = new Map<string, Extent>()
+  // Ownership needs GEOMETRY, not just membership: a logical member placed
+  // outside the container's box (a sink on its own rail, a pair half seated
+  // in another zone) makes any wire to it cross-boundary in practice — if
+  // such a wire counted as "internal", the box would stretch to the rail and
+  // overlap everything in between (the observed near-figure-sized,
+  // 100+-pair subgraph overlap). Cross-boundary wiring belongs to the
+  // enclosing level, exactly as documented below.
+  const insideBounds = (nodeId: string): ((b: NonNullable<Subgraph['bounds']>) => boolean) => {
+    const pos = comp.nodes.get(nodeId)?.position
+    if (!pos) return () => false
+    return (b) =>
+      pos.x >= b.x - 2 &&
+      pos.x <= b.x + b.width + 2 &&
+      pos.y >= b.y - 2 &&
+      pos.y <= b.y + b.height + 2
+  }
   for (const edge of edges.values()) {
     if (edge.coupling) continue
     const pts = edge.route?.points ?? edge.points
     const half = edge.width / 2 + 2
+    const fromInside = insideBounds(edge.fromNodeId)
+    const toInside = insideBounds(edge.toNodeId)
     const owners: string[] = []
     for (const [id, members] of memberSets) {
-      if (members.has(edge.fromNodeId) && members.has(edge.toNodeId)) owners.push(id)
+      if (!members.has(edge.fromNodeId) || !members.has(edge.toNodeId)) continue
+      const bounds = comp.subgraphs.get(id)?.bounds
+      if (bounds && (!fromInside(bounds) || !toInside(bounds))) continue
+      owners.push(id)
     }
     for (const p of pts) {
       figure = grow(figure, p.x, p.y, half)


### PR DESCRIPTION
## 質問「サブグラフ同士が被さってたりする?」への答え

**被さっていた**：test6で**116ペア**、最悪は 4589×11620（ほぼ全面）。

## 原因

ルーティング後の「箱は内部で完結する配線を含むよう広がる」処理が、所有判定を**論理メンバーシップのみ**で行っていた。sink（共有サービス）は最下部レールに、冗長ペアの片割れは別ゾーンに**配置される**が、parent的にはグループのメンバーのまま。そこへの配線が「内部配線」と誤認され、箱が図の高さいっぱいまで引き伸ばされて全部に重なっていた。

## 修正

所有判定に**幾何条件**を追加：配線の両端ノードが箱の配置boundsの内側に実在する場合のみ、その配線が箱を広げられる。外に座ったメンバーへの線は境界跨ぎ＝上位レベルの配線（このパスのコメントに書かれた設計意図そのもの）。ガター迂回など正当に箱の外へ膨らむ経路は引き続き箱を広げる（判定は端点であってポリラインではない）。

## 結果（test6・フル探索160評価）

- 重なりペア: **116 → 0**
- 探索コスト軌跡は完全一致（bounds計算のみの変更、配置・配線は不変）
- layoutテスト183本緑 / RESOLVER_VERSION→4 で旧アーティファクト自動再ベイク

🤖 Generated with [Claude Code](https://claude.com/claude-code)