### PR TITLE
fix(layout): nodes never sit outside their group box — seated sinks, final-extent boxes, containment re-pack

### DIFF
--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -130,10 +130,10 @@ interface ScopeCriterionRow {
  * `topology_resolved_graph` artifacts built by an older version are treated as
  * stale and recomputed without a manual purge.
  */
-// v4: subgraph bounds expansion requires geometric containment of both wire
-// endpoints — boxes no longer stretch to rail-seated sinks / cross-zone pair
-// halves (was: 116 overlapping subgraph pairs on test6).
-const RESOLVER_VERSION = 4
+// v5: grouped sinks seat inside their zone (rail only for group-less),
+// zone boxes grow to final refined content + bands re-pack — containment
+// violations and box overlaps both at zero on test6.
+const RESOLVER_VERSION = 5
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {

--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -379,8 +379,19 @@ export function layoutComposite(
   const PAIR_GAP = 16
   const units: Unit[] = []
   const unitOf = new Map<string, string>()
+  // Containment beats the rail heuristic: a sink that BELONGS to a group
+  // (has a real zone) seats inside that group's box — on its bottom row —
+  // instead of being exiled to the global rail 10k+ px away from the box
+  // that claims it. Only group-less sinks still rail. Sink semantics for
+  // depth anchoring / zone ordering are unchanged (they're about graph
+  // traversal, not seating).
+  let maxFiniteDepth = 0
+  for (const d of depth.values()) {
+    if (Number.isFinite(d)) maxFiniteDepth = Math.max(maxFiniteDepth, d)
+  }
+  const railSink = (id: string): boolean => sinkSet.has(id) && zoneOf(id).startsWith('__solo:')
   for (const id of ids) {
-    if (sinkSet.has(id)) continue // sinks live on their own rail, not in zones
+    if (railSink(id)) continue // group-less sinks live on their own rail
     const partner = pairedWith.get(id)
     if (partner !== undefined && partner < id) continue
     const members = partner !== undefined ? [id, partner].sort() : [id]
@@ -394,7 +405,12 @@ export function layoutComposite(
       const size = resolveNodeSize(node)
       width += size.width
       height = Math.max(height, size.height)
-      minDepth = Math.min(minDepth, depth.get(member) ?? 0)
+      // A seated sink goes to its zone's LAST row — it feeds everything,
+      // so it reads as the zone's collector shelf.
+      minDepth = Math.min(
+        minDepth,
+        sinkSet.has(member) ? maxFiniteDepth + 1 : (depth.get(member) ?? 0),
+      )
     }
     units.push({ id: unitId, members, width, height, zone: zoneOf(id), depth: minDepth })
     for (const member of members) unitOf.set(member, unitId)
@@ -543,7 +559,15 @@ export function layoutComposite(
       }
     }
     zoneRows.set(zone, rows)
-    zoneBox.set(zone, { w: maxRowWidth + zonePad * 2, h: y + zonePad })
+    // Box width from the FINAL unit positions: the barycenter sweeps re-lay
+    // rows with order-dependent pair gaps, so a row can end up wider than
+    // the pre-sweep measurement — sizing the box from the stale width left
+    // the rightmost units sticking out of their own zone box.
+    let finalMaxX = maxRowWidth + zonePad
+    for (const unit of members) {
+      finalMaxX = Math.max(finalMaxX, (localX.get(unit.id) ?? 0) + unit.width / 2)
+    }
+    zoneBox.set(zone, { w: finalMaxX + zonePad, h: y + zonePad })
   }
 
   // -- quotient: bands by zone rank, child-block packing under feeders ---------
@@ -644,7 +668,8 @@ export function layoutComposite(
 
   const zoneX = new Map<string, number>()
   const zoneY = new Map<string, number>()
-  const { bandRanges, bandBlocks } = placeZoneBands(
+  // Re-assigned when refinement widens a zone box (containment re-pack below).
+  let { bandRanges, bandBlocks } = placeZoneBands(
     zoneIds,
     zoneRank,
     zoneAdj,
@@ -737,6 +762,56 @@ export function layoutComposite(
     for (const row of zoneRows.get(zone) ?? []) resolveRow(row, localX, box.w, pairGap)
   }
 
+  // -- containment repair: refinement (cross-zone pulls, nudges, snap) reorders
+  // rows, and the label-aware pair gaps are ORDER-DEPENDENT — a re-ordered row
+  // can need more width than the box measured at zone-local time, and
+  // resolveRow's left-shift can only reclaim the leading slack. Grow each box
+  // to its final content extent and re-pack the bands so widened boxes don't
+  // collide; a unit must never sit outside its own zone box.
+  {
+    let widened = false
+    for (const zone of zoneIds) {
+      const box = zoneBox.get(zone)
+      if (!box) continue
+      let maxExtent = 0
+      for (const unit of zoneUnits.get(zone) ?? []) {
+        maxExtent = Math.max(maxExtent, (localX.get(unit.id) ?? 0) + unit.width / 2)
+      }
+      const needed = maxExtent + zonePad
+      if (needed > box.w + 0.5) {
+        zoneBox.set(zone, { w: needed, h: box.h })
+        widened = true
+      }
+    }
+    if (widened) {
+      zoneX.clear()
+      zoneY.clear()
+      // Same aspect-targeted band budget formula, fed the WIDENED areas —
+      // reusing the stale budget squeezed the wider boxes into more stacked
+      // bands and the figure went 1:5 portrait.
+      let widenedArea = 0
+      for (const [, box] of zoneBox) widenedArea += (box.w + zoneGap) * (box.h + bandGap)
+      const repackBandW =
+        options.maxBandW ?? Math.max(1700, Math.round(Math.sqrt(widenedArea * 1.5)))
+      ;({ bandRanges, bandBlocks } = placeZoneBands(
+        zoneIds,
+        zoneRank,
+        zoneAdj,
+        zoneParent,
+        zoneBox,
+        zoneX,
+        zoneY,
+        zoneGap,
+        bandGap,
+        repackBandW,
+        labelBandExtra,
+        options.bandOrder,
+        zoneDownReach,
+        zoneUpReach,
+      ))
+    }
+  }
+
   // -- compose to absolute centers ----------------------------------------------
   for (const unit of units) {
     const gx = (zoneX.get(unit.zone) ?? 0) + (localX.get(unit.id) ?? 0)
@@ -781,12 +856,14 @@ export function layoutComposite(
     node.position = { x: node.position.x + shiftX, y: node.position.y + shiftY }
   }
 
-  // -- sink rail: shared-service sinks sit on their own row below the zones
-  //    (v3 collector rail) instead of dragging 15+ links into one zone box --
+  // -- sink rail: GROUP-LESS shared-service sinks sit on their own row below
+  //    the zones (v3 collector rail). Sinks that belong to a group were
+  //    seated inside their zone above — containment wins over the rail.
   let railBottom = maxY - minY + PAD
-  if (sinkSet.size > 0) {
+  const railSinkIds = [...sinkSet].filter((id) => railSink(id)).sort()
+  if (railSinkIds.length > 0) {
     const railY = maxY - minY + PAD + 110
-    const sinkIds = [...sinkSet].sort()
+    const sinkIds = railSinkIds
     let railWidth = 0
     let railHeight = 0
     for (const id of sinkIds) {


### PR DESCRIPTION
## 「サブグラフからはみ出てるノードがある」の調査結果

test6で**39ノード**が親グループ箱の外（最大14.5k px）。原因は3つの内包リーク：

1. **sinkのレール隔離** — グループ所属のsink（共有サービス・コアルータ等）も全部、図の最下部のグローバルレールへ exile されていた。**内包がレールheuristicに勝つ**よう変更：実ゾーンを持つsinkは自分のゾーンの最下行（collector shelf）に座り、グループレスのsinkだけレールに残る。深さアンカリング/ゾーン順序のsink意味論は不変
2. **箱幅の計測タイミング** — バリセンター2スイープの**前**に測った行幅で箱を確定していたが、並べ替え後はラベル幅依存のペアギャップが変わって行が伸びる → 最終配置から箱幅を計測
3. **クロスゾーンリファイン後の溢れ** — port pull / nudge / parent snap が行をさらに広げ、resolveRowの左シフトは先頭スラックしか回収できない → **内包修復パス**：各箱を最終コンテンツ幅まで広げ、バンドを再パッキング（広げた箱同士が衝突しないよう、面積再計算のアスペクト目標予算で）

## 「サブグラフも同じ層で配置されてる?」への答え

原則そうなってる（ゾーン箱は配置の一級要素・ルーティングの障害物）。破っていたのは上記のsinkレールとリファイン溢れだけで、今回それを内包契約に従わせた。

## 結果（test6・フル探索）

- 親箱の外のノード: **39 → 0**
- 箱の重なり: **3 → 0**
- sinkレール廃止の副作用で図を横断する配線が消え、探索コスト **148.5k → 55.7k**
- 図形は 3578×19875（縦長）— コスト関数がアスペクトを罰しないため幅狭variantが勝つ。見た目の好みは実物確認で次の調整へ
- layoutテスト183本緑 / RESOLVER_VERSION→5

🤖 Generated with [Claude Code](https://claude.com/claude-code)