### PR TITLE
fix(layout): content-derived zone wrap width + aspect term in the search cost

### DIFF
--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -130,10 +130,10 @@ interface ScopeCriterionRow {
  * `topology_resolved_graph` artifacts built by an older version are treated as
  * stale and recomputed without a manual purge.
  */
-// v5: grouped sinks seat inside their zone (rail only for group-less),
-// zone boxes grow to final refined content + bands re-pack — containment
-// violations and box overlaps both at zero on test6.
-const RESOLVER_VERSION = 5
+// v6: zone wrap width derives from zone content area (no fixed cap) and the
+// search cost carries an aspect term — the 1:6 vertical-column figure
+// becomes ~1:1.3.
+const RESOLVER_VERSION = 6
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {

--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -482,9 +482,19 @@ export function layoutComposite(
     const rowKeys = [...rowMap.keys()].sort((a, b) => a - b)
     // Wrap each depth-row at a max width. Depth alone decided the row, so a
     // zone with 100+ same-depth members (a big host group) became one
-    // figure-wide strip — the "everything in a single line" defect. Width
-    // stays deterministic: chunks are cut in the original sort order.
-    const ZONE_ROW_MAX_W = 2200
+    // figure-wide strip — the "everything in a single line" defect.
+    //
+    // The wrap target scales with the ZONE's content (landscape-ish aspect),
+    // not a fixed constant: a fixed cap made every box equally wide, so the
+    // band packer fit only ONE box per band and the whole figure degenerated
+    // into a single vertical column. Small groups now wrap into compact
+    // boxes that pack several per band. Deterministic: chunks are cut in
+    // the original sort order.
+    let contentArea = 0
+    for (const unit of members) {
+      contentArea += (unit.width + cellGapXBase) * (unit.height + rowGapBase / 2)
+    }
+    const zoneRowMaxW = Math.max(420, Math.min(2400, Math.round(Math.sqrt(contentArea * PHI))))
     const rows: Unit[][] = []
     for (const key of rowKeys) {
       const depthRow = rowMap.get(key) ?? []
@@ -493,7 +503,7 @@ export function layoutComposite(
       for (const unit of depthRow) {
         const prev = current[current.length - 1]
         const addition = unit.width + (prev ? pairGap(prev, unit) : 0)
-        if (current.length > 0 && width + addition > ZONE_ROW_MAX_W) {
+        if (current.length > 0 && width + addition > zoneRowMaxW) {
           rows.push(current)
           current = [unit]
           width = unit.width

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -776,19 +776,41 @@ export function scoreRoutedEdges(
       if (yDeep !== undefined && yShallow !== undefined && yDeep < yShallow - 10) upward++
     }
   }
+  // Aspect sanity: without this term the search gladly stacks every band
+  // into a 1:6 portrait strip — narrow variants shorten horizontal wires
+  // and nothing resists the collapse. Multiplicative so it scales with the
+  // rest of the cost; tolerant band (1:1.8 tall … 2.6:1 wide) costs nothing.
+  let nx1 = Number.POSITIVE_INFINITY
+  let ny1 = Number.POSITIVE_INFINITY
+  let nx2 = Number.NEGATIVE_INFINITY
+  let ny2 = Number.NEGATIVE_INFINITY
+  for (const [, node] of nodes) {
+    if (!node.position) continue
+    nx1 = Math.min(nx1, node.position.x)
+    ny1 = Math.min(ny1, node.position.y)
+    nx2 = Math.max(nx2, node.position.x)
+    ny2 = Math.max(ny2, node.position.y)
+  }
+  const figureW = Math.max(1, nx2 - nx1)
+  const figureH = Math.max(1, ny2 - ny1)
+  const tallExcess = Math.max(0, figureH / figureW - 1.8)
+  const wideExcess = Math.max(0, figureW / figureH - 2.6)
+  const aspectFactor = 1 + 0.15 * (tallExcess + wideExcess)
+
   return {
     cost:
-      crossings +
-      collinear * 8 +
-      // a wire under a node is a defect, not a trade-off (90° crossings
-      // are the grammar; piercing is not)
-      pierce * 20 +
-      bends * 0.4 +
-      length / 400 +
-      upward * 12 +
-      // overlap-free is a REQUIREMENT, not a preference — weight high
-      // enough that no crossing/length win can buy a collision
-      clutter * 40,
+      (crossings +
+        collinear * 8 +
+        // a wire under a node is a defect, not a trade-off (90° crossings
+        // are the grammar; piercing is not)
+        pierce * 20 +
+        bends * 0.4 +
+        length / 400 +
+        upward * 12 +
+        // overlap-free is a REQUIREMENT, not a preference — weight high
+        // enough that no crossing/length win can buy a collision
+        clutter * 40) *
+      aspectFactor,
     crossings,
     collinear,
     pierce,


### PR DESCRIPTION
## 「なんで縦1列?」の答え

依存関係パッキング自体は生きていたが、置く余地が無かった：

1. **折り返し幅がハードコード2200px** — 全グループ箱が一律同じ幅になり、バンド幅予算に1箱しか入らない → 全ゾーン縦積み。**ゾーンの中身の面積から導出**（√(面積×φ)、420..2400は可読性ガードレールのみ）に変更。小グループは小箱になり、バンドに複数並ぶ
2. **コスト関数が縦潰れに無抵抗** — 幅狭variantは横配線が短くなるため常勝。**乗算のアスペクト項**（1:1.8縦〜2.6:1横は無料、外側で増加）を追加し、プロポーションを定数でなく探索で最適化

## 結果（test6）

- 図形: 3578×19875（1:5.6）→ **7632×10013（1:1.31）**
- はみ出し 0 維持 / 箱の重なり実質ゼロ（配線拡張による微小2件のみ）
- layoutテスト183本緑 / RESOLVER_VERSION→6

🤖 Generated with [Claude Code](https://claude.com/claude-code)