### PR TITLE
fix(layout): port labels are node-owned box footprint; drop wrap-width guardrails

### DIFF
--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -130,10 +130,10 @@ interface ScopeCriterionRow {
  * `topology_resolved_graph` artifacts built by an older version are treated as
  * stale and recomputed without a manual purge.
  */
-// v6: zone wrap width derives from zone content area (no fixed cap) and the
-// search cost carries an aspect term — the 1:6 vertical-column figure
-// becomes ~1:1.3.
-const RESOLVER_VERSION = 6
+// v7: zone boxes reserve their outer-face port-label reach (labels are
+// node-owned, drawn INSIDE the box); wrap-width guardrails dropped (floor =
+// widest unit, no artificial cap).
+const RESOLVER_VERSION = 7
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {

--- a/libs/@shumoku/core/src/layout/composite/index.ts
+++ b/libs/@shumoku/core/src/layout/composite/index.ts
@@ -491,10 +491,16 @@ export function layoutComposite(
     // boxes that pack several per band. Deterministic: chunks are cut in
     // the original sort order.
     let contentArea = 0
+    let widestUnit = 0
     for (const unit of members) {
       contentArea += (unit.width + cellGapXBase) * (unit.height + rowGapBase / 2)
+      widestUnit = Math.max(widestUnit, unit.width)
     }
-    const zoneRowMaxW = Math.max(420, Math.min(2400, Math.round(Math.sqrt(contentArea * PHI))))
+    // The only principled floor: a row must fit its widest unit (anything
+    // narrower just breaks every row anyway). No artificial cap — the
+    // content-derived target is already aspect-balanced, and the global
+    // proportion is the search cost's job, not a constant's.
+    const zoneRowMaxW = Math.max(widestUnit, Math.round(Math.sqrt(contentArea * PHI)))
     const rows: Unit[][] = []
     for (const key of rowKeys) {
       const depthRow = rowMap.get(key) ?? []
@@ -577,7 +583,25 @@ export function layoutComposite(
     for (const unit of members) {
       finalMaxX = Math.max(finalMaxX, (localX.get(unit.id) ?? 0) + unit.width / 2)
     }
-    zoneBox.set(zone, { w: finalMaxX + zonePad, h: y + zonePad })
+    // The box reserves its OWN outer-face port-label reach: labels are
+    // node-owned geometry that must sit INSIDE the box, and the band packer
+    // can only keep boxes apart if it knows their true extent. Inner-face
+    // labels are already paid for by the pair/row corridors.
+    const latReach = Math.max(0, ...members.map(unitLReach))
+    const firstRow = rows[0]
+    const lastRow = rows[rows.length - 1]
+    const topReach = firstRow ? rowUpReach(firstRow) : 0
+    const botReach = lastRow ? rowDownReach(lastRow) : 0
+    if (latReach > 0 || topReach > 0) {
+      for (const unit of members) {
+        localX.set(unit.id, (localX.get(unit.id) ?? 0) + latReach)
+        localY.set(unit.id, (localY.get(unit.id) ?? 0) + topReach)
+      }
+    }
+    zoneBox.set(zone, {
+      w: finalMaxX + zonePad + latReach * 2,
+      h: y + zonePad + topReach + botReach,
+    })
   }
 
   // -- quotient: bands by zone rank, child-block packing under feeders ---------

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -220,16 +220,27 @@ async function evaluate(
       figure = grow(figure, p.x, p.y, half)
       for (const id of owners) internal.set(id, grow(internal.get(id), p.x, p.y, half))
     }
-    // Port labels are owned geometry — their boxes are footprint too.
+    // Port labels are NODE-owned geometry — they count toward every
+    // container the PORT'S node sits in, regardless of where the wire
+    // goes. (Attributing them to the edge's owners let a cross-boundary
+    // wire's label poke out of the box its node lives in.)
     for (const port of [edge.fromPort, edge.toPort]) {
       const labelRect = portLabelBox(port)
       if (!labelRect) continue
+      const nodeInside = insideBounds(port.nodeId)
+      const labelOwners: string[] = []
+      for (const [id, members] of memberSets) {
+        if (!members.has(port.nodeId)) continue
+        const bounds = comp.subgraphs.get(id)?.bounds
+        if (bounds && !nodeInside(bounds)) continue
+        labelOwners.push(id)
+      }
       for (const [x, y] of [
         [labelRect.x, labelRect.y],
         [labelRect.x + labelRect.width, labelRect.y + labelRect.height],
       ] as const) {
         figure = grow(figure, x, y, 2)
-        for (const id of owners) internal.set(id, grow(internal.get(id), x, y, 2))
+        for (const id of labelOwners) internal.set(id, grow(internal.get(id), x, y, 2))
       }
     }
     // Labels are part of the edge's rendered footprint too. Mirror the


### PR DESCRIPTION
## 変更

1. **ポートラベル=ノード所有のfootprint** — 従来は「配線が箱内部で完結する場合」だけラベルが箱の拡張に算入され、境界跨ぎ配線のラベルはノードが箱の中なのに箱の外へはみ出せた。footprintパスはラベルを**ポートのノードが属する全コンテナ**に帰属させ、さらに各ゾーン箱は**配置時点で外周ラベル到達幅を予約**（側面+先頭行の上面+末尾行の下面）。バンドパッカーが本当の箱サイズで詰めるので衝突しない
2. **折り返し幅のガードレール撤去** — 420..2400クランプを「最幅ユニットが1行に入る」という唯一原理的な床に置き換え、上限は廃止（コンテンツ導出がアスペクト均衡済みで、全体比率は探索コストの仕事）

## 結果（test6・フル探索）

- コスト **68.9k → 46.5k**（今日の最良）、アスペクト 1:1.22
- はみ出し 0 維持、箱の重なりは ≤41px の微小3件（内部配線のガター膨らみ由来、化粧レベル）
- layoutテスト183本緑 / RESOLVER_VERSION→7

🤖 Generated with [Claude Code](https://claude.com/claude-code)