### PR TITLE
feat(layout): declarative constraint registry — 禁止事項の宣言・検証・assertを単一情報源化 (Phase A, closes #482)

### DIFF
--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -22,7 +22,14 @@
 import type { NetworkGraph, Subgraph } from '../../models/types.js'
 import { placePorts } from '../auto-placement/flat-tree/port-placement.js'
 import { resolveNodeSize } from '../engine/index.js'
-import { findCollinearOverlaps, findPortClutter, type PolylineSpec } from '../invariants.js'
+import {
+  type BoxSpec,
+  findCollinearOverlaps,
+  findEdgeNodePiercing,
+  findPortClutter,
+  type PolylineSpec,
+  segmentsIntersect,
+} from '../invariants.js'
 import { getLinkWidthForMode } from '../link-utils.js'
 import { portLabelBox } from '../port-geometry.js'
 import type { ResolvedEdge, ResolvedLayout, ResolvedPort } from '../resolved-types.js'
@@ -702,52 +709,26 @@ export function scoreRoutedEdges(
     const ba = busOf.get(o.a)
     return ba === undefined || ba !== busOf.get(o.b)
   }).length
-  // wires running through unrelated node boxes — box grid + per-segment
-  // queries; a segment can only pierce a box whose inflated bbox its own
-  // bbox overlaps, so the candidate sweep counts exactly the same pairs.
-  let pierce = 0
-  const boxes: { id: string; x: number; y: number; w: number; h: number }[] = []
+  // wires running through unrelated node boxes — the constraint check and
+  // this score share ONE definition (invariants.findEdgeNodePiercing, the
+  // exact loop that used to live here).
+  const nodeBoxSpecsForPierce: BoxSpec[] = []
   for (const [id, node] of nodes) {
     if (!node.position) continue
     const size = resolveNodeSize(node)
-    boxes.push({ id, x: node.position.x, y: node.position.y, w: size.width, h: size.height })
+    nodeBoxSpecsForPierce.push({
+      id,
+      x: node.position.x,
+      y: node.position.y,
+      width: size.width,
+      height: size.height,
+    })
   }
-  const boxGrid = new BBoxGrid(320)
-  for (const [idx, box] of boxes.entries()) {
-    boxGrid.insert(
-      idx,
-      box.x - box.w / 2 - 2,
-      box.y - box.h / 2 - 2,
-      box.x + box.w / 2 + 2,
-      box.y + box.h / 2 + 2,
-    )
-  }
-  for (const poly of polys) {
-    const hitBoxes = new Set<number>()
-    for (let s = 1; s < poly.pts.length; s++) {
-      const a = poly.pts[s - 1]
-      const b = poly.pts[s]
-      if (!a || !b) continue
-      boxGrid.query(a.x, a.y, b.x, b.y, (bi) => {
-        if (hitBoxes.has(bi)) return
-        const box = boxes[bi]
-        if (!box || box.id === poly.a || box.id === poly.b) return
-        const bx = box.x - box.w / 2 - 2
-        const by = box.y - box.h / 2 - 2
-        const bw = box.w + 4
-        const bh = box.h + 4
-        if (Math.max(a.x, b.x) < bx || Math.min(a.x, b.x) > bx + bw) return
-        if (Math.max(a.y, b.y) < by || Math.min(a.y, b.y) > by + bh) return
-        const hit =
-          segmentsIntersect(a, b, { x: bx, y: by }, { x: bx + bw, y: by }) ||
-          segmentsIntersect(a, b, { x: bx, y: by + bh }, { x: bx + bw, y: by + bh }) ||
-          segmentsIntersect(a, b, { x: bx, y: by }, { x: bx, y: by + bh }) ||
-          segmentsIntersect(a, b, { x: bx + bw, y: by }, { x: bx + bw, y: by + bh })
-        if (hit) hitBoxes.add(bi)
-      })
-    }
-    pierce += hitBoxes.size
-  }
+  const pierce = findEdgeNodePiercing(
+    polys.map((p) => ({ id: p.id, points: p.pts, fromNodeId: p.a, toNodeId: p.b })),
+    nodeBoxSpecsForPierce,
+    2,
+  ).length
   // port/label clutter: collisions among owned geometry (port boxes,
   // label boxes, labels vs foreign nodes). With the demand feedback
   // this should be zero; the term makes any residual visible to the
@@ -830,17 +811,4 @@ export function scoreRoutedEdges(
     upward,
     clutter,
   }
-}
-
-function segmentsIntersect(
-  a1: { x: number; y: number },
-  a2: { x: number; y: number },
-  b1: { x: number; y: number },
-  b2: { x: number; y: number },
-): boolean {
-  const d1 = (a2.x - a1.x) * (b1.y - a1.y) - (a2.y - a1.y) * (b1.x - a1.x)
-  const d2 = (a2.x - a1.x) * (b2.y - a1.y) - (a2.y - a1.y) * (b2.x - a1.x)
-  const d3 = (b2.x - b1.x) * (a1.y - b1.y) - (b2.y - b1.y) * (a1.x - b1.x)
-  const d4 = (b2.x - b1.x) * (a2.y - b1.y) - (b2.y - b1.y) * (a2.x - b1.x)
-  return d1 > 0 !== d2 > 0 && d3 > 0 !== d4 > 0
 }

--- a/libs/@shumoku/core/src/layout/constraints.test.ts
+++ b/libs/@shumoku/core/src/layout/constraints.test.ts
@@ -1,0 +1,215 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Constraint registry (#482): verification derives from the declared specs,
+ * blocking violations throw under test env, and the extracted pierce finder
+ * matches the verbatim O(n²) reference.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import type { Node } from '../models/types.js'
+import {
+  assertLayoutConstraints,
+  LAYOUT_CONSTRAINTS,
+  verifyLayoutConstraints,
+} from './constraints.js'
+import { findEdgeNodePiercing, type PierceLineSpec, segmentsIntersect } from './invariants.js'
+import type { ResolvedLayout } from './resolved-types.js'
+
+const mkNode = (id: string, parent?: string): Node =>
+  ({ id, label: id, shape: 'rect', ...(parent ? { parent } : {}) }) as Node
+
+function layoutOf(input: {
+  nodes: Array<{ id: string; x: number; y: number; w?: number; h?: number; parent?: string }>
+  subgraphs?: Array<{
+    id: string
+    x: number
+    y: number
+    w: number
+    h: number
+    parent?: string
+  }>
+}): ResolvedLayout {
+  return {
+    nodes: new Map(
+      input.nodes.map((n) => [
+        n.id,
+        {
+          ...mkNode(n.id, n.parent),
+          position: { x: n.x, y: n.y },
+          size: { width: n.w ?? 60, height: n.h ?? 40 },
+        },
+      ]),
+    ),
+    ports: new Map(),
+    edges: new Map(),
+    subgraphs: new Map(
+      (input.subgraphs ?? []).map((s) => [
+        s.id,
+        {
+          id: s.id,
+          label: s.id,
+          ...(s.parent ? { parent: s.parent } : {}),
+          bounds: { x: s.x, y: s.y, width: s.w, height: s.h },
+        },
+      ]),
+    ),
+    bounds: { x: 0, y: 0, width: 1000, height: 1000 },
+    metadata: { algorithm: 'test', duration: 0 },
+  } as ResolvedLayout
+}
+
+describe('constraint registry', () => {
+  test('every constraint id is unique and carries a level', () => {
+    const ids = LAYOUT_CONSTRAINTS.map((s) => s.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    for (const s of LAYOUT_CONSTRAINTS) {
+      expect(['blocking', 'warn', 'score-only']).toContain(s.level)
+    }
+  })
+
+  test('clean layout verifies ok', () => {
+    const report = verifyLayoutConstraints(
+      layoutOf({
+        nodes: [
+          { id: 'a', x: 100, y: 100, parent: 'g' },
+          { id: 'b', x: 300, y: 100, parent: 'g' },
+        ],
+        subgraphs: [{ id: 'g', x: 0, y: 0, w: 500, h: 300 }],
+      }),
+    )
+    expect(report.ok).toBe(true)
+    expect(report.counts['node-overlap']).toBe(0)
+    expect(report.counts.containment).toBe(0)
+  })
+
+  test('node overlap is a blocking violation and asserts throw under test env', () => {
+    const layout = layoutOf({
+      nodes: [
+        { id: 'a', x: 100, y: 100 },
+        { id: 'b', x: 110, y: 105 },
+      ],
+    })
+    const report = verifyLayoutConstraints(layout)
+    expect(report.counts['node-overlap']).toBe(1)
+    expect(report.blockingViolations).toContain('node-overlap')
+    expect(report.ok).toBe(false)
+    expect(() => assertLayoutConstraints(layout, 'unit-test')).toThrow(/node-overlap/)
+  })
+
+  test('member outside its parent box is a blocking containment violation', () => {
+    const report = verifyLayoutConstraints(
+      layoutOf({
+        nodes: [{ id: 'a', x: 900, y: 900, parent: 'g' }],
+        subgraphs: [{ id: 'g', x: 0, y: 0, w: 200, h: 200 }],
+      }),
+    )
+    expect(report.counts.containment).toBe(1)
+    expect(report.blockingViolations).toContain('containment')
+  })
+
+  test('nested container boxes are legal; sibling overlap is reported (warn level)', () => {
+    const nested = verifyLayoutConstraints(
+      layoutOf({
+        nodes: [],
+        subgraphs: [
+          { id: 'outer', x: 0, y: 0, w: 500, h: 500 },
+          { id: 'inner', x: 50, y: 50, w: 100, h: 100, parent: 'outer' },
+        ],
+      }),
+    )
+    expect(nested.counts['container-overlap']).toBe(0)
+    expect(nested.ok).toBe(true)
+
+    const siblings = verifyLayoutConstraints(
+      layoutOf({
+        nodes: [],
+        subgraphs: [
+          { id: 'g1', x: 0, y: 0, w: 300, h: 300 },
+          { id: 'g2', x: 200, y: 200, w: 300, h: 300 },
+        ],
+      }),
+    )
+    expect(siblings.counts['container-overlap']).toBe(1)
+    // warn level: reported but NOT blocking (promotion tracked by #483)
+    expect(siblings.blockingViolations).not.toContain('container-overlap')
+    expect(siblings.ok).toBe(true)
+  })
+})
+
+describe('findEdgeNodePiercing equals the O(n²) reference', () => {
+  /** Deterministic PRNG (mulberry32). */
+  function rng(seed: number): () => number {
+    let s = seed
+    return () => {
+      s = (s + 0x6d2b79f5) | 0
+      let t = Math.imul(s ^ (s >>> 15), 1 | s)
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+  }
+
+  function referencePierce(
+    lines: readonly PierceLineSpec[],
+    boxes: readonly { id: string; x: number; y: number; width: number; height: number }[],
+    inflate: number,
+  ): string[] {
+    const out: string[] = []
+    for (const line of lines) {
+      for (const box of boxes) {
+        if (box.id === line.fromNodeId || box.id === line.toNodeId) continue
+        const bx = box.x - box.width / 2 - inflate
+        const by = box.y - box.height / 2 - inflate
+        const bw = box.width + inflate * 2
+        const bh = box.height + inflate * 2
+        let hit = false
+        for (let s = 1; s < line.points.length && !hit; s++) {
+          const a = line.points[s - 1]
+          const b = line.points[s]
+          if (!a || !b) continue
+          if (Math.max(a.x, b.x) < bx || Math.min(a.x, b.x) > bx + bw) continue
+          if (Math.max(a.y, b.y) < by || Math.min(a.y, b.y) > by + bh) continue
+          hit =
+            segmentsIntersect(a, b, { x: bx, y: by }, { x: bx + bw, y: by }) ||
+            segmentsIntersect(a, b, { x: bx, y: by + bh }, { x: bx + bw, y: by + bh }) ||
+            segmentsIntersect(a, b, { x: bx, y: by }, { x: bx, y: by + bh }) ||
+            segmentsIntersect(a, b, { x: bx + bw, y: by }, { x: bx + bw, y: by + bh })
+        }
+        if (hit) out.push(`${line.id}|${box.id}`)
+      }
+    }
+    return out.sort()
+  }
+
+  test('random polylines vs random boxes', () => {
+    const rand = rng(21)
+    for (let round = 0; round < 5; round++) {
+      const boxes = Array.from({ length: 60 }, (_, i) => ({
+        id: `n${i}`,
+        x: rand() * 2000,
+        y: rand() * 1200,
+        width: 40 + rand() * 100,
+        height: 30 + rand() * 50,
+      }))
+      const lines: PierceLineSpec[] = Array.from({ length: 80 }, (_, i) => {
+        const pts = [{ x: rand() * 2000, y: rand() * 1200 }]
+        for (let s = 0; s < 3; s++) {
+          const last = pts[pts.length - 1]
+          if (!last) break
+          pts.push(rand() < 0.5 ? { x: rand() * 2000, y: last.y } : { x: last.x, y: rand() * 1200 })
+        }
+        return {
+          id: `e${i}`,
+          points: pts,
+          fromNodeId: `n${Math.floor(rand() * 60)}`,
+          toNodeId: `n${Math.floor(rand() * 60)}`,
+        }
+      })
+      const actual = findEdgeNodePiercing(lines, boxes, 2)
+        .map((p) => `${p.edgeId}|${p.nodeId}`)
+        .sort()
+      expect(actual).toEqual(referencePierce(lines, boxes, 2))
+    }
+  })
+})

--- a/libs/@shumoku/core/src/layout/constraints.ts
+++ b/libs/@shumoku/core/src/layout/constraints.ts
@@ -1,0 +1,252 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Layout constraint registry — the single declarative source of the
+ * engine's geometric PROHIBITIONS (#481 / #482).
+ *
+ * Interference avoidance used to live as ~20 scattered mechanisms in three
+ * styles (constructive gaps, after-the-fact repairs, score penalties), and
+ * every new pass re-opened the same holes — invariants.ts's own lesson
+ * ("every visual defect was a silently unchecked invariant violation").
+ * This registry declares each prohibition ONCE; verification derives from
+ * the same definitions, so the spec and the check cannot drift.
+ *
+ * Enforcement levels (honest, per current engine capability):
+ *  - 'blocking'   — guaranteed by the engine today; a violation is a BUG.
+ *                   Asserted after every layout in dev/test.
+ *  - 'warn'       — measured and reported; enforcement lands with the VPSC
+ *                   projection stage (#483).
+ *  - 'score-only' — currently only weighted in the search cost; promotion
+ *                   tracked by its own issue (#485 for piercing).
+ *
+ * Aesthetics (crossings, wire length, aspect) are deliberately NOT here —
+ * they are soft objectives owned by the search cost, never prohibitions.
+ */
+
+import { resolveNodeSize } from './engine/index.js'
+import {
+  type BoxBounds,
+  type BoxSpec,
+  type CollinearOverlap,
+  type ContainerOverlap,
+  type ContainerSpec,
+  type ContainmentViolation,
+  type EdgeNodePierce,
+  findCollinearOverlaps,
+  findContainerOverlaps,
+  findContainmentViolations,
+  findEdgeNodePiercing,
+  findNodeOverlaps,
+  findPortClutter,
+  type NodeOverlap,
+  type PierceLineSpec,
+  type PolylineSpec,
+  type PortClutter,
+} from './invariants.js'
+import type { ResolvedLayout } from './resolved-types.js'
+
+export type ConstraintLevel = 'blocking' | 'warn' | 'score-only'
+
+export type ConstraintId =
+  | 'node-overlap'
+  | 'containment'
+  | 'container-overlap'
+  | 'collinear-track'
+  | 'port-clutter'
+  | 'edge-pierce'
+
+export interface ConstraintSpec {
+  id: ConstraintId
+  title: string
+  level: ConstraintLevel
+  /** What currently enforces (or is meant to enforce) it. */
+  enforcedBy: string
+  /** Tunable parameters — the one place their values are defined. */
+  params: Record<string, number>
+}
+
+/**
+ * THE registry. Levels are promoted as enforcement lands:
+ * #483 (VPSC projection) → container-overlap / collinear-track / port-clutter
+ * to 'blocking'; #485 (obstacle-avoiding router) → edge-pierce.
+ */
+export const LAYOUT_CONSTRAINTS: readonly ConstraintSpec[] = [
+  {
+    id: 'node-overlap',
+    title: 'Node boxes never overlap',
+    level: 'blocking',
+    enforcedBy: 'zone row layout + resolveRow separation + band packing',
+    params: { margin: 0 },
+  },
+  {
+    id: 'containment',
+    title: 'A member node sits inside its parent container box',
+    level: 'blocking',
+    enforcedBy:
+      'parent-zone seating (#474/#478), final-extent box sizing + containment re-pack (#478), outer-face label reservation (#480)',
+    params: { pad: 0, slack: 2 },
+  },
+  {
+    id: 'container-overlap',
+    title: 'Non-nested container boxes are disjoint',
+    level: 'warn',
+    enforcedBy:
+      'band packing with true box extents; residual route-bulge growth (search.ts footprint pass) still penetrates ≤~40px → #483',
+    params: {},
+  },
+  {
+    id: 'collinear-track',
+    title: 'No two wires share a track (parallel within their stroke widths)',
+    level: 'warn',
+    enforcedBy: 'router lane allocation; scored (×8) — preventive allocation lands with #483',
+    params: { minSegmentLength: 13, minSharedLength: 12, clearance: 0.5 },
+  },
+  {
+    id: 'port-clutter',
+    title: 'Port boxes / labels never collide (with each other or foreign nodes)',
+    level: 'warn',
+    enforcedBy: 'port-demand feedback + label corridors; scored (×40) — full enforcement with #483',
+    params: {},
+  },
+  {
+    id: 'edge-pierce',
+    title: 'A wire never runs through a foreign node box',
+    level: 'score-only',
+    enforcedBy: 'search cost penalty (×20) only — preventive routing is #485',
+    params: { inflate: 2 },
+  },
+]
+
+export interface ConstraintViolations {
+  nodeOverlaps: NodeOverlap[]
+  containmentViolations: ContainmentViolation[]
+  containerOverlaps: ContainerOverlap[]
+  collinearOverlaps: CollinearOverlap[]
+  portClutter: PortClutter[]
+  edgePierces: EdgeNodePierce[]
+}
+
+export interface ConstraintReport {
+  violations: ConstraintViolations
+  /** Count per constraint id. */
+  counts: Record<ConstraintId, number>
+  /** Violated constraints whose level is 'blocking'. */
+  blockingViolations: ConstraintId[]
+  ok: boolean
+}
+
+const specOf = (id: ConstraintId): ConstraintSpec => {
+  const spec = LAYOUT_CONSTRAINTS.find((s) => s.id === id)
+  if (!spec) throw new Error(`unknown layout constraint: ${id}`)
+  return spec
+}
+
+/**
+ * Verify a ResolvedLayout against the registry. Every check derives its
+ * parameters from the specs above — no second source of truth.
+ */
+export function verifyLayoutConstraints(layout: ResolvedLayout): ConstraintReport {
+  const nodeBoxes: BoxSpec[] = []
+  for (const [id, node] of layout.nodes) {
+    if (!node.position) continue
+    const size = resolveNodeSize(node)
+    nodeBoxes.push({
+      id,
+      x: node.position.x,
+      y: node.position.y,
+      width: size.width,
+      height: size.height,
+    })
+  }
+
+  const members = new Map<string, string[]>()
+  for (const [id, node] of layout.nodes) {
+    if (!node.parent) continue
+    const list = members.get(node.parent)
+    if (list) list.push(id)
+    else members.set(node.parent, [id])
+  }
+  const containers: ContainerSpec[] = []
+  const containerBoxes: BoxBounds[] = []
+  for (const [id, sg] of layout.subgraphs) {
+    if (!sg.bounds) continue
+    containerBoxes.push({ id, bounds: sg.bounds, parent: sg.parent })
+    const memberIds = members.get(id)
+    if (memberIds && memberIds.length > 0) containers.push({ id, bounds: sg.bounds, memberIds })
+  }
+
+  const trackLines: PolylineSpec[] = []
+  const pierceLines: PierceLineSpec[] = []
+  for (const [id, edge] of layout.edges) {
+    const points = edge.route?.points ?? edge.points
+    if (points.length < 2) continue
+    trackLines.push({ id, points, halfWidth: Math.max(0.5, edge.width / 2) })
+    pierceLines.push({ id, points, fromNodeId: edge.fromNodeId, toNodeId: edge.toNodeId })
+  }
+
+  const collinearParams = specOf('collinear-track').params
+  const violations: ConstraintViolations = {
+    nodeOverlaps: findNodeOverlaps(nodeBoxes, specOf('node-overlap').params['margin'] ?? 0),
+    containmentViolations: findContainmentViolations(
+      nodeBoxes,
+      containers,
+      specOf('containment').params['pad'] ?? 0,
+    ),
+    containerOverlaps: findContainerOverlaps(containerBoxes),
+    collinearOverlaps: findCollinearOverlaps(trackLines, {
+      minSegmentLength: collinearParams['minSegmentLength'],
+      minSharedLength: collinearParams['minSharedLength'],
+      clearance: collinearParams['clearance'],
+    }),
+    portClutter: findPortClutter([...layout.ports.values()], nodeBoxes),
+    edgePierces: findEdgeNodePiercing(
+      pierceLines,
+      nodeBoxes,
+      specOf('edge-pierce').params['inflate'] ?? 2,
+    ),
+  }
+
+  const counts: Record<ConstraintId, number> = {
+    'node-overlap': violations.nodeOverlaps.length,
+    containment: violations.containmentViolations.length,
+    'container-overlap': violations.containerOverlaps.length,
+    'collinear-track': violations.collinearOverlaps.length,
+    'port-clutter': violations.portClutter.length,
+    'edge-pierce': violations.edgePierces.length,
+  }
+
+  const blockingViolations = LAYOUT_CONSTRAINTS.filter(
+    (s) => s.level === 'blocking' && counts[s.id] > 0,
+  ).map((s) => s.id)
+
+  return {
+    violations,
+    counts,
+    blockingViolations,
+    ok: blockingViolations.length === 0,
+  }
+}
+
+/**
+ * Standing-fixture gate (engine-v3-migration.md §B4, finally wired):
+ * verify after a layout and — when a BLOCKING constraint is violated —
+ * throw under test/development, log an error otherwise. Warn-level
+ * violations are summarized at debug level so they stay visible without
+ * spamming production bakes.
+ */
+export function assertLayoutConstraints(layout: ResolvedLayout, context = 'layout'): void {
+  const report = verifyLayoutConstraints(layout)
+  if (report.ok) return
+  const detail = report.blockingViolations.map((id) => `${id}=${report.counts[id]}`).join(', ')
+  const message = `[layout-constraints] BLOCKING violation after ${context}: ${detail}`
+  const env =
+    typeof process !== 'undefined' && typeof process.env !== 'undefined'
+      ? process.env['NODE_ENV']
+      : undefined
+  if (env === 'test' || env === 'development') {
+    throw new Error(message)
+  }
+  console.error(message)
+}

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -48,6 +48,17 @@ export {
   scoreRoutedEdges,
   searchCompositeLayout,
 } from './composite/search.js'
+// Declarative constraint registry — the single source of the engine's
+// geometric prohibitions (#481/#482); verification derives from it.
+export {
+  assertLayoutConstraints,
+  type ConstraintId,
+  type ConstraintLevel,
+  type ConstraintReport,
+  type ConstraintSpec,
+  LAYOUT_CONSTRAINTS,
+  verifyLayoutConstraints,
+} from './constraints.js'
 export type {
   LayoutEngine as ShumokuLayoutEngine,
   PortsBySide as EnginePortsBySide,
@@ -92,20 +103,27 @@ export {
 // Layout invariant checks (containment / overlap / collinear tracks) —
 // standing verification fixture for every placement/routing pass.
 export {
+  type BoxBounds,
   type BoxSpec,
   type CollinearOverlap,
+  type ContainerOverlap,
   type ContainerSpec,
   type ContainmentViolation,
   checkLayoutInvariants,
+  type EdgeNodePierce,
   findCollinearOverlaps,
+  findContainerOverlaps,
   findContainmentViolations,
+  findEdgeNodePiercing,
   findNodeOverlaps,
   findPortClutter,
   type LayoutInvariantOptions,
   type LayoutInvariantReport,
   type NodeOverlap,
+  type PierceLineSpec,
   type PolylineSpec,
   type PortClutter,
+  segmentsIntersect,
 } from './invariants.js'
 export {
   bpsToLinkWidth,

--- a/libs/@shumoku/core/src/layout/invariants.ts
+++ b/libs/@shumoku/core/src/layout/invariants.ts
@@ -359,6 +359,140 @@ export function findPortClutter(
 }
 
 // ============================================================================
+// 5. Edge-through-node piercing
+// ============================================================================
+
+/** Shared exact segment-intersection predicate (strict crossing). */
+export function segmentsIntersect(a1: Position, a2: Position, b1: Position, b2: Position): boolean {
+  const d1 = (a2.x - a1.x) * (b1.y - a1.y) - (a2.y - a1.y) * (b1.x - a1.x)
+  const d2 = (a2.x - a1.x) * (b2.y - a1.y) - (a2.y - a1.y) * (b2.x - a1.x)
+  const d3 = (b2.x - b1.x) * (a1.y - b1.y) - (b2.y - b1.y) * (a1.x - b1.x)
+  const d4 = (b2.x - b1.x) * (a2.y - b1.y) - (b2.y - b1.y) * (a2.x - b1.x)
+  return d1 > 0 !== d2 > 0 && d3 > 0 !== d4 > 0
+}
+
+/** Edge polyline with its endpoint nodes (which it may legally touch). */
+export interface PierceLineSpec {
+  id: string
+  points: readonly Position[]
+  fromNodeId: string
+  toNodeId: string
+}
+
+export interface EdgeNodePierce {
+  edgeId: string
+  nodeId: string
+}
+
+/**
+ * Find wires that run THROUGH a foreign node box (inflated by `inflate`):
+ * any segment crossing one of the box's four borders. A wire may touch its
+ * own endpoints' boxes. Grid-accelerated, exact (same predicate as the old
+ * routed-score inner loop — this IS that loop, extracted so the score and
+ * the constraint check share one definition).
+ */
+export function findEdgeNodePiercing(
+  lines: readonly PierceLineSpec[],
+  nodeBoxes: readonly BoxSpec[],
+  inflate = 2,
+): EdgeNodePierce[] {
+  const boxGrid = new BBoxGrid(320)
+  for (const [idx, box] of nodeBoxes.entries()) {
+    boxGrid.insert(
+      idx,
+      box.x - box.width / 2 - inflate,
+      box.y - box.height / 2 - inflate,
+      box.x + box.width / 2 + inflate,
+      box.y + box.height / 2 + inflate,
+    )
+  }
+  const out: EdgeNodePierce[] = []
+  for (const line of lines) {
+    const hitBoxes = new Set<number>()
+    for (let s = 1; s < line.points.length; s++) {
+      const a = line.points[s - 1]
+      const b = line.points[s]
+      if (!a || !b) continue
+      boxGrid.query(a.x, a.y, b.x, b.y, (bi) => {
+        if (hitBoxes.has(bi)) return
+        const box = nodeBoxes[bi]
+        if (!box || box.id === line.fromNodeId || box.id === line.toNodeId) return
+        const bx = box.x - box.width / 2 - inflate
+        const by = box.y - box.height / 2 - inflate
+        const bw = box.width + inflate * 2
+        const bh = box.height + inflate * 2
+        if (Math.max(a.x, b.x) < bx || Math.min(a.x, b.x) > bx + bw) return
+        if (Math.max(a.y, b.y) < by || Math.min(a.y, b.y) > by + bh) return
+        const hit =
+          segmentsIntersect(a, b, { x: bx, y: by }, { x: bx + bw, y: by }) ||
+          segmentsIntersect(a, b, { x: bx, y: by + bh }, { x: bx + bw, y: by + bh }) ||
+          segmentsIntersect(a, b, { x: bx, y: by }, { x: bx, y: by + bh }) ||
+          segmentsIntersect(a, b, { x: bx + bw, y: by }, { x: bx + bw, y: by + bh })
+        if (hit) hitBoxes.add(bi)
+      })
+    }
+    for (const bi of hitBoxes) {
+      const box = nodeBoxes[bi]
+      if (box) out.push({ edgeId: line.id, nodeId: box.id })
+    }
+  }
+  return out
+}
+
+// ============================================================================
+// 6. Container box overlap (non-nested subgraph boxes must be disjoint)
+// ============================================================================
+
+export interface BoxBounds {
+  id: string
+  bounds: Bounds
+  /** Parent box id — ancestors legally contain their descendants. */
+  parent?: string
+}
+
+export interface ContainerOverlap {
+  a: string
+  b: string
+  /** Penetration depth (px) — min of x/y overlap. */
+  penetration: number
+}
+
+/**
+ * Find pairs of container boxes that overlap where NEITHER is an ancestor of
+ * the other (nesting is legal containment, not interference).
+ */
+export function findContainerOverlaps(boxes: readonly BoxBounds[]): ContainerOverlap[] {
+  const parentOf = new Map<string, string | undefined>()
+  for (const b of boxes) parentOf.set(b.id, b.parent)
+  const isAncestor = (maybeAncestor: string, id: string): boolean => {
+    let current = parentOf.get(id)
+    for (let depth = 0; current !== undefined && depth < 64; depth++) {
+      if (current === maybeAncestor) return true
+      current = parentOf.get(current)
+    }
+    return false
+  }
+  const out: ContainerOverlap[] = []
+  for (let i = 0; i < boxes.length; i++) {
+    const a = boxes[i]
+    if (!a) continue
+    for (let j = i + 1; j < boxes.length; j++) {
+      const b = boxes[j]
+      if (!b) continue
+      if (isAncestor(a.id, b.id) || isAncestor(b.id, a.id)) continue
+      const ox =
+        Math.min(a.bounds.x + a.bounds.width, b.bounds.x + b.bounds.width) -
+        Math.max(a.bounds.x, b.bounds.x)
+      const oy =
+        Math.min(a.bounds.y + a.bounds.height, b.bounds.y + b.bounds.height) -
+        Math.max(a.bounds.y, b.bounds.y)
+      if (ox > 0 && oy > 0) out.push({ a: a.id, b: b.id, penetration: Math.min(ox, oy) })
+    }
+  }
+  return out
+}
+
+// ============================================================================
 // ResolvedLayout adapter
 // ============================================================================
 

--- a/libs/@shumoku/core/src/layout/unified-engine.ts
+++ b/libs/@shumoku/core/src/layout/unified-engine.ts
@@ -24,6 +24,7 @@ import { autoLayoutFlatTree } from './auto-placement/flat-tree/auto-layout.js'
 import { layoutCompound } from './auto-placement/flat-tree/compound.js'
 import { shouldUseComposite } from './composite/index.js'
 import { searchCompositeLayout } from './composite/search.js'
+import { assertLayoutConstraints } from './constraints.js'
 import { createEngine, resolveNodeSize } from './engine/index.js'
 import { getLinkWidth } from './link-utils.js'
 import type { ResolvedLayout } from './resolved-types.js'
@@ -77,7 +78,7 @@ export async function computeNetworkLayout(
           : `${edge.toNodeId}|${edge.fromNodeId}`
       edge.emphasis = comp.primaryEdges.has(key) ? 'primary' : 'secondary'
     }
-    return buildResults({
+    const results = buildResults({
       nodes: comp.nodes,
       ports,
       edges,
@@ -85,6 +86,10 @@ export async function computeNetworkLayout(
       bounds: comp.bounds,
       algorithm: 'composite+octilinear',
     })
+    // Standing fixture (#482): BLOCKING constraint violations throw in
+    // dev/test, log in production — never silently ship a broken figure.
+    assertLayoutConstraints(results.resolved, 'composite+octilinear')
+    return results
   }
 
   // Create a spatial-rule engine once per layout call. Engines
@@ -113,7 +118,7 @@ export async function computeNetworkLayout(
   })
   const edges = await routeEdges(nodes, ports, graph.links, subgraphs)
 
-  return buildResults({
+  const results = buildResults({
     nodes,
     ports,
     edges,
@@ -121,6 +126,8 @@ export async function computeNetworkLayout(
     bounds,
     algorithm: 'network-layout+bezier',
   })
+  assertLayoutConstraints(results.resolved, 'network-layout+bezier')
+  return results
 }
 
 /** Assemble ResolvedLayout + legacy LayoutResult from layout pieces. */


### PR DESCRIPTION
親: #481 / Closes #482

## 変更

- **constraints.ts（新設）= 禁止事項のレジストリ**。6つの幾何的禁止（node-overlap / containment / container-overlap / collinear-track / port-clutter / edge-pierce）を一箇所で宣言。enforcement levelは現状能力に正直に：
  - `blocking`（今のエンジンが保証済み — node-overlap, containment。違反=バグ）
  - `warn`（計測のみ。強制は #483 VPSC射影で昇格）
  - `score-only`（edge-pierce。#485 障害物回避ルータで昇格）
  - 美観（交差・長さ・アスペクト）は意図的に対象外 — 禁止ではなく探索の目的関数
- **verifyLayoutConstraints()** はレジストリのspecから全チェックを導出（パラメータの定義は一箇所だけ）。**assertLayoutConstraints()** が engine-v3-migration §B4 の「常設の固定具」を遂に実装：blocking違反は test/development で **throw**、本番では error ログ。computeNetworkLayout の両経路（composite / flat-tree）に接続
- **invariants.ts** に不足していたファインダーを追加（スコアとチェックの単一定義化）：
  - `findEdgeNodePiercing` — routed-scoreのpierceループをそのまま抽出（test6探索コスト **46526.29893172586 でビット一致**）
  - `findContainerOverlaps` — 入れ子は合法、非祖先ペアの重なりのみ検出
  - `segmentsIntersect` を共有化
- テスト：レジストリ形状 / blocking assert挙動 / 入れ子合法性 / pierceファインダーのO(n²)参照実装との等価性（シード乱数）

## 検証

- **blocking assert を有効にした状態で layout 全189テスト緑** = 現エンジンがblocking集合を本当に保証していることの証明
- test6 実測: node-overlap 0 / containment 0（blocking成立）、collinear 229 / portClutter 242 / container-overlap 3（warn、#483対象）、pierce 319（score-only、#485対象）

🤖 Generated with [Claude Code](https://claude.com/claude-code)