### PR TITLE
feat(server): Signal Streams M0 — 全ストリームの収集側（蓄積開始）

### DIFF
--- a/apps/server/api/src/api/datasources.ts
+++ b/apps/server/api/src/api/datasources.ts
@@ -9,6 +9,7 @@ import { getAllPlugins } from '../plugins/loader.js'
 import type { AlertQueryOptions } from '../plugins/types.js'
 import { hasNativeApi } from '../plugins/types.js'
 import { DataSourceService } from '../services/datasource.js'
+import { getSignalStreams } from '../services/signal-streams.js'
 import type { DataSourceInput } from '../types.js'
 import { getTopologyService } from './topologies.js'
 
@@ -422,6 +423,15 @@ export function createDataSourcesApi(): Hono {
 
     try {
       const alerts = await service.getAlerts(id, options)
+      // Alert stream (signal-streams.md): append state transitions.
+      // Disappearance counts as resolution ONLY for an unfiltered active
+      // query — a filtered fetch must never resolve alerts it didn't ask
+      // about. Best-effort: stream failures never break the response.
+      const unfiltered =
+        options.timeRange === undefined && options.minSeverity === undefined && !options.activeOnly
+      getSignalStreams()
+        .ingestAlerts(id, null, alerts, { fullActiveSet: unfiltered })
+        .catch((err) => console.error('[Datasources] alert stream ingest failed:', err))
       return c.json(alerts)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)

--- a/apps/server/api/src/db/migrations/024_signal_streams.sql
+++ b/apps/server/api/src/db/migrations/024_signal_streams.sql
@@ -1,0 +1,56 @@
+-- Signal streams (design: apps/server/docs/design/signal-streams.md).
+-- Append-only, source-attributed, timestamped records are the PRIMARY data;
+-- current state (contribution store / resolved artifact) is a projection.
+-- This migration adds the metrics and alert streams and the as-of index on
+-- the existing topology stream (topology_observations).
+
+-- topology stream: as-of queries walk (topology_id, captured_at DESC)
+CREATE INDEX IF NOT EXISTS idx_topology_observations_asof
+  ON topology_observations (topology_id, captured_at DESC);
+
+-- metrics stream, layer 1: raw per-tick snapshot for point-in-time
+-- weathermap reproduction. One row per poll tick per topology; payload is
+-- the full MetricsData JSON, gzip-compressed. Retention ~72h (housekeeping).
+CREATE TABLE IF NOT EXISTS metrics_history (
+  topology_id TEXT NOT NULL,
+  captured_at INTEGER NOT NULL,
+  payload     BLOB NOT NULL,
+  PRIMARY KEY (topology_id, captured_at)
+);
+
+-- metrics stream, layer 2: hourly aggregates per entity for sparklines and
+-- baseline-deviation coloring. Retention ~400d (housekeeping).
+CREATE TABLE IF NOT EXISTS metrics_trends (
+  topology_id  TEXT NOT NULL,
+  entity_kind  TEXT NOT NULL,            -- 'node' | 'link'
+  entity_id    TEXT NOT NULL,
+  hour_start   INTEGER NOT NULL,         -- Unix ms, top of hour
+  samples      INTEGER NOT NULL,
+  util_min     REAL,
+  util_avg     REAL,
+  util_max     REAL,
+  bps_avg      REAL,
+  status_worst TEXT,
+  PRIMARY KEY (topology_id, entity_kind, entity_id, hour_start)
+);
+CREATE INDEX IF NOT EXISTS idx_metrics_trends_entity
+  ON metrics_trends (topology_id, entity_kind, entity_id, hour_start DESC);
+
+-- alert stream: state TRANSITIONS only (fired / resolved / changed), never
+-- overwritten. The current-state view (e.g. grafana_alerts) stays a
+-- projection. Retention ~180d (housekeeping).
+CREATE TABLE IF NOT EXISTS alert_events (
+  id           TEXT PRIMARY KEY,
+  topology_id  TEXT,
+  source_id    TEXT NOT NULL,
+  alert_key    TEXT NOT NULL,
+  transition   TEXT NOT NULL,            -- 'fired' | 'resolved' | 'changed'
+  severity     TEXT NOT NULL,
+  node_id      TEXT,
+  at           INTEGER NOT NULL,
+  payload_json TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_alert_events_key
+  ON alert_events (source_id, alert_key, at DESC);
+CREATE INDEX IF NOT EXISTS idx_alert_events_topology
+  ON alert_events (topology_id, at DESC);

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -28,6 +28,7 @@ import migration020 from './migrations/020_topology_scope.sql'
 import migration021 from './migrations/021_topology_scope_criteria.sql'
 import migration022 from './migrations/022_topology_composition_mode.sql'
 import migration023 from './migrations/023_contribution_content_hash.sql'
+import migration024 from './migrations/024_signal_streams.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -52,6 +53,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '021_topology_scope_criteria.sql', sql: migration021 },
   { name: '022_topology_composition_mode.sql', sql: migration022 },
   { name: '023_contribution_content_hash.sql', sql: migration023 },
+  { name: '024_signal_streams.sql', sql: migration024 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -25,6 +25,8 @@ import { DataSourceService } from './services/datasource.js'
 import { startDiscoveryScheduler, stopDiscoveryScheduler } from './services/discovery-scheduler.js'
 import { startHealthChecker, stopHealthChecker } from './services/health-checker.js'
 import { publishMetrics } from './services/metrics-hub.js'
+import { ObservationsService } from './services/observations.js'
+import { getSignalStreams } from './services/signal-streams.js'
 import type { ParsedTopology, TopologyService } from './services/topology.js'
 import { TopologySourcesService } from './services/topology-sources.js'
 import { TopologyManager } from './topology.js'
@@ -86,6 +88,7 @@ export class Server {
   private metricsProvider: MockMetricsProvider
   private clients: Map<ServerWebSocket<ClientState>, ClientState> = new Map()
   private pollInterval: ReturnType<typeof setInterval> | null = null
+  private housekeepingInterval: ReturnType<typeof setInterval> | null = null
   private bunServer: BunServer<ClientState> | null = null
   private dbTopologyMetrics: Map<string, MetricsData> = new Map()
 
@@ -352,6 +355,24 @@ export class Server {
         isPolling = false
       }
     }, interval)
+
+    // Signal-stream housekeeping (signal-streams.md retentions): once at
+    // startup, then every 6h. Cheap deletes; never let it crash the server.
+    const runHousekeeping = () => {
+      try {
+        const pruned = getSignalStreams().housekeeping()
+        const observations = new ObservationsService().pruneOldObservations()
+        if (pruned.history + pruned.trends + pruned.alerts + observations > 0) {
+          console.log(
+            `[SignalStreams] housekeeping: history=${pruned.history} trends=${pruned.trends} alerts=${pruned.alerts} observations=${observations}`,
+          )
+        }
+      } catch (err) {
+        console.error('[SignalStreams] housekeeping failed:', err)
+      }
+    }
+    runHousekeeping()
+    this.housekeepingInterval = setInterval(runHousekeeping, 6 * 3600_000)
   }
 
   private async updateAllMetrics(): Promise<void> {
@@ -479,6 +500,13 @@ export class Server {
         // Feed the hub so token-scoped share SSE streams can read/observe live
         // metrics off the same central poll (no second poll loop).
         publishMetrics(topology.id, metrics)
+        // Metrics stream (signal-streams.md): raw history + hourly trends.
+        // Best-effort — a stream write must never break the poll loop.
+        try {
+          getSignalStreams().recordMetrics(topology.id, metrics)
+        } catch (err) {
+          console.error('[Server] metrics stream record failed:', err)
+        }
       }
     }
   }
@@ -595,6 +623,16 @@ export class Server {
     if (this.pollInterval) {
       clearInterval(this.pollInterval)
       this.pollInterval = null
+    }
+    if (this.housekeepingInterval) {
+      clearInterval(this.housekeepingInterval)
+      this.housekeepingInterval = null
+    }
+    // flush open trend hour-buckets so a graceful shutdown loses nothing
+    try {
+      getSignalStreams().flushAll()
+    } catch {
+      // best-effort
     }
 
     for (const ws of this.clients.keys()) {

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -364,20 +364,25 @@ export class ObservationsService {
   }
 
   /**
-   * Retention: keep at most `keepPerSource` rows per (topology, source).
-   * Older rows beyond that window are dropped. Failed-status rows are
-   * pruned more aggressively (only the very latest one is kept).
+   * Retention (signal-streams.md): the topology stream keeps rows by AGE,
+   * not by count — observations are the primary history that powers as-of
+   * rendering and the timeline, so "10 per source" is replaced by a
+   * retention window. A small per-source floor survives regardless of age
+   * (a stable network that never changes must keep its evidence), and
+   * failed-status rows still collapse to the latest one.
    *
    * Returns the count of rows deleted.
    */
-  pruneOldObservations(keepPerSource = 10): number {
-    // Successful (or partial / empty) rows: keep the most recent N per source.
+  pruneOldObservations(retentionDays = 90, keepFloorPerSource = 3): number {
+    const cutoff = timestamp() - retentionDays * 86_400_000
+    // Successful (or partial / empty) rows: drop only rows that are BOTH
+    // older than the window AND beyond the per-source floor.
     const ok = this.db
       .query(
         `DELETE FROM topology_observations
          WHERE id IN (
            SELECT id FROM (
-             SELECT id,
+             SELECT id, captured_at,
                     ROW_NUMBER() OVER (
                       PARTITION BY topology_id, source_id
                       ORDER BY captured_at DESC, rowid DESC
@@ -385,10 +390,10 @@ export class ObservationsService {
              FROM topology_observations
              WHERE status != 'failed'
            ) ranked
-           WHERE rn > ?
+           WHERE rn > ? AND captured_at < ?
          )`,
       )
-      .run(keepPerSource)
+      .run(keepFloorPerSource, cutoff)
 
     // Failed rows: keep only the most recent 1 per (topology, source).
     const failed = this.db

--- a/apps/server/api/src/services/signal-streams.ts
+++ b/apps/server/api/src/services/signal-streams.ts
@@ -1,0 +1,327 @@
+/**
+ * Signal streams — collection side (design: docs/design/signal-streams.md).
+ *
+ * Append-only, source-attributed, timestamped records are the PRIMARY data;
+ * current state is a projection. This service owns the metrics stream
+ * (raw history + hourly trends) and the alert stream (state transitions),
+ * plus housekeeping for all stream retentions. The topology stream lives in
+ * ObservationsService (it predates this module and was promoted in place).
+ *
+ * All writes are best-effort: a stream insert failure must never break the
+ * poll loop or an alert fetch — callers wrap in try/catch or use the
+ * `record*` helpers that swallow + log.
+ */
+
+import type { Database } from 'bun:sqlite'
+import type { Alert, MetricsData } from '@shumoku/core'
+import { generateId, getDatabase } from '../db/index.js'
+
+// Retention defaults (ms). Deliberately module constants for now — the
+// design reserves a settings surface, but none of these need live tuning
+// to start accumulating. Change here = next housekeeping applies it.
+export const RETENTION = {
+  /** raw per-tick metrics snapshots (point-in-time weathermap) */
+  metricsHistoryMs: 72 * 3600_000,
+  /** hourly aggregates (sparklines, baseline deviation) */
+  metricsTrendsMs: 400 * 86_400_000,
+  /** alert state transitions */
+  alertEventsMs: 180 * 86_400_000,
+  /** topology observations (as-of rendering) — used by ObservationsService */
+  topologyObservationsMs: 90 * 86_400_000,
+} as const
+
+const HOUR_MS = 3600_000
+
+const STATUS_RANK: Record<string, number> = { up: 0, unknown: 1, degraded: 2, down: 3 }
+
+interface TrendBucket {
+  topologyId: string
+  entityKind: 'node' | 'link'
+  entityId: string
+  hourStart: number
+  samples: number
+  utilMin: number | null
+  utilMax: number | null
+  utilSum: number
+  utilSamples: number
+  bpsSum: number
+  bpsSamples: number
+  statusWorst: string | null
+}
+
+export class SignalStreamsService {
+  private db: Database
+  /** open hour buckets, keyed `${topologyId}|${kind}|${id}` */
+  private buckets = new Map<string, TrendBucket>()
+
+  constructor() {
+    this.db = getDatabase()
+  }
+
+  // -- metrics stream ----------------------------------------------------------
+
+  /**
+   * Record one poll tick. Layer 1 stores the full MetricsData snapshot
+   * (gzip) keyed by capture time; layer 2 accumulates per-entity hour
+   * buckets in RAM and flushes them when the hour rolls over (a process
+   * restart loses at most the open hour — accepted, no interpolation).
+   */
+  recordMetrics(topologyId: string, data: MetricsData): void {
+    const at = data.timestamp || Date.now()
+    try {
+      const payload = Bun.gzipSync(Buffer.from(JSON.stringify(data)))
+      this.db
+        .query(
+          'INSERT OR REPLACE INTO metrics_history (topology_id, captured_at, payload) VALUES (?, ?, ?)',
+        )
+        .run(topologyId, at, payload)
+    } catch (err) {
+      console.error('[SignalStreams] metrics_history insert failed:', err)
+    }
+
+    const hourStart = Math.floor(at / HOUR_MS) * HOUR_MS
+    try {
+      this.flushBucketsBefore(hourStart)
+      for (const [nodeId, m] of Object.entries(data.nodes ?? {})) {
+        this.accumulate(topologyId, 'node', nodeId, hourStart, {
+          status: m.status,
+        })
+      }
+      for (const [linkId, m] of Object.entries(data.links ?? {})) {
+        const util = m.utilization ?? maxOf(m.inUtilization, m.outUtilization)
+        const bps = sumOf(m.inBps, m.outBps)
+        this.accumulate(topologyId, 'link', linkId, hourStart, {
+          status: m.status,
+          util,
+          bps,
+        })
+      }
+    } catch (err) {
+      console.error('[SignalStreams] trend accumulation failed:', err)
+    }
+  }
+
+  private accumulate(
+    topologyId: string,
+    entityKind: 'node' | 'link',
+    entityId: string,
+    hourStart: number,
+    sample: { status?: string; util?: number; bps?: number },
+  ): void {
+    const key = `${topologyId}|${entityKind}|${entityId}`
+    let bucket = this.buckets.get(key)
+    if (!bucket || bucket.hourStart !== hourStart) {
+      if (bucket) this.flushBucket(bucket)
+      bucket = {
+        topologyId,
+        entityKind,
+        entityId,
+        hourStart,
+        samples: 0,
+        utilMin: null,
+        utilMax: null,
+        utilSum: 0,
+        utilSamples: 0,
+        bpsSum: 0,
+        bpsSamples: 0,
+        statusWorst: null,
+      }
+      this.buckets.set(key, bucket)
+    }
+    bucket.samples++
+    if (sample.util !== undefined && Number.isFinite(sample.util)) {
+      bucket.utilMin = bucket.utilMin === null ? sample.util : Math.min(bucket.utilMin, sample.util)
+      bucket.utilMax = bucket.utilMax === null ? sample.util : Math.max(bucket.utilMax, sample.util)
+      bucket.utilSum += sample.util
+      bucket.utilSamples++
+    }
+    if (sample.bps !== undefined && Number.isFinite(sample.bps)) {
+      bucket.bpsSum += sample.bps
+      bucket.bpsSamples++
+    }
+    if (sample.status !== undefined) {
+      const current = bucket.statusWorst === null ? -1 : (STATUS_RANK[bucket.statusWorst] ?? 1)
+      const incoming = STATUS_RANK[sample.status] ?? 1
+      if (incoming > current) bucket.statusWorst = sample.status
+    }
+  }
+
+  /** Flush all open buckets from hours strictly before `hourStart`. */
+  private flushBucketsBefore(hourStart: number): void {
+    for (const [key, bucket] of this.buckets) {
+      if (bucket.hourStart < hourStart) {
+        this.flushBucket(bucket)
+        this.buckets.delete(key)
+      }
+    }
+  }
+
+  private flushBucket(bucket: TrendBucket): void {
+    try {
+      this.db
+        .query(
+          `INSERT OR REPLACE INTO metrics_trends
+             (topology_id, entity_kind, entity_id, hour_start, samples,
+              util_min, util_avg, util_max, bps_avg, status_worst)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          bucket.topologyId,
+          bucket.entityKind,
+          bucket.entityId,
+          bucket.hourStart,
+          bucket.samples,
+          bucket.utilMin,
+          bucket.utilSamples > 0 ? bucket.utilSum / bucket.utilSamples : null,
+          bucket.utilMax,
+          bucket.bpsSamples > 0 ? bucket.bpsSum / bucket.bpsSamples : null,
+          bucket.statusWorst,
+        )
+    } catch (err) {
+      console.error('[SignalStreams] metrics_trends flush failed:', err)
+    }
+  }
+
+  /** Flush every open bucket (graceful shutdown). */
+  flushAll(): void {
+    for (const bucket of this.buckets.values()) this.flushBucket(bucket)
+    this.buckets.clear()
+  }
+
+  // -- alert stream ------------------------------------------------------------
+
+  /**
+   * Ingest a fetched alert batch and append STATE TRANSITIONS only:
+   * fired (new active), changed (severity moved while active), resolved
+   * (explicit resolved status — or, when `fullActiveSet` is true,
+   * disappearance from the batch). Idempotent against re-fetches of the
+   * same state: no transition → no row.
+   */
+  async ingestAlerts(
+    sourceId: string,
+    topologyId: string | null,
+    alerts: readonly Alert[],
+    options: { fullActiveSet?: boolean; at?: number } = {},
+  ): Promise<number> {
+    const at = options.at ?? Date.now()
+    let appended = 0
+    // rowid tiebreak: several transitions for one key can land in the
+    // same millisecond (webhook bursts, test batches) — "latest" must be
+    // insertion order, not an arbitrary pick among `at` ties.
+    const lastOf = this.db.query(
+      `SELECT transition, severity FROM alert_events
+       WHERE source_id = ? AND alert_key = ?
+       ORDER BY at DESC, rowid DESC LIMIT 1`,
+    )
+    const seen = new Set<string>()
+    for (const alert of alerts) {
+      const key = alert.id
+      seen.add(key)
+      const last = lastOf.get(sourceId, key) as { transition: string; severity: string } | undefined
+      if (alert.status === 'active') {
+        if (!last || last.transition === 'resolved') {
+          await this.appendAlertEvent(sourceId, topologyId, key, 'fired', alert, at)
+          appended++
+        } else if (last.severity !== alert.severity) {
+          await this.appendAlertEvent(sourceId, topologyId, key, 'changed', alert, at)
+          appended++
+        }
+      } else if (last && last.transition !== 'resolved') {
+        await this.appendAlertEvent(sourceId, topologyId, key, 'resolved', alert, at)
+        appended++
+      }
+    }
+    // Disappearance = resolution, but ONLY when the caller guarantees the
+    // batch is the complete active set (an unfiltered poll). A filtered
+    // query must never resolve alerts it simply didn't ask about.
+    if (options.fullActiveSet) {
+      const open = this.db
+        .query(
+          `SELECT alert_key, severity FROM alert_events a
+           WHERE source_id = ?
+             AND rowid = (SELECT b.rowid FROM alert_events b
+                          WHERE b.source_id = a.source_id AND b.alert_key = a.alert_key
+                          ORDER BY b.at DESC, b.rowid DESC LIMIT 1)
+             AND transition != 'resolved'`,
+        )
+        .all(sourceId) as { alert_key: string; severity: Alert['severity'] }[]
+      for (const row of open) {
+        if (seen.has(row.alert_key)) continue
+        await this.appendAlertEvent(
+          sourceId,
+          topologyId,
+          row.alert_key,
+          'resolved',
+          { id: row.alert_key, severity: row.severity, status: 'resolved' },
+          at,
+        )
+        appended++
+      }
+    }
+    return appended
+  }
+
+  private async appendAlertEvent(
+    sourceId: string,
+    topologyId: string | null,
+    alertKey: string,
+    transition: 'fired' | 'changed' | 'resolved',
+    alert: Partial<Alert> & { severity: Alert['severity'] },
+    at: number,
+  ): Promise<void> {
+    try {
+      this.db
+        .query(
+          `INSERT INTO alert_events
+             (id, topology_id, source_id, alert_key, transition, severity, node_id, at, payload_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          await generateId(),
+          topologyId,
+          sourceId,
+          alertKey,
+          transition,
+          alert.severity,
+          alert.nodeId ?? null,
+          at,
+          JSON.stringify(alert),
+        )
+    } catch (err) {
+      console.error('[SignalStreams] alert_events insert failed:', err)
+    }
+  }
+
+  // -- housekeeping --------------------------------------------------------------
+
+  /** Apply stream retentions. Cheap; run at startup and periodically. */
+  housekeeping(now = Date.now()): { history: number; trends: number; alerts: number } {
+    const history = this.db
+      .query('DELETE FROM metrics_history WHERE captured_at < ?')
+      .run(now - RETENTION.metricsHistoryMs).changes
+    const trends = this.db
+      .query('DELETE FROM metrics_trends WHERE hour_start < ?')
+      .run(now - RETENTION.metricsTrendsMs).changes
+    const alerts = this.db
+      .query('DELETE FROM alert_events WHERE at < ?')
+      .run(now - RETENTION.alertEventsMs).changes
+    return { history, trends, alerts }
+  }
+}
+
+function maxOf(a?: number, b?: number): number | undefined {
+  if (a === undefined) return b
+  if (b === undefined) return a
+  return Math.max(a, b)
+}
+
+function sumOf(a?: number, b?: number): number | undefined {
+  if (a === undefined && b === undefined) return undefined
+  return (a ?? 0) + (b ?? 0)
+}
+
+let instance: SignalStreamsService | null = null
+export function getSignalStreams(): SignalStreamsService {
+  if (!instance) instance = new SignalStreamsService()
+  return instance
+}

--- a/apps/server/api/test/db/signal-streams.test.ts
+++ b/apps/server/api/test/db/signal-streams.test.ts
@@ -1,0 +1,121 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { Alert } from '@shumoku/core'
+import { getDatabase } from '../../src/db/index.ts'
+import { RETENTION, SignalStreamsService } from '../../src/services/signal-streams.ts'
+import { setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+let streams: SignalStreamsService
+beforeAll(() => {
+  db_ = setupTempDb()
+  streams = new SignalStreamsService()
+})
+afterAll(() => db_.teardown())
+
+const HOUR = 3600_000
+
+const metricsAt = (at: number, util: number) => ({
+  nodes: { n1: { status: 'up' as const } },
+  links: { l1: { status: 'up' as const, utilization: util, inBps: 100, outBps: 50 } },
+  timestamp: at,
+})
+
+describe('metrics stream — raw history + hourly trends', () => {
+  test('records raw snapshots and flushes a trend row on hour rollover', () => {
+    const hour0 = Math.floor(Date.now() / HOUR) * HOUR - 3 * HOUR
+    streams.recordMetrics('topo1', metricsAt(hour0 + 60_000, 10))
+    streams.recordMetrics('topo1', metricsAt(hour0 + 120_000, 30))
+    // hour rollover → previous hour's buckets flush
+    streams.recordMetrics('topo1', metricsAt(hour0 + HOUR + 60_000, 50))
+
+    const db = getDatabase()
+    const history = db
+      .query('SELECT COUNT(*) AS n FROM metrics_history WHERE topology_id = ?')
+      .get('topo1') as { n: number }
+    expect(history.n).toBe(3)
+
+    const trend = db
+      .query(
+        `SELECT samples, util_min, util_avg, util_max, status_worst
+         FROM metrics_trends
+         WHERE topology_id = ? AND entity_kind = 'link' AND entity_id = 'l1' AND hour_start = ?`,
+      )
+      .get('topo1', hour0) as {
+      samples: number
+      util_min: number
+      util_avg: number
+      util_max: number
+      status_worst: string
+    }
+    expect(trend.samples).toBe(2)
+    expect(trend.util_min).toBe(10)
+    expect(trend.util_max).toBe(30)
+    expect(trend.util_avg).toBe(20)
+    expect(trend.status_worst).toBe('up')
+  })
+
+  test('raw payload round-trips through gzip', () => {
+    const db = getDatabase()
+    const row = db
+      .query(
+        'SELECT payload FROM metrics_history WHERE topology_id = ? ORDER BY captured_at LIMIT 1',
+      )
+      .get('topo1') as { payload: Uint8Array }
+    const decoded = JSON.parse(Buffer.from(Bun.gunzipSync(row.payload)).toString())
+    expect(decoded.links.l1.utilization).toBe(10)
+  })
+})
+
+describe('alert stream — state transitions only', () => {
+  const alert = (id: string, severity: Alert['severity'], status: Alert['status']): Alert =>
+    ({ id, severity, status, title: id, startTime: 0, source: 's' }) as Alert
+
+  test('fired → changed → resolved, idempotent against re-fetches', async () => {
+    expect(await streams.ingestAlerts('src1', null, [alert('a1', 'high', 'active')])).toBe(1)
+    // same state again → no new transition
+    expect(await streams.ingestAlerts('src1', null, [alert('a1', 'high', 'active')])).toBe(0)
+    // severity moved → changed
+    expect(await streams.ingestAlerts('src1', null, [alert('a1', 'critical', 'active')])).toBe(1)
+    // explicit resolved
+    expect(await streams.ingestAlerts('src1', null, [alert('a1', 'critical', 'resolved')])).toBe(1)
+    // resolved again → nothing
+    expect(await streams.ingestAlerts('src1', null, [alert('a1', 'critical', 'resolved')])).toBe(0)
+
+    const db = getDatabase()
+    const transitions = db
+      .query('SELECT transition FROM alert_events WHERE alert_key = ? ORDER BY rowid')
+      .all('a1') as { transition: string }[]
+    expect(transitions.map((t) => t.transition)).toEqual(['fired', 'changed', 'resolved'])
+  })
+
+  test('disappearance resolves ONLY with fullActiveSet', async () => {
+    await streams.ingestAlerts('src2', null, [alert('b1', 'high', 'active')])
+    // filtered fetch without b1 — must NOT resolve it
+    expect(await streams.ingestAlerts('src2', null, [], { fullActiveSet: false })).toBe(0)
+    // unfiltered active set without b1 — resolves it
+    expect(await streams.ingestAlerts('src2', null, [], { fullActiveSet: true })).toBe(1)
+    const db = getDatabase()
+    const last = db
+      .query('SELECT transition FROM alert_events WHERE alert_key = ? ORDER BY rowid DESC LIMIT 1')
+      .get('b1') as { transition: string }
+    expect(last.transition).toBe('resolved')
+  })
+})
+
+describe('housekeeping — stream retentions', () => {
+  test('deletes rows beyond each retention window', () => {
+    const db = getDatabase()
+    const now = Date.now()
+    db.query(
+      'INSERT OR REPLACE INTO metrics_history (topology_id, captured_at, payload) VALUES (?, ?, ?)',
+    ).run('old', now - RETENTION.metricsHistoryMs - 1000, Buffer.from('x'))
+    const before = (db.query('SELECT COUNT(*) AS n FROM metrics_history').get() as { n: number }).n
+    const pruned = streams.housekeeping(now)
+    expect(pruned.history).toBeGreaterThanOrEqual(1)
+    const after = (db.query('SELECT COUNT(*) AS n FROM metrics_history').get() as { n: number }).n
+    expect(after).toBe(before - pruned.history)
+  })
+})


### PR DESCRIPTION
## 概要

signal-streams.md（#486）の収集側を実装。**この PR のデプロイ時点からログが貯まり始める**。消費側（タイムスライダー / 図diff / widget）は次段。

- **Migration 024**: `metrics_history`（tick毎の MetricsData 生スナップショット, gzip）/ `metrics_trends`（エンティティ×時間集計）/ `alert_events`（状態遷移）/ topology_observations の as-of index
- **services/signal-streams.ts**: recordMetrics（生値 insert + RAM時間バケット→ロールオーバーで flush、graceful shutdown で flushAll）、ingestAlerts（fired/changed/resolved、再取得に冪等。**消失=解決はフィルタなし取得のときだけ**）、housekeeping（72h / 400d / 180d、起動時+6h毎）
- **topologyストリーム昇格**: observations の prune を「ソースあたり10件」→ **90日 retention**（ソースあたり最低3件のフロア付き — 変化しないネットワークも証拠を失わない）
- 配線: poll loop / alerts エンドポイント / shutdown。**全書込み best-effort**（ストリーム障害が poll やレスポンスを壊さない）
- テストが実バグを捕獲: 同一ms内の複数遷移で「最新遷移」が不定になる → rowid タイブレーク追加

DBテスト5本新規パス。`sync-options.test.ts` の失敗は #465 由来の既存問題（vitest 下で bun:test import）で本PRと無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
