### PR TITLE
fix(layout): constraint gate throws only under NODE_ENV=test

### DIFF
--- a/libs/@shumoku/core/src/layout/constraints.ts
+++ b/libs/@shumoku/core/src/layout/constraints.ts
@@ -243,9 +243,12 @@ export function verifyLayoutConstraints(layout: ResolvedLayout): ConstraintRepor
 /**
  * Standing-fixture gate (engine-v3-migration.md §B4, finally wired):
  * verify after a layout and — when a BLOCKING constraint is violated —
- * throw under test/development, log an error otherwise. Warn-level
- * violations are summarized at debug level so they stay visible without
- * spamming production bakes.
+ * throw under `NODE_ENV=test` (CI fixtures pin the guarantee), log an
+ * error otherwise. A runtime layout must NEVER fail to render because of
+ * the gate: Bun defaults NODE_ENV to 'development', and throwing there
+ * turned a constraint report into "no diagram at all" (the flat-tree path
+ * on a 1.5k-node graph violates massively — that's a finding for #481,
+ * not a reason to refuse the bake).
  */
 export function assertLayoutConstraints(layout: ResolvedLayout, context = 'layout'): void {
   const report = verifyLayoutConstraints(layout)
@@ -256,7 +259,7 @@ export function assertLayoutConstraints(layout: ResolvedLayout, context = 'layou
     typeof process !== 'undefined' && typeof process.env !== 'undefined'
       ? process.env['NODE_ENV']
       : undefined
-  if (env === 'test' || env === 'development') {
+  if (env === 'test') {
     throw new Error(message)
   }
   console.error(message)


### PR DESCRIPTION
## 問題

BunはNODE_ENVデフォルトが development のため、#487のゲートがdevサーバーの実行時ベイクでthrowし、flat-tree経路のトポロジー（Zabbix単独のtest4/test5）が**描画不能**になった（node-overlap 446/696, container-overlap 64/13）。制約レポートが「図が出ない」に化けるのはゲートの目的に反する。

## 修正

- throw は **NODE_ENV=test のみ**（CIフィクスチャが保証をピン留め）。実行時は常に error ログ

## 副次的発見（#481に追記すべき）

**flat-tree経路は大規模グラフでblocking集合をまったく保証していない**。大規模グループ化グラフはcomposite経路に誘導するか、flat-treeにも同じ実行可能性処理が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)