### PR TITLE
docs: overhaul READMEs across the monorepo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,20 +13,26 @@ bun install
 # Build
 bun run build
 
-# Run playground
-cd apps/playground && bun run dev
+# Run the docs site + playground
+cd apps/docs && bun run dev
 ```
 
 ## Project Structure
 
 ```
-packages/
-├── @shumoku/core         # Core library
-├── @shumoku/parser-yaml  # YAML parser
-└── @shumoku/netbox       # NetBox integration
+libs/
+├── shumoku              # All-in-one package
+├── @shumoku/core        # Models, parser, layout, themes, plugin kit
+├── @shumoku/renderer-*  # SVG / HTML / PNG / Svelte renderers
+├── @shumoku/catalog     # Device / service catalog
+├── @shumoku/plugin-sdk  # HTTP client for data-source plugins
+└── plugins/             # Zabbix, Prometheus, NetBox, Grafana, Aruba, network-scan
 
 apps/
-└── playground            # Demo site
+├── server               # Real-time monitoring platform (API + web)
+├── editor               # Visual topology designer
+├── cli                  # `shumoku render` CLI
+└── docs                 # Documentation site + playground
 ```
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
 <img src="assets/logo-symbol.svg" alt="Shumoku Logo" width="128" height="128">
 
-**Network topology visualization and monitoring platform.** Define your network in YAML, get interactive diagrams with real-time metrics from Zabbix, Prometheus, and more.
+**Network topology visualization and monitoring platform.** Define your network in YAML, get interactive diagrams with real-time metrics from Zabbix, Prometheus, NetBox, and more.
 
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](./LICENSE)
 [![npm version](https://img.shields.io/npm/v/shumoku.svg)](https://www.npmjs.com/package/shumoku)
 [![Discord](https://img.shields.io/discord/1476527182669938720?logo=discord&logoColor=white&label=Discord)](https://discord.gg/dyYbEsDZYr)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow?logo=buy-me-a-coffee&logoColor=white)](https://buymeacoffee.com/akitoshi)
 
-**[Website](https://www.shumoku.dev/)** | **[Server Documentation](https://www.shumoku.dev/ja/docs/server)** | **[Discord](https://discord.gg/dyYbEsDZYr)**
+**[Website](https://www.shumoku.dev/)** | **[Documentation](https://www.shumoku.dev/ja/docs/server)** | **[Discord](https://discord.gg/dyYbEsDZYr)**
 
 <picture>
   <img src="assets/screenshots/topology.png" alt="Topology viewer with live weathermap">
@@ -28,38 +28,62 @@
 </picture>
 <p align="center"><em>Dashboard in production — JANOG57 NOC Live</em></p>
 
+## What's in the box
+
+Shumoku is a monorepo with three ways to use it:
+
+| | | |
+|---|---|---|
+| 🖥️ **Server** | Real-time monitoring platform — connect data sources, overlay live metrics, build dashboards, share read-only links | [`apps/server`](apps/server) |
+| 📦 **Library + CLI** | The rendering engine on npm — turn a `NetworkGraph` into SVG / HTML / PNG, in Node or the browser | [`libs/shumoku`](libs/shumoku) |
+| ✏️ **Editor** | Visual topology designer — lay out devices, modules, and cables; derive a bill of materials | [`apps/editor`](apps/editor) |
+
 ## Features
 
 - **Live weathermap** — Overlay real-time traffic utilization on links, color-coded by load
 - **Alert visualization** — Show active alerts from Zabbix, Prometheus, and Grafana on topology
 - **Auto-generate from NetBox** — Pull devices and cables from NetBox to build topology automatically
+- **Network discovery** — Seed-crawl SNMP + LLDP to discover topology with no inventory at all
 - **Interactive dashboards** — Pan, zoom, and drill into multi-layer network views in the browser
 - **900+ vendor icons** — Yamaha, Aruba, AWS, Juniper, and more — rendered at correct aspect ratios
 - **Shareable links** — Publish topology views with a share token — no login required
 
-## Getting Started
+## Server
 
-See **[Server Setup Guide](apps/server/README.md)** for Docker, systemd, and manual deployment options.
+The server is the full platform: a Bun + Hono API with an SQLite store and a SvelteKit web UI.
 
-### What You Can Do
+See the **[Server Setup Guide](apps/server/README.md)** for Docker, systemd, and manual deployment options.
+
+```bash
+# Quick start with Docker
+cd apps/server
+docker compose up -d            # http://localhost:8080
+DEMO_MODE=true docker compose up -d   # preload a sample network
+```
+
+What you can do:
 
 1. **Create topologies** — Upload YAML files or write them in the built-in editor
 2. **Connect data sources** — Link Zabbix, Prometheus, or NetBox to pull live metrics
-3. **Monitor in real-time** — See node status and link utilization update live on your diagrams
+3. **Monitor in real-time** — See node status and link utilization update live over WebSocket
 4. **Build dashboards** — Combine multiple topologies and metric widgets into custom views
 5. **Share** — Generate public links for read-only access without authentication
 
-## Integrations
+### Integrations
 
-| | |
+| Source | What it pulls |
 |---|---|
-| **Zabbix** | Pull traffic metrics, host status, and alerts via JSON-RPC API |
-| **Prometheus** | Query SNMP and node exporter metrics for link utilization |
-| **Grafana** | Receive alerts via webhook and display them on topology |
-| **NetBox** | Auto-discover topology from DCIM inventory and IPAM data |
+| **Zabbix** | Traffic metrics, host status, LLDP topology, and alerts via JSON-RPC |
+| **Prometheus** | SNMP / node-exporter metrics for link utilization, hosts, and Alertmanager alerts |
+| **NetBox** | Topology and hosts auto-discovered from DCIM / IPAM |
+| **Grafana** | Alerts via webhook or Alertmanager |
+| **Aruba Instant On** | Access points, switches, and site alerts from the cloud portal |
+| **Network scan** | Topology discovered by SNMP + LLDP seed-crawl, no inventory required |
 | **REST API** | Render topologies and fetch metrics programmatically from your own tools |
 
-## YAML Example
+See **[Plugin Authoring](docs/plugin-authoring.md)** to write your own data source.
+
+## YAML format
 
 ```yaml
 name: "Simple Network"
@@ -95,9 +119,9 @@ links:
     bandwidth: 10G
 ```
 
-## npm Library
+## Library
 
-The rendering engine is also available as standalone npm packages.
+The rendering engine is also published to npm as standalone packages.
 
 ![Sample network diagram](apps/docs/public/hero-diagram.png)
 
@@ -106,34 +130,68 @@ npm install shumoku
 ```
 
 ```typescript
-import { YamlParser, HierarchicalLayoutEngine, SvgRenderer } from 'shumoku'
+import { YamlParser, renderGraphToHtml } from 'shumoku'
 
-const graph = new YamlParser().parse(yamlString)
-const layout = await new HierarchicalLayoutEngine().layout(graph)
-const svg = new SvgRenderer().render(layout)
+const { graph } = new YamlParser().parse(yamlString)
+
+// Interactive HTML (pan / zoom / tooltips)
+const html = await renderGraphToHtml(graph, { title: 'My Network' })
 ```
 
-CLI is also available:
+Need SVG or PNG instead? Use the dedicated renderers:
+
+```typescript
+import { renderGraphToSvg } from '@shumoku/renderer-svg'
+import { renderGraphToPng } from '@shumoku/renderer-png' // Node.js only
+
+const svg = await renderGraphToSvg(graph)
+const png = await renderGraphToPng(graph, { scale: 2 })
+```
+
+### CLI
 
 ```bash
 npx shumoku render network.yaml -o diagram.svg
 npx shumoku render network.yaml -f html -o diagram.html
+npx shumoku render network.yaml -f png -o diagram.png --scale 3
 ```
 
-**[Playground](https://www.shumoku.dev/)** | **[npm Documentation](https://www.shumoku.dev/docs/npm/yaml-reference)**
+**[Playground](https://www.shumoku.dev/)** | **[YAML Reference](https://www.shumoku.dev/docs/npm/yaml-reference)**
 
 <details>
 <summary>Packages</summary>
 
-| Package | Description |
-|---------|-------------|
-| [`shumoku`](packages/shumoku) | Main package (all-in-one) |
-| [`@shumoku/core`](packages/@shumoku/core) | Core library (models, layout) |
-| [`@shumoku/renderer`](packages/@shumoku/renderer) | SVG/HTML renderers + CLI |
-| [`@shumoku/parser-yaml`](packages/@shumoku/parser-yaml) | YAML parser |
-| [`@shumoku/netbox`](packages/@shumoku/netbox) | NetBox API integration |
+| Package | Path | Description |
+|---------|------|-------------|
+| [`shumoku`](libs/shumoku) | `libs/shumoku` | All-in-one — core + SVG/HTML renderers |
+| [`@shumoku/core`](libs/@shumoku/core) | `libs/@shumoku/core` | Models, parser, layout engine, themes, plugin kit |
+| [`@shumoku/renderer-svg`](libs/@shumoku/renderer-svg) | `libs/@shumoku/renderer-svg` | SVG render pipeline (`prepareRender` → `renderSvg`) |
+| [`@shumoku/renderer-html`](libs/@shumoku/renderer-html) | `libs/@shumoku/renderer-html` | Interactive HTML output |
+| [`@shumoku/renderer-png`](libs/@shumoku/renderer-png) | `libs/@shumoku/renderer-png` | PNG output (Node.js, via resvg) |
+| [`@shumoku/renderer`](libs/@shumoku/renderer) | `libs/@shumoku/renderer` | Svelte interactive renderer (pan/zoom components) |
+| [`@shumoku/catalog`](libs/@shumoku/catalog) | `libs/@shumoku/catalog` | Device / service catalog (vendor, model, sysObjectID) |
+| [`@shumoku/plugin-sdk`](libs/@shumoku/plugin-sdk) | `libs/@shumoku/plugin-sdk` | HTTP client + pagination for data-source plugins |
+| [`@shumoku/cli`](apps/cli) | `apps/cli` | `shumoku render` command-line tool |
+
+Data-source plugins live in [`libs/plugins`](libs/plugins): `zabbix`, `prometheus`, `netbox`, `grafana`, `aruba-instant-on`, `network-scan`.
 
 </details>
+
+## Repository layout
+
+```
+apps/
+  server/   Real-time monitoring platform — Bun + Hono API, SvelteKit web UI
+  editor/   Visual topology designer — SvelteKit + xyflow
+  cli/      Render YAML → SVG / HTML / PNG
+  docs/     Documentation site (Next.js + Fumadocs)
+libs/
+  shumoku            All-in-one npm package
+  @shumoku/*         Core engine, renderers, catalog, plugin SDK
+  plugins/*          Data-source integrations
+docs/                Architecture, YAML reference, plugin authoring
+examples/            Sample YAML networks + a sample plugin
+```
 
 ## Documentation
 
@@ -141,8 +199,8 @@ npx shumoku render network.yaml -f html -o diagram.html
 - [YAML Reference](https://www.shumoku.dev/docs/npm/yaml-reference) — Full YAML syntax
 - [Vendor Icons](https://www.shumoku.dev/docs/npm/vendor-icons) — Available icons
 - [Playground](https://www.shumoku.dev/) — Try without installation
-- [Architecture](docs/ARCHITECTURE.md) — Monorepo overview, load pipeline, layout engine (Mermaid diagrams)
-- [Plugin Authoring](docs/plugin-authoring.md) — Writing a `DataSourcePlugin`: capability mixins, data shapes, severity mapping, security practices
+- [Architecture](docs/ARCHITECTURE.md) — Monorepo overview, load pipeline, layout engine
+- [Plugin Authoring](docs/plugin-authoring.md) — Writing a `DataSourcePlugin`: capability mixins, data shapes, severity mapping
 
 ## Development
 
@@ -150,9 +208,12 @@ npx shumoku render network.yaml -f html -o diagram.html
 git clone https://github.com/konoe-akitoshi/shumoku.git
 cd shumoku
 bun install
-bun run build
-bun run dev
+bun run build      # build all libraries (excludes the server app)
+bun run dev        # run everything in dev mode
 ```
+
+Common scripts: `bun run test`, `bun run lint`, `bun run typecheck`, `bun run format`.
+This is a [Bun](https://bun.sh) workspaces + [Turborepo](https://turbo.build) monorepo — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Star History
 
@@ -168,5 +229,5 @@ bun run dev
 
 This project is dual-licensed:
 
-- **AGPL-3.0** - For open-source use ([LICENSE](./LICENSE))
-- **Commercial License** - For proprietary use, contact contact@shumoku.dev
+- **AGPL-3.0** — For open-source use ([LICENSE](./LICENSE))
+- **Commercial License** — For proprietary use, contact contact@shumoku.dev

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,59 @@
+# @shumoku/cli
+
+Command-line renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Turns a `NetworkGraph` YAML or JSON file into an **SVG**, interactive **HTML**, or **PNG** diagram.
+
+## Install
+
+No install needed — run it with `npx`:
+
+```bash
+npx shumoku render network.yaml -o diagram.svg
+```
+
+Or install globally:
+
+```bash
+npm install -g @shumoku/cli
+shumoku render network.yaml -o diagram.svg
+```
+
+## Usage
+
+```
+shumoku render [options] <input>
+```
+
+| Argument / option | Description |
+|-------------------|-------------|
+| `<input>` | NetworkGraph YAML or JSON file. Use `-` to read from stdin. Format auto-detected from extension (`.yaml`, `.yml`, `.json`) |
+| `-f, --format <type>` | Output format: `svg` \| `html` \| `png` (default: auto from output extension) |
+| `-o, --output <file>` | Output file (default: `output.svg`) |
+| `--theme <theme>` | `light` \| `dark` (default: `light`) |
+| `--scale <number>` | PNG scale factor (default: `2`) |
+| `-h, --help` | Show help |
+| `-v, --version` | Show version |
+
+## Examples
+
+```bash
+# SVG (default)
+shumoku render network.yaml -o diagram.svg
+
+# Interactive HTML (pan / zoom / tooltips)
+shumoku render network.yaml -f html -o diagram.html
+
+# High-resolution PNG
+shumoku render network.yaml -f png -o diagram.png --scale 3
+
+# JSON input, dark theme
+shumoku render topology.json --theme dark -o diagram.svg
+
+# Pipe from stdin
+cat network.yaml | shumoku render - -o diagram.svg
+```
+
+See the [YAML Reference](https://www.shumoku.dev/docs/npm/yaml-reference) for the input format. For programmatic rendering, use the [`shumoku`](../../libs/shumoku) library directly.
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,45 +1,39 @@
-# docs
+# @shumoku/docs
 
-This is a Next.js application generated with
-[Create Fumadocs](https://github.com/fuma-nama/fumadocs).
+The documentation site for [Shumoku](https://github.com/konoe-akitoshi/shumoku), published at **[shumoku.dev](https://www.shumoku.dev/)**. Built with [Next.js](https://nextjs.org) and [Fumadocs](https://fumadocs.dev), with English and Japanese content.
 
-Run development server:
+## Develop
 
 ```bash
-npm run dev
-# or
-pnpm dev
-# or
-yarn dev
+bun install            # from the repo root
+cd apps/docs
+bun run dev            # http://localhost:3000
 ```
 
-Open http://localhost:3000 with your browser to see the result.
+| Script | Purpose |
+|--------|---------|
+| `bun run dev` | Dev server with hot reload |
+| `bun run build` | Production build |
+| `bun start` | Serve the production build |
+| `bun run typecheck` | Type check (runs the Fumadocs MDX generator first) |
 
-## Explore
+## Content
 
-In the project, you can see:
+Docs are MDX files under `content/docs/`, organized into two trees:
 
-- `lib/source.ts`: Code for content source adapter, [`loader()`](https://fumadocs.dev/docs/headless/source-api) provides the interface to access your content.
-- `lib/layout.shared.tsx`: Shared options for layouts, optional but preferred to keep.
+- **`server/`** — installation, data sources, topologies, dashboards, REST API
+- **`npm/`** — YAML reference, vendor icons, custom integration, NetBox
 
-| Route                     | Description                                            |
-| ------------------------- | ------------------------------------------------------ |
-| `app/(home)`              | The route group for your landing page and other pages. |
-| `app/docs`                | The documentation layout and pages.                    |
-| `app/api/search/route.ts` | The Route Handler for search.                          |
+Each page is bilingual via filename suffix — `installation.en.mdx` and `installation.ja.mdx`. A page is fully translated when both variants exist. Full-text search is served from `app/api/search/route.ts`, and the content source adapter is wired in `lib/source.ts`.
 
-### Fumadocs MDX
+## Adding a page
 
-A `source.config.ts` config file has been included, you can customise different options like frontmatter schema.
+1. Create `content/docs/<section>/<slug>.en.mdx` (and `.ja.mdx` for Japanese).
+2. Add frontmatter (`title`, `description`) and, if needed, an entry in the section's `meta.json` to order it in the sidebar.
+3. `bun run dev` and verify both languages render.
 
-Read the [Introduction](https://fumadocs.dev/docs/mdx) for further details.
+Frontmatter schema and MDX options live in `source.config.ts`.
 
-## Learn More
+## License
 
-To learn more about Next.js and Fumadocs, take a look at the following
-resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js
-  features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-- [Fumadocs](https://fumadocs.dev) - learn about Fumadocs
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/apps/editor/README.md
+++ b/apps/editor/README.md
@@ -1,0 +1,42 @@
+# @shumoku/editor
+
+Visual editor for designing **physical** network topologies. Manage devices, modules, and cables as first-class *products*, lay them out on a canvas, and derive a bill of materials — then export a portable project file.
+
+> Status: early and under active development (v0.1.0). Some pages are still being built out.
+
+## Develop
+
+```bash
+bun install            # from the repo root
+cd apps/editor
+bun run dev            # http://localhost:5173
+```
+
+| Script | Purpose |
+|--------|---------|
+| `bun run dev` | Vite dev server |
+| `bun run build` | Production build (SvelteKit) |
+| `bun run preview` | Preview the production build |
+| `bun run typecheck` | `svelte-check` + `tsc` |
+
+## What it does
+
+- **Projects** — a project list on the home page, with a built-in sample (a multi-site campus network with PoE) and file import.
+- **Diagram canvas** — place and wire nodes with [@xyflow/svelte](https://svelteflow.dev), pan/zoom, with undo support.
+- **Materials** — a product catalog of devices, modules, and cables with quantities and specs.
+- **Bill of materials** — derived from the materials and the diagram.
+- **PoE analysis** — power-budget calculations across the topology.
+
+Projects persist locally in IndexedDB and export to a portable **`.neted`** file (a JSON snapshot of the project and its diagram). The editor can also import `.yaml` / `.json` network definitions.
+
+## Stack
+
+SvelteKit + Svelte 5, [@xyflow/svelte](https://svelteflow.dev) for the graph canvas, Tailwind CSS, and Vite. Rendering and layout reuse the shared Shumoku engine.
+
+## Internals
+
+Architecture and data-model design notes live in [`docs/`](docs/) (data structures, icon flow, layout, the sheet model, and per-page design). Start there before changing the project schema — migrations live in [`src/lib/migrations/`](src/lib/migrations).
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,176 +1,84 @@
 # API Reference
 
-Shumoku の TypeScript API リファレンスです。
+Shumoku の TypeScript API の概要です。各パッケージの詳しい使い方は、それぞれの README とウェブサイトのドキュメントを参照してください。
 
 ## Packages
 
 | パッケージ | 説明 |
 |-----------|------|
-| `shumoku` | メインパッケージ（全機能を含む） |
-| `@shumoku/core` | コアライブラリ（モデル、レイアウト、レンダラー） |
-| `@shumoku/parser-yaml` | YAML パーサー |
+| [`shumoku`](../libs/shumoku/README.md) | メインパッケージ（core + SVG/HTML レンダラーを再エクスポート） |
+| [`@shumoku/core`](../libs/@shumoku/core/README.md) | モデル・パーサー・レイアウトエンジン・テーマ・プラグインキット |
+| [`@shumoku/renderer-svg`](../libs/@shumoku/renderer-svg/README.md) | SVG レンダーパイプライン |
+| [`@shumoku/renderer-html`](../libs/@shumoku/renderer-html/README.md) | インタラクティブ HTML 出力 |
+| [`@shumoku/renderer-png`](../libs/@shumoku/renderer-png/README.md) | PNG 出力（Node.js のみ） |
+| [`@shumoku/catalog`](../libs/@shumoku/catalog/README.md) | デバイス／サービスカタログ |
+| [`@shumoku/plugin-sdk`](../libs/@shumoku/plugin-sdk/README.md) | データソースプラグイン用 HTTP クライアント |
 
-## YamlParser
+> 旧 API（`HierarchicalLayoutEngine` / `SvgRenderer` クラス、`@shumoku/parser-yaml` パッケージ）は削除されました。現在はパイプライン関数（`prepareRender` → `renderSvg` 等）と `computeNetworkLayout()` を使います。
 
-YAML 文字列を `NetworkGraph` にパースします。
+## パース
 
 ```typescript
 import { YamlParser } from 'shumoku'
 
-const parser = new YamlParser()
-const graph = parser.parse(yamlString)
+const { graph, warnings } = new YamlParser().parse(yamlString)
 ```
 
-### Methods
+`parse()` は `{ graph: NetworkGraph, warnings?: ParseWarning[] }` を返します（回復可能な問題では例外を投げず `warnings` に積みます）。複数ファイル（`file:` 参照）には `HierarchicalParser` を使います。
 
-#### `parse(yaml: string): NetworkGraph`
-
-YAML 文字列をパースして `NetworkGraph` を返します。
-
-## HierarchicalLayoutEngine
-
-ネットワークグラフを階層的にレイアウトします。ELK.js を使用。
+## レイアウト
 
 ```typescript
-import { HierarchicalLayoutEngine } from 'shumoku'
+import { computeNetworkLayout } from 'shumoku'
 
-const engine = new HierarchicalLayoutEngine()
-const layout = await engine.layout(graph, options)
+const layout = await computeNetworkLayout(graph)
 ```
 
-### Methods
+ノード・リンク・サブグラフを配置した `LayoutResult` を返します（Sugiyama 系のタイア化レイアウト）。通常はレンダラーが内部で呼ぶため、直接呼ぶ必要はありません。
 
-#### `layout(graph: NetworkGraph, options?: LayoutOptions): Promise<LayoutResult>`
-
-グラフをレイアウトして結果を返します。
-
-### LayoutOptions
+## レンダリング
 
 ```typescript
-interface LayoutOptions {
-  direction?: 'TB' | 'BT' | 'LR' | 'RL'  // レイアウト方向
-  nodeWidth?: number                      // ノード幅
-  nodeHeight?: number                     // ノード高さ
-  spacing?: number                        // ノード間隔
-}
+import { prepareRender, renderSvg, renderGraphToSvg } from '@shumoku/renderer-svg'
+import { renderGraphToHtml } from '@shumoku/renderer-html'
+import { renderGraphToPng } from '@shumoku/renderer-png' // Node.js のみ
+
+// 一括
+const svg = await renderGraphToSvg(graph)
+const html = await renderGraphToHtml(graph, { title: 'My Network' })
+const png = await renderGraphToPng(graph, { scale: 2 })
+
+// パイプラインを分割（prepared を複数の出力で再利用）
+const prepared = await prepareRender(graph) // アイコン寸法解決 + レイアウト
+const svg2 = await renderSvg(prepared)
 ```
 
-## SvgRenderer
+`prepareRender` / `renderSvg` / `renderGraphToSvg` / `renderGraphToHtml` / `renderGraphToPng` はいずれも `async` です（`renderHtml(prepared)` のみ同期）。
 
-レイアウト結果を SVG 文字列にレンダリングします。
+## テーマ
 
 ```typescript
-import { SvgRenderer } from 'shumoku'
-
-const renderer = new SvgRenderer()
-const svg = renderer.render(layout, options)
+import { lightTheme, darkTheme, createTheme, mergeTheme } from 'shumoku'
 ```
 
-### Methods
-
-#### `render(layout: LayoutResult, options?: RenderOptions): string`
-
-レイアウト結果を SVG 文字列に変換します。
-
-### RenderOptions
-
-```typescript
-interface RenderOptions {
-  theme?: Theme           // テーマ設定
-  padding?: number        // SVG のパディング
-  showPorts?: boolean     // ポートを表示するか
-}
-```
-
-## Theme
-
-SVG のスタイルをカスタマイズします。
-
-```typescript
-import { modernTheme, darkTheme, createTheme } from 'shumoku'
-
-// 組み込みテーマ
-const renderer = new SvgRenderer()
-renderer.render(layout, { theme: darkTheme })
-
-// カスタムテーマ
-const customTheme = createTheme({
-  background: '#1a1a2e',
-  node: {
-    fill: '#16213e',
-    stroke: '#0f3460',
-    text: '#e94560'
-  }
-})
-```
-
-### Built-in Themes
-
-- `modernTheme` - ライトテーマ（デフォルト）
-- `darkTheme` - ダークテーマ
+組み込みテーマは `lightTheme`（デフォルト）と `darkTheme`。`createTheme()` / `mergeTheme()` でカスタマイズできます。テーマは `NetworkGraph.settings.theme`（`'light' | 'dark'`）でも指定できます。
 
 ## NetworkGraph
-
-ネットワークトポロジーのデータ構造です。
 
 ```typescript
 interface NetworkGraph {
   version: string
   name?: string
-  devices: Device[]
-  ports?: Port[]
+  description?: string
+  nodes: Node[]
   links: Link[]
-  modules?: Module[]
-  locations?: Location[]
+  subgraphs?: Subgraph[]
   settings?: NetworkSettings
 }
 ```
 
-## Device
+`Node` / `Link` / `Subgraph` / `NetworkSettings` の完全な型定義は [`@shumoku/core`](../libs/@shumoku/core/README.md)（`@shumoku/core/models`）を参照してください。
 
-ネットワークデバイスを表します。
+## アイコン
 
-```typescript
-interface Device {
-  id: string
-  name?: string
-  type?: DeviceType
-  role?: DeviceRole
-  status?: DeviceStatus
-  vendor?: string
-  model?: string
-  // ...
-}
-```
-
-### DeviceType
-
-```typescript
-enum DeviceType {
-  Router = 'router',
-  L3Switch = 'l3-switch',
-  L2Switch = 'l2-switch',
-  Firewall = 'firewall',
-  LoadBalancer = 'load-balancer',
-  Server = 'server',
-  AccessPoint = 'access-point',
-  Cloud = 'cloud',
-  Internet = 'internet',
-  VPN = 'vpn',
-  Database = 'database',
-  Generic = 'generic'
-}
-```
-
-## Icons
-
-ベンダーアイコンは CDN (`https://icons.shumoku.packof.me`) から自動的に配信されます。レンダラーがアイコンの寸法を取得し、適切なアスペクト比でレンダリングします。
-
-### Supported Vendors
-
-| ベンダー | アイコン数 |
-|---------|----------|
-| Yamaha | 103 |
-| Aruba | 55 |
-| AWS | 477 |
-| Juniper | 343 |
+ベンダーアイコンは CDN から配信され、レンダラーが寸法を取得して正しいアスペクト比で描画します。利用可能なアイコンは[ベンダーアイコン一覧](https://www.shumoku.dev/docs/npm/vendor-icons)を参照してください。

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ npm install shumoku
 ### NetBox 連携（オプション）
 
 ```bash
-npm install @shumoku/netbox
+npm install shumoku-plugin-netbox
 ```
 
 ## Basic Usage
@@ -48,28 +48,29 @@ links:
     bandwidth: 1G
 ```
 
-### 2. TypeScript/JavaScript で SVG を生成
+### 2. TypeScript/JavaScript で図をレンダリング
 
 ```typescript
-import { YamlParser, HierarchicalLayoutEngine, SvgRenderer } from 'shumoku'
+import { YamlParser, renderGraphToHtml } from 'shumoku'
 
-// YAML をパース
-const parser = new YamlParser()
-const graph = parser.parse(yamlString)
+// YAML をパース（parse() は { graph, warnings } を返す）
+const { graph } = new YamlParser().parse(yamlString)
 
-// レイアウト計算
-const engine = new HierarchicalLayoutEngine()
-const layout = await engine.layout(graph)
-
-// SVG 生成
-const renderer = new SvgRenderer()
-const svg = renderer.render(layout)
-
-// DOM に追加
-document.getElementById('diagram').innerHTML = svg
+// インタラクティブな HTML を生成（パン / ズーム / ツールチップ）
+const html = await renderGraphToHtml(graph, { title: 'My Network' })
 ```
 
-ベンダーアイコンは `shumoku` をインポートした時点で自動的に登録されます。
+SVG や PNG が必要な場合は専用のレンダラーを使います:
+
+```typescript
+import { renderGraphToSvg } from '@shumoku/renderer-svg'
+import { renderGraphToPng } from '@shumoku/renderer-png' // Node.js のみ
+
+const svg = await renderGraphToSvg(graph)
+const png = await renderGraphToPng(graph, { scale: 2 })
+```
+
+アイコンはレンダリング時に CDN から解決され、正しいアスペクト比で描画されます。
 
 ## Next Steps
 

--- a/docs/netbox.md
+++ b/docs/netbox.md
@@ -1,160 +1,44 @@
 # NetBox Integration
 
-NetBox からネットワーク構成を取得し、Shumoku ダイアグラムを自動生成します。
+NetBox の DCIM/IPAM からデバイス・ケーブルを取得し、Shumoku のトポロジーを自動生成します。
 
-## インストール
+利用方法は2つあります:
 
-```bash
-npm install @shumoku/netbox
-```
+- **サーバー（推奨）** — NetBox をデータソースとして追加すると、トポロジーが自動生成されます。設定は[サーバードキュメント](https://www.shumoku.dev/ja/docs/server)を参照してください。
+- **ライブラリ** — `shumoku-plugin-netbox` の API クライアントとコンバーターを直接使います。
 
-## CLI での使用
-
-コマンドラインから NetBox データを Shumoku YAML に変換できます。
+## インストール（ライブラリ利用時）
 
 ```bash
-# 基本的な使い方
-npx netbox-to-shumoku --url https://netbox.example.com --token YOUR_API_TOKEN
-
-# ファイルに出力
-npx netbox-to-shumoku --url https://netbox.example.com --token YOUR_API_TOKEN -o network.yaml
-
-# サイトでフィルタリング
-npx netbox-to-shumoku --url https://netbox.example.com --token YOUR_API_TOKEN --site tokyo-dc
+npm install shumoku-plugin-netbox @shumoku/renderer-svg
 ```
 
-### CLI オプション
-
-| オプション | 説明 |
-|-----------|------|
-| `--url, -u` | NetBox の URL（必須） |
-| `--token, -t` | API トークン（必須） |
-| `--output, -o` | 出力ファイル（省略時は標準出力） |
-| `--site, -s` | サイトでフィルタリング |
-| `--role, -r` | デバイスロールでフィルタリング |
-| `--theme` | テーマ: light または dark |
-| `--status` | ステータスでフィルタリング |
-| `--tag` | タグでフィルタリング |
-| `--group-by, -g` | グループ化: tag, site, location, prefix, none |
-| `--no-ports` | ポート名を非表示 |
-| `--no-colors` | ケーブル種別による色分けを無効化 |
-| `--color-by-status` | デバイスをステータスで色分け |
-| `--legend` | 凡例を表示（SVG出力時のみ） |
+> サーバーにはこのプラグインがバンドルされているため、別途インストールは不要です。
 
 ## ライブラリとしての使用
 
-### 基本的な使い方
-
 ```typescript
-import { NetBoxClient, convertToShumoku } from '@shumoku/netbox'
-import { HierarchicalLayoutEngine, SvgRenderer } from '@shumoku/core'
+import { NetBoxClient, convertToNetworkGraph } from 'shumoku-plugin-netbox'
+import { renderGraphToSvg } from '@shumoku/renderer-svg'
 
 // NetBox クライアントを作成
-const client = new NetBoxClient({
-  url: 'https://netbox.example.com',
-  token: 'your-api-token'
-})
+const client = new NetBoxClient({ url: 'https://netbox.example.com', token: 'your-api-token' })
 
-// デバイスとケーブルを取得
-const devices = await client.getDevices()
-const cables = await client.getCables()
+// デバイス・インターフェース・ケーブルを取得
+const devices = await client.fetchDevices()
+const interfaces = await client.fetchInterfaces()
+const cables = await client.fetchCables()
 
-// Shumoku NetworkGraph に変換
-const graph = convertToShumoku({ devices, cables })
-
-// レイアウトとレンダリング
-const engine = new HierarchicalLayoutEngine()
-const layout = await engine.layout(graph)
-
-const renderer = new SvgRenderer()
-const svg = renderer.render(layout)
+// Shumoku の NetworkGraph に変換してレンダリング
+const graph = convertToNetworkGraph(devices, interfaces, cables, { groupBy: 'site' })
+const svg = await renderGraphToSvg(graph)
 ```
 
-### サイト情報を含める
+仮想マシンも含める場合は `client.fetchAllWithVMs()` と `convertToNetworkGraphWithVMs()` を使います。クライアントの全メソッド（`fetchSites` / `fetchLocations` / `fetchTags` / `fetchDeviceRoles` / `fetchPrefixes` / `fetchIPAddresses` / `fetchAll` …）やコンバーターのオプションは、[プラグインの README](../libs/plugins/netbox/README.md) を参照してください。
 
-```typescript
-const devices = await client.getDevices()
-const cables = await client.getCables()
-const sites = await client.getSites()
+## グループ化とフィルタリング
 
-const graph = convertToShumoku({
-  devices,
-  cables,
-  sites  // サイトを subgraph として変換
-})
-```
-
-### フィルタリング
-
-```typescript
-// 特定のサイトのデバイスのみ取得
-const devices = await client.getDevices({
-  site: 'tokyo-dc'
-})
-
-// 特定のロールのデバイスのみ取得
-const devices = await client.getDevices({
-  role: 'core-router'
-})
-
-// 複数条件
-const devices = await client.getDevices({
-  site: 'tokyo-dc',
-  role: 'core-router',
-  status: 'active'
-})
-```
-
-## API Reference
-
-### NetBoxClient
-
-```typescript
-interface NetBoxClientOptions {
-  url: string      // NetBox の URL
-  token: string    // API トークン
-}
-
-const client = new NetBoxClient(options)
-```
-
-#### getDevices
-
-```typescript
-interface DeviceFilter {
-  site?: string
-  role?: string
-  status?: 'active' | 'planned' | 'staged' | 'failed' | 'offline'
-  manufacturer?: string
-  model?: string
-}
-
-client.getDevices(filter?: DeviceFilter): Promise<NetBoxDevice[]>
-```
-
-#### getCables
-
-```typescript
-client.getCables(): Promise<NetBoxCable[]>
-```
-
-#### getSites
-
-```typescript
-client.getSites(): Promise<NetBoxSite[]>
-```
-
-### convertToShumoku
-
-```typescript
-interface ConvertOptions {
-  devices: NetBoxDevice[]
-  cables: NetBoxCable[]
-  sites?: NetBoxSite[]
-}
-
-convertToShumoku(options: ConvertOptions): NetworkGraph
-```
+グループ化（`tag` / `site` / `location` / `prefix` / `none`）とサイト・タグ・ロールによるフィルタリングが指定できます。サーバーではデータソースのオプションとして UI から設定できます。詳細は[プラグイン README](../libs/plugins/netbox/README.md) の「Topology options」を参照してください。
 
 ## NetBox のセットアップ
 
@@ -182,13 +66,13 @@ NetBox のデータは以下のように Shumoku に変換されます：
 |--------|---------|
 | Device | Node |
 | Cable | Link |
-| Site | Subgraph |
+| Site / Location / Tag / Prefix | Subgraph（グループ化に応じて） |
 | Interface | Port |
-| Device Role | type の推測に使用 |
+| Device Role | `type` の推測に使用 |
 
 ### デバイスタイプの自動推測
 
-NetBox の `device_role` から Shumoku の `type` を自動推測します：
+NetBox の device role から Shumoku の `type` を推測します（`useRoleForType` オプション、既定で有効）。対応は `ROLE_TO_TYPE`（プラグインからエクスポート）で定義されています。代表例:
 
 | NetBox Device Role | Shumoku Type |
 |-------------------|--------------|
@@ -204,25 +88,15 @@ NetBox の `device_role` から Shumoku の `type` を自動推測します：
 
 ### 接続エラー
 
-```
-Error: Failed to connect to NetBox
-```
-
 - URL が正しいか確認
 - API トークンが有効か確認
-- ネットワーク接続を確認
+- ネットワーク接続を確認（自己署名証明書の場合は `insecure: true` を検討）
 
-### 権限エラー
+### 権限エラー（403 Forbidden）
 
-```
-Error: 403 Forbidden
-```
-
-- API トークンの権限を確認
-- 必要な権限が付与されているか確認
+- API トークンに必要な権限が付与されているか確認
 
 ### デバイスが表示されない
 
-- デバイスのステータスが `active` か確認
-- フィルタ条件を確認
-- NetBox でデバイスが正しく登録されているか確認
+- フィルタ条件（サイト・タグ・ロール）を確認
+- NetBox 上でデバイスとケーブルが正しく登録されているか確認

--- a/libs/@shumoku/catalog/README.md
+++ b/libs/@shumoku/catalog/README.md
@@ -1,0 +1,41 @@
+# @shumoku/catalog
+
+Device and service catalog for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Registers hardware, compute, and service entries and looks them up by **vendor + model**, **part number**, or **SNMP `sysObjectID`** — plus IANA enterprise-number → vendor resolution and PoE-standard helpers.
+
+## Install
+
+```bash
+npm install @shumoku/catalog @shumoku/core
+```
+
+## Quick start
+
+```typescript
+import { Catalog, builtinEntries, vendorFromOid } from '@shumoku/catalog'
+
+const catalog = new Catalog()
+catalog.registerAll(builtinEntries())
+
+// Resolve a device discovered over SNMP
+const entry = catalog.findBySysObjectId('1.3.6.1.4.1.9.1.2495')
+
+// Resolve just the vendor from an enterprise OID (via IANA enterprise numbers)
+const vendor = vendorFromOid('1.3.6.1.4.1.9.1.2495')
+```
+
+## API
+
+| Group | Exports |
+|-------|---------|
+| **Registry** | `Catalog` — `register`, `registerAll`, `findBySysObjectId`, `findByPartNumber`, `lookup`, `list`, `listByKind` |
+| **Built-ins** | `builtinEntries()` — the bundled device/service entries |
+| **Custom data** | `parseCatalogYaml`, `parseCatalogYamlMulti` — load catalog entries from YAML |
+| **IANA / OID** | `ianaEnterpriseFromOid`, `vendorFromIanaEnterpriseId`, `vendorFromOid` |
+| **PoE** | `effectivePoeClass`, `classReservationW`, `POE_CLASS_RESERVATION_W`, `POE_STANDARD_MAX_CLASS`, `PoEStandard` |
+| **Ports** | `expandCatalogPorts`, `CatalogPortTemplate` |
+
+Entries are typed as `HardwareCatalogEntry`, `ComputeCatalogEntry`, or `ServiceCatalogEntry` (all `CatalogEntry`), each with structured properties (physical, management, switching, wireless, power, PoE, …).
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/@shumoku/core/README.md
+++ b/libs/@shumoku/core/README.md
@@ -1,0 +1,77 @@
+# @shumoku/core
+
+Core library for [Shumoku](https://github.com/konoe-akitoshi/shumoku) network topology visualization — the data models, parser, layout engine, themes, and plugin toolkit that every other package builds on.
+
+It is **render-agnostic and browser-safe**: it turns a network definition into a positioned layout, but does not emit SVG/HTML/PNG itself. Pair it with [`@shumoku/renderer-svg`](../renderer-svg), [`@shumoku/renderer-html`](../renderer-html), or [`@shumoku/renderer-png`](../renderer-png) — or just use the all-in-one [`shumoku`](../../shumoku) package.
+
+## Install
+
+```bash
+npm install @shumoku/core
+```
+
+## Quick start
+
+```typescript
+import { YamlParser, computeNetworkLayout } from '@shumoku/core'
+
+// 1. Parse YAML into a NetworkGraph
+const { graph, warnings } = new YamlParser().parse(`
+name: Edge
+nodes:
+  - id: rt-01
+    type: router
+    vendor: yamaha
+  - id: sw-01
+    type: l3-switch
+links:
+  - from: { node: rt-01, port: lan1 }
+    to:   { node: sw-01, port: ge-0/0/0 }
+    bandwidth: 10G
+`)
+
+// 2. Compute positions (Sugiyama-style tiered layout)
+const layout = await computeNetworkLayout(graph)
+
+// `layout` holds positioned nodes, links, and subgraphs — hand it to a renderer.
+console.log(layout.nodes.length, 'nodes placed')
+```
+
+`YamlParser.parse()` returns `{ graph: NetworkGraph, warnings?: ParseWarning[] }` — it never throws on recoverable issues; check `warnings` instead.
+
+## What's inside
+
+| Area | Key exports |
+|------|-------------|
+| **Models** | `NetworkGraph`, `Node`, `Link`, `Subgraph`, `Port`, `NetworkSettings` |
+| **Parser** | `YamlParser` (single file), `HierarchicalParser` (multi-file `file:` references), `parser` (shared instance) |
+| **Layout** | `computeNetworkLayout()` (primary entry), `createEngine()`, `routeEdges()`, `checkLayoutInvariants()` |
+| **Themes** | `lightTheme`, `darkTheme` presets; `createTheme()`, `mergeTheme()` utilities |
+| **Icons** | icon ID constants and dimension helpers |
+| **Fixtures** | `sampleNetwork` — a multi-file demo network used across the test suite |
+| **Plugin types** | `DataSourcePlugin`, `TopologyCapable`, `HostsCapable`, `MetricsCapable`, `AlertsCapable`, `AutoMappingCapable`, `Alert`, `AlertSeverity`, `MetricsData` |
+| **Plugin kit** | `flattenObject`, `stampObserved`, `validateAgainstSchema`, `mapAlertmanagerSeverity`, and other pure helpers for plugin authors |
+
+> The old class-based API (`HierarchicalLayoutEngine`, `SvgRenderer`) has been removed. Layout is now the function `computeNetworkLayout()`; rendering moved to the dedicated renderer packages.
+
+## Subpath exports
+
+For smaller imports you can reach into a single area instead of the package root:
+
+```typescript
+import { Node, Link } from '@shumoku/core/models'
+import { YamlParser } from '@shumoku/core/parser'
+import { computeNetworkLayout } from '@shumoku/core/layout'
+import { darkTheme } from '@shumoku/core/themes'
+import { ICON_IDS } from '@shumoku/core/icons'
+```
+
+The plugin-kit helpers and plugin types are exported from the package **root** (`@shumoku/core`), not a subpath.
+
+## For plugin authors
+
+Plugins implement `DataSourcePlugin` and translate their upstream vocabulary into core's neutral types at the boundary — core types are the display contract. The plugin kit gives you the shared building blocks (severity mapping, Alertmanager parsing, generic record flattening, observation stamping, schema validation) so every plugin behaves consistently. See [Plugin Authoring](../../../docs/plugin-authoring.md) for the full reference, and [`libs/plugins/zabbix`](../../plugins/zabbix) for a complete example.
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/@shumoku/core/package.json
+++ b/libs/@shumoku/core/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
     "directory": "libs/@shumoku/core"
   },
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },

--- a/libs/@shumoku/plugin-sdk/README.md
+++ b/libs/@shumoku/plugin-sdk/README.md
@@ -1,0 +1,47 @@
+# @shumoku/plugin-sdk
+
+Node-runtime SDK for [Shumoku](https://github.com/konoe-akitoshi/shumoku) data-source plugins. Provides an HTTP client (with auth strategies and self-signed-TLS support) and a pagination helper.
+
+This is **layer 2** of the shared plugin toolkit: it needs Node (fetch dispatcher / TLS control), so it lives outside the browser-safe [`@shumoku/core`](../core). Pure, runtime-agnostic helpers (severity mapping, Alertmanager parsing, `flattenObject`, `stampObserved`, `validateAgainstSchema`) stay in core's plugin kit.
+
+## Install
+
+```bash
+npm install @shumoku/plugin-sdk
+```
+
+## Quick start
+
+```typescript
+import { HttpClient, paginate } from '@shumoku/plugin-sdk'
+
+const client = new HttpClient({
+  baseUrl: 'https://netbox.example.com',
+  auth: { type: 'token', token: process.env.NETBOX_TOKEN ?? '' }, // NetBox's scheme is `Token`
+  insecure: false, // set true only for trusted self-signed upstreams
+})
+
+// Single request — returns a standard Response
+const res = await client.request('/api/dcim/sites/', { query: { limit: 50 } })
+const { results } = await res.json()
+
+// Follow `next` links to the end
+const devices = await paginate('/api/dcim/devices/?limit=100', async (path) => {
+  const r = await client.request(path)
+  const body = await r.json()
+  return { items: body.results, next: body.next }
+})
+```
+
+## API
+
+- **`HttpClient`** — `new HttpClient(options)` with `request(path, opts?) → Promise<Response>`. Options: `baseUrl`, `auth`, `timeoutMs` (default 10000), `insecure`, `defaultHeaders`, `debug`, `fetchImpl`. Request options: `method`, `query`, `headers`, `body` (non-string is JSON-encoded), `timeoutMs`, `signal`.
+- **`AuthStrategy`** — `{ type: 'none' }`, `{ type: 'bearer', token }`, `{ type: 'token', token, scheme? }`, `{ type: 'basic', username, password }`.
+- **`HttpError`** — thrown on non-2xx; carries `status`, `url`, `bodyText`.
+- **`paginate(firstPath, fetchPage, options?)`** — walks `next` cursors, accumulating `items`. `options.maxPages` defaults to 1000 (`onTruncated` fires if hit).
+
+See [Plugin Authoring](../../../docs/plugin-authoring.md) and the bundled plugins in [`libs/plugins`](../../plugins) for real usage.
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/@shumoku/plugin-sdk/package.json
+++ b/libs/@shumoku/plugin-sdk/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
     "directory": "libs/@shumoku/plugin-sdk"
   },
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },

--- a/libs/@shumoku/renderer-html/README.md
+++ b/libs/@shumoku/renderer-html/README.md
@@ -1,0 +1,46 @@
+# @shumoku/renderer-html
+
+Interactive HTML renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Wraps the [`@shumoku/renderer-svg`](../renderer-svg) pipeline to produce a self-contained HTML page with pan, zoom, tooltips, and — for large networks — multi-sheet navigation.
+
+## Install
+
+```bash
+npm install @shumoku/renderer-html @shumoku/core
+```
+
+## Quick start
+
+```typescript
+import { YamlParser } from '@shumoku/core'
+import { renderGraphToHtml } from '@shumoku/renderer-html'
+
+const { graph } = new YamlParser().parse(yaml)
+
+const html = await renderGraphToHtml(graph, { title: 'My Network', toolbar: true })
+```
+
+## API
+
+| Function | Description |
+|----------|-------------|
+| `renderGraphToHtml(graph, options?)` | `async` — parse-to-HTML convenience |
+| `renderGraphToHtmlHierarchical(graph, options?)` | `async` — convenience with sheet navigation |
+| `renderHtml(prepared, options?)` | **sync** — render a `PreparedRender` to HTML |
+| `renderHtmlHierarchical(prepared, options?)` | `async` — render with sheets |
+
+### Options (`HTMLRenderOptions`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `title` | string | Page / document title |
+| `branding` | boolean | Show the Shumoku mark |
+| `toolbar` | boolean | Show the pan/zoom toolbar |
+| `sheets` | `Map<string, SheetData>` | Pre-computed hierarchical sheets (skips recomputation) |
+
+### Embedding
+
+The interactive behavior ships as an IIFE bundle. Use `getIIFE()` / `setIIFE()` / `INTERACTIVE_IIFE` to inline or supply it, and `initInteractive()` to wire up an already-rendered SVG in the browser.
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/@shumoku/renderer-png/README.md
+++ b/libs/@shumoku/renderer-png/README.md
@@ -1,0 +1,37 @@
+# @shumoku/renderer-png
+
+PNG renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Renders the [`@shumoku/renderer-svg`](../renderer-svg) output to a raster image with [`@resvg/resvg-js`](https://github.com/yisibl/resvg-js).
+
+> **Node.js only** — depends on the native `@resvg/resvg-js` binding, so it does not run in the browser.
+
+## Install
+
+```bash
+npm install @shumoku/renderer-png @shumoku/core
+```
+
+## Quick start
+
+```typescript
+import { writeFileSync } from 'node:fs'
+import { YamlParser } from '@shumoku/core'
+import { renderGraphToPng } from '@shumoku/renderer-png'
+
+const { graph } = new YamlParser().parse(yaml)
+
+const png = await renderGraphToPng(graph, { scale: 2 }) // → Buffer
+writeFileSync('diagram.png', png)
+```
+
+## API
+
+| Function | Description |
+|----------|-------------|
+| `renderGraphToPng(graph, options?)` | `async` → `Buffer`. Convenience: `prepareRender` + `renderPng` |
+| `renderPng(prepared, options?)` | `async` → `Buffer`. Renders an existing `PreparedRender` |
+
+`PNGRenderOptions` has a single field, `scale` (default `2`), the output resolution multiplier. External CDN icons are automatically embedded as base64 before rasterizing.
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/@shumoku/renderer-svg/README.md
+++ b/libs/@shumoku/renderer-svg/README.md
@@ -1,0 +1,46 @@
+# @shumoku/renderer-svg
+
+SVG renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Provides the **unified render pipeline** — layout, icon-dimension resolution, and SVG generation — and is the foundation that [`@shumoku/renderer-html`](../renderer-html) and [`@shumoku/renderer-png`](../renderer-png) build on.
+
+## Install
+
+```bash
+npm install @shumoku/renderer-svg @shumoku/core
+```
+
+## Quick start
+
+```typescript
+import { YamlParser } from '@shumoku/core'
+import { prepareRender, renderSvg, renderGraphToSvg } from '@shumoku/renderer-svg'
+
+const { graph } = new YamlParser().parse(yaml)
+
+// One-liner
+const svg = await renderGraphToSvg(graph)
+
+// Or split the pipeline — `prepared` can feed SVG, HTML, and PNG renderers
+const prepared = await prepareRender(graph) // resolves icon dimensions + computes layout
+const svg2 = await renderSvg(prepared)
+```
+
+## Pipeline
+
+| Function | Description |
+|----------|-------------|
+| `prepareRender(graph, options?)` | → `PreparedRender`. Resolves icon dimensions (CDN fetch + cache) and computes layout |
+| `renderSvg(prepared, options?)` | → SVG string |
+| `renderGraphToSvg(graph, options?)` | Convenience: `prepareRender` + `renderSvg` |
+| `renderEmbeddable(prepared, options?)` | → `{ svg, css, … }` for embedding in a web app with scoped styles |
+
+All four are `async` (icon resolution may fetch over the network).
+
+### Icon utilities
+
+`resolveAllIconDimensions`, `fetchIconAsDataUrl`, `fetchImageDimensions`, `clearIconCache`, `DEFAULT_ICON_FETCH_TIMEOUT`, and `collectIconUrls` are exported for callers that manage icon fetching themselves (e.g. a server resolving dimensions ahead of time).
+
+> The removed class-based API (`new SvgRenderer()`) is gone. A lower-level `SVGRenderer` is still exported for advanced use, but prefer the pipeline functions above.
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/@shumoku/renderer/README.md
+++ b/libs/@shumoku/renderer/README.md
@@ -1,0 +1,26 @@
+# @shumoku/renderer
+
+Interactive [Svelte](https://svelte.dev) renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku) diagrams. Provides the building blocks for a live, manipulable topology view — pan/zoom camera, coordinate helpers, layout serialization, and overlay hooks — used by the [editor](../../../apps/editor) and the [server](../../../apps/server) web UI.
+
+> Requires Svelte 5 (peer dependency). For static, non-interactive SVG output use [`@shumoku/renderer-svg`](../renderer-svg) instead.
+
+## Install
+
+```bash
+npm install @shumoku/renderer @shumoku/core svelte
+```
+
+## What it provides
+
+| Area | Exports |
+|------|---------|
+| **Camera** | `attachCamera` (opt-in pan/zoom), `Camera`, `CameraOptions`, `PanFilter` |
+| **Serialization** | `layoutToJson` / `jsonToLayout`, `serializeLayout` / `deserializeLayout`, `SerializedLayout` — save and restore manual layout edits |
+| **Colors** | `themeToColors` — turn a Shumoku theme into a resolved color map |
+| **SVG coordinates** | `screenToSvg`, `svgToScreen`, `svgPointToContainer`, `svgRectToContainer`, `bezierEdgePath`, `bezierOffsetPath`, `computePortLabelPosition`, `getNodeLabel`, `getVlanStroke` |
+| **Overlays** | typed snippet hooks for custom node / link / port / subgraph rendering (`RendererOverlaySnippets`) |
+| **Static SVG** | `renderGraphToSvg`, `renderSvgString` — server-side / SSR fallback |
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/plugins/aruba-instant-on/README.md
+++ b/libs/plugins/aruba-instant-on/README.md
@@ -1,0 +1,40 @@
+# shumoku-plugin-aruba-instant-on
+
+[Aruba Instant On](https://www.arubainstanton.com/) data source plugin for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Pulls access points, switches, per-device metrics, and site alerts from the cloud portal.
+
+> Uses the **unofficial** `portal.arubainstanton.com` API. There is no published contract, so failures are deliberately loud to catch upstream changes early.
+
+## Capabilities
+
+| Capability | What it provides |
+|------------|------------------|
+| `hosts` | Access points and switches across the account's sites |
+| `metrics` | Per-device up/down (from the inventory snapshot) and per-port throughput |
+| `alerts` | Site-level alerts mapped to Shumoku's neutral severity scale |
+
+## Configuration
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `username` | string (email) | ✅ | — | Portal account email. **The account must not have MFA enabled** |
+| `password` | string (password) | ✅ | — | Portal password |
+| `siteId` | string | | _all_ | Restrict to one site. Blank polls every site the account can see |
+
+## Usage
+
+Bundled with [`apps/server`](../../../apps/server). To register elsewhere:
+
+```typescript
+import { register } from 'shumoku-plugin-aruba-instant-on'
+register(pluginRegistry)
+```
+
+## Exports
+
+`register(registry)`, `ArubaInstantOnPlugin`, and the type `ArubaInstantOnConfig`.
+
+Depends on [`@shumoku/core`](../../@shumoku/core). See [Plugin Authoring](../../../docs/plugin-authoring.md).
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/plugins/aruba-instant-on/package.json
+++ b/libs/plugins/aruba-instant-on/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
     "directory": "libs/plugins/aruba-instant-on"
   },
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },

--- a/libs/plugins/grafana/README.md
+++ b/libs/plugins/grafana/README.md
@@ -1,0 +1,39 @@
+# shumoku-plugin-grafana
+
+[Grafana](https://grafana.com/) data source plugin for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Surfaces Grafana alerts on your topology — either by **polling** the bundled Alertmanager, or by **receiving a webhook** push from a Grafana contact point.
+
+## Capabilities
+
+| Capability | What it provides |
+|------------|------------------|
+| `alerts` | Active / resolved alerts, with severity mapped to Shumoku's neutral scale |
+
+The descriptor declares `webhook: true`, so the host exposes a generic `/api/webhooks/:type/:id` endpoint (via `getConnectionInfo`) to point a Grafana contact point at.
+
+## Configuration
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `url` | string (uri) | ✅ | — | Grafana base URL |
+| `token` | string (password) | ✅ | — | API token |
+| `useWebhook` | boolean | | `false` | Receive alerts via webhook instead of polling |
+| `webhookSecret` | string (password) | | _auto_ | Shown when `useWebhook` is on. Leave blank to auto-generate on save |
+
+## Usage
+
+Bundled with [`apps/server`](../../../apps/server). To register elsewhere:
+
+```typescript
+import { register } from 'shumoku-plugin-grafana'
+register(pluginRegistry)
+```
+
+## Exports
+
+`register(registry)`, `GrafanaPlugin`, `isGrafanaWebhookPayload`, and the types `GrafanaPluginConfig`, `GrafanaWebhookPayload`, `GrafanaWebhookAlert`, `AlertStoreService`.
+
+Alert parsing and severity mapping reuse the shared Alertmanager helpers from [`@shumoku/core`](../../@shumoku/core)'s plugin kit, so Grafana and Prometheus alerts render identically. See [Plugin Authoring](../../../docs/plugin-authoring.md).
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/plugins/grafana/package.json
+++ b/libs/plugins/grafana/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
     "directory": "libs/plugins/grafana"
   },
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },

--- a/libs/plugins/netbox/README.md
+++ b/libs/plugins/netbox/README.md
@@ -1,0 +1,59 @@
+# shumoku-plugin-netbox
+
+[NetBox](https://netbox.dev/) data source plugin for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Builds topology from DCIM/IPAM — devices, virtual machines, interfaces, and cables — and lists hosts, with rich filtering by site, tag, role, and location.
+
+## Capabilities
+
+| Capability | What it provides |
+|------------|------------------|
+| `topology` | A `NetworkGraph` from devices + VMs + cables, grouped and with cross-location links |
+| `hosts` | Devices and virtual machines, with interface lookup |
+
+It also exposes dynamic candidates (sites, tags, roles) for the filter dropdowns via `getConfigOptions`.
+
+## Configuration
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `url` | string (uri) | ✅ | — | NetBox base URL |
+| `token` | string (password) | ✅ | — | API token |
+| `insecure` | boolean | | `false` | Skip TLS verification. Self-signed certs in trusted networks only |
+
+## Topology options
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `groupBy` | `tag` \| `site` \| `location` \| `prefix` \| `none` | `tag` | How to nest nodes |
+| `siteFilter` | string[] | — | Include only these sites (candidates from NetBox) |
+| `tagFilter` | string[] | — | Include only these tags |
+| `roleFilter` | string[] | — | Include only these device roles |
+| `excludeRoleFilter` | string[] | — | Exclude these roles |
+| `excludeTagFilter` | string[] | — | Exclude these tags |
+
+## Usage
+
+Bundled with [`apps/server`](../../../apps/server). To register elsewhere:
+
+```typescript
+import { register } from 'shumoku-plugin-netbox'
+register(pluginRegistry)
+```
+
+### As a library
+
+The NetBox API client and converters are exported for standalone use:
+
+```typescript
+import { NetBoxClient, convertToNetworkGraph, toYaml } from 'shumoku-plugin-netbox'
+
+const client = new NetBoxClient({ url: 'https://netbox.example.com', token })
+const graph = await convertToNetworkGraph(/* fetched devices + cables */)
+```
+
+Other exports: `NetBoxPlugin`, `convertToHierarchicalYaml`, `convertToNetworkGraphWithVMs`, mapping constants (`ROLE_TO_TYPE`, `CABLE_COLORS`, `CABLE_STYLES`, `DEFAULT_TAG_MAPPING`, `getVlanColor`, `convertSpeedToBandwidth`), and the full set of `NetBox*` response types.
+
+Depends on [`@shumoku/core`](../../@shumoku/core) and [`@shumoku/plugin-sdk`](../../@shumoku/plugin-sdk). See [Plugin Authoring](../../../docs/plugin-authoring.md).
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/plugins/netbox/package.json
+++ b/libs/plugins/netbox/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
     "directory": "libs/plugins/netbox"
   },
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },

--- a/libs/plugins/network-scan/README.md
+++ b/libs/plugins/network-scan/README.md
@@ -1,0 +1,40 @@
+# shumoku-plugin-network-scan
+
+Active network discovery plugin for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Seed-crawls a network over **SNMP** and **LLDP** — identifying devices (System-MIB), walking ports (IF-MIB), and harvesting neighbors (LLDP-MIB) — to discover topology with no upstream inventory at all.
+
+## Capability
+
+| Capability | What it provides |
+|------------|------------------|
+| `autoscan` | `scan(input) → Snapshot` — probes the targets and returns a discovered graph |
+
+> Unlike the inventory plugins, this implements **`autoscan`**, not `topology`. The host dispatches to `scan()` (a one-shot crawl that returns a `Snapshot` with `status`, `graph`, and `warnings`) rather than `fetchTopology()`.
+
+## Configuration
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `community` | string | `public` | SNMPv2c community used for every target |
+| `targets` | string[] | — | IPv4 addresses, hostnames, or CIDR blocks (e.g. `10.0.0.0/24`). CIDR is expanded and liveness-probed |
+| `timeoutMs` | number | `2000` | Per-device timeout (200–30000) |
+
+`instanceId` is intentionally **not** a config field — the server supplies it at construction. Per-target credential overrides arrive on the scan input, resolved from the server's policy chain.
+
+## Usage
+
+Bundled with [`apps/server`](../../../apps/server). To register elsewhere:
+
+```typescript
+import { register } from 'shumoku-plugin-network-scan'
+register(pluginRegistry)
+```
+
+## Exports
+
+`register(registry)`, `NetworkScanPlugin`, `spikeBunCompat`.
+
+Uses `net-snmp` for the SNMP transport and depends on [`@shumoku/core`](../../@shumoku/core). See [Plugin Authoring](../../../docs/plugin-authoring.md).
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/plugins/network-scan/package.json
+++ b/libs/plugins/network-scan/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
     "directory": "libs/plugins/network-scan"
   },
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },

--- a/libs/plugins/prometheus/README.md
+++ b/libs/plugins/prometheus/README.md
@@ -1,0 +1,46 @@
+# shumoku-plugin-prometheus
+
+[Prometheus](https://prometheus.io/) data source plugin for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Polls link and node metrics, discovers hosts from label values, and reads alerts from Alertmanager.
+
+## Capabilities
+
+| Capability | What it provides |
+|------------|------------------|
+| `metrics` | Node up/down and link traffic (interface counters via `rate(...[5m])`) |
+| `hosts` | Hosts discovered from a label (default `instance`), with their interfaces |
+| `alerts` | Active / resolved alerts from the Alertmanager API |
+
+## Configuration
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `url` | string (uri) | ✅ | — | Prometheus base URL |
+| `preset` | `snmp` \| `node_exporter` \| `custom` | ✅ | `snmp` | Which metric names to query |
+| `customMetrics` | object | when `preset=custom` | — | `inOctets`, `outOctets`, `interfaceLabel` (required), `upMetric` (optional) |
+| `hostLabel` | string | | `instance` | Label that identifies a host |
+| `jobFilter` | string | | — | Optional `job` label to restrict hosts |
+| `alertmanagerUrl` | string (uri) | | _Prometheus URL_ | Alertmanager endpoint |
+| `basicAuth` | object | | — | `username` / `password` |
+
+**Presets** — `snmp` uses `ifHCInOctets` / `ifHCOutOctets`; `node_exporter` uses `node_network_receive_bytes_total` / `node_network_transmit_bytes_total`; `custom` lets you name your own. Label values are escaped before being interpolated into PromQL selectors.
+
+## Usage
+
+Bundled with [`apps/server`](../../../apps/server). To register elsewhere:
+
+```typescript
+import { register } from 'shumoku-plugin-prometheus'
+register(pluginRegistry)
+```
+
+The host validates config against `configSchema` and renders the form generically — no per-plugin UI code.
+
+## Exports
+
+`register(registry)`, `PrometheusPlugin`, and the types `PrometheusPluginConfig`, `PrometheusCustomMetrics`, `PrometheusMetricPreset`, `PrometheusNodeMapping`, `PrometheusLinkMapping`.
+
+Depends on [`@shumoku/core`](../../@shumoku/core) and [`@shumoku/plugin-sdk`](../../@shumoku/plugin-sdk). See [Plugin Authoring](../../../docs/plugin-authoring.md).
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/plugins/prometheus/package.json
+++ b/libs/plugins/prometheus/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
     "directory": "libs/plugins/prometheus"
   },
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },

--- a/libs/plugins/zabbix/README.md
+++ b/libs/plugins/zabbix/README.md
@@ -1,0 +1,67 @@
+# shumoku-plugin-zabbix
+
+[Zabbix](https://www.zabbix.com/) data source plugin for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Pulls device inventory, interface traffic, LLDP-derived topology, and trigger events from a Zabbix server over its JSON-RPC API.
+
+## Capabilities
+
+| Capability | What it provides |
+|------------|------------------|
+| `topology` | Builds a `NetworkGraph` from hosts (nodes) + LLDP neighbor items (links), grouped by host group |
+| `hosts` | Lists Zabbix hosts with management IP, interfaces, and discoverable metrics |
+| `metrics` | Polls node health (ICMP ping / fresh item data / maintenance) and link traffic; stale data is reported as `unknown` |
+| `alerts` | Fetches trigger events, mapping Zabbix severities (0–5) into the neutral `AlertSeverity` scale |
+
+## Usage
+
+This plugin ships bundled with [`apps/server`](../../../apps/server). To use it elsewhere, register it into a Shumoku plugin registry — the registry then constructs an instance from validated config:
+
+```typescript
+import { register } from 'shumoku-plugin-zabbix'
+
+register(pluginRegistry) // exposes the descriptor below; the host validates config + builds the plugin
+```
+
+Each plugin self-describes via `registry.registerDescriptor({ type, displayName, capabilities, configSchema, optionsSchema }, factory)`. The server renders the config form generically from `configSchema` — there are no per-plugin branches.
+
+## Configuration
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `url` | string (uri) | ✅ | — | Zabbix base URL, e.g. `https://zabbix.example.com` |
+| `token` | string (password) | ✅ | — | API token |
+| `insecure` | boolean | | `false` | Skip TLS verification. Self-signed certs in trusted networks only |
+| `pollInterval` | number (ms) | | `60000` | One of 5s / 10s / 30s / 1m / 5m |
+
+## Topology options
+
+Per-attachment options (stored as the source's `optionsJson`, rendered on the Sources page). Topology is generated from hosts + LLDP neighbor items.
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `hostGroups` | string[] | _all_ | Only keep hosts in these host groups (by name). Candidates come from `getConfigOptions('hostgroup')` |
+| `groupBy` | `hostgroup` \| `none` | `hostgroup` | Nest each node under its most-specific host group, or emit a flat graph |
+| `groupExclude` | string[] | — | Drop hosts in these groups (admin / catch-all groups) |
+| `includeExternalNeighbors` | boolean | `true` | Add nodes for LLDP neighbors that are not Zabbix hosts, so their links still render |
+| `parentTag` | string | `PARENT` | Host-tag name whose value names an upstream device — draws a link where LLDP saw no neighbor. Empty to disable |
+
+## How it maps Zabbix → Shumoku
+
+Core types are the display contract; the plugin translates Zabbix vocabulary at the boundary:
+
+- **Severity** — Zabbix priorities `0–5` map to the neutral `critical | high | medium | low | info | ok` scale (shared severity helper, never Zabbix-flavored values).
+- **Health** — fresh ICMP ping wins; otherwise any fresh real device item (SNMP / Agent, excluding internal `zabbix[...]` keys); otherwise `unknown`. Link metrics older than ~5 min are treated as stale.
+- **Topology** — interface adjacencies come from per-interface LLDP-MIB items (`lldp.rem.sysname`, `lldp.rem.port.id`, `lldp.rem.chassisid`); `parentTag` provides a manual fallback link.
+
+## Exports
+
+| Export | Description |
+|--------|-------------|
+| `register(registry)` | Registers the descriptor + factory (entry point) |
+| `ZabbixPlugin` | The plugin class (advanced / direct use) |
+| `ZabbixHost`, `ZabbixItem`, `ZabbixPluginConfig` | Types |
+
+Depends on [`@shumoku/core`](../../@shumoku/core) (types + plugin kit) and [`@shumoku/plugin-sdk`](../../@shumoku/plugin-sdk) (HTTP client). See [Plugin Authoring](../../../docs/plugin-authoring.md) for the plugin contract.
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/plugins/zabbix/package.json
+++ b/libs/plugins/zabbix/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
     "directory": "libs/plugins/zabbix"
   },
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },

--- a/libs/shumoku/README.md
+++ b/libs/shumoku/README.md
@@ -1,0 +1,51 @@
+# shumoku
+
+[![npm version](https://img.shields.io/npm/v/shumoku.svg)](https://www.npmjs.com/package/shumoku)
+
+The all-in-one package for [Shumoku](https://github.com/konoe-akitoshi/shumoku) — network topology visualization for Markdown and the web. Re-exports [`@shumoku/core`](../@shumoku/core) (models, parser, layout, themes) plus the HTML renderer, so most apps only need this one dependency.
+
+## Install
+
+```bash
+npm install shumoku
+```
+
+## Quick start
+
+```typescript
+import { YamlParser, renderGraphToHtml } from 'shumoku'
+
+const { graph } = new YamlParser().parse(`
+name: Edge
+nodes:
+  - { id: rt-01, type: router, vendor: yamaha }
+  - { id: sw-01, type: l3-switch }
+links:
+  - from: { node: rt-01, port: lan1 }
+    to:   { node: sw-01, port: ge-0/0/0 }
+    bandwidth: 10G
+`)
+
+// Interactive HTML (pan / zoom / tooltips)
+const html = await renderGraphToHtml(graph, { title: 'Edge', toolbar: true })
+```
+
+## What you get
+
+- **Everything in `@shumoku/core`** — `YamlParser`, `HierarchicalParser`, `computeNetworkLayout`, models, `lightTheme` / `darkTheme`, the plugin kit, and plugin types.
+- **HTML rendering** — `renderGraphToHtml`, `renderHtml`, hierarchical variants, `initInteractive`, and the `INTERACTIVE_IIFE` bundle for embedding.
+- **SVG access** — the `svg` namespace re-exported from [`@shumoku/renderer-svg`](../@shumoku/renderer-svg) (`svg.renderGraphToSvg`, `svg.prepareRender`, …).
+
+Need standalone SVG or PNG output? Depend on the dedicated renderers directly:
+
+```typescript
+import { renderGraphToSvg } from '@shumoku/renderer-svg'
+import { renderGraphToPng } from '@shumoku/renderer-png' // Node.js only
+
+const svg = await renderGraphToSvg(graph)
+const png = await renderGraphToPng(graph, { scale: 2 })
+```
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/libs/shumoku/package.json
+++ b/libs/shumoku/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
     "directory": "libs/shumoku"
   },
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/konoe-akitoshi/shumoku.git"
   },
   "author": "konoe-akitoshi",
-  "homepage": "https://shumoku.packof.me/",
+  "homepage": "https://www.shumoku.dev/",
   "bugs": {
     "url": "https://github.com/konoe-akitoshi/shumoku/issues"
   },


### PR DESCRIPTION
Rewrite the root README from the actual current structure and add a README to every app, library, and plugin (17 components). Fix the broken/stale docs that referenced the removed class-based API.

- Root README: working npm example (`YamlParser().parse()` → `renderGraphToHtml`), accurate package table + repo layout, all six data-source integrations
- New per-package READMEs (cli, editor; shumoku, core, renderer-svg/html/png, renderer, catalog, plugin-sdk; zabbix, prometheus, netbox, grafana, aruba-instant-on, network-scan)
- Replace the generic Fumadocs template in apps/docs
- Fix dead-API examples in docs/getting-started, docs/netbox, docs/api-reference (drop `HierarchicalLayoutEngine`/`SvgRenderer`; `convertToShumoku` → `convertToNetworkGraph`)
- Update CONTRIBUTING structure; point package.json homepage fields at shumoku.dev

All code examples were verified against the current source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)