### PR TITLE
docs: refresh server READMEs + add directory indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Shumoku
 
 > [!IMPORTANT]
-> 製作者がcloudnativekaigi NOCに参加中です。サーバー系機能のreadmeが全体的に整備されていません。
+> 製作者がcloudnativekaigi NOCに参加中です。
 > 導入支援・技術サポートについてもお気軽にご相談ください。
 >
 > &ensp; 📧 &ensp;[contact@shumoku.dev](mailto:contact@shumoku.dev)
@@ -196,6 +196,8 @@ libs/
 docs/                Architecture, YAML reference, plugin authoring
 examples/            Sample YAML networks + a sample plugin
 ```
+
+Each top-level directory has its own index: [`apps/`](apps/README.md) · [`libs/`](libs/README.md) · [`examples/`](examples/README.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,19 @@ Shumoku is a monorepo with three ways to use it:
 
 ## Server
 
-The server is the full platform: a Bun + Hono API with an SQLite store and a SvelteKit web UI.
+The server is the full platform: a Bun + Hono API with an SQLite store and a SvelteKit web UI. It **runs from source** (not a published npm package).
 
-See the **[Server Setup Guide](apps/server/README.md)** for Docker, systemd, and manual deployment options.
+See the **[Server Setup Guide](apps/server/README.md)** for Docker, Kubernetes (Helm), systemd, and manual deployment.
 
 ```bash
-# Quick start with Docker
+# Docker (recommended)
 cd apps/server
-docker compose up -d            # http://localhost:8080
-DEMO_MODE=true docker compose up -d   # preload a sample network
+docker compose up -d                    # http://localhost:8080
+DEMO_MODE=true docker compose up -d     # preload a sample network
+
+# Or run from the repo root in dev mode (API :8080 + web UI :5173)
+bun install
+bun run dev:server
 ```
 
 What you can do:

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,20 @@
+# apps/
+
+End-user applications built on the Shumoku libraries.
+
+| App | Package | What it is |
+|-----|---------|-----------|
+| [`server`](server) | `@shumoku/server` | Real-time monitoring platform — Bun + Hono API with SQLite, and a SvelteKit web UI. Connect data sources, overlay live metrics, build dashboards, share read-only views. Split into [`api`](server/api) and [`web`](server/web). |
+| [`editor`](editor) | `@shumoku/editor` | Visual designer for **physical** topologies — devices / modules / cables as products, a diagram canvas, and a derived bill of materials. |
+| [`cli`](cli) | `@shumoku/cli` | `shumoku render` — turn a YAML/JSON `NetworkGraph` into SVG / HTML / PNG. |
+| [`docs`](docs) | `@shumoku/docs` | The documentation site at [shumoku.dev](https://www.shumoku.dev) (Next.js + Fumadocs, bilingual EN/JA). |
+
+Each app has its own README with setup and usage. Most run from the repo root via Turborepo:
+
+```bash
+bun install
+bun run dev            # every app in dev mode
+bun run dev:server     # just the server (API :8080 + web UI :5173)
+```
+
+See the root [README](../README.md) and [CONTRIBUTING](../CONTRIBUTING.md).

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -4,17 +4,18 @@ Command-line renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). 
 
 ## Install
 
-No install needed — run it with `npx`:
+Run it with `npx` (no install):
 
 ```bash
 npx shumoku render network.yaml -o diagram.svg
 ```
 
-Or install globally:
+Or, from a clone of this monorepo, build and run the source:
 
 ```bash
-npm install -g @shumoku/cli
-shumoku render network.yaml -o diagram.svg
+cd apps/cli
+bun run build
+node dist/shumoku.js render network.yaml -o diagram.svg
 ```
 
 ## Usage

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,160 +1,126 @@
 # @shumoku/server
 
-Real-time network topology visualization server with Zabbix integration for Shumoku.
+Real-time network topology visualization and monitoring server for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Connect data sources, overlay live metrics and alerts on your diagrams, build dashboards, and share read-only views.
+
+A **Bun + [Hono](https://hono.dev)** API with an SQLite store and a **SvelteKit** web UI, split into two workspaces:
+
+- [`api/`](api) — `@shumoku/server-api`: HTTP + WebSocket, SQLite, the data-source plugin loader
+- [`web/`](web) — `@shumoku/server-web`: SvelteKit single-page UI
+
+> The server **runs from source** — it is not a published npm package. Use Docker, the workspace dev scripts, or a build (below).
 
 ## Features
 
-- **Web UI Configuration**: Grafana-like interface for managing data sources and topologies
-- **Real-time Metrics**: WebSocket-based live updates for link utilization and node status
-- **Weathermap Visualization**: Color-coded links based on traffic utilization
-- **Zabbix Integration**: Pull metrics from Zabbix monitoring system
-- **Docker Ready**: Single container deployment with SQLite persistence
-- **Interactive Diagrams**: Pan, zoom, and explore network topologies
+- **Multi-source** — Zabbix, Prometheus, NetBox, Grafana, Aruba Instant On, and SNMP/LLDP network discovery
+- **Real-time metrics** — WebSocket live updates for link utilization and node status
+- **Weathermap** — links color-coded by traffic load
+- **Dashboards** — gridstack widget layouts combining topologies and metrics
+- **Shareable links** — token-gated, read-only public views (no login)
+- **Interactive diagrams** — pan, zoom, drill-in
+- **Docker-ready** — single container with SQLite persistence
 
-## Quick Start
+## Quick start
 
-### Option 1: Docker (Recommended)
-
-```bash
-cd apps/server
-docker compose up -d
-
-# Use port 80 (for production)
-SHUMOKU_PORT=80 docker compose up -d
-
-# With sample network for demo
-DEMO_MODE=true docker compose up -d
-```
-
-### Option 2: Local (Bun)
+### Option 1 — Docker (recommended)
 
 ```bash
 cd apps/server
-
-# Setup (first time only)
-make setup
-
-# Start server
-make dev
-
-# With sample network for demo
-DEMO_MODE=true make dev
+docker compose up -d                    # http://localhost:8080
+SHUMOKU_PORT=80 docker compose up -d    # production port
+DEMO_MODE=true docker compose up -d     # preload a sample network
 ```
 
-Open http://localhost:8080 to access the Web UI.
-
-## Available Commands
+### Option 2 — From the repo root (Bun, dev)
 
 ```bash
-make setup      # Initial setup (install deps & build)
-make dev        # Start development server
-make start      # Start production server
-make docker     # Start with Docker Compose
-make help       # Show all commands
+bun install
+bun run dev:server     # turbo: API (:8080) + web UI (:5173, HMR)
 ```
 
-## Development
-
-For development with hot reload:
+### Option 3 — From apps/server (Bun)
 
 ```bash
 cd apps/server
-bun run dev    # Start API + Web UI together
+make setup     # first run: install deps + build
+make dev       # dev server (or: bun run dev)
+make start     # production (or: bun run start)
+make help      # list all targets
 ```
 
-Access http://localhost:5173 for development (HMR enabled).
-API is proxied to http://localhost:8080.
+Web UI: **http://localhost:8080** (prod) or **http://localhost:5173** (dev — proxies `/api` and `/ws` to `:8080`).
 
-## Data Persistence
+## Data sources
 
-All configuration is stored in SQLite and managed via the Web UI:
+Configured entirely from the web UI — forms render generically from each plugin's schema (no per-plugin UI code). Bundled plugins (see each one's README under [`libs/plugins`](../../libs/plugins)):
 
-- **Data Sources**: Configure Zabbix API connections
-- **Topologies**: Upload and manage network topology YAML files
-- **Settings**: Application-wide configuration
-
-Data is persisted in `/data/shumoku.db` (Docker volume: `shumoku-data`).
+| Source | Pulls |
+|--------|-------|
+| **Zabbix** | metrics, hosts, LLDP topology, alerts |
+| **Prometheus** | metrics, hosts, alerts (Alertmanager) |
+| **NetBox** | topology, hosts |
+| **Grafana** | alerts (webhook or Alertmanager) |
+| **Aruba Instant On** | hosts, metrics, alerts |
+| **Network discovery** | SNMP + LLDP seed-crawl (autoscan) |
 
 ## Web UI
 
-### Pages
-
 | Path | Description |
 |------|-------------|
-| `/` | Home - Dashboard overview |
-| `/topologies` | Topology list and management |
-| `/topologies/:id` | Topology viewer with live metrics |
-| `/datasources` | Data source (Zabbix) configuration |
+| `/` | Home / overview |
+| `/topologies`, `/topologies/:id` | Topology list and live viewer |
+| `/dashboards` | Custom widget dashboards |
+| `/datasources` | Data source configuration |
+| `/plugins` | Installed plugins |
 | `/settings` | Application settings |
-
-### Managing Data Sources
-
-1. Navigate to **Data Sources** in the sidebar
-2. Click **Add Data Source**
-3. Enter Zabbix server URL and API token
-4. Click **Test Connection** to verify
-5. Save the configuration
-
-### Managing Topologies
-
-1. Navigate to **Topologies** in the sidebar
-2. Click **Add Topology**
-3. Upload a YAML topology file or paste YAML content
-4. Optionally link to a data source for live metrics
-5. Configure Zabbix mapping for nodes and links
+| `/share/:token` | Public, read-only shared view |
+| `/login` | Authentication |
 
 ## API
 
-### HTTP Endpoints
+Base path `/api`. (`/api/auth` and `/api/share` are public; everything else requires a session.)
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/datasources` | GET | List all data sources |
-| `/api/datasources` | POST | Create data source |
-| `/api/datasources/:id` | GET | Get data source details |
-| `/api/datasources/:id` | PUT | Update data source |
-| `/api/datasources/:id` | DELETE | Delete data source |
-| `/api/datasources/:id/test` | POST | Test connection |
-| `/api/topologies` | GET | List all topologies |
-| `/api/topologies` | POST | Create topology |
-| `/api/topologies/:id` | GET | Get topology details |
-| `/api/topologies/:id` | PUT | Update topology |
-| `/api/topologies/:id` | DELETE | Delete topology |
-| `/api/topologies/:id/render` | GET | Get rendered SVG |
-| `/api/health` | GET | Health check |
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/health` | Health check |
+| `/api/auth/*` | Authentication |
+| `/api/datasources`, `/:id/test`, `/:id/scan` | Data source CRUD, connection test, discovery scan |
+| `/api/plugins` | Plugin registry |
+| `/api/topologies`, `/:id/render` | Topology CRUD and SVG/HTML render |
+| `/api/topologies/:id/sources` | Data sources linked to a topology |
+| `/api/topologies/:id/observations`, `/resolved` | Observation history and resolved graph |
+| `/api/topologies/:id/discovery-policy` | Network discovery rules |
+| `/api/dashboards` | Dashboard CRUD |
+| `/api/settings` | Application settings |
+| `/api/webhooks` | Inbound webhooks (e.g. Grafana alerts) |
+| `/api/share/*` | Public shared topology / dashboard views |
+| `GET /api/runtime.js` | Interactive render runtime (IIFE) for the browser |
+| `/ws` | WebSocket — real-time metrics stream |
 
 ### WebSocket
 
 Connect to `ws://<host>/ws` for real-time metrics.
 
-**Client Messages:**
+**Client → server:**
 
 ```javascript
-// Subscribe to topology updates
 { "type": "subscribe", "topology": "<topology-id>" }
-
-// Filter specific nodes/links
 { "type": "filter", "nodes": ["router1"], "links": ["link-0"] }
 ```
 
-**Server Messages:**
+**Server → client:**
 
 ```javascript
 {
   "type": "metrics",
   "data": {
-    "nodes": {
-      "router1": { "status": "up" }
-    },
-    "links": {
-      "link-0": { "status": "up", "utilization": 45.2 }
-    },
+    "nodes": { "router1": { "status": "up" } },
+    "links": { "link-0": { "status": "up", "utilization": 45.2 } },
     "timestamp": 1705849200000
   }
 }
 ```
 
-## Topology YAML Format
+## Topology YAML
 
 ```yaml
 name: My Network
@@ -164,176 +130,37 @@ nodes:
     type: router
   - id: switch1
     label: Distribution Switch
-    type: switch
-  - id: server1
-    label: Web Server
-    type: server
+    type: l2-switch
 links:
   - from: router1
     to: switch1
     bandwidth: 10G
-  - from: switch1
-    to: server1
-    bandwidth: 1G
 ```
 
-## Environment Variables
+See the [YAML Reference](https://www.shumoku.dev/docs/npm/yaml-reference) for the full format.
+
+## Environment variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `PORT` | Server port | 8080 |
-| `HOST` | Bind address | 0.0.0.0 |
-| `DATA_DIR` | Data directory for SQLite | /data |
-| `SHUMOKU_PORT` | External port (Docker Compose) | 8080 |
-| `DEMO_MODE` | Load sample network on empty DB (`true`/`false`) | `false` |
+| `PORT` | Server port | `8080` |
+| `HOST` | Bind address | `0.0.0.0` |
+| `DATA_DIR` | SQLite data directory | `/data` |
+| `SHUMOKU_PORT` | External port (Docker Compose) | `8080` |
+| `DEMO_MODE` | Load the sample network on an empty DB (`true`/`false`) | `false` |
 
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                      Browser (SPA)                          │
-│  ┌─────────┐  ┌─────────────────────────────────────────┐  │
-│  │ Sidebar │  │  Main Content (Topology / Settings)     │  │
-│  └─────────┘  └─────────────────────────────────────────┘  │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                    HTTP / WebSocket
-                              │
-┌─────────────────────────────────────────────────────────────┐
-│                   Shumoku Server (Bun)                      │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐      │
-│  │  API Routes  │  │  WebSocket   │  │ Static Files │      │
-│  │   /api/*     │  │    /ws       │  │  /assets/*   │      │
-│  └──────────────┘  └──────────────┘  └──────────────┘      │
-│         │                                                   │
-│  ┌──────────────────────────────────────────────────────┐  │
-│  │  Services (DataSource, Topology, Metrics)            │  │
-│  └──────────────────────────────────────────────────────┘  │
-│         │                                                   │
-│  ┌──────────────┐  ┌──────────────┐                        │
-│  │   SQLite     │  │  Zabbix API  │                        │
-│  │   /data/     │  │  (External)  │                        │
-│  └──────────────┘  └──────────────┘                        │
-└─────────────────────────────────────────────────────────────┘
-```
+Configuration is otherwise stored in SQLite (`$DATA_DIR/shumoku.db`) and managed from the web UI.
 
 ## Deployment
 
-### Option 1: Docker (Recommended)
+### Docker (recommended)
 
 ```bash
 cd apps/server
 docker compose up -d
 ```
 
-Data is persisted in Docker volume `shumoku-data`.
-
-### Option 2: Systemd (Linux)
-
-#### Prerequisites
-
-- [Bun](https://bun.sh) runtime installed
-- Git
-
-#### Installation
-
-```bash
-# Clone repository
-git clone https://github.com/konoe-akitoshi/shumoku.git /opt/shumoku
-cd /opt/shumoku/apps/server
-
-# Setup (install dependencies and build)
-make setup
-
-# Create data directory
-sudo mkdir -p /var/lib/shumoku
-sudo chown shumoku:shumoku /var/lib/shumoku
-
-# Install systemd service
-sudo cp scripts/shumoku.service /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable shumoku
-sudo systemctl start shumoku
-```
-
-#### Service Management
-
-```bash
-# Status
-sudo systemctl status shumoku
-
-# Logs
-sudo journalctl -u shumoku -f
-
-# Restart
-sudo systemctl restart shumoku
-
-# Stop
-sudo systemctl stop shumoku
-```
-
-#### Update
-
-```bash
-cd /opt/shumoku
-git pull
-cd apps/server
-make setup
-sudo systemctl restart shumoku
-```
-
-### Option 3: Manual
-
-```bash
-cd apps/server
-
-# Setup (first time)
-make setup
-
-# Start (foreground)
-make start
-
-# Or with custom settings
-DATA_DIR=/path/to/data PORT=8080 bun dist/index.js
-```
-
-### Reverse Proxy (nginx)
-
-```nginx
-server {
-    listen 80;
-    server_name shumoku.example.com;
-
-    location / {
-        proxy_pass http://127.0.0.1:8080;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
-}
-```
-
-### Backup & Restore
-
-```bash
-# Backup (Docker)
-docker compose cp shumoku:/data/shumoku.db ./backup.db
-
-# Backup (Systemd)
-cp /var/lib/shumoku/shumoku.db ./backup.db
-
-# Restore
-cp ./backup.db /var/lib/shumoku/shumoku.db
-sudo systemctl restart shumoku
-```
-
----
-
-## Docker Compose
-
-The `compose.yaml` provides a production-ready configuration:
+`compose.yaml` builds from the monorepo root and persists data in the `shumoku-data` volume:
 
 ```yaml
 services:
@@ -351,28 +178,77 @@ volumes:
   shumoku-data:
 ```
 
-### Commands
+```bash
+docker compose up -d            # start
+docker compose down             # stop
+docker compose logs -f          # logs
+docker compose up -d --build    # rebuild after code changes
+```
+
+### Kubernetes (Helm)
+
+A Helm chart is provided under [`chart/shumoku`](chart/shumoku):
 
 ```bash
-# Start
-docker compose up -d
+helm install shumoku ./chart/shumoku
+```
 
-# Stop
-docker compose down
+### Systemd (Linux)
 
-# View logs
-docker compose logs -f
+Requires [Bun](https://bun.sh) and Git.
 
-# Rebuild after code changes
-docker compose up -d --build
+```bash
+git clone https://github.com/konoe-akitoshi/shumoku.git /opt/shumoku
+cd /opt/shumoku/apps/server
+make setup
 
-# Backup database
-docker compose cp shumoku:/data/shumoku.db ./backup.db
+sudo mkdir -p /var/lib/shumoku
+sudo chown shumoku:shumoku /var/lib/shumoku
 
-# Restore database
-docker compose cp ./backup.db shumoku:/data/shumoku.db
+sudo cp scripts/shumoku.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now shumoku
+```
+
+Manage with `systemctl status|restart|stop shumoku` and `journalctl -u shumoku -f`. To update: `git pull && make setup && sudo systemctl restart shumoku`.
+
+### Manual
+
+```bash
+cd apps/server
+make setup
+make start                                  # or: DATA_DIR=/path PORT=8080 bun dist/index.js
+```
+
+### Reverse proxy (nginx)
+
+```nginx
+server {
+    listen 80;
+    server_name shumoku.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+### Backup & restore
+
+```bash
+# Docker
+docker compose cp shumoku:/data/shumoku.db ./backup.db    # backup
+docker compose cp ./backup.db shumoku:/data/shumoku.db    # restore
+
+# Systemd
+cp /var/lib/shumoku/shumoku.db ./backup.db
 ```
 
 ## License
 
-MIT
+AGPL-3.0-only — part of the [Shumoku](https://github.com/konoe-akitoshi/shumoku) monorepo. For commercial licensing, contact contact@shumoku.dev.

--- a/apps/server/api/README.md
+++ b/apps/server/api/README.md
@@ -1,0 +1,36 @@
+# @shumoku/server-api
+
+HTTP + WebSocket API for the Shumoku [server](../README.md). Bun + [Hono](https://hono.dev), with an SQLite store and the data-source plugin loader. In production it also serves the built [web UI](../web).
+
+## Run
+
+From the repo root (recommended — starts API + web together):
+
+```bash
+bun run dev:server
+```
+
+Or just the API, from here:
+
+```bash
+cd apps/server/api
+bun run dev      # NODE_ENV=development bun --watch src/index.ts  → :8080
+bun run start    # production
+bun run build
+```
+
+Scripts: `dev`, `start`, `build`, `typecheck`, `lint`, `format`, and tests (`test`, `test:unit`, `test:db`).
+
+## Layout
+
+- `src/index.ts` — entry point
+- `src/server.ts` — Hono app: static serving, health checker, WebSocket
+- `src/api/*` — route modules: `auth`, `share`, `datasources` (+ `scan`), `plugins`, `topologies` (+ `sources`, `observations`, `resolved`, `discovery-policy`), `dashboards`, `settings`, `webhooks`, and `runtime.js`
+- `src/plugins/loader.ts` — discovers bundled plugins and calls each one's `register(pluginRegistry)`
+- `src/config.ts` — reads `PORT` / `HOST` / `DATA_DIR`; SQLite lives at `$DATA_DIR/shumoku.db` (default `/data`)
+
+See the [server README](../README.md) for the full endpoint list, environment variables, and deployment.
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/apps/server/web/README.md
+++ b/apps/server/web/README.md
@@ -1,0 +1,36 @@
+# @shumoku/server-web
+
+SvelteKit web UI for the Shumoku [server](../README.md) — topology viewer with live metrics, dashboards, data-source configuration, and shareable read-only views.
+
+## Run
+
+From the repo root (recommended — brings up the API first, then this):
+
+```bash
+bun run dev:server
+```
+
+Or just the web UI, from here (needs the API running on `:8080`):
+
+```bash
+cd apps/server/web
+bun run dev       # Vite dev server on :5173 — proxies /api and /ws → :8080
+bun run build
+bun run preview
+```
+
+Scripts: `dev`, `build`, `preview`, `typecheck`, `check`, `lint`, `format`, `test`.
+
+## Stack
+
+Svelte 5 + SvelteKit, Vite, Tailwind CSS, [gridstack](https://gridstackjs.com) (dashboard grid), and bits-ui. Diagram rendering and interaction reuse the shared engine in [`@shumoku/renderer`](../../../libs/@shumoku/renderer).
+
+## Pages
+
+`src/routes/(app)`: home, `topologies`, `dashboards`, `datasources`, `plugins`, `settings`. Plus top-level `login` and `share/:token` (public, token-gated).
+
+In production the built output is served by [`@shumoku/server-api`](../api) on the same port (`8080`).
+
+## License
+
+AGPL-3.0-only. For commercial licensing, contact contact@shumoku.dev.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,20 @@
+# examples/
+
+Sample `NetworkGraph` YAML files and a sample plugin. Render any of them with the CLI:
+
+```bash
+npx shumoku render examples/full-featured.yaml -o diagram.svg
+```
+
+| File | Shows |
+|------|-------|
+| [`full-featured.yaml`](full-featured.yaml) | A broad feature showcase |
+| [`device-status.yaml`](device-status.yaml) | Per-device status visualization |
+| [`enterprise-ogp.yaml`](enterprise-ogp.yaml) | A realistic enterprise network |
+| [`location-based.yaml`](location-based.yaml) | Grouping nodes by location |
+| [`prefix-subgraph.yaml`](prefix-subgraph.yaml) | Grouping by IP prefix / subnet |
+| [`netbox-enhanced.yaml`](netbox-enhanced.yaml) | A NetBox-derived topology |
+
+[`sample-plugin/`](sample-plugin) is a minimal external data-source plugin (`sample-hosts`) — see its [README](sample-plugin/README.md).
+
+See the [YAML Reference](https://www.shumoku.dev/docs/npm/yaml-reference) for the full format.

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,0 +1,31 @@
+# libs/
+
+The Shumoku libraries — the rendering engine, its supporting packages, and the data-source plugins.
+
+## Core engine & renderers
+
+| Package | What it is |
+|---------|-----------|
+| [`shumoku`](shumoku) | All-in-one — re-exports core + the SVG/HTML renderers. Start here. |
+| [`@shumoku/core`](@shumoku/core) | Models, YAML parser, layout engine, themes, plugin kit. Browser-safe and render-agnostic. |
+| [`@shumoku/renderer-svg`](@shumoku/renderer-svg) | SVG render pipeline (`prepareRender` → `renderSvg`). |
+| [`@shumoku/renderer-html`](@shumoku/renderer-html) | Interactive HTML output. |
+| [`@shumoku/renderer-png`](@shumoku/renderer-png) | PNG output (Node.js, via resvg). |
+| [`@shumoku/renderer`](@shumoku/renderer) | Svelte interactive renderer (pan/zoom, serialization) — used by the editor and the server web UI. |
+| [`@shumoku/catalog`](@shumoku/catalog) | Device / service catalog (vendor, model, SNMP sysObjectID). |
+| [`@shumoku/plugin-sdk`](@shumoku/plugin-sdk) | Node HTTP client + pagination for data-source plugins. |
+
+## Data-source plugins
+
+[`plugins/`](plugins) — each implements `DataSourcePlugin` and translates its upstream vocabulary into core's neutral types at the boundary:
+
+| Plugin | Capabilities |
+|--------|--------------|
+| [`zabbix`](plugins/zabbix) | metrics, hosts, topology, alerts |
+| [`prometheus`](plugins/prometheus) | metrics, hosts, alerts |
+| [`netbox`](plugins/netbox) | topology, hosts |
+| [`grafana`](plugins/grafana) | alerts |
+| [`aruba-instant-on`](plugins/aruba-instant-on) | hosts, metrics, alerts |
+| [`network-scan`](plugins/network-scan) | autoscan (SNMP / LLDP discovery) |
+
+See [Plugin Authoring](../docs/plugin-authoring.md) to write your own.


### PR DESCRIPTION
Follow-up to #491. Refreshes the server docs (untouched in #491) and adds directory-level index READMEs.

### Server
- `apps/server/README`: fix license **MIT → AGPL-3.0**; replace the Zabbix-only framing with all six data sources; update the API + web-page tables to the current routes; organize launch methods (Docker / `bun run dev:server` / `make`); add the Helm deploy option
- New `apps/server/api` and `apps/server/web` READMEs
- Root README: add `bun run dev:server` and note the server runs from source

### Directory indexes
- New `apps/`, `libs/`, `examples/` index READMEs, linked from the root README

### Other
- `apps/cli` README: drop the broken global-install of the private `@shumoku/cli`; add a from-source invocation
- Root README: drop the now-stale "server READMEs not maintained" banner line

All commands/routes verified against source.

> Note: `npx shumoku render` is documented in the root README and the docs site, but no published package currently exposes a `shumoku` bin (`@shumoku/cli` is private, `shumoku` has `bin: null`). Flagged for a separate packaging fix — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)