### PR TITLE
docs(server): document the published Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,18 @@ Shumoku is a monorepo with three ways to use it:
 
 ## Server
 
-The server is the full platform: a Bun + Hono API with an SQLite store and a SvelteKit web UI. It **runs from source** (not a published npm package).
+The server is the full platform: a Bun + Hono API with an SQLite store and a SvelteKit web UI. Run it from the **published Docker image**, or build from source.
 
 See the **[Server Setup Guide](apps/server/README.md)** for Docker, Kubernetes (Helm), systemd, and manual deployment.
 
 ```bash
-# Docker (recommended)
-cd apps/server
-docker compose up -d                    # http://localhost:8080
-DEMO_MODE=true docker compose up -d     # preload a sample network
+# Published Docker image (quickest)
+docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/konoe-akitoshi/shumoku:latest
+# → http://localhost:8080   (add `-e DEMO_MODE=true` to preload a sample network)
 
-# Or run from the repo root in dev mode (API :8080 + web UI :5173)
-bun install
-bun run dev:server
+# Or build from source / run in dev (API :8080 + web UI :5173)
+cd apps/server && docker compose up -d
+bun run dev:server     # from the repo root
 ```
 
 What you can do:

--- a/apps/docs/content/docs/server/installation.en.mdx
+++ b/apps/docs/content/docs/server/installation.en.mdx
@@ -5,6 +5,17 @@ description: Deploy Shumoku Server with Docker, systemd, or manually
 
 ## Docker (Recommended)
 
+The quickest way — pull the published image, no clone required:
+
+```bash
+docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/konoe-akitoshi/shumoku:latest
+# → http://localhost:8080   (add `-e DEMO_MODE=true` to preload a sample network)
+```
+
+Tags: `latest` (built from `main`), plus `X.Y.Z` and `X.Y` for releases — see the [container package](https://github.com/konoe-akitoshi/shumoku/pkgs/container/shumoku).
+
+Or build from source with Compose:
+
 ```bash
 git clone https://github.com/konoe-akitoshi/shumoku.git
 cd shumoku/apps/server

--- a/apps/docs/content/docs/server/installation.ja.mdx
+++ b/apps/docs/content/docs/server/installation.ja.mdx
@@ -5,6 +5,17 @@ description: Docker、systemd、手動で Shumoku Server をデプロイ
 
 ## Docker（推奨）
 
+最も簡単な方法 — 公開イメージを取得するだけ（clone 不要）:
+
+```bash
+docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/konoe-akitoshi/shumoku:latest
+# → http://localhost:8080   （`-e DEMO_MODE=true` でサンプルネットワークを投入）
+```
+
+タグ: `latest`（`main` からビルド）、リリースは `X.Y.Z` / `X.Y` — [コンテナパッケージ](https://github.com/konoe-akitoshi/shumoku/pkgs/container/shumoku)を参照。
+
+ソースからビルドする場合は Compose:
+
 ```bash
 git clone https://github.com/konoe-akitoshi/shumoku.git
 cd shumoku/apps/server

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -21,7 +21,21 @@ A **Bun + [Hono](https://hono.dev)** API with an SQLite store and a **SvelteKit*
 
 ## Quick start
 
-### Option 1 — Docker (recommended)
+### Docker image (quickest — no clone)
+
+Pull the published image from GitHub Container Registry:
+
+```bash
+docker run -d -p 8080:8080 -v shumoku-data:/data \
+  ghcr.io/konoe-akitoshi/shumoku:latest          # http://localhost:8080
+
+# preload a sample network:
+docker run -d -p 8080:8080 -e DEMO_MODE=true ghcr.io/konoe-akitoshi/shumoku:latest
+```
+
+Tags: `latest` (built from `main`), plus `X.Y.Z` and `X.Y` for tagged releases — see the [container package](https://github.com/konoe-akitoshi/shumoku/pkgs/container/shumoku).
+
+### Docker Compose (build from source)
 
 ```bash
 cd apps/server
@@ -30,14 +44,14 @@ SHUMOKU_PORT=80 docker compose up -d    # production port
 DEMO_MODE=true docker compose up -d     # preload a sample network
 ```
 
-### Option 2 — From the repo root (Bun, dev)
+### From the repo root (Bun, dev)
 
 ```bash
 bun install
 bun run dev:server     # turbo: API (:8080) + web UI (:5173, HMR)
 ```
 
-### Option 3 — From apps/server (Bun)
+### From apps/server (Bun)
 
 ```bash
 cd apps/server
@@ -154,6 +168,8 @@ Configuration is otherwise stored in SQLite (`$DATA_DIR/shumoku.db`) and managed
 ## Deployment
 
 ### Docker (recommended)
+
+Use the [published image](https://github.com/konoe-akitoshi/shumoku/pkgs/container/shumoku) (`ghcr.io/konoe-akitoshi/shumoku`), or build from source with Compose:
 
 ```bash
 cd apps/server


### PR DESCRIPTION
The server ships as a container image (`ghcr.io/konoe-akitoshi/shumoku`), but the READMEs only documented building from source with Compose. This adds the `docker run` path.

- `apps/server/README`: lead the Quick start with the published image (`docker run … ghcr.io/konoe-akitoshi/shumoku:latest`), document the tag scheme (`latest` + `X.Y.Z` / `X.Y`), link the container package, and note it under Deployment
- Root README: the Server section now leads with the published Docker image and drops the misleading "runs from source" wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)