### PR TITLE
chore: independent per-product release streams

### DIFF
--- a/.changeset/bright-cli-release.md
+++ b/.changeset/bright-cli-release.md
@@ -1,0 +1,5 @@
+---
+"@shumoku/cli": patch
+---
+
+Publish the Shumoku command-line renderer as the public `@shumoku/cli` npm package.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,9 +3,17 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [["@shumoku/*"]],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "snapshot": {
+    "useCalculatedVersion": false,
+    "prereleaseTemplate": "{tag}-{datetime}"
+  },
+  "privatePackages": {
+    "version": false,
+    "tag": false
+  },
   "ignore": []
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Verify product versions
+        run: bun run version:products:check
+
       - name: Lint+Format
         run: bunx biome check .
 
@@ -122,3 +125,28 @@ jobs:
 
       - name: Unused code detection (knip)
         run: bun run knip
+
+  # Fail a PR that changes a published package (libs/@shumoku/* or apps/cli)
+  # without declaring a release intent. Escape hatch for non-release changes
+  # (tests, internal refactors): `bun x changeset add --empty`.
+  changeset:
+    # Skip the release PR itself (changeset-release/*): it has consumed all
+    # changesets and bumped versions, which this check would otherwise flag.
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'changeset-release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+          cache: true
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Require a changeset for published-package changes
+        run: bun x changeset status --since=origin/${{ github.base_ref }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     branches: [main]
-    tags: ['v*']
+    tags: ['server-v*.*.*']
   pull_request:
     branches: [main]
 
@@ -24,7 +24,43 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Resolve build information
+        id: build
+        shell: bash
+        run: |
+          echo "version=$(node -p "require('./apps/server/package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "built_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_REF" == refs/tags/server-v* ]]; then
+            if [[ "$GITHUB_REF_NAME" == *-beta.* ]]; then
+              echo "channel=beta" >> "$GITHUB_OUTPUT"
+            else
+              echo "channel=stable" >> "$GITHUB_OUTPUT"
+            fi
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "channel=development" >> "$GITHUB_OUTPUT"
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify release version
+        if: steps.build.outputs.release == 'true'
+        shell: bash
+        run: |
+          package_version="${{ steps.build.outputs.version }}"
+          tag_version="${GITHUB_REF_NAME#server-v}"
+
+          if [[ ! "$tag_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$ ]]; then
+            echo "::error::Server release tags must use server-vX.Y.Z or server-vX.Y.Z-beta.N"
+            exit 1
+          fi
+
+          if [[ "$tag_version" != "$package_version" ]]; then
+            echo "::error::Tag server-v${tag_version} does not match @shumoku/server ${package_version}"
+            exit 1
+          fi
+
       - name: Log in to Container Registry
+        if: steps.build.outputs.release == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -36,20 +72,55 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,enable={{is_default_branch}}
-            type=ref,event=pr
+            type=raw,value=${{ steps.build.outputs.version }},enable=${{ steps.build.outputs.release == 'true' }}
+            type=raw,value=latest,enable=${{ steps.build.outputs.channel == 'stable' }}
+            type=raw,value=beta,enable=${{ steps.build.outputs.channel == 'beta' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/server/Dockerfile
-          push: true
+          push: ${{ steps.build.outputs.release == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SHUMOKU_VERSION=${{ steps.build.outputs.version }}
+            SHUMOKU_COMMIT=${{ github.sha }}
+            SHUMOKU_BUILD_DATE=${{ steps.build.outputs.built_at }}
+            SHUMOKU_CHANNEL=${{ steps.build.outputs.channel }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/server-v')
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create GitHub Release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "GitHub Release $GITHUB_REF_NAME already exists"
+          elif [[ "$GITHUB_REF_NAME" == *-beta.* ]]; then
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --generate-notes \
+              --prerelease \
+              --title "Shumoku Server ${GITHUB_REF_NAME#server-v}"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --generate-notes \
+              --latest \
+              --title "Shumoku Server ${GITHUB_REF_NAME#server-v}"
+          fi

--- a/.github/workflows/editor.yml
+++ b/.github/workflows/editor.yml
@@ -1,0 +1,52 @@
+name: Editor Release
+
+on:
+  push:
+    tags: ['editor-v*.*.*']
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify release version
+        shell: bash
+        run: |
+          package_version="$(node -p "require('./apps/editor/package.json').version")"
+          tag_version="${GITHUB_REF_NAME#editor-v}"
+
+          if [[ ! "$tag_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$ ]]; then
+            echo "::error::Editor release tags must use editor-vX.Y.Z or editor-vX.Y.Z-beta.N"
+            exit 1
+          fi
+
+          if [[ "$tag_version" != "$package_version" ]]; then
+            echo "::error::Tag editor-v${tag_version} does not match @shumoku/editor ${package_version}"
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "GitHub Release $GITHUB_REF_NAME already exists"
+          elif [[ "$GITHUB_REF_NAME" == *-beta.* ]]; then
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --generate-notes \
+              --prerelease \
+              --title "Shumoku Editor ${GITHUB_REF_NAME#editor-v}"
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --generate-notes \
+              --latest=false \
+              --title "Shumoku Editor ${GITHUB_REF_NAME#editor-v}"
+          fi

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,50 @@
+name: Release npm Beta
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: npm-beta-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+          cache: true
+
+      - name: Setup npm registry
+        uses: actions/setup-node@v4
+        with:
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify pending changesets
+        run: bun x changeset status
+
+      - name: Create snapshot versions
+        run: bun x changeset version --snapshot beta
+
+      - name: Build packages
+        run: bun run build:packages
+
+      - name: Publish beta packages
+        run: bun x changeset publish --tag beta --no-git-tag
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build packages
-        run: bun run build --filter='./libs/**'
+        run: bun run build:packages
 
       - name: Create Release Pull Request or Publish
         id: changesets
@@ -37,6 +37,10 @@ jobs:
           version: bun run version-packages
           title: "chore: release packages"
           commit: "chore: release packages"
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Emit npm provenance attestations (requires id-token: write above).
+          # Links each published package to this source commit and build.
+          NPM_CONFIG_PROVENANCE: "true"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
 ## Project Overview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,8 @@ bun run test        # Test
 - TypeScript with strict mode
 - Biome for formatting and linting
 - ESM modules
+
+## Releases
+
+See [Releasing Shumoku](docs/releasing.md) for npm, CLI, Server, and Editor
+stable/beta release processes.

--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ See the **[Server Setup Guide](apps/server/README.md)** for Docker, Kubernetes (
 docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/konoe-akitoshi/shumoku:latest
 # → http://localhost:8080   (add `-e DEMO_MODE=true` to preload a sample network)
 
-# Or build from source / run in dev (API :8080 + web UI :5173)
-cd apps/server && docker compose up -d
+# Docker Compose with an exact production version
+cd apps/server && SHUMOKU_VERSION=0.1.1 docker compose up -d
+
+# Development from source (API :8080 + web UI :5173)
 bun run dev:server     # from the repo root
 ```
 
@@ -117,6 +119,13 @@ What you can do:
 3. **Monitor in real-time** — See node status and link utilization update live over WebSocket
 4. **Build dashboards** — Combine multiple topologies and metric widgets into custom views
 5. **Share** — Generate public links for read-only access without authentication
+
+## Editor
+
+The [Editor](https://editor.shumoku.dev/) is hosted on Vercel independently from
+the Server. Branches and pull requests receive isolated Preview deployments;
+merging to `main` updates Production. The running version, deployment channel,
+and commit are shown on the Editor home screen.
 
 ### Integrations
 
@@ -200,9 +209,9 @@ const png = await renderGraphToPng(graph, { scale: 2 })
 ### CLI
 
 ```bash
-npx shumoku render network.yaml -o diagram.svg
-npx shumoku render network.yaml -f html -o diagram.html
-npx shumoku render network.yaml -f png -o diagram.png --scale 3
+npx @shumoku/cli render network.yaml -o diagram.svg
+npx @shumoku/cli render network.yaml -f html -o diagram.html
+npx @shumoku/cli render network.yaml -f png -o diagram.png --scale 3
 ```
 
 **[Playground](https://www.shumoku.dev/)** | **[YAML Reference](https://www.shumoku.dev/docs/npm/yaml-reference)**

--- a/apps/README.md
+++ b/apps/README.md
@@ -9,6 +9,10 @@ End-user applications built on the Shumoku libraries.
 | [`cli`](cli) | `@shumoku/cli` | `shumoku render` — turn a YAML/JSON `NetworkGraph` into SVG / HTML / PNG. |
 | [`docs`](docs) | `@shumoku/docs` | The documentation site at [shumoku.dev](https://www.shumoku.dev) (Next.js + Fumadocs, bilingual EN/JA). |
 
+Release streams are independent: npm packages (including CLI), Server
+containers, and Editor Vercel deployments do not share one product version. See
+[`docs/releasing.md`](../docs/releasing.md).
+
 Each app has its own README with setup and usage. Most run from the repo root via Turborepo:
 
 ```bash

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -7,7 +7,13 @@ Command-line renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). 
 Run it with `npx` (no install):
 
 ```bash
-npx shumoku render network.yaml -o diagram.svg
+npx @shumoku/cli render network.yaml -o diagram.svg
+```
+
+Beta snapshots are published under the `beta` npm dist-tag:
+
+```bash
+npx @shumoku/cli@beta render network.yaml -o diagram.svg
 ```
 
 Or, from a clone of this monorepo, build and run the source:

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,23 +4,35 @@
   "description": "Shumoku CLI for rendering network diagrams",
   "license": "AGPL-3.0-only",
   "author": "konoe-akitoshi",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
+    "directory": "apps/cli"
+  },
   "type": "module",
-  "private": true,
+  "files": [
+    "dist"
+  ],
   "bin": {
     "shumoku": "./dist/shumoku.js"
   },
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
+    "build": "bun build src/shumoku.ts --outfile dist/shumoku.js --target node --format esm --external @resvg/resvg-js",
+    "dev": "bun build src/shumoku.ts --outfile dist/shumoku.js --target node --format esm --external @resvg/resvg-js --watch",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "format": "biome check --write ."
   },
   "dependencies": {
+    "@resvg/resvg-js": "^2.6.2"
+  },
+  "devDependencies": {
     "@shumoku/core": "workspace:*",
     "@shumoku/renderer-svg": "workspace:*",
     "@shumoku/renderer-html": "workspace:*",
     "@shumoku/renderer-png": "workspace:*"
   },
-  "devDependencies": {}
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/apps/docs/content/docs/npm/cli.en.mdx
+++ b/apps/docs/content/docs/npm/cli.en.mdx
@@ -8,7 +8,7 @@ description: How to use the Shumoku command-line tool
 Render diagrams from YAML/JSON files.
 
 ```bash
-npx shumoku render <input> [options]
+npx @shumoku/cli render <input> [options]
 ```
 
 ### Options
@@ -25,22 +25,22 @@ npx shumoku render <input> [options]
 
 ```bash
 # SVG output
-npx shumoku render network.yaml -o diagram.svg
+npx @shumoku/cli render network.yaml -o diagram.svg
 
 # Interactive HTML output
-npx shumoku render network.yaml -f html -o diagram.html
+npx @shumoku/cli render network.yaml -f html -o diagram.html
 
 # PNG output
-npx shumoku render network.yaml -f png -o diagram.png
+npx @shumoku/cli render network.yaml -f png -o diagram.png
 
 # Dark theme
-npx shumoku render network.yaml --theme dark -o diagram.svg
+npx @shumoku/cli render network.yaml --theme dark -o diagram.svg
 
 # Generate from JSON
-npx shumoku render topology.json -o diagram.svg
+npx @shumoku/cli render topology.json -o diagram.svg
 
 # Read from stdin
-cat network.yaml | npx shumoku render - -o diagram.svg
+cat network.yaml | npx @shumoku/cli render - -o diagram.svg
 ```
 
 ### Input Formats
@@ -67,7 +67,7 @@ Additional options for PNG output:
 
 ```bash
 # High resolution output (default: scale=2)
-npx shumoku render network.yaml -f png -o diagram.png
+npx @shumoku/cli render network.yaml -f png -o diagram.png
 ```
 
 When using from TypeScript:
@@ -173,7 +173,7 @@ npx netbox-to-shumoku -f json -o netbox.json
 node merge-data.js netbox.json custom.json > merged.json
 
 # 3. Generate diagram from merged JSON
-npx shumoku render merged.json -f html -o diagram.html
+npx @shumoku/cli render merged.json -f html -o diagram.html
 ```
 
 See [Custom Integration](/docs/npm/custom-integration) for details.

--- a/apps/docs/content/docs/npm/cli.ja.mdx
+++ b/apps/docs/content/docs/npm/cli.ja.mdx
@@ -8,7 +8,7 @@ description: Shumoku コマンドラインツールの使い方
 YAML/JSON ファイルからダイアグラムをレンダリングします。
 
 ```bash
-npx shumoku render <input> [options]
+npx @shumoku/cli render <input> [options]
 ```
 
 ### オプション
@@ -25,22 +25,22 @@ npx shumoku render <input> [options]
 
 ```bash
 # SVG 出力
-npx shumoku render network.yaml -o diagram.svg
+npx @shumoku/cli render network.yaml -o diagram.svg
 
 # インタラクティブ HTML 出力
-npx shumoku render network.yaml -f html -o diagram.html
+npx @shumoku/cli render network.yaml -f html -o diagram.html
 
 # PNG 出力
-npx shumoku render network.yaml -f png -o diagram.png
+npx @shumoku/cli render network.yaml -f png -o diagram.png
 
 # ダークテーマ
-npx shumoku render network.yaml --theme dark -o diagram.svg
+npx @shumoku/cli render network.yaml --theme dark -o diagram.svg
 
 # JSON から生成
-npx shumoku render topology.json -o diagram.svg
+npx @shumoku/cli render topology.json -o diagram.svg
 
 # stdin から読み込み
-cat network.yaml | npx shumoku render - -o diagram.svg
+cat network.yaml | npx @shumoku/cli render - -o diagram.svg
 ```
 
 ### 入力形式
@@ -67,7 +67,7 @@ PNG 出力時の追加オプション：
 
 ```bash
 # 高解像度出力（デフォルト: scale=2）
-npx shumoku render network.yaml -f png -o diagram.png
+npx @shumoku/cli render network.yaml -f png -o diagram.png
 ```
 
 TypeScript からの場合：
@@ -173,7 +173,7 @@ npx netbox-to-shumoku -f json -o netbox.json
 node merge-data.js netbox.json custom.json > merged.json
 
 # 3. マージした JSON からダイアグラム生成
-npx shumoku render merged.json -f html -o diagram.html
+npx @shumoku/cli render merged.json -f html -o diagram.html
 ```
 
 詳細は [カスタム連携](/docs/npm/custom-integration) を参照してください。

--- a/apps/docs/content/docs/npm/custom-integration.en.mdx
+++ b/apps/docs/content/docs/npm/custom-integration.en.mdx
@@ -88,7 +88,7 @@ The pipeline automatically resolves icon dimensions from CDN for proper aspect r
 node generate-from-api.js > network.json
 
 # 2. Render with Shumoku
-npx shumoku render network.json -o diagram.html
+npx @shumoku/cli render network.json -o diagram.html
 ```
 
 ## Merging with NetBox Data
@@ -149,7 +149,7 @@ writeFileSync('merged.json', JSON.stringify(netbox, null, 2))
 ```bash
 # Merge and generate diagram
 node merge-data.js
-npx shumoku render merged.json -f html -o diagram.html
+npx @shumoku/cli render merged.json -f html -o diagram.html
 ```
 
 ## JSON Schema
@@ -251,7 +251,7 @@ jobs:
       - name: Merge and render
         run: |
           node scripts/merge-data.js
-          npx shumoku render merged.json -f html -o docs/network.html
+          npx @shumoku/cli render merged.json -f html -o docs/network.html
 
       - name: Commit changes
         run: |

--- a/apps/docs/content/docs/npm/custom-integration.ja.mdx
+++ b/apps/docs/content/docs/npm/custom-integration.ja.mdx
@@ -88,7 +88,7 @@ const png = await renderPng(prepared)  // Node.js のみ
 node generate-from-api.js > network.json
 
 # 2. Shumoku でレンダリング
-npx shumoku render network.json -o diagram.html
+npx @shumoku/cli render network.json -o diagram.html
 ```
 
 ## NetBox データとのマージ
@@ -149,7 +149,7 @@ writeFileSync('merged.json', JSON.stringify(netbox, null, 2))
 ```bash
 # マージして図を生成
 node merge-data.js
-npx shumoku render merged.json -f html -o diagram.html
+npx @shumoku/cli render merged.json -f html -o diagram.html
 ```
 
 ## JSON スキーマ
@@ -251,7 +251,7 @@ jobs:
       - name: Merge and render
         run: |
           node scripts/merge-data.js
-          npx shumoku render merged.json -f html -o docs/network.html
+          npx @shumoku/cli render merged.json -f html -o docs/network.html
 
       - name: Commit changes
         run: |

--- a/apps/docs/content/docs/npm/index.en.mdx
+++ b/apps/docs/content/docs/npm/index.en.mdx
@@ -71,13 +71,13 @@ links:
 
 ```bash
 # SVG output
-npx shumoku render network.yaml -o diagram.svg
+npx @shumoku/cli render network.yaml -o diagram.svg
 
 # Interactive HTML output
-npx shumoku render network.yaml -f html -o diagram.html
+npx @shumoku/cli render network.yaml -f html -o diagram.html
 
 # PNG output
-npx shumoku render network.yaml -f png -o diagram.png
+npx @shumoku/cli render network.yaml -f png -o diagram.png
 ```
 
 ### 3. Use vendor icons

--- a/apps/docs/content/docs/npm/index.ja.mdx
+++ b/apps/docs/content/docs/npm/index.ja.mdx
@@ -71,13 +71,13 @@ links:
 
 ```bash
 # SVG 出力
-npx shumoku render network.yaml -o diagram.svg
+npx @shumoku/cli render network.yaml -o diagram.svg
 
 # インタラクティブ HTML 出力
-npx shumoku render network.yaml -f html -o diagram.html
+npx @shumoku/cli render network.yaml -f html -o diagram.html
 
 # PNG 出力
-npx shumoku render network.yaml -f png -o diagram.png
+npx @shumoku/cli render network.yaml -f png -o diagram.png
 ```
 
 ### 3. ベンダーアイコンを使う

--- a/apps/docs/content/docs/npm/interactive-features.en.mdx
+++ b/apps/docs/content/docs/npm/interactive-features.en.mdx
@@ -8,7 +8,7 @@ HTML format output provides interactive features.
 ## HTML Output
 
 ```bash
-npx shumoku render network.yaml -f html -o diagram.html
+npx @shumoku/cli render network.yaml -f html -o diagram.html
 ```
 
 ## Pan & Zoom

--- a/apps/docs/content/docs/npm/interactive-features.ja.mdx
+++ b/apps/docs/content/docs/npm/interactive-features.ja.mdx
@@ -8,7 +8,7 @@ HTML 形式で出力すると、インタラクティブな機能が利用でき
 ## HTML 出力
 
 ```bash
-npx shumoku render network.yaml -f html -o diagram.html
+npx @shumoku/cli render network.yaml -f html -o diagram.html
 ```
 
 ## パン & ズーム

--- a/apps/docs/content/docs/npm/json-reference.en.mdx
+++ b/apps/docs/content/docs/npm/json-reference.en.mdx
@@ -328,5 +328,5 @@ Run:
 
 ```bash
 node merge-data.js
-npx shumoku render merged.json -o diagram.html
+npx @shumoku/cli render merged.json -o diagram.html
 ```

--- a/apps/docs/content/docs/npm/json-reference.ja.mdx
+++ b/apps/docs/content/docs/npm/json-reference.ja.mdx
@@ -328,5 +328,5 @@ writeFileSync('merged.json', JSON.stringify(netbox, null, 2))
 
 ```bash
 node merge-data.js
-npx shumoku render merged.json -o diagram.html
+npx @shumoku/cli render merged.json -o diagram.html
 ```

--- a/apps/docs/content/docs/npm/multi-file.en.mdx
+++ b/apps/docs/content/docs/npm/multi-file.en.mdx
@@ -83,7 +83,7 @@ links:
 
 ```bash
 # Just specify the main file, referenced files are loaded automatically
-npx shumoku render main.yaml -f html -o network.html
+npx @shumoku/cli render main.yaml -f html -o network.html
 ```
 
 ## Sheet Navigation

--- a/apps/docs/content/docs/npm/multi-file.ja.mdx
+++ b/apps/docs/content/docs/npm/multi-file.ja.mdx
@@ -83,7 +83,7 @@ links:
 
 ```bash
 # メインファイルを指定するだけで、参照ファイルも自動で読み込まれます
-npx shumoku render main.yaml -f html -o network.html
+npx @shumoku/cli render main.yaml -f html -o network.html
 ```
 
 ## シートナビゲーション

--- a/apps/docs/content/docs/npm/styling-themes.en.mdx
+++ b/apps/docs/content/docs/npm/styling-themes.en.mdx
@@ -17,7 +17,7 @@ settings:
 ### Specify Theme via CLI
 
 ```bash
-npx shumoku render network.yaml --theme dark -o diagram.svg
+npx @shumoku/cli render network.yaml --theme dark -o diagram.svg
 ```
 
 ## Node Styling

--- a/apps/docs/content/docs/npm/styling-themes.ja.mdx
+++ b/apps/docs/content/docs/npm/styling-themes.ja.mdx
@@ -17,7 +17,7 @@ settings:
 ### CLI でテーマを指定
 
 ```bash
-npx shumoku render network.yaml --theme dark -o diagram.svg
+npx @shumoku/cli render network.yaml --theme dark -o diagram.svg
 ```
 
 ## ノードスタイル

--- a/apps/editor/README.md
+++ b/apps/editor/README.md
@@ -2,7 +2,23 @@
 
 Visual editor for designing **physical** network topologies. Manage devices, modules, and cables as first-class *products*, lay them out on a canvas, and derive a bill of materials — then export a portable project file.
 
-> Status: early and under active development (v0.1.0). Some pages are still being built out.
+> Status: early and under active development. Some pages are still being built out.
+
+## Deployments
+
+The Editor is hosted at [editor.shumoku.dev](https://editor.shumoku.dev/) using
+Vercel's Git integration:
+
+- Branch pushes and pull requests create isolated Preview deployments.
+- Merges to `main` create Production deployments.
+- The running version, deployment channel, and Git commit are shown on the home
+  screen.
+
+Use a Preview deployment for beta testing. Because projects are stored in
+browser IndexedDB, its separate origin also keeps test data isolated from
+Production. Keep Vercel's **Automatically expose System Environment Variables**
+setting enabled so the deployment channel and commit are embedded at build
+time.
 
 ## Develop
 
@@ -18,6 +34,9 @@ bun run dev            # http://localhost:5173
 | `bun run build` | Production build (SvelteKit) |
 | `bun run preview` | Preview the production build |
 | `bun run typecheck` | `svelte-check` + `tsc` |
+
+Versioning and release tag conventions are documented in
+[`docs/releasing.md`](../../docs/releasing.md).
 
 ## What it does
 

--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "vite dev",
     "build": "svelte-kit sync && vite build",
@@ -27,7 +30,7 @@
   "devDependencies": {
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@internationalized/date": "^3.12.0",
-    "@sveltejs/adapter-auto": "^6.0.0",
+    "@sveltejs/adapter-vercel": "^6.3.3",
     "@sveltejs/kit": "^2.15.2",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@tailwindcss/vite": "^4.1.18",

--- a/apps/editor/src/app.d.ts
+++ b/apps/editor/src/app.d.ts
@@ -1,0 +1,3 @@
+declare const __SHUMOKU_EDITOR_VERSION__: string
+declare const __SHUMOKU_EDITOR_COMMIT__: string
+declare const __SHUMOKU_EDITOR_CHANNEL__: 'stable' | 'beta' | 'preview' | 'development'

--- a/apps/editor/src/routes/+page.svelte
+++ b/apps/editor/src/routes/+page.svelte
@@ -127,8 +127,28 @@
 <div class="min-h-screen bg-background px-6 py-8 max-w-4xl mx-auto">
   <div class="flex items-center justify-between mb-8">
     <div>
-      <h1 class="text-2xl font-bold">shumoku</h1>
-      <p class="text-sm text-muted-foreground">Network Topology Editor</p>
+      <div class="flex items-center gap-2">
+        <h1 class="text-2xl font-bold">shumoku</h1>
+        {#if __SHUMOKU_EDITOR_CHANNEL__ === 'beta'}
+          <span
+            class="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800 dark:bg-amber-950 dark:text-amber-200"
+          >
+            Beta
+          </span>
+        {:else if __SHUMOKU_EDITOR_CHANNEL__ === 'preview'}
+          <span
+            class="rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-800 dark:bg-blue-950 dark:text-blue-200"
+          >
+            Preview
+          </span>
+        {/if}
+      </div>
+      <p class="text-sm text-muted-foreground">
+        Network Topology Editor · v{__SHUMOKU_EDITOR_VERSION__}
+        {#if __SHUMOKU_EDITOR_COMMIT__}
+          <span title={__SHUMOKU_EDITOR_COMMIT__}> ({__SHUMOKU_EDITOR_COMMIT__.slice(0, 7)}) </span>
+        {/if}
+      </p>
     </div>
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>

--- a/apps/editor/svelte.config.js
+++ b/apps/editor/svelte.config.js
@@ -1,11 +1,13 @@
-import adapter from '@sveltejs/adapter-auto'
+import adapter from '@sveltejs/adapter-vercel'
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   preprocess: vitePreprocess(),
   kit: {
-    adapter: adapter(),
+    adapter: adapter({
+      runtime: 'nodejs24.x',
+    }),
   },
 }
 

--- a/apps/editor/vite.config.ts
+++ b/apps/editor/vite.config.ts
@@ -1,8 +1,32 @@
+import { readFileSync } from 'node:fs'
 import { sveltekit } from '@sveltejs/kit/vite'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
 import wasm from 'vite-plugin-wasm'
 
+const manifest = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8')) as {
+  version: string
+}
+
+const version = process.env['SHUMOKU_EDITOR_VERSION'] ?? manifest.version
+const vercelEnvironment = process.env['VERCEL_TARGET_ENV'] ?? process.env['VERCEL_ENV']
+const channel =
+  process.env['SHUMOKU_EDITOR_CHANNEL'] ??
+  (version.includes('-beta.')
+    ? 'beta'
+    : vercelEnvironment === 'production'
+      ? 'stable'
+      : vercelEnvironment === 'preview'
+        ? 'preview'
+        : 'development')
+
 export default defineConfig({
+  define: {
+    __SHUMOKU_EDITOR_VERSION__: JSON.stringify(version),
+    __SHUMOKU_EDITOR_COMMIT__: JSON.stringify(
+      process.env['SHUMOKU_EDITOR_COMMIT'] ?? process.env['VERCEL_GIT_COMMIT_SHA'] ?? '',
+    ),
+    __SHUMOKU_EDITOR_CHANNEL__: JSON.stringify(channel),
+  },
   plugins: [tailwindcss(), wasm(), sveltekit()],
 })

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -5,6 +5,15 @@
 # ============================================
 FROM oven/bun:1.3.4 AS builder
 
+ARG SHUMOKU_VERSION=dev
+ARG SHUMOKU_COMMIT=unknown
+ARG SHUMOKU_BUILD_DATE=unknown
+ARG SHUMOKU_CHANNEL=development
+ENV SHUMOKU_VERSION=$SHUMOKU_VERSION
+ENV SHUMOKU_COMMIT=$SHUMOKU_COMMIT
+ENV SHUMOKU_BUILD_DATE=$SHUMOKU_BUILD_DATE
+ENV SHUMOKU_CHANNEL=$SHUMOKU_CHANNEL
+
 WORKDIR /app
 
 # Copy monorepo config and required packages
@@ -57,10 +66,18 @@ RUN bun run esbuild.config.js
 # ============================================
 FROM oven/bun:1.3.4-slim
 
+ARG SHUMOKU_VERSION=dev
+ARG SHUMOKU_COMMIT=unknown
+ARG SHUMOKU_BUILD_DATE=unknown
+ARG SHUMOKU_CHANNEL=development
+
 # Metadata
 LABEL org.opencontainers.image.title="Shumoku"
 LABEL org.opencontainers.image.description="Network topology visualization server"
 LABEL org.opencontainers.image.source="https://github.com/konoe-akitoshi/shumoku"
+LABEL org.opencontainers.image.version=$SHUMOKU_VERSION
+LABEL org.opencontainers.image.revision=$SHUMOKU_COMMIT
+LABEL org.opencontainers.image.created=$SHUMOKU_BUILD_DATE
 
 WORKDIR /app
 
@@ -87,6 +104,11 @@ RUN mkdir -p /data && chown -R 1000:1000 /data /app
 ENV DATA_DIR=/data
 ENV PORT=8080
 ENV HOST=0.0.0.0
+ENV SHUMOKU_VERSION=$SHUMOKU_VERSION
+ENV SHUMOKU_COMMIT=$SHUMOKU_COMMIT
+ENV SHUMOKU_BUILD_DATE=$SHUMOKU_BUILD_DATE
+ENV SHUMOKU_CHANNEL=$SHUMOKU_CHANNEL
+ENV SHUMOKU_DEPLOYMENT=docker
 
 # Switch to non-root user
 USER 1000

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -33,15 +33,40 @@ docker run -d -p 8080:8080 -v shumoku-data:/data \
 docker run -d -p 8080:8080 -e DEMO_MODE=true ghcr.io/konoe-akitoshi/shumoku:latest
 ```
 
-Tags: `latest` (built from `main`), plus `X.Y.Z` and `X.Y` for tagged releases — see the [container package](https://github.com/konoe-akitoshi/shumoku/pkgs/container/shumoku).
+Tags: `X.Y.Z` is the immutable production release and `latest` follows the
+newest stable release. `X.Y.Z-beta.N` is an immutable beta and `beta` follows
+the newest beta. Main and pull requests are built without being pushed. See the
+[container package](https://github.com/konoe-akitoshi/shumoku/pkgs/container/shumoku)
+and the [release process](../../docs/releasing.md).
 
-### Docker Compose (build from source)
+For production, pin an exact version rather than `latest`:
+
+```bash
+docker run -d -p 8080:8080 -v shumoku-data:/data \
+  ghcr.io/konoe-akitoshi/shumoku:0.1.1
+```
+
+Test the newest beta without changing `latest`:
+
+```bash
+docker run -d -p 8080:8080 -v shumoku-beta-data:/data \
+  ghcr.io/konoe-akitoshi/shumoku:beta
+```
+
+### Docker Compose
 
 ```bash
 cd apps/server
-docker compose up -d                    # http://localhost:8080
+SHUMOKU_VERSION=0.1.1 docker compose up -d
 SHUMOKU_PORT=80 docker compose up -d    # production port
 DEMO_MODE=true docker compose up -d     # preload a sample network
+```
+
+Upgrade by changing `SHUMOKU_VERSION`, then recreating the service:
+
+```bash
+docker compose pull
+docker compose up -d
 ```
 
 ### From the repo root (Bun, dev)
@@ -95,7 +120,8 @@ Base path `/api`. (`/api/auth` and `/api/share` are public; everything else requ
 
 | Endpoint | Description |
 |----------|-------------|
-| `GET /api/health` | Health check |
+| `GET /api/health` | Health check with running build metadata |
+| `GET /api/system` | Current build and cached latest-release information |
 | `/api/auth/*` | Authentication |
 | `/api/datasources`, `/:id/test`, `/:id/scan` | Data source CRUD, connection test, discovery scan |
 | `/api/plugins` | Plugin registry |
@@ -162,6 +188,8 @@ See the [YAML Reference](https://www.shumoku.dev/docs/npm/yaml-reference) for th
 | `DATA_DIR` | SQLite data directory | `/data` |
 | `SHUMOKU_PORT` | External port (Docker Compose) | `8080` |
 | `DEMO_MODE` | Load the sample network on an empty DB (`true`/`false`) | `false` |
+| `SHUMOKU_UPDATE_CHECK` | Set to `off` to disable GitHub release checks | enabled |
+| `SHUMOKU_GITHUB_TOKEN` | Optional token for a higher GitHub API rate limit | — |
 
 Configuration is otherwise stored in SQLite (`$DATA_DIR/shumoku.db`) and managed from the web UI.
 
@@ -169,21 +197,20 @@ Configuration is otherwise stored in SQLite (`$DATA_DIR/shumoku.db`) and managed
 
 ### Docker (recommended)
 
-Use the [published image](https://github.com/konoe-akitoshi/shumoku/pkgs/container/shumoku) (`ghcr.io/konoe-akitoshi/shumoku`), or build from source with Compose:
+Use the [published image](https://github.com/konoe-akitoshi/shumoku/pkgs/container/shumoku)
+(`ghcr.io/konoe-akitoshi/shumoku`). The included Compose file pulls that image:
 
 ```bash
 cd apps/server
 docker compose up -d
 ```
 
-`compose.yaml` builds from the monorepo root and persists data in the `shumoku-data` volume:
+`compose.yaml` persists data in the `shumoku-data` volume:
 
 ```yaml
 services:
   shumoku:
-    build:
-      context: ../..
-      dockerfile: apps/server/Dockerfile
+    image: ghcr.io/konoe-akitoshi/shumoku:${SHUMOKU_VERSION:-latest}
     ports:
       - "${SHUMOKU_PORT:-8080}:8080"
     volumes:
@@ -198,7 +225,8 @@ volumes:
 docker compose up -d            # start
 docker compose down             # stop
 docker compose logs -f          # logs
-docker compose up -d --build    # rebuild after code changes
+docker compose pull             # fetch the configured release
+docker compose up -d            # recreate after an upgrade
 ```
 
 ### Kubernetes (Helm)

--- a/apps/server/api/esbuild.config.js
+++ b/apps/server/api/esbuild.config.js
@@ -4,6 +4,13 @@ import * as esbuild from 'esbuild'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+const buildInfoDefines = {
+  __SHUMOKU_VERSION__: JSON.stringify(process.env.SHUMOKU_VERSION ?? 'development'),
+  __SHUMOKU_COMMIT__: JSON.stringify(process.env.SHUMOKU_COMMIT ?? ''),
+  __SHUMOKU_BUILD_DATE__: JSON.stringify(process.env.SHUMOKU_BUILD_DATE ?? ''),
+  __SHUMOKU_CHANNEL__: JSON.stringify(process.env.SHUMOKU_CHANNEL ?? 'development'),
+}
+
 await esbuild.build({
   entryPoints: ['dist/api/src/index.js'],
   bundle: true,
@@ -12,6 +19,7 @@ await esbuild.build({
   format: 'esm',
   outfile: 'dist/bundle.js',
   external: ['bun:sqlite', 'bun'],
+  define: buildInfoDefines,
   loader: { '.sql': 'text' },
   alias: {
     '@shumoku/renderer-html/iife-string': path.resolve(
@@ -33,6 +41,7 @@ await esbuild.build({
   format: 'esm',
   outfile: 'dist/derive-worker.js',
   external: ['bun:sqlite', 'bun'],
+  define: buildInfoDefines,
 })
 
 console.log('Bundles created: dist/bundle.js, dist/derive-worker.js')

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shumoku/server-api",
-  "version": "0.1.1",
+  "version": "0.0.0",
   "private": true,
   "description": "Shumoku API server",
   "type": "module",

--- a/apps/server/api/src/api/index.ts
+++ b/apps/server/api/src/api/index.ts
@@ -6,6 +6,7 @@
 import { INTERACTIVE_IIFE } from '@shumoku/renderer-html/iife-string'
 import { Hono } from 'hono'
 import { authMiddleware } from '../middleware/auth.js'
+import { getBuildInfo } from '../services/system-info.js'
 import { createAuthApi } from './auth.js'
 import { createDashboardsApi } from './dashboards.js'
 import { createDataSourcesApi } from './datasources.js'
@@ -14,6 +15,7 @@ import { createObservationsRoute, createScanRoute } from './observations.js'
 import { createPluginsApi } from './plugins.js'
 import { createSettingsApi } from './settings.js'
 import { createShareApi } from './share.js'
+import { createSystemApi } from './system.js'
 import { createTopologiesApi } from './topologies.js'
 import { topologySourcesApi } from './topology-sources.js'
 import { webhooksApi } from './webhooks.js'
@@ -24,6 +26,14 @@ export function createApiRouter(): Hono {
   // Public routes (must be before auth middleware)
   api.route('/auth', createAuthApi())
   api.route('/share', createShareApi())
+  api.get('/health', (c) => {
+    return c.json({ status: 'ok', timestamp: Date.now(), build: getBuildInfo() })
+  })
+  api.get('/runtime.js', (c) => {
+    c.header('Content-Type', 'application/javascript')
+    c.header('Cache-Control', 'public, max-age=86400')
+    return c.body(INTERACTIVE_IIFE)
+  })
 
   // Apply authentication middleware to all subsequent routes
   api.use('*', authMiddleware)
@@ -38,19 +48,8 @@ export function createApiRouter(): Hono {
   api.route('/topologies', createObservationsRoute()) // /topologies/:id/observations + /resolved
   api.route('/topologies', createDiscoveryPolicyApi()) // /topologies/:id/discovery-policy
   api.route('/settings', createSettingsApi())
+  api.route('/system', createSystemApi())
   api.route('/webhooks', webhooksApi)
-
-  // API health check
-  api.get('/health', (c) => {
-    return c.json({ status: 'ok', timestamp: Date.now() })
-  })
-
-  // Serve interactive runtime script
-  api.get('/runtime.js', (c) => {
-    c.header('Content-Type', 'application/javascript')
-    c.header('Cache-Control', 'public, max-age=86400')
-    return c.body(INTERACTIVE_IIFE)
-  })
 
   return api
 }

--- a/apps/server/api/src/api/system.ts
+++ b/apps/server/api/src/api/system.ts
@@ -1,0 +1,13 @@
+import { Hono } from 'hono'
+import { getSystemInfo } from '../services/system-info.js'
+
+export function createSystemApi(): Hono {
+  const app = new Hono()
+
+  app.get('/', async (c) => {
+    const force = c.req.query('refresh') === 'true'
+    return c.json(await getSystemInfo(force))
+  })
+
+  return app
+}

--- a/apps/server/api/src/services/system-info.test.ts
+++ b/apps/server/api/src/services/system-info.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest'
+import { compareVersions, parseReleaseVersion, UpdateChecker } from './system-info.js'
+
+describe('system version helpers', () => {
+  it('accepts only Server stable and beta release tags', () => {
+    expect(parseReleaseVersion('server-v1.2.3')).toBe('1.2.3')
+    expect(parseReleaseVersion('server-v1.2.3-beta.1')).toBe('1.2.3-beta.1')
+    expect(parseReleaseVersion('1.2.3-beta.1')).toBe('1.2.3-beta.1')
+    expect(parseReleaseVersion('v1.2.3')).toBeNull()
+    expect(parseReleaseVersion('editor-v1.2.3')).toBeNull()
+    expect(parseReleaseVersion('@shumoku/core@1.2.3')).toBeNull()
+  })
+
+  it('compares stable and beta semantic versions', () => {
+    expect(compareVersions('server-v0.1.1', 'server-v0.1.2')).toBe(-1)
+    expect(compareVersions('server-v0.2.0-beta.1', 'server-v0.2.0-beta.2')).toBe(-1)
+    expect(compareVersions('server-v0.2.0-beta.2', 'server-v0.2.0')).toBe(-1)
+    expect(compareVersions('server-v0.2.0', 'server-v0.1.9')).toBe(1)
+    expect(compareVersions('server-v1.0.0', 'server-v1.0.0')).toBe(0)
+    expect(compareVersions('development', 'server-v1.0.0')).toBeNull()
+  })
+
+  it('does not describe a development build as current', async () => {
+    const checker = new UpdateChecker({
+      fetcher: vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(JSON.stringify([{ tag_name: 'server-v0.1.2' }]), { status: 200 }),
+        ),
+    })
+
+    const result = await checker.get('development', 'development')
+
+    expect(result.status).toBe('unknown')
+    expect(result.latestVersion).toBe('0.1.2')
+  })
+
+  it('caches the latest release response', async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { tag_name: 'server-v0.1.1' },
+          { tag_name: 'server-v9.0.0-beta.1', prerelease: true },
+          { tag_name: 'server-v8.0.0', draft: true },
+          { tag_name: '@shumoku/core@0.3.0' },
+          {
+            tag_name: 'server-v0.1.2',
+            html_url: 'https://github.com/konoe-akitoshi/shumoku/releases/tag/server-v0.1.2',
+            published_at: '2026-06-14T00:00:00Z',
+          },
+        ]),
+        { status: 200 },
+      ),
+    )
+    const checker = new UpdateChecker({
+      fetcher,
+      now: () => Date.parse('2026-06-14T01:00:00Z'),
+    })
+
+    const first = await checker.get('0.1.1')
+    const second = await checker.get('0.1.1')
+
+    expect(first.status).toBe('available')
+    expect(first.latestVersion).toBe('0.1.2')
+    expect(second).toEqual(first)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers beta builds a newer beta without exposing it to stable builds', async () => {
+    const releases = [
+      { tag_name: 'server-v0.2.0-beta.2', prerelease: true },
+      { tag_name: 'server-v0.1.2' },
+    ]
+    const betaChecker = new UpdateChecker({
+      fetcher: vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(JSON.stringify(releases), { status: 200 })),
+    })
+    const stableChecker = new UpdateChecker({
+      fetcher: vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(JSON.stringify(releases), { status: 200 })),
+    })
+
+    const beta = await betaChecker.get('0.2.0-beta.1', 'beta')
+    const stable = await stableChecker.get('0.1.1', 'stable')
+
+    expect(beta.latestVersion).toBe('0.2.0-beta.2')
+    expect(beta.status).toBe('available')
+    expect(stable.latestVersion).toBe('0.1.2')
+  })
+
+  it('reports an unavailable update source without failing the API', async () => {
+    const checker = new UpdateChecker({
+      fetcher: vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 503 })),
+    })
+
+    const result = await checker.get('0.1.1')
+
+    expect(result.status).toBe('unknown')
+    expect(result.error).toContain('HTTP 503')
+  })
+})

--- a/apps/server/api/src/services/system-info.ts
+++ b/apps/server/api/src/services/system-info.ts
@@ -1,0 +1,245 @@
+const DEFAULT_RELEASES_API_URL =
+  'https://api.github.com/repos/konoe-akitoshi/shumoku/releases?per_page=50'
+const DEFAULT_CACHE_TTL_MS = 6 * 60 * 60 * 1000
+const DEFAULT_TIMEOUT_MS = 5000
+
+declare const __SHUMOKU_VERSION__: string | undefined
+declare const __SHUMOKU_COMMIT__: string | undefined
+declare const __SHUMOKU_BUILD_DATE__: string | undefined
+declare const __SHUMOKU_CHANNEL__: string | undefined
+
+export type ReleaseChannel = 'stable' | 'beta' | 'development'
+export type DeploymentType = 'docker' | 'docker-compose' | 'kubernetes' | 'source'
+export type UpdateStatus = 'available' | 'current' | 'unknown' | 'disabled'
+
+export interface BuildInfo {
+  version: string
+  channel: ReleaseChannel
+  commit?: string
+  builtAt?: string
+  deployment: DeploymentType
+}
+
+export interface UpdateInfo {
+  status: UpdateStatus
+  currentVersion: string
+  latestVersion?: string
+  releaseUrl?: string
+  publishedAt?: string
+  checkedAt?: string
+  error?: string
+}
+
+export interface SystemInfo {
+  build: BuildInfo
+  update: UpdateInfo
+}
+
+interface GitHubRelease {
+  tag_name?: unknown
+  html_url?: unknown
+  published_at?: unknown
+  draft?: unknown
+  prerelease?: unknown
+}
+
+interface UpdateCheckerOptions {
+  fetcher?: typeof fetch
+  now?: () => number
+  cacheTtlMs?: number
+  timeoutMs?: number
+  releasesApiUrl?: string
+}
+
+function compiledValue(value: string | undefined): string | undefined {
+  return value && value.length > 0 ? value : undefined
+}
+
+function deploymentType(value: string | undefined): DeploymentType {
+  if (value === 'docker-compose' || value === 'kubernetes' || value === 'source') return value
+  return value === 'docker' ? value : 'source'
+}
+
+export function getBuildInfo(): BuildInfo {
+  const version =
+    (typeof __SHUMOKU_VERSION__ !== 'undefined' ? compiledValue(__SHUMOKU_VERSION__) : undefined) ??
+    compiledValue(process.env['SHUMOKU_VERSION']) ??
+    'development'
+  const commit =
+    (typeof __SHUMOKU_COMMIT__ !== 'undefined' ? compiledValue(__SHUMOKU_COMMIT__) : undefined) ??
+    compiledValue(process.env['SHUMOKU_COMMIT'])
+  const builtAt =
+    (typeof __SHUMOKU_BUILD_DATE__ !== 'undefined'
+      ? compiledValue(__SHUMOKU_BUILD_DATE__)
+      : undefined) ?? compiledValue(process.env['SHUMOKU_BUILD_DATE'])
+  const compiledChannel =
+    typeof __SHUMOKU_CHANNEL__ !== 'undefined' ? compiledValue(__SHUMOKU_CHANNEL__) : undefined
+
+  return {
+    version,
+    channel:
+      compiledChannel === 'stable' || compiledChannel === 'beta' ? compiledChannel : 'development',
+    commit,
+    builtAt,
+    deployment: deploymentType(process.env['SHUMOKU_DEPLOYMENT']),
+  }
+}
+
+export function parseReleaseVersion(tag: string): string | null {
+  const match = tag.match(/^(?:server-v)?(\d+\.\d+\.\d+(?:-beta\.\d+)?)$/)
+  return match?.[1] ?? null
+}
+
+export function compareVersions(left: string, right: string): number | null {
+  const leftVersion = parseReleaseVersion(left)
+  const rightVersion = parseReleaseVersion(right)
+  if (!leftVersion || !rightVersion) return null
+
+  const [leftCore, leftPrerelease] = leftVersion.split('-beta.')
+  const [rightCore, rightPrerelease] = rightVersion.split('-beta.')
+  if (!leftCore || !rightCore) return null
+
+  const leftParts = leftCore.split('.').map(Number)
+  const rightParts = rightCore.split('.').map(Number)
+  for (const [index, leftPart] of leftParts.entries()) {
+    const rightPart = rightParts[index]
+    if (rightPart === undefined) return null
+    if (leftPart !== rightPart) return leftPart > rightPart ? 1 : -1
+  }
+
+  if (leftPrerelease === undefined && rightPrerelease === undefined) return 0
+  if (leftPrerelease === undefined) return 1
+  if (rightPrerelease === undefined) return -1
+
+  const leftBeta = Number(leftPrerelease)
+  const rightBeta = Number(rightPrerelease)
+  if (!Number.isInteger(leftBeta) || !Number.isInteger(rightBeta)) return null
+  if (leftBeta !== rightBeta) return leftBeta > rightBeta ? 1 : -1
+  return 0
+}
+
+function isServerRelease(candidate: unknown): candidate is GitHubRelease & { tag_name: string } {
+  if (typeof candidate !== 'object' || candidate === null) return false
+
+  const release = candidate as GitHubRelease
+  const version =
+    typeof release.tag_name === 'string' ? parseReleaseVersion(release.tag_name) : null
+  return (
+    typeof release.tag_name === 'string' &&
+    release.tag_name.startsWith('server-v') &&
+    release.draft !== true &&
+    version !== null &&
+    (release.prerelease !== true || version.includes('-beta.'))
+  )
+}
+
+export class UpdateChecker {
+  private fetcher: typeof fetch
+  private now: () => number
+  private cacheTtlMs: number
+  private timeoutMs: number
+  private releasesApiUrl: string
+  private cached: { expiresAt: number; value: UpdateInfo } | null = null
+  private pending: Promise<UpdateInfo> | null = null
+
+  constructor(options: UpdateCheckerOptions = {}) {
+    this.fetcher = options.fetcher ?? fetch
+    this.now = options.now ?? Date.now
+    this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.releasesApiUrl =
+      options.releasesApiUrl ?? process.env['SHUMOKU_RELEASES_API_URL'] ?? DEFAULT_RELEASES_API_URL
+  }
+
+  async get(
+    currentVersion: string,
+    channel: ReleaseChannel = 'stable',
+    force = false,
+  ): Promise<UpdateInfo> {
+    if (process.env['SHUMOKU_UPDATE_CHECK'] === 'off') {
+      return { status: 'disabled', currentVersion }
+    }
+
+    if (!force && this.cached && this.cached.expiresAt > this.now()) {
+      return this.cached.value
+    }
+    if (this.pending) return this.pending
+
+    this.pending = this.fetchLatest(currentVersion, channel)
+    try {
+      const value = await this.pending
+      this.cached = { expiresAt: this.now() + this.cacheTtlMs, value }
+      return value
+    } finally {
+      this.pending = null
+    }
+  }
+
+  private async fetchLatest(currentVersion: string, channel: ReleaseChannel): Promise<UpdateInfo> {
+    const checkedAt = new Date(this.now()).toISOString()
+    try {
+      const headers: Record<string, string> = {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': `shumoku-server/${currentVersion}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      }
+      const token = process.env['SHUMOKU_GITHUB_TOKEN']
+      if (token) headers['Authorization'] = `Bearer ${token}`
+
+      const response = await this.fetcher(this.releasesApiUrl, {
+        headers,
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+      if (!response.ok) {
+        throw new Error(`GitHub Releases returned HTTP ${response.status}`)
+      }
+
+      const releases = (await response.json()) as unknown
+      if (!Array.isArray(releases)) {
+        throw new Error('GitHub Releases response is not an array')
+      }
+      let release: (GitHubRelease & { tag_name: string }) | undefined
+      for (const candidate of releases) {
+        if (!isServerRelease(candidate)) continue
+        const candidateVersion = parseReleaseVersion(candidate.tag_name)
+        if (!candidateVersion) continue
+        if (channel === 'stable' && candidateVersion.includes('-beta.')) continue
+        if (!release || compareVersions(candidate.tag_name, release.tag_name) === 1) {
+          release = candidate
+        }
+      }
+      if (!release) {
+        throw new Error('No Shumoku Server release tag was found')
+      }
+      const latestVersion = parseReleaseVersion(release.tag_name)
+      if (!latestVersion) throw new Error('Invalid Shumoku Server release tag')
+
+      const comparison = compareVersions(currentVersion, latestVersion)
+      return {
+        status: comparison === null ? 'unknown' : comparison < 0 ? 'available' : 'current',
+        currentVersion,
+        latestVersion,
+        releaseUrl: typeof release.html_url === 'string' ? release.html_url : undefined,
+        publishedAt: typeof release.published_at === 'string' ? release.published_at : undefined,
+        checkedAt,
+      }
+    } catch (error) {
+      return {
+        status: 'unknown',
+        currentVersion,
+        checkedAt,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+}
+
+const updateChecker = new UpdateChecker()
+
+export async function getSystemInfo(force = false): Promise<SystemInfo> {
+  const build = getBuildInfo()
+  return {
+    build,
+    update: await updateChecker.get(build.version, build.channel, force),
+  }
+}

--- a/apps/server/chart/shumoku/Chart.yaml
+++ b/apps/server/chart/shumoku/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: shumoku
 description: Network topology visualization server
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.1"
-home: https://shumoku.packof.me/
+home: https://www.shumoku.dev/
 sources:
   - https://github.com/konoe-akitoshi/shumoku
 maintainers:

--- a/apps/server/chart/shumoku/templates/deployment.yaml
+++ b/apps/server/chart/shumoku/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
               value: "0.0.0.0"
             - name: DATA_DIR
               value: /data
+            - name: SHUMOKU_DEPLOYMENT
+              value: kubernetes
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/apps/server/compose.yaml
+++ b/apps/server/compose.yaml
@@ -4,9 +4,7 @@
 services:
   shumoku:
     container_name: shumoku
-    build:
-      context: ../..
-      dockerfile: apps/server/Dockerfile
+    image: ghcr.io/konoe-akitoshi/shumoku:${SHUMOKU_VERSION:-latest}
     ports:
       - "${SHUMOKU_PORT:-8080}:8080"
     volumes:
@@ -15,6 +13,7 @@ services:
       - PORT=8080
       - HOST=0.0.0.0
       - DATA_DIR=/data
+      - SHUMOKU_DEPLOYMENT=docker-compose
       # Set DEMO_MODE=true to seed the sample-network topology and stream
       # mock metrics on first start (no Prometheus/Zabbix needed).
       # Defaults to "false" so production deployments stay clean.

--- a/apps/server/docs/helm-chart.md
+++ b/apps/server/docs/helm-chart.md
@@ -21,6 +21,13 @@ helm install shumoku apps/server/chart/shumoku -n shumoku --create-namespace
 helm install shumoku apps/server/chart/shumoku -f my-values.yaml
 ```
 
+Production deployments should pin an exact Server release:
+
+```bash
+helm upgrade --install shumoku apps/server/chart/shumoku \
+  --set image.tag=0.1.1
+```
+
 ## Configuration
 
 `values.yaml` で設定可能なパラメータ一覧です。

--- a/apps/server/web/package.json
+++ b/apps/server/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shumoku/server-web",
-  "version": "0.1.1",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/apps/server/web/src/app.d.ts
+++ b/apps/server/web/src/app.d.ts
@@ -1,1 +1,0 @@
-declare const __APP_VERSION__: string

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   ScopeMode,
   SyncJob,
   SyncMode,
+  SystemInfo,
   Topology,
   TopologyContext,
   TopologyDataSource,
@@ -736,7 +737,16 @@ export const dashboards = {
 
 // Health check
 export const health = {
-  check: () => request<{ status: string; timestamp: number }>('/health'),
+  check: () =>
+    request<{
+      status: string
+      timestamp: number
+      build: SystemInfo['build']
+    }>('/health'),
+}
+
+export const system = {
+  get: (refresh = false) => request<SystemInfo>(`/system${refresh ? '?refresh=true' : ''}`),
 }
 
 // Plugin types for UI
@@ -874,5 +884,6 @@ export const api = {
   topologies,
   settings,
   health,
+  system,
   auth,
 }

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -194,6 +194,29 @@ export interface ApiError {
   error: string
 }
 
+export type ReleaseChannel = 'stable' | 'beta' | 'development'
+export type DeploymentType = 'docker' | 'docker-compose' | 'kubernetes' | 'source'
+export type UpdateStatus = 'available' | 'current' | 'unknown' | 'disabled'
+
+export interface SystemInfo {
+  build: {
+    version: string
+    channel: ReleaseChannel
+    commit?: string
+    builtAt?: string
+    deployment: DeploymentType
+  }
+  update: {
+    status: UpdateStatus
+    currentVersion: string
+    latestVersion?: string
+    releaseUrl?: string
+    publishedAt?: string
+    checkedAt?: string
+    error?: string
+  }
+}
+
 // ============================================
 // Sync Job (progress modal / reload re-attach)
 // ============================================

--- a/apps/server/web/src/routes/(app)/+layout.svelte
+++ b/apps/server/web/src/routes/(app)/+layout.svelte
@@ -14,7 +14,7 @@
   import { browser } from '$app/environment'
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
-  import { auth } from '$lib/api'
+  import { auth, system } from '$lib/api'
   import Header from '$lib/components/header.svelte'
   import Logo from '$lib/components/Logo.svelte'
 
@@ -41,6 +41,9 @@
   // Sidebar collapsed state
   let sidebarCollapsed = false
   let authenticated = false
+  let version = 'development'
+  let updateAvailable = false
+  let releaseUrl: string | undefined
 
   // Load sidebar state on mount + check auth
   onMount(async () => {
@@ -62,6 +65,11 @@
           goto('/login')
           return
         }
+
+        const systemInfo = await system.get()
+        version = systemInfo.build.version
+        updateAvailable = systemInfo.update.status === 'available'
+        releaseUrl = systemInfo.update.releaseUrl
       } catch {
         // Server down — allow viewing
       }
@@ -172,9 +180,26 @@
           {/if}
         </button>
       {/if}
-      <div class="text-xs text-theme-text-muted {sidebarCollapsed ? 'text-center' : 'px-3'}">
-        {sidebarCollapsed ? `v${__APP_VERSION__.split('.').slice(0, 2).join('.')}` : `v${__APP_VERSION__}`}
-      </div>
+      {#if updateAvailable}
+        <a
+          href={releaseUrl ?? '/settings'}
+          target={releaseUrl ? '_blank' : undefined}
+          rel={releaseUrl ? 'noreferrer' : undefined}
+          class="flex items-center text-xs text-warning hover:text-warning/80 {sidebarCollapsed
+            ? 'justify-center'
+            : 'justify-between px-3'}"
+          title="A Shumoku update is available"
+        >
+          <span>{sidebarCollapsed ? '↑' : `v${version}`}</span>
+          {#if !sidebarCollapsed}
+            <span>Update available</span>
+          {/if}
+        </a>
+      {:else}
+        <div class="text-xs text-theme-text-muted {sidebarCollapsed ? 'text-center' : 'px-3'}">
+          {sidebarCollapsed ? `v${version.split('.').slice(0, 2).join('.')}` : `v${version}`}
+        </div>
+      {/if}
     </div>
   </nav>
 

--- a/apps/server/web/src/routes/(app)/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/settings/+page.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
-  import { FileTextIcon, GithubLogoIcon } from 'phosphor-svelte'
+  import { ArrowsClockwiseIcon, FileTextIcon, GithubLogoIcon } from 'phosphor-svelte'
   import { onMount } from 'svelte'
   import { api, auth } from '$lib/api'
   import { themeSetting } from '$lib/stores'
   import type { ThemeValue } from '$lib/stores/theme'
+  import type { SystemInfo } from '$lib/types'
 
   let loading = true
 
   // Local settings (stored in localStorage)
   let theme: ThemeValue = 'system'
   let updateInterval = '30000'
+  let systemInfo: SystemInfo | null = null
+  let systemError = ''
+  let checkingUpdates = false
 
   onMount(async () => {
     // Load local settings
@@ -20,11 +24,11 @@
       updateInterval = String(parsed.updateInterval || 30000)
     }
 
-    // Load server settings
+    // Load server build and release information
     try {
-      await api.settings.get()
-    } catch {
-      // Settings load failed; non-critical for local-only page
+      systemInfo = await api.system.get()
+    } catch (error) {
+      systemError = error instanceof Error ? error.message : 'Failed to load server information'
     } finally {
       loading = false
     }
@@ -86,10 +90,35 @@
     try {
       const result = await api.health.check()
       alert(
-        `Server is ${result.status} (timestamp: ${new Date(result.timestamp).toLocaleString()})`,
+        `Server is ${result.status}, version ${result.build.version} (${new Date(result.timestamp).toLocaleString()})`,
       )
     } catch (e) {
       alert(`Health check failed: ${e instanceof Error ? e.message : 'Unknown error'}`)
+    }
+  }
+
+  async function checkForUpdates() {
+    checkingUpdates = true
+    systemError = ''
+    try {
+      systemInfo = await api.system.get(true)
+    } catch (error) {
+      systemError = error instanceof Error ? error.message : 'Failed to check for updates'
+    } finally {
+      checkingUpdates = false
+    }
+  }
+
+  function updateInstructions(info: SystemInfo): string {
+    switch (info.build.deployment) {
+      case 'docker-compose':
+        return 'Run docker compose pull && docker compose up -d to recreate the service.'
+      case 'docker':
+        return 'Pull the new image and recreate the container while keeping the /data volume.'
+      case 'kubernetes':
+        return 'Update the image tag to the exact release version and run your Helm upgrade.'
+      default:
+        return 'Check out the release tag, rebuild the server, and restart the service.'
     }
   }
 </script>
@@ -153,8 +182,24 @@
           <div class="space-y-3">
             <div class="flex justify-between">
               <span class="text-theme-text-muted">Version</span>
-              <span class="text-theme-text">{__APP_VERSION__}</span>
+              <span class="text-theme-text">{systemInfo?.build.version ?? 'Unknown'}</span>
             </div>
+            <div class="flex justify-between">
+              <span class="text-theme-text-muted">Channel</span>
+              <span class="text-theme-text capitalize">
+                {systemInfo?.build.channel ?? 'Unknown'}
+              </span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-theme-text-muted">Deployment</span>
+              <span class="text-theme-text">{systemInfo?.build.deployment ?? 'Unknown'}</span>
+            </div>
+            {#if systemInfo?.build.commit}
+              <div class="flex justify-between gap-4">
+                <span class="text-theme-text-muted">Commit</span>
+                <code class="text-theme-text">{systemInfo.build.commit.slice(0, 12)}</code>
+              </div>
+            {/if}
             <div class="flex justify-between">
               <span class="text-theme-text-muted">Database</span>
               <span class="text-theme-text">SQLite</span>
@@ -166,6 +211,69 @@
               Check Server Health
             </button>
           </div>
+        </div>
+      </div>
+
+      <!-- Updates -->
+      <div class="card lg:col-span-2">
+        <div class="card-header flex items-center justify-between">
+          <h2 class="font-medium text-theme-text-emphasis">Software Updates</h2>
+          <button
+            class="btn btn-secondary flex items-center gap-2"
+            onclick={checkForUpdates}
+            disabled={checkingUpdates}
+          >
+            <ArrowsClockwiseIcon size={16} class={checkingUpdates ? 'animate-spin' : ''} />
+            {checkingUpdates ? 'Checking...' : 'Check now'}
+          </button>
+        </div>
+        <div class="card-body space-y-4">
+          {#if systemError}
+            <div class="text-sm text-danger bg-danger/10 rounded-lg px-3 py-2">{systemError}</div>
+          {:else if systemInfo?.update.status === 'available'}
+            <div class="rounded-lg border border-warning/30 bg-warning/10 p-4 space-y-3">
+              <div class="flex items-center justify-between gap-4">
+                <div>
+                  <p class="font-medium text-theme-text-emphasis">
+                    Shumoku {systemInfo.update.latestVersion} is available
+                  </p>
+                  <p class="text-sm text-theme-text-muted">
+                    You are running {systemInfo.update.currentVersion}.
+                  </p>
+                </div>
+                {#if systemInfo.update.releaseUrl}
+                  <a
+                    class="btn btn-primary"
+                    href={systemInfo.update.releaseUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    View release
+                  </a>
+                {/if}
+              </div>
+              <p class="text-sm text-theme-text">{updateInstructions(systemInfo)}</p>
+            </div>
+          {:else if systemInfo?.update.status === 'current'}
+            <p class="text-sm text-success">
+              This server is running the latest stable release ({systemInfo.update.latestVersion ?? systemInfo.build.version}).
+            </p>
+          {:else if systemInfo?.update.status === 'disabled'}
+            <p class="text-sm text-theme-text-muted">
+              Update checks are disabled with <code>SHUMOKU_UPDATE_CHECK=off</code>.
+            </p>
+          {:else}
+            <p class="text-sm text-theme-text-muted">
+              The latest release could not be determined.
+              {systemInfo?.update.error ?? ''}
+            </p>
+          {/if}
+
+          {#if systemInfo?.update.checkedAt}
+            <p class="text-xs text-theme-text-muted">
+              Last checked {new Date(systemInfo.update.checkedAt).toLocaleString()}
+            </p>
+          {/if}
         </div>
       </div>
 
@@ -249,7 +357,7 @@
               GitHub Repository
             </a>
             <a
-              href="https://shumoku-docs.dev"
+              href="https://www.shumoku.dev/"
               target="_blank"
               class="text-primary hover:text-primary-dark flex items-center gap-2"
             >

--- a/apps/server/web/vite.config.ts
+++ b/apps/server/web/vite.config.ts
@@ -1,14 +1,8 @@
-import { readFileSync } from 'node:fs'
 import { sveltekit } from '@sveltejs/kit/vite'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
 
-const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
-
 export default defineConfig({
-  define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
-  },
   plugins: [tailwindcss(), sveltekit()],
   server: {
     proxy: {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -61,6 +61,7 @@
     "includes": [
       "**",
       "!**/dist",
+      "!**/build",
       "!**/node_modules",
       "!**/.next",
       "!**/.turbo",

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,9 @@
         "shumoku": "./dist/shumoku.js",
       },
       "dependencies": {
+        "@resvg/resvg-js": "^2.6.2",
+      },
+      "devDependencies": {
         "@shumoku/core": "workspace:*",
         "@shumoku/renderer-html": "workspace:*",
         "@shumoku/renderer-png": "workspace:*",
@@ -78,7 +81,7 @@
       "devDependencies": {
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@internationalized/date": "^3.12.0",
-        "@sveltejs/adapter-auto": "^6.0.0",
+        "@sveltejs/adapter-vercel": "^6.3.3",
         "@sveltejs/kit": "^2.15.2",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@tailwindcss/vite": "^4.1.18",
@@ -105,7 +108,7 @@
     },
     "apps/server/api": {
       "name": "@shumoku/server-api",
-      "version": "0.1.1",
+      "version": "0.0.0",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "@shumoku/renderer-html": "workspace:*",
@@ -132,7 +135,7 @@
     },
     "apps/server/web": {
       "name": "@shumoku/server-web",
-      "version": "0.1.1",
+      "version": "0.0.0",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "@shumoku/renderer": "workspace:*",
@@ -518,6 +521,8 @@
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
 
+    "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
+
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
@@ -728,6 +733,8 @@
 
     "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
 
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
+
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
@@ -828,9 +835,9 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.9", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA=="],
 
-    "@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@6.1.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-cBNt4jgH4KuaNO5gRSB2CZKkGtz+OCZ8lPjRQGjhvVUD4akotnj2weUia6imLl2v07K3IgsQRyM36909miSwoQ=="],
-
     "@sveltejs/adapter-static": ["@sveltejs/adapter-static@3.0.10", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew=="],
+
+    "@sveltejs/adapter-vercel": ["@sveltejs/adapter-vercel@6.3.3", "", { "dependencies": { "@vercel/nft": "^1.3.2", "esbuild": "^0.25.4" }, "peerDependencies": { "@sveltejs/kit": "^2.4.0" } }, "sha512-jI7jT/XqRyFe9oqKvFcNPQfyNBi3pXqN1iQXa2lmeKT5Vzgr9iSOqJOD3pXf/9Q2Os6SXzqYYm6osRjHYEhkyw=="],
 
     "@sveltejs/kit": ["@sveltejs/kit@2.57.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.6.4", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3 || ^6.0.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw=="],
 
@@ -946,6 +953,8 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
+    "@vercel/nft": ["@vercel/nft@1.10.2", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^13.0.0", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.2", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-w+WyX5Ulmj4dtTZrxaulqrjaLZHSbnPzx75SJsTNYmotKsqn1JlLnDJa+lz5hn90HJofhl/2MAtw0mCrgM3qYw=="],
+
     "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
@@ -964,11 +973,17 @@
 
     "@xyflow/system": ["@xyflow/system@0.0.76", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA=="],
 
+    "abbrev": ["abbrev@3.0.1", "", {}, "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -990,6 +1005,8 @@
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
+    "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
+
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "axios": ["axios@1.15.2", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A=="],
@@ -998,11 +1015,17 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
     "bits-ui": ["bits-ui@2.18.0", "", { "dependencies": { "@floating-ui/core": "^1.7.1", "@floating-ui/dom": "^1.7.1", "esm-env": "^1.1.2", "runed": "^0.35.1", "svelte-toolbelt": "^0.10.6", "tabbable": "^6.2.0" }, "peerDependencies": { "@internationalized/date": "^3.8.1", "svelte": "^5.33.0" } }, "sha512-GLOBZRVy3hxNHIQ2MpD/+5aK9KcBFZRhUJtZ1UDABXdlVR4K6zFpgt4T+Rwuhf2sQzlc6yK1q/DprHPjwT4Pjw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -1055,6 +1078,8 @@
     "compute-scroll-into-view": ["compute-scroll-into-view@3.1.1", "", {}, "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="],
 
     "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -1174,6 +1199,8 @@
 
     "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
 
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
@@ -1208,6 +1235,8 @@
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
@@ -1239,6 +1268,8 @@
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
 
@@ -1343,6 +1374,8 @@
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
+    "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
     "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
@@ -1466,6 +1499,8 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
@@ -1488,7 +1523,13 @@
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "nopt": ["nopt@8.1.0", "", { "dependencies": { "abbrev": "^3.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A=="],
 
     "npm-to-yarn": ["npm-to-yarn@3.0.1", "", {}, "sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A=="],
 
@@ -1521,6 +1562,8 @@
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
@@ -1728,6 +1771,8 @@
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
@@ -1788,6 +1833,10 @@
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "wheel-gestures": ["wheel-gestures@2.2.48", "", {}, "sha512-f+Gy33Oa5Z14XY9679Zze+7VFhbsQfBFXodnU2x589l4kxGM9L5Y8zETTmcMR5pWOPQyRv4Z0lNax6xCO0NSlA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -1824,6 +1873,10 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@sveltejs/adapter-vercel/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -1838,9 +1891,13 @@
 
     "@types/net-snmp/@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
 
+    "@vercel/nft/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "fumadocs-ui/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -1849,6 +1906,8 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -1861,6 +1920,58 @@
     "tar/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@sveltejs/adapter-vercel/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@types/net-snmp/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,183 @@
+# Releasing Shumoku
+
+Shumoku has independent release streams. A version belongs to one product or
+package; there is no monorepo-wide Shumoku version.
+
+| Stream | Source of truth | Stable | Beta |
+|--------|-----------------|--------|------|
+| npm libraries and CLI | each `package.json` | npm `latest` | npm `beta` snapshot |
+| Server | `apps/server/package.json` | `server-vX.Y.Z` | `server-vX.Y.Z-beta.N` |
+| Editor | `apps/editor/package.json` | Vercel Production + `editor-vX.Y.Z` | Vercel Preview + `editor-vX.Y.Z-beta.N` |
+| Docs | deployed from `main` | no product version | pull-request preview |
+
+## npm Libraries And CLI
+
+Public libraries and `@shumoku/cli` use independent versions managed by
+Changesets:
+
+```bash
+bun run changeset
+```
+
+Merging the Changesets release PR publishes affected packages under npm's
+`latest` dist-tag. Package-specific Git tags such as
+`@shumoku/core@0.2.24` are created, but npm releases do not create GitHub
+Releases.
+
+The CLI is installed independently from the `shumoku` library:
+
+```bash
+npx @shumoku/cli render network.yaml -o network.svg
+```
+
+### npm Beta
+
+Run the **Release npm Beta** workflow manually on a branch that contains
+changeset files. It creates ephemeral versions such as
+`0.0.0-beta-20260614123000` and publishes only the affected packages under the
+`beta` dist-tag:
+
+```bash
+npm install @shumoku/core@beta
+npx @shumoku/cli@beta render network.yaml -o network.svg
+```
+
+Snapshot versions are never committed and never update npm's `latest` tag.
+
+## Product Version Command
+
+Server and Editor versions may be stable or numbered beta versions:
+
+```bash
+bun run version:server 0.2.0-beta.1
+bun run version:editor 0.2.0-beta.1
+bun run version:products:check
+```
+
+The Server command also synchronizes the Helm chart. Both commands synchronize
+the corresponding workspace entry in `bun.lock`. API and web implementation
+workspaces remain at `0.0.0`.
+
+## Shumoku Server
+
+Server release tags are product-qualified:
+
+```bash
+# Beta
+bun run version:server 0.2.0-beta.1
+git add apps/server/package.json apps/server/chart/shumoku/Chart.yaml bun.lock
+git commit -m "chore(server): release 0.2.0-beta.1"
+git tag -a server-v0.2.0-beta.1 -m "Shumoku Server 0.2.0-beta.1"
+git push origin HEAD server-v0.2.0-beta.1
+
+# Stable
+bun run version:server 0.2.0
+git add apps/server/package.json apps/server/chart/shumoku/Chart.yaml bun.lock
+git commit -m "chore(server): release 0.2.0"
+git tag -a server-v0.2.0 -m "Shumoku Server 0.2.0"
+git push origin HEAD server-v0.2.0
+```
+
+The Docker workflow verifies that the tag matches
+`apps/server/package.json`.
+
+| Release | GHCR tags changed | GitHub Release |
+|---------|-------------------|----------------|
+| Beta | `X.Y.Z-beta.N`, `beta` | prerelease |
+| Stable | `X.Y.Z`, `latest` | stable release |
+
+Pushes to `main` and pull requests build the image for verification but do not
+publish it. Stable releases never move `beta`, and beta releases never move
+`latest`.
+
+The running Server checks GitHub Releases whose tags begin with `server-v`.
+Stable builds ignore beta releases. Beta builds can report a newer beta or the
+eventual stable release.
+
+### Test A Server Beta
+
+Use a separate data volume because database migrations may make downgrade
+testing unsafe:
+
+```bash
+docker run -d --name shumoku-beta -p 8081:8080 \
+  -v shumoku-beta-data:/data \
+  ghcr.io/konoe-akitoshi/shumoku:beta
+```
+
+For a reproducible test, replace `beta` with the immutable
+`X.Y.Z-beta.N` tag.
+
+## Shumoku Editor
+
+The Editor is deployed by Vercel's Git integration. Branch pushes and pull
+requests create Preview deployments; merging to `main` creates a Production
+deployment at [editor.shumoku.dev](https://editor.shumoku.dev/).
+
+### Test An Editor Beta
+
+Create a branch, set a numbered beta version, and push it:
+
+```bash
+git switch -c release/editor-0.2.0-beta.1
+bun run version:editor 0.2.0-beta.1
+git add apps/editor/package.json bun.lock
+git commit -m "chore(editor): release 0.2.0-beta.1"
+git push -u origin HEAD
+```
+
+Vercel adds the Preview URL to the commit and pull request. The Preview origin
+has separate IndexedDB storage from Production, which keeps beta projects
+isolated. After the Preview has passed testing, optionally record that exact
+commit as a prerelease:
+
+```bash
+git tag -a editor-v0.2.0-beta.1 -m "Shumoku Editor 0.2.0-beta.1"
+git push origin editor-v0.2.0-beta.1
+```
+
+The tag creates a GitHub prerelease. It does not trigger a second Vercel
+deployment.
+
+### Release The Editor
+
+Change the version to stable in the same release pull request:
+
+```bash
+bun run version:editor 0.2.0
+git add apps/editor/package.json bun.lock
+git commit -m "chore(editor): release 0.2.0"
+git push
+```
+
+Merge only after the Vercel Preview and repository checks pass. Vercel deploys
+the merge commit to Production. After the Production deployment succeeds, tag
+that exact commit:
+
+```bash
+git switch main
+git pull --ff-only
+git tag -a editor-v0.2.0 -m "Shumoku Editor 0.2.0"
+git push origin editor-v0.2.0
+```
+
+The tag creates the stable GitHub Release and provides an immutable source
+reference for the Vercel deployment. The Editor home screen derives its channel
+and commit from Vercel's system environment variables. Keep **Automatically
+expose System Environment Variables** enabled in the Vercel project settings.
+
+## Deployment Updates
+
+Production should pin immutable tags:
+
+```bash
+SHUMOKU_VERSION=0.2.0 docker compose up -d
+
+helm upgrade shumoku apps/server/chart/shumoku \
+  --set image.tag=0.2.0
+```
+
+The Server Settings page reports its running version, commit, build timestamp,
+latest relevant release, and deployment-specific update guidance. Update checks
+are cached for six hours. Set `SHUMOKU_UPDATE_CHECK=off` for offline
+installations.

--- a/knip.json
+++ b/knip.json
@@ -15,7 +15,9 @@
     "libs/plugins/netbox": {},
     "libs/plugins/prometheus": {},
     "libs/plugins/zabbix": {},
-    "apps/cli": {},
+    "apps/cli": {
+      "ignoreDependencies": ["@resvg/resvg-js"]
+    },
     "apps/docs": {
       "entry": ["source.config.ts"]
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,13 @@
     "typecheck": "turbo run typecheck",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo run build --filter='./libs/**' && changeset publish"
+    "build:packages": "turbo run build --filter='./libs/**' --filter=@shumoku/cli",
+    "version:server": "bun scripts/product-version.ts server",
+    "version:server:check": "bun scripts/product-version.ts server --check",
+    "version:editor": "bun scripts/product-version.ts editor",
+    "version:editor:check": "bun scripts/product-version.ts editor --check",
+    "version:products:check": "bun run version:server:check && bun run version:editor:check",
+    "release": "bun run build:packages && changeset publish"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",

--- a/scripts/product-version.ts
+++ b/scripts/product-version.ts
@@ -1,0 +1,152 @@
+import { readFile, writeFile } from 'node:fs/promises'
+
+type ProductName = 'server' | 'editor'
+
+interface ProductConfig {
+  packagePath: string
+  workspacePath: string
+  chartPath?: string
+}
+
+interface PackageManifest {
+  version?: string
+  [key: string]: unknown
+}
+
+interface BunLockfile {
+  workspaces?: Record<string, PackageManifest>
+}
+
+const products: Record<ProductName, ProductConfig> = {
+  server: {
+    packagePath: 'apps/server/package.json',
+    workspacePath: 'apps/server',
+    chartPath: 'apps/server/chart/shumoku/Chart.yaml',
+  },
+  editor: {
+    packagePath: 'apps/editor/package.json',
+    workspacePath: 'apps/editor',
+  },
+}
+
+const versionPattern = /^\d+\.\d+\.\d+(?:-beta\.\d+)?$/
+
+function getProduct(value: string | undefined): ProductName {
+  if (value === 'server' || value === 'editor') return value
+  throw new Error('Product must be "server" or "editor"')
+}
+
+async function readProductVersion(config: ProductConfig): Promise<string> {
+  const manifest = JSON.parse(await readFile(config.packagePath, 'utf8')) as PackageManifest
+  if (!manifest.version) {
+    throw new Error(`${config.packagePath} does not contain a version`)
+  }
+  return manifest.version
+}
+
+async function readChartVersions(
+  chartPath: string,
+): Promise<{ version: string; appVersion: string }> {
+  const chart = await readFile(chartPath, 'utf8')
+  const version = chart.match(/^version:\s*["']?([^"'\s]+)["']?\s*$/m)?.[1]
+  const appVersion = chart.match(/^appVersion:\s*["']?([^"'\s]+)["']?\s*$/m)?.[1]
+  if (!version || !appVersion) {
+    throw new Error(`${chartPath} must contain version and appVersion`)
+  }
+  return { version, appVersion }
+}
+
+async function readLockVersion(workspacePath: string): Promise<string | undefined> {
+  if (!(await Bun.file('bun.lock').exists())) return undefined
+
+  const lockfile = Bun.JSONC.parse(await readFile('bun.lock', 'utf8')) as BunLockfile
+  const version = lockfile.workspaces?.[workspacePath]?.version
+  if (!version) {
+    throw new Error(`bun.lock does not contain a version for ${workspacePath}`)
+  }
+  return version
+}
+
+async function checkProduct(product: ProductName): Promise<void> {
+  const config = products[product]
+  const expected = await readProductVersion(config)
+  const versions = new Map<string, string | undefined>([
+    [config.packagePath, expected],
+    [`bun.lock#${config.workspacePath}`, await readLockVersion(config.workspacePath)],
+  ])
+
+  if (config.chartPath) {
+    const chart = await readChartVersions(config.chartPath)
+    versions.set(`${config.chartPath}#version`, chart.version)
+    versions.set(`${config.chartPath}#appVersion`, chart.appVersion)
+  }
+
+  const mismatches = [...versions].filter(([, version]) => version && version !== expected)
+  if (mismatches.length > 0) {
+    for (const [path, version] of versions) {
+      console.error(`${path}: ${version ?? 'not present'}`)
+    }
+    throw new Error(`Shumoku ${product} versions are not synchronized`)
+  }
+
+  console.log(`Shumoku ${product} version: ${expected}`)
+}
+
+async function updateLockfile(workspacePath: string, version: string): Promise<void> {
+  if (!(await Bun.file('bun.lock').exists())) return
+
+  const lines = (await readFile('bun.lock', 'utf8')).split('\n')
+  let inWorkspace = false
+  let updated = false
+
+  for (const [index, line] of lines.entries()) {
+    const workspaceMatch = line.match(/^ {4}"([^"]+)": \{$/)
+    if (workspaceMatch?.[1]) {
+      inWorkspace = workspaceMatch[1] === workspacePath
+      continue
+    }
+    if (inWorkspace && /^ {6}"version": "[^"]+",$/.test(line)) {
+      lines[index] = `      "version": "${version}",`
+      updated = true
+      break
+    }
+  }
+
+  if (!updated) {
+    throw new Error(`Failed to update bun.lock workspace ${workspacePath}`)
+  }
+  await writeFile('bun.lock', lines.join('\n'))
+}
+
+async function setProductVersion(product: ProductName, version: string): Promise<void> {
+  if (!versionPattern.test(version)) {
+    throw new Error(`Invalid version: ${version}. Expected X.Y.Z or X.Y.Z-beta.N`)
+  }
+
+  const config = products[product]
+  const manifest = JSON.parse(await readFile(config.packagePath, 'utf8')) as PackageManifest
+  manifest.version = version
+  await writeFile(config.packagePath, `${JSON.stringify(manifest, null, 2)}\n`)
+
+  if (config.chartPath) {
+    const chart = await readFile(config.chartPath, 'utf8')
+    const updatedChart = chart
+      .replace(/^version:\s*["']?[^"'\s]+["']?\s*$/m, `version: ${version}`)
+      .replace(/^appVersion:\s*["']?[^"'\s]+["']?\s*$/m, `appVersion: "${version}"`)
+    await writeFile(config.chartPath, updatedChart)
+  }
+
+  await updateLockfile(config.workspacePath, version)
+  await checkProduct(product)
+}
+
+const product = getProduct(Bun.argv[2])
+const argument = Bun.argv[3]
+
+if (argument === '--check') {
+  await checkProduct(product)
+} else if (argument) {
+  await setProductVersion(product, argument.replace(/^(?:server|editor)-v/, ''))
+} else {
+  throw new Error('Usage: bun scripts/product-version.ts <server|editor> <X.Y.Z[-beta.N]|--check>')
+}


### PR DESCRIPTION
## What

Replace the monorepo-wide version with **independent release streams per product/package**. A version now belongs to one artifact; there is no single Shumoku version. Full runbook: `docs/releasing.md`.

| Stream | Source of truth | Release trigger |
|--------|-----------------|-----------------|
| npm libraries + CLI | each `package.json` (Changesets, unlinked) | merge the bot's `chore: release packages` PR |
| Server | `apps/server/package.json` | push `server-vX.Y.Z` tag |
| Editor | `apps/editor/package.json` | merge to `main` (Vercel); optional `editor-vX.Y.Z` tag |

## Highlights

- Publish the CLI as the public **`@shumoku/cli`** package (was private); docs renamed `npx shumoku` → `npx @shumoku/cli`.
- `scripts/product-version.ts` bumps Server/Editor and syncs the Helm chart + `bun.lock` (`version:server`, `version:editor`, `--check`).
- Server self-reports running version / commit / update status (`system-info`).
- `docker.yml` / `editor.yml` verify the tag matches the manifest before releasing.

## Hardening & agent-facing docs

- **npm provenance** wired on the release and beta workflows (`NPM_CONFIG_PROVENANCE` + `id-token: write`).
- **CI changeset gate**: PRs touching `libs/@shumoku/*` or `apps/cli` must declare a changeset (the bot's `changeset-release/*` PR is excluded). Escape hatch: `changeset add --empty`.
- `version:products:check` wired into CI.
- `CLAUDE.md` / `AGENTS.md` document the release rules for agents (changeset required, never hand-edit versions, human review points). Default bump stays **patch** during 0.x.
- biome: stop linting gitignored `build/` output (was blocking every commit).

## Operating model

Merging a normal PR never publishes — it only accumulates a changeset. Versions rise only when a human merges the bot's release PR (npm) or pushes a product tag (Server). Betas are on-demand: the **Release npm Beta** workflow (snapshot `@beta` dist-tag), `server-vX.Y.Z-beta.N` tags, and Editor Preview deploys.

## Prerequisites (GitHub settings)

- `NPM_TOKEN` secret with publish rights to the `@shumoku` scope.
- Settings → Actions → General → **Allow GitHub Actions to create and approve pull requests** (otherwise the release PR never opens).

## Not in this PR

Unrelated composite-layout WIP is kept out (separate branch). GitHub Environments approval gates, Docker SBOM/signing, and a `release:server` convenience script are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
