### PR TITLE
chore: temporarily hold new plugins from npm publish

### DIFF
--- a/libs/plugins/aruba-instant-on/package.json
+++ b/libs/plugins/aruba-instant-on/package.json
@@ -1,6 +1,7 @@
 {
   "name": "shumoku-plugin-aruba-instant-on",
   "version": "0.1.0",
+  "private": true,
   "description": "Aruba Instant On (cloud-managed AP / switch) data source plugin for Shumoku. Uses the undocumented portal.arubainstanton.com API.",
   "license": "AGPL-3.0-only",
   "author": "konoe-akitoshi",

--- a/libs/plugins/network-scan/package.json
+++ b/libs/plugins/network-scan/package.json
@@ -1,6 +1,7 @@
 {
   "name": "shumoku-plugin-network-scan",
   "version": "0.0.0",
+  "private": true,
   "description": "SNMP/LLDP autoscan data source plugin for Shumoku",
   "license": "AGPL-3.0-only",
   "author": "konoe-akitoshi",


### PR DESCRIPTION
Mark `shumoku-plugin-aruba-instant-on` and `shumoku-plugin-network-scan` as `private: true` so the first automated release (publishing the whole package family for the first time) does **not** ship these two new plugins yet.

Safe: both are leaf packages — only the private `@shumoku/server-api` depends on them, so no published package breaks.

`@shumoku/plugin-sdk` (needed by netbox/zabbix) and the other libs stay public.

Flip `private` back to `false`/remove when ready to publish them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)