### PR TITLE
chore: bump Server 0.1.2 and Editor 0.1.1 for first product release

### DIFF
--- a/apps/editor/package.json
+++ b/apps/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shumoku/editor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/server/chart/shumoku/Chart.yaml
+++ b/apps/server/chart/shumoku/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: shumoku
 description: Network topology visualization server
 type: application
-version: 0.1.1
-appVersion: "0.1.1"
+version: 0.1.2
+appVersion: "0.1.2"
 home: https://www.shumoku.dev/
 sources:
   - https://github.com/konoe-akitoshi/shumoku

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shumoku/server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Real-time network topology visualization server with Zabbix integration",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
     },
     "apps/editor": {
       "name": "@shumoku/editor",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@shumoku/catalog": "workspace:*",
         "@shumoku/core": "workspace:*",
@@ -96,7 +96,7 @@
     },
     "apps/server": {
       "name": "@shumoku/server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@shumoku/server-api": "workspace:*",
         "@shumoku/server-web": "workspace:*",


### PR DESCRIPTION
Patch bumps to cut the first tagged product releases:

- Server `0.1.1` → `0.1.2` (package.json + Helm chart + bun.lock)
- Editor `0.1.0` → `0.1.1` (package.json + bun.lock)

After merge: push `server-v0.1.2` (→ GHCR image + GitHub Release) and `editor-v0.1.1` (→ GitHub Release; Vercel already serves Production from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)