### PR TITLE
ci: path-scoped product release notes via git-cliff

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -1,0 +1,40 @@
+# git-cliff configuration for Shumoku product (Server / Editor) release notes.
+# Used by the Docker (server-v*) and Editor (editor-v*) release workflows to
+# generate path-scoped, conventional-commit-grouped notes. npm library changes
+# are intentionally NOT included here — they ship with their own Changesets
+# CHANGELOGs. Pass --include-path / --tag-pattern on the CLI per product.
+
+[changelog]
+header = ""
+body = """
+{% if commits | length == 0 %}\
+_No app-level changes in this release._
+{% else %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {{ commit.message | split(pat="\n") | first | upper_first }} ({{ commit.id | truncate(length=7, end="") }})
+{% endfor %}\
+{% endfor %}\
+{% endif %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+protect_breaking_commits = true
+filter_commits = false
+topo_order = false
+sort_commits = "newest"
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactor" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^(chore|ci|build|test|style)", skip = true },
+  { message = "^revert", group = "Reverts" },
+  { message = ".*", group = "Other" },
+]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,6 +103,24 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Generate release notes
+        env:
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          if ! bash scripts/release-notes.sh server "$GITHUB_REF_NAME" > release-notes.md 2>/dev/null || [ ! -s release-notes.md ]; then
+            printf '**Shumoku Server %s**\n' "${GITHUB_REF_NAME#server-v}" > release-notes.md
+          fi
+
       - name: Create GitHub Release
         env:
           GH_REPO: ${{ github.repository }}
@@ -114,13 +132,13 @@ jobs:
           elif [[ "$GITHUB_REF_NAME" == *-beta.* ]]; then
             gh release create "$GITHUB_REF_NAME" \
               --verify-tag \
-              --generate-notes \
+              --notes-file release-notes.md \
               --prerelease \
               --title "Shumoku Server ${GITHUB_REF_NAME#server-v}"
           else
             gh release create "$GITHUB_REF_NAME" \
               --verify-tag \
-              --generate-notes \
+              --notes-file release-notes.md \
               --latest \
               --title "Shumoku Server ${GITHUB_REF_NAME#server-v}"
           fi

--- a/.github/workflows/editor.yml
+++ b/.github/workflows/editor.yml
@@ -12,6 +12,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
 
       - name: Verify release version
         shell: bash
@@ -29,6 +36,15 @@ jobs:
             exit 1
           fi
 
+      - name: Generate release notes
+        env:
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          if ! bash scripts/release-notes.sh editor "$GITHUB_REF_NAME" > release-notes.md 2>/dev/null || [ ! -s release-notes.md ]; then
+            printf '**Shumoku Editor %s** — https://editor.shumoku.dev/\n' "${GITHUB_REF_NAME#editor-v}" > release-notes.md
+          fi
+
       - name: Create GitHub Release
         env:
           GH_REPO: ${{ github.repository }}
@@ -40,13 +56,13 @@ jobs:
           elif [[ "$GITHUB_REF_NAME" == *-beta.* ]]; then
             gh release create "$GITHUB_REF_NAME" \
               --verify-tag \
-              --generate-notes \
+              --notes-file release-notes.md \
               --prerelease \
               --title "Shumoku Editor ${GITHUB_REF_NAME#editor-v}"
           else
             gh release create "$GITHUB_REF_NAME" \
               --verify-tag \
-              --generate-notes \
+              --notes-file release-notes.md \
               --latest=false \
               --title "Shumoku Editor ${GITHUB_REF_NAME#editor-v}"
           fi

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Generate GitHub Release notes for a Shumoku product release.
+#
+#   scripts/release-notes.sh <server|editor> <tag>
+#
+# App-level changes only (path-scoped, grouped by Conventional Commit type via
+# git-cliff). npm library changes are NOT re-listed here — they ship with their
+# own Changesets CHANGELOGs; this just records which library versions the build
+# bundles. Requires: git (full history + tags), bunx.
+set -euo pipefail
+
+product="${1:?usage: release-notes.sh <server|editor> <tag>}"
+tag="${2:?usage: release-notes.sh <server|editor> <tag>}"
+repo="${GH_REPO:-konoe-akitoshi/shumoku}"
+cliff_version="git-cliff@2.13.1"
+
+case "$product" in
+  server)
+    title="Shumoku Server"
+    scope='apps/server/**'
+    prefix='server-v'
+    version="${tag#server-v}"
+    header=$(cat <<EOF
+**${title} ${version}**
+
+\`\`\`bash
+docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/${repo}:${version}
+\`\`\`
+
+Image: \`ghcr.io/${repo}:${version}\` · \`:latest\`
+EOF
+)
+    ;;
+  editor)
+    title="Shumoku Editor"
+    scope='apps/editor/**'
+    prefix='editor-v'
+    version="${tag#editor-v}"
+    header=$(cat <<EOF
+**${title} ${version}** — https://editor.shumoku.dev/ (deployed from this commit)
+EOF
+)
+    ;;
+  *)
+    echo "unknown product: $product" >&2; exit 1 ;;
+esac
+
+# App-level changelog, scoped to the product's own paths.
+changes="$(bunx "$cliff_version" --config .github/cliff.toml \
+  --include-path "$scope" --tag-pattern "${prefix}[0-9].*" \
+  --latest --strip all 2>/dev/null || true)"
+[ -z "${changes//[$'\n\r\t ']/}" ] && changes="_No app-level changes in this release._"
+
+# Library versions bundled in this build (scoped @shumoku/* public packages).
+bundled="$(
+  for pj in libs/@shumoku/*/package.json; do
+    bun -e 'const p=JSON.parse(await Bun.file(process.argv[1]).text());
+      if(p.name?.startsWith("@shumoku/") && !p.private && p.version) console.log(`${p.name}@${p.version}`)' "$pj" 2>/dev/null
+  done | sort | sed 's/^/- `/; s/$/`/'
+)"
+
+# Compare link to the previous release of the same product (omitted on first release).
+prev="$(git tag -l "${prefix}*" --sort=-version:refname | grep -A1 -xF "$tag" | tail -1 || true)"
+compare=""
+[ -n "$prev" ] && [ "$prev" != "$tag" ] && \
+  compare="**Full changelog:** https://github.com/${repo}/compare/${prev}...${tag}"
+
+printf '%s\n\n## Changes\n%s\n' "$header" "$changes"
+[ -n "$bundled" ] && printf '\n## Bundled libraries\n%s\n' "$bundled"
+[ -n "$compare" ] && printf '\n%s\n' "$compare"


### PR DESCRIPTION
Product (Server/Editor) GitHub Releases used repo-wide `--generate-notes`, which dumped **every PR** and produced **identical** notes for Server and Editor.

Now `scripts/release-notes.sh` generates, per product:
- **App-level changes only** — path-scoped (`apps/server/**` / `apps/editor/**`), grouped by Conventional Commit type via **git-cliff** (`bunx`, no new deps).
- **Bundled libraries** — the `@shumoku/*` versions shipped in this build.
- **Full changelog** compare link to the previous product tag.

npm library changes are NOT re-listed (they ship with their own Changesets CHANGELOGs). Generation falls back to a minimal title on error, so releases never break.

Effective from the next `server-v*` / `editor-v*` tag (current 0.1.x notes already hand-written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)