### PR TITLE
docs: add OSS governance, support, security, and contribution docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & Discussions
+    url: https://github.com/konoe-akitoshi/shumoku/discussions
+    about: Ask questions, share ideas, and get usage help.
+  - name: 🗨️ Discord
+    url: https://discord.gg/dyYbEsDZYr
+    about: Chat with the community in real time.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/konoe-akitoshi/shumoku/security/advisories/new
+    about: Please report security issues privately — not as a public issue. See SECURITY.md.
+  - name: 🏢 Commercial / implementation support
+    url: mailto:contact@shumoku.dev
+    about: Implementation, NetBox/Zabbix integration, PoC, or custom development help.

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,17 @@
+# Configuration for the DCO GitHub App — https://github.com/apps/dco
+# This keeps the Developer Certificate of Origin (see CONTRIBUTING.md) friendly
+# for external contributors: nobody gets blocked over a missing sign-off that
+# can be fixed without rewriting history.
+
+require:
+  # Trusted project members / collaborators are not required to sign off.
+  # Set this to `true` if you want every commit — including maintainers' — to
+  # carry a Signed-off-by line.
+  members: false
+
+allowRemediationCommits:
+  # A contributor can fix a missing sign-off by adding a follow-up commit,
+  # instead of having to amend/rebase and force-push.
+  individual: true
+  # A maintainer can add the remediation sign-off on a contributor's behalf.
+  thirdParty: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,10 +11,20 @@
 - [ ] Refactoring
 - [ ] Other (please describe)
 
+## Screenshots
+
+<!-- For UI changes (Editor, Server web UI, rendered diagrams), include before/after screenshots or a short clip. Otherwise, write "N/A". -->
+
+## Breaking changes
+
+<!-- If this PR contains breaking changes, describe what breaks and the migration path. Otherwise, write "None". -->
+
 ## Checklist
 
 - [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
-- [ ] My code follows the project's code style
+- [ ] My commits are signed off for the DCO (`git commit -s`)
+- [ ] My code follows the project's code style (`bun run lint`)
 - [ ] I have added tests that prove my fix/feature works
-- [ ] All new and existing tests pass
+- [ ] All new and existing tests pass (`bun run test`)
+- [ ] I added a changeset if I changed a published package (`bun run changeset`)
 - [ ] I have updated the documentation if needed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in the
+Shumoku community a welcoming and respectful experience for everyone, regardless
+of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion, or any
+other personal characteristic.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that helps create a positive environment:
+
+- Showing empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Taking responsibility, apologizing to those affected by our mistakes, and
+  learning from the experience.
+- Focusing on what is best for the overall community.
+
+Examples of unacceptable behavior:
+
+- Harassment of any kind, public or private, including unwelcome personal
+  attention.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Discriminatory jokes, language, or imagery.
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission.
+- Other conduct that could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing these standards
+and will take appropriate and fair corrective action in response to any behavior
+they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, issues, and other contributions that are not aligned with this Code
+of Conduct, and will communicate reasons for moderation decisions when
+appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces — the repository, issues,
+pull requests, discussions, Discord, and similar — and also applies when an
+individual is officially representing the project in public spaces.
+
+## Reporting and enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers at **[contact@shumoku.dev](mailto:contact@shumoku.dev)**.
+
+All complaints will be reviewed and investigated promptly and fairly. Maintainers
+are obligated to respect the privacy and security of the reporter of any incident.
+
+Maintainers will follow these community impact guidelines in determining the
+consequences for any action they deem in violation of this Code of Conduct,
+ranging from a private warning, to a temporary ban, to a permanent ban, depending
+on the severity and pattern of the behavior.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>. For
+answers to common questions, see the FAQ at
+<https://www.contributor-covenant.org/faq>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,75 @@
 # Contributing to Shumoku
 
-## Development Setup
+Thanks for your interest in contributing! Shumoku is an open-source project and
+we welcome issues, pull requests, documentation improvements, and ideas.
+
+By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+For how the project is organized and how decisions are made, see
+[GOVERNANCE.md](GOVERNANCE.md).
+
+## Ways to contribute
+
+- **Report a bug** — open a [Bug Report](https://github.com/konoe-akitoshi/shumoku/issues/new?template=bug_report.yml).
+- **Request a feature** — open a [Feature Request](https://github.com/konoe-akitoshi/shumoku/issues/new?template=feature_request.yml).
+- **Ask a question / discuss an idea** — use [GitHub Discussions](https://github.com/konoe-akitoshi/shumoku/discussions) or [Discord](https://discord.gg/dyYbEsDZYr).
+- **Send a pull request** — fix a bug, add a feature, or improve the docs.
+
+> **Security issues are different.** Please do **not** open a public issue for a
+> security vulnerability. Follow [SECURITY.md](SECURITY.md) instead.
+
+Before starting non-trivial work, please search existing issues and discussions,
+and consider opening an issue first so we can agree on the approach. This avoids
+wasted effort and makes review faster.
+
+## Reporting bugs
+
+A good bug report includes:
+
+- **What happened** and **what you expected** to happen.
+- **Steps to reproduce** — ideally a minimal YAML/JSON `NetworkGraph` or a small
+  code snippet.
+- **Version** of the package, CLI, or server you are using.
+- **Environment** — OS, runtime (Bun/Node), and browser if relevant.
+- **Logs, error messages, or screenshots** where applicable.
+
+The [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml) walks you through
+this.
+
+## Requesting features
+
+Open a [feature request](.github/ISSUE_TEMPLATE/feature_request.yml) describing:
+
+- The **problem** you are trying to solve (not just the proposed solution).
+- A **proposed solution** and any **alternatives** you considered.
+
+Feature requests are very welcome, but please note that acceptance and
+prioritization are at the discretion of the maintainers and Project Lead — see
+[GOVERNANCE.md](GOVERNANCE.md).
+
+## Development setup
+
+Shumoku is a [Bun](https://bun.sh) workspaces + [Turborepo](https://turbo.build)
+monorepo.
 
 ```bash
 # Clone
 git clone https://github.com/konoe-akitoshi/shumoku.git
 cd shumoku
 
-# Install (requires Bun)
+# Install (requires Bun — see packageManager in package.json for the version)
 bun install
 
-# Build
+# Install git hooks (runs format/lint/typecheck on commit)
+bunx lefthook install
+
+# Build all libraries (excludes the server app)
 bun run build
 
 # Run the docs site + playground
 cd apps/docs && bun run dev
 ```
 
-## Project Structure
+### Project structure
 
 ```
 libs/
@@ -35,33 +87,115 @@ apps/
 └── docs                 # Documentation site + playground
 ```
 
-## Commands
+## Running tests, lint, and format
+
+Run these from the repository root before opening a pull request:
 
 ```bash
-bun run build       # Build all packages
-bun run dev         # Dev server
-bun run typecheck   # Type check
-bun run lint        # Lint
-bun run format      # Format
-bun run test        # Test
+bun run typecheck   # Type check all packages
+bun run lint        # Lint (Biome)
+bun run format      # Auto-format (Biome)
+bun run test        # Run tests across packages
+bun run build       # Build all libraries
 ```
 
-## Pull Requests
+You can also lint only the files you changed:
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/...`)
-3. Make your changes
-4. Run `bun run typecheck && bun run lint`
-5. Commit and push
-6. Open a Pull Request
+```bash
+bunx biome check <changed-files>
+```
 
-## Code Style
+If you installed the git hooks (`bunx lefthook install`), format, lint, and
+typecheck also run automatically on commit.
 
-- TypeScript with strict mode
-- Biome for formatting and linting
-- ESM modules
+## Code style
+
+- TypeScript with strict mode; ESM modules (`"type": "module"`).
+- [Biome](https://biomejs.dev/) for formatting and linting.
+- Single quotes, no semicolons, trailing commas, 100-character line width.
+- Avoid non-null assertions (`!`) and `any`; prefer `for...of`; don't leave unused
+  imports/variables. See [CLAUDE.md](CLAUDE.md) for the full house rules.
+
+## Pull requests
+
+1. **Fork** the repository and create a feature branch:
+   `git checkout -b feature/short-description`.
+2. **Keep PRs small and focused.** One logical change per PR is much easier to
+   review and merge than a large, mixed change. If a change is large, consider
+   splitting it or opening an issue to discuss the plan first.
+3. **Run** `bun run typecheck && bun run lint && bun run test` and make sure the
+   build passes.
+4. **Sign off your commits** for the DCO (see below) — use `git commit -s`.
+5. **Open the pull request** against `main` and fill out the
+   [PR template](.github/pull_request_template.md).
+
+### What to include in a pull request
+
+- **Tests** for new behavior or bug fixes where practical.
+- **Screenshots or short clips** for any change that affects the UI (Editor,
+  Server web UI, rendered diagrams). Before/after is ideal.
+- **A clear note if the change is breaking** — call it out in the PR description
+  and check the "Breaking change" box in the template, so it can be released
+  appropriately.
+- **A changeset** if you changed a published package (anything under
+  `libs/@shumoku/*` or `apps/cli`). CI fails PRs that touch published packages
+  without one:
+
+  ```bash
+  bun run changeset            # pick the package(s) + bump type (patch for 0.x)
+  bun x changeset add --empty  # for changes that need no release (tests, internal refactors)
+  ```
+
+  Do **not** hand-edit version numbers. See [docs/releasing.md](docs/releasing.md)
+  for the full release process.
+
+Maintainers review PRs and may ask for changes. Please be patient and responsive —
+small, well-described PRs are reviewed fastest.
+
+## Developer Certificate of Origin (DCO)
+
+This project uses the [Developer Certificate of Origin](https://developercertificate.org/)
+(DCO) rather than a CLA. The DCO is a lightweight way for contributors to certify
+that they wrote, or otherwise have the right to submit, the code they are
+contributing.
+
+To comply, **sign off every commit** by adding a `Signed-off-by` line. The easiest
+way is the `-s` flag:
+
+```bash
+git commit -s -m "Fix link bandwidth normalization"
+```
+
+This adds a line like:
+
+```
+Signed-off-by: Your Name <you@example.com>
+```
+
+By signing off, you certify that you agree to the terms of the
+[DCO](https://developercertificate.org/): that you have the right to submit the
+contribution, and that you understand it is provided under the project's license.
+
+> **Forgot to sign off? No problem.** A missing sign-off won't block an otherwise
+> good contribution. You can:
+> - amend the last commit: `git commit --amend -s`,
+> - sign off several commits at once: `git rebase --signoff main`, or
+> - simply add the sign-off in a follow-up commit — our DCO check accepts that,
+>   and a maintainer is happy to help you get it sorted.
+>
+> Tip: set `git config user.name` / `git config user.email` so the sign-off
+> matches your commit author.
+
+## License of contributions
+
+Shumoku is released under the **GNU Affero General Public License v3.0
+(AGPL-3.0)**. Unless explicitly stated otherwise, all contributions are accepted
+under AGPL-3.0 and become part of the project under that license. By submitting a
+contribution (and signing off with the DCO), you agree to license your
+contribution under AGPL-3.0.
 
 ## Releases
 
-See [Releasing Shumoku](docs/releasing.md) for npm, CLI, Server, and Editor
-stable/beta release processes.
+You don't need to publish anything to contribute. Releases are handled separately
+by the maintainers — see [docs/releasing.md](docs/releasing.md) for the npm, CLI,
+Server, and Editor release processes.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,152 @@
+# Shumoku Project Governance
+
+This document describes how the Shumoku open-source project is organized and how
+decisions are made. It is intended to keep the project transparent and welcoming
+to contributors, while making it clear who is responsible for the direction of
+the project.
+
+Shumoku is, and intends to remain, a community-driven open-source project. This
+document is a description of how we work, not a legal contract.
+
+## Mission
+
+Shumoku is an open-source toolkit for generating readable, trustworthy network
+topology diagrams from structured data (YAML, NetBox, LLDP, SNMP, and more), and
+for overlaying live metrics and alerts from monitoring systems such as Zabbix and
+Prometheus on top of those diagrams.
+
+The project's goal is to make network diagrams **reproducible, updateable, and
+grounded in a source of truth**, rather than static drawings that drift away from
+reality.
+
+Shumoku is licensed under **AGPL-3.0**. The freedom to use, study, modify, and
+redistribute the software under that license is a core value of this project and
+will not be taken away.
+
+## Roles
+
+### Project Lead
+
+The Project Lead is **Akitoshi Saeki (佐伯明俊, GitHub [@konoe-akitoshi](https://github.com/konoe-akitoshi))**.
+
+The Project Lead:
+
+- Sets and maintains the overall vision and direction of the project.
+- Has the final say on decisions when maintainers cannot reach agreement.
+- Is responsible for the roadmap, together with the maintainers.
+- Approves the addition and removal of maintainers.
+
+The Project Lead role is a stewardship role, not an ownership claim over
+contributors' work. All contributions remain licensed under AGPL-3.0 to the
+community (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+
+### Maintainers
+
+Maintainers are contributors who have taken on ongoing responsibility for the
+health of the project. They:
+
+- Review and merge pull requests.
+- Triage issues and help contributors.
+- Participate in roadmap and release discussions.
+- Help uphold the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+#### Current maintainers
+
+- Akitoshi Saeki — [@konoe-akitoshi](https://github.com/konoe-akitoshi) (Project Lead)
+- Joichiro Hayashi — [@jo16oh](https://github.com/jo16oh)
+- Koichi Hirachi — [@csenet](https://github.com/csenet)
+- 黒猫 — [@jg1vxg](https://github.com/jg1vxg)
+- [@nullpo7z](https://github.com/nullpo7z)
+
+New maintainers are invited by the Project Lead, typically after a sustained
+track record of high-quality contributions and good judgement. There is no fixed
+quota; the number of maintainers grows with the project.
+
+### Contributors
+
+Anyone who opens an issue, proposes a change, improves documentation, reports a
+bug, or otherwise helps the project is a contributor. You do not need any special
+status to contribute — see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
+
+### Partners
+
+A **partner** is an organization or individual that provides commercial services
+around Shumoku — for example implementation support, integration help, or
+first-line support for enterprise users. See [SUPPORT.md](SUPPORT.md) for what
+such services may cover.
+
+Partners are an important part of making Shumoku usable in production
+environments, but their role is deliberately bounded:
+
+- Partnerships are **non-exclusive**. There is no sole agent, exclusive
+  distributor, or single official reseller of Shumoku.
+- A partner does **not** own, control, or speak on behalf of the Shumoku project.
+- Providing commercial support does **not** grant control over the roadmap,
+  release decisions, or project governance.
+- Feature requests from partners and their customers are welcome and valued, but
+  are treated like any other request — they are not guaranteed to be implemented
+  or prioritized.
+
+> A partner company may provide commercial support or implementation services for
+> Shumoku, but such services are separate from the Shumoku open-source project
+> unless explicitly stated otherwise.
+
+## Decision-making
+
+Most decisions are made informally, through discussion on GitHub issues and pull
+requests, using **lazy consensus**: a proposal is assumed to be accepted if no
+maintainer objects within a reasonable time.
+
+When a decision is contested:
+
+1. Maintainers discuss the trade-offs openly, usually in the relevant issue or PR.
+2. The group aims for consensus among maintainers.
+3. If consensus cannot be reached, the **Project Lead makes the final decision**.
+
+Decisions should favor the long-term health of the project and its users over any
+single stakeholder.
+
+## Roadmap
+
+The roadmap is owned by the **Project Lead and the maintainers**. It is shaped by:
+
+- The project's mission and design philosophy.
+- Community feedback from issues and discussions.
+- Requests from users, including enterprise users and partners.
+
+Requests from partners or enterprise customers are welcome, but listing a request
+on the roadmap — or implementing it at all — is at the discretion of the
+maintainers and Project Lead. No external party can require a feature to be added.
+
+## Releases
+
+Release decisions belong to the **Shumoku project** (maintainers and Project
+Lead). Merging a pull request does **not** publish or deploy anything by itself;
+releases are a separate, deliberate action.
+
+The detailed, authoritative release process lives in
+[docs/releasing.md](docs/releasing.md). Shumoku ships several independent release
+streams (npm packages, CLI, Server, Editor), and there is intentionally no single
+monorepo-wide version.
+
+No partner or external organization can trigger or block a release on its own.
+
+## Open source vs. commercial support
+
+Two things are kept clearly separate:
+
+- **The open-source project.** The Shumoku software is provided under AGPL-3.0,
+  as-is and without warranty. Anyone may use, modify, and redistribute it under
+  that license.
+- **Commercial support and services.** Implementation help, integration support,
+  PoC assistance, and similar offerings may be provided commercially by the
+  Project Lead and/or by partners. These are separate services and are not part of
+  the AGPL-3.0 license grant. See [SUPPORT.md](SUPPORT.md).
+
+Use of Shumoku as open-source software never requires a commercial relationship.
+
+## Changes to this document
+
+This document may evolve as the project grows. Changes are proposed via pull
+request and follow the same decision-making process described above, with the
+Project Lead having final approval.

--- a/README.md
+++ b/README.md
@@ -285,9 +285,23 @@ This is a [Bun](https://bun.sh) workspaces + [Turborepo](https://turbo.build) mo
  </picture>
 </a>
 
+## Community & governance
+
+Shumoku is an open-source project led by [@konoe-akitoshi](https://github.com/konoe-akitoshi).
+Contributions are welcome under the AGPL-3.0 license.
+
+- [Contributing](CONTRIBUTING.md) — dev setup, pull requests, DCO sign-off
+- [Governance](GOVERNANCE.md) — roles, decision-making, releases
+- [Support](SUPPORT.md) — community help and commercial / implementation support
+- [Code of Conduct](CODE_OF_CONDUCT.md) · [Security](SECURITY.md) · [Brand guidelines](TRADEMARK.md)
+
 ## License
 
-This project is dual-licensed:
+Shumoku is free and open-source software, licensed under **AGPL-3.0**
+([LICENSE](./LICENSE)).
 
-- **AGPL-3.0** — For open-source use ([LICENSE](./LICENSE))
-- **Commercial License** — For proprietary use, contact contact@shumoku.dev
+For enterprise use, we can provide commercial **support and implementation
+services** (deployment, NetBox/Zabbix integration, PoC, custom development) —
+separate from the open-source license. See [SUPPORT.md](SUPPORT.md), or reach out
+at [contact@shumoku.dev](mailto:contact@shumoku.dev). If AGPL-3.0 does not fit your
+use case, contact us to discuss the options.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,51 @@
 # Security Policy
 
-## Supported Versions
+We take the security of Shumoku seriously and appreciate responsible disclosure.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.2.x   | :white_check_mark: |
-| < 0.2   | :x:                |
+## Reporting a vulnerability
 
-## Reporting a Vulnerability
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
 
-If you discover a security vulnerability, please report it by opening a [GitHub Security Advisory](https://github.com/konoe-akitoshi/shumoku/security/advisories/new).
+Instead, report privately through either of these channels:
 
-Please do **not** report security vulnerabilities through public GitHub issues.
+- **GitHub Security Advisory (preferred):**
+  [open a private advisory](https://github.com/konoe-akitoshi/shumoku/security/advisories/new).
+- **Email:** [contact@shumoku.dev](mailto:contact@shumoku.dev).
 
-### What to Include
+### What to include
 
-- Description of the vulnerability
-- Steps to reproduce
-- Potential impact
-- Suggested fix (if any)
+To help us understand and reproduce the issue, please include as much of the
+following as you can:
 
-### Response Time
+- **Impact** — what an attacker can achieve, and which component is affected
+  (library, CLI, Server, Editor, or a specific plugin).
+- **Affected versions** — the version(s) where you observed the issue.
+- **Steps to reproduce** — a minimal, reliable reproduction.
+- **Proof of concept** — a brief summary or snippet, if you have one.
+- **Suggested fix or mitigation** — optional, but welcome.
 
-We will acknowledge receipt of your report within 48 hours and aim to provide a detailed response within 7 days.
+## What to expect
+
+- We will acknowledge your report and investigate it as our time and resources
+  allow, and work with you on a fix and coordinated disclosure.
+- Shumoku is an early-stage open-source project. **There is currently no
+  commercial SLA or guaranteed response time.** We will do our best on a
+  best-effort basis.
+- We ask that you give us a reasonable opportunity to address the issue before
+  any public disclosure, and that you avoid accessing or modifying other users'
+  data while researching.
+
+## Supported versions
+
+Security fixes are generally applied to the latest released version. Older
+versions are addressed on a best-effort basis only. We recommend always running a
+current release.
+
+## No warranty
+
+Shumoku is free and open-source software provided under the **AGPL-3.0** license,
+**as-is and without warranty of any kind**, as described in the
+[LICENSE](LICENSE). Reporting a vulnerability does not create any warranty,
+support obligation, or service-level commitment. We are nonetheless grateful for
+responsible disclosure and will work with reporters in good faith.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,61 @@
+# Getting Support
+
+There are two kinds of support around Shumoku: free **community support** for
+everyone, and optional **commercial / partner support** for organizations that
+want hands-on help. This page explains the difference and where to go.
+
+## Where to ask what
+
+| I want to… | Go to |
+|---|---|
+| Report a bug | [Bug report](https://github.com/konoe-akitoshi/shumoku/issues/new?template=bug_report.yml) |
+| Request a feature | [Feature request](https://github.com/konoe-akitoshi/shumoku/issues/new?template=feature_request.yml) |
+| Ask a question / share an idea | [GitHub Discussions](https://github.com/konoe-akitoshi/shumoku/discussions) · [Discord](https://discord.gg/dyYbEsDZYr) |
+| Report a security issue | [SECURITY.md](SECURITY.md) (do **not** open a public issue) |
+| Get commercial / hands-on help | Email [contact@shumoku.dev](mailto:contact@shumoku.dev) |
+
+## Community support
+
+Community support is free and open to everyone:
+
+- **GitHub Issues** — for bugs and feature requests.
+- **GitHub Discussions** and **Discord** — for questions, usage help, and ideas.
+
+Community support is provided on a **best-effort basis by maintainers and the
+community**. There is **no guaranteed response time** and no service-level
+agreement. The friendliest, fastest path to help is a clear, reproducible report
+and a searchable question — see [CONTRIBUTING.md](CONTRIBUTING.md) for tips on
+filing good issues.
+
+## Commercial / partner support
+
+For production deployments, some organizations want more than best-effort
+community help. Commercial support and services may be available — provided by the
+Project Lead and/or by partner companies — and can cover things like:
+
+- Implementation and deployment support for the Shumoku Server and Editor.
+- **NetBox integration** support (topology and host discovery).
+- **Zabbix integration** support (metrics, LLDP topology, alerts).
+- Investigation of specific bugs or issues affecting your environment.
+- **Proof-of-concept (PoC)** assistance.
+- Consulting on custom development and integrations.
+
+To discuss commercial support, email **[contact@shumoku.dev](mailto:contact@shumoku.dev)**.
+We can scope what you need and, where appropriate, involve a partner.
+
+### Important boundaries
+
+- **The OSS itself comes with no warranty.** Shumoku is provided under AGPL-3.0,
+  as-is and without warranty (see [LICENSE](LICENSE)). Using the open-source
+  software never requires a commercial relationship.
+- **Commercial support is a separate service** from your rights under the
+  open-source license. Paying for support buys help and services — it does not
+  change the AGPL-3.0 terms of the software.
+- **Partners may provide this support, but do not control the project.** A partner
+  company may offer commercial support or implementation services for Shumoku, but
+  such services are separate from the open-source project unless explicitly stated
+  otherwise. Partners do **not** control the Shumoku roadmap or release decisions —
+  see [GOVERNANCE.md](GOVERNANCE.md).
+- **Commercial licensing / relicensing** is not an established program at this
+  time. If you have a specific need that AGPL-3.0 does not fit, reach out and we
+  can discuss it individually.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,80 @@
+# Shumoku Name & Brand Guidelines
+
+This document explains how the **Shumoku** name and logo may be used. It is meant
+to be practical and friendly — we want people to talk about, build on, and offer
+services around Shumoku. The goal is only to prevent confusion about what is
+official and who endorses what.
+
+These brand guidelines are separate from the software license. The **AGPL-3.0**
+license covers your right to use, modify, and redistribute the *code*. It does
+**not** grant rights to use the Shumoku *name and logo* in ways that could imply
+official status, endorsement, or affiliation. This document covers that second
+part.
+
+The Shumoku name and logo are managed by the **Shumoku Project**. If you are
+unsure whether a use is allowed, just ask: [contact@shumoku.dev](mailto:contact@shumoku.dev).
+
+## Uses that are always fine
+
+You don't need permission to:
+
+- State that your product, service, or documentation **uses** or is **built with**
+  Shumoku.
+- Describe something as **"compatible with Shumoku"**, a **"Shumoku integration"**,
+  or **"Shumoku-compatible"**, as long as it is accurate.
+- Say that you **provide implementation help, support, or consulting for Shumoku**
+  (as long as you don't imply this is official or exclusive — see below).
+- Use the name in truthful, descriptive references — blog posts, talks, tutorials,
+  comparisons, and academic work.
+- Link to the project and use the logo in unmodified form to refer to the project
+  (e.g. a small "powered by Shumoku" mark), without implying endorsement.
+
+## Uses that need prior permission
+
+Please contact us first if you want to:
+
+- Describe yourself or your organization as an **"official Shumoku partner"**,
+  **"certified"**, or **"authorized"** anything.
+- Use the Shumoku **logo prominently** in sales materials, marketing, or on a
+  website in a way that suggests an official relationship.
+- Create a **commercial product or service name that contains "Shumoku"**
+  (for example, a hosted service or paid edition branded with the name).
+- Use names that could be mistaken for an official product, such as
+  **"Shumoku Enterprise"**, **"Shumoku Pro"**, or **"Shumoku Cloud"**.
+
+We are generally happy to discuss these uses — the point is just to coordinate so
+that the official project and third-party offerings stay clearly distinguishable.
+
+## Uses that are not allowed
+
+Please do **not**:
+
+- Imply that your product or service is **official, certified, endorsed, or
+  guaranteed** by the Shumoku Project when it is not.
+- Present yourself as an **exclusive distributor, sole agent, or sole reseller**
+  of Shumoku. No such exclusive arrangement exists.
+- Suggest that the **Shumoku Project endorses or guarantees** a specific
+  third-party service, product, or company.
+- Present a **fork or modified version** in a way that could be mistaken for the
+  official Shumoku project or its releases.
+- Use the name or logo in a misleading, defamatory, or unlawful way.
+
+## A note on partners and commercial services
+
+Third parties — including companies — may offer commercial support, integration,
+or implementation services around Shumoku. That is welcome and encouraged. To
+keep things clear:
+
+> A partner company may provide commercial support or implementation services for
+> Shumoku, but such services are separate from the Shumoku open-source project
+> unless explicitly stated otherwise.
+
+In other words, offering services *for* Shumoku is fine; presenting those services
+*as* the official Shumoku project, or as an exclusive/official arrangement,
+requires prior permission (see above).
+
+## Questions
+
+This is a young project and these guidelines are intentionally lightweight. If
+something here is unclear or you have a use case that isn't covered, reach out at
+[contact@shumoku.dev](mailto:contact@shumoku.dev) and we'll work it out.


### PR DESCRIPTION
## Summary

Adds the GitHub-facing OSS documents Shumoku needs to read as a continuously-run
project rather than a personal repo. The license stays **AGPL-3.0** (LICENSE
unchanged); all docs point to `contact@shumoku.dev`.

Validated against the Linux Foundation report *Recommended Practices for Hosting
and Managing Open Source Projects on GitHub* (2023) — this completes the core
community-health set.

## Changes

**New**
- `GOVERNANCE.md` — Project Lead (Akitoshi Saeki), maintainers, roles,
  lazy-consensus decisions with Lead final say, project-owned releases, and
  non-exclusive partner boundaries (partners don't control roadmap/release).
- `SUPPORT.md` — community vs. commercial/partner support; OSS no-warranty.
- `TRADEMARK.md` — name/logo usage rules, separate from the code license.
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1.
- `.github/dco.yml` — contributor-friendly DCO app config (remediation, members exempt).
- `.github/ISSUE_TEMPLATE/config.yml` — route to Discussions / Discord / Security / commercial.

**Updated**
- `CONTRIBUTING.md` — DCO sign-off, small PRs, UI screenshots, breaking changes, changesets.
- `SECURITY.md` — GHSA + email reporting, best-effort (no SLA), no warranty.
- `README.md` — soften license section to AGPL-3.0 OSS + commercial support (drop
  dual-license framing); add a Community & governance pointer block.
- `.github/pull_request_template.md` — DCO, screenshots, breaking-change, changeset items.

## Type of Change

- [x] Documentation update

## Follow-ups (not in this PR)

- **DCO GitHub App**: install *after* merge — it reads `.github/dco.yml` from
  `main`. Keep it non-required initially (existing history is unsigned; Dependabot
  PRs would show red but won't block).
- **GitHub Discussions**: enabled — doc links now resolve.
- **Dependabot security updates**: enable in Settings → Code security.
- Optional: CodeQL code scanning, OpenSSF Best Practices Badge.

Maintainers listed in GOVERNANCE: @konoe-akitoshi (Lead), @jo16oh, @csenet, @jg1vxg, @nullpo7z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
