### PR TITLE
ci: add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+# Static analysis for security vulnerabilities and code-quality issues.
+# JavaScript/TypeScript is analyzed directly from source (no build required).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly sweep so newly-disclosed query packs catch issues even without a push.
+    - cron: "31 3 * * 1"
+
+# Cancel in-progress analysis for the same ref when new commits arrive.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds **CodeQL code scanning**, completing the security recommendation from the
Linux Foundation *Recommended Practices for Hosting and Managing Open Source
Projects on GitHub* report.

- Analyzes **JavaScript/TypeScript** directly from source (`build-mode: none` — no
  build step, lightweight).
- Runs on **push to `main`**, **PRs to `main`**, and a **weekly schedule**.
- Uses the **`security-and-quality`** query suite; results appear under the repo's
  **Security → Code scanning** tab and inline on PRs.

## Type of Change

- [x] Other: CI / security tooling

## Notes

- Code scanning is free for public repositories.
- This PR's own run will perform the first analysis; any findings are advisory
  (the check is not a required status check unless you add it in branch protection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
