### PR TITLE
chore: add OpenSSF Scorecard, ROADMAP, and LF practices citation

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,57 @@
+name: Scorecard supply-chain security
+
+# OpenSSF Scorecard — scores the project's security posture (branch protection,
+# token permissions, pinned dependencies, etc.) and publishes results to GitHub
+# code scanning and the public OpenSSF API. A low initial score is expected; the
+# findings act as a hardening to-do list rather than a failure.
+
+on:
+  # Re-run when branch protection changes (Scorecard checks this directly).
+  branch_protection_rule:
+  schedule:
+    - cron: "20 7 * * 2"
+  push:
+    branches: [main]
+
+# Read-only by default; the job below elevates only what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload SARIF results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results to the public OpenSSF API (enables the badge).
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish so a Scorecard badge becomes available for the README.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+
+# Tip: pinning the actions above to commit SHAs (instead of tags) raises the
+# Scorecard "Pinned-Dependencies" score. Tags are used here for readability;
+# Dependabot keeps them current.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -150,3 +150,16 @@ Use of Shumoku as open-source software never requires a commercial relationship.
 This document may evolve as the project grows. Changes are proposed via pull
 request and follow the same decision-making process described above, with the
 Project Lead having final approval.
+
+## References
+
+The community and governance practices in this repository — this document plus
+[CONTRIBUTING.md](CONTRIBUTING.md), [SECURITY.md](SECURITY.md),
+[SUPPORT.md](SUPPORT.md), [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md), and
+[TRADEMARK.md](TRADEMARK.md) — are informed by the Linux Foundation's recommended
+practices for running open-source projects on GitHub:
+
+- Ibrahim Haddad, Ph.D., *Recommended Practices for Hosting and Managing Open
+  Source Projects on GitHub*, foreword by Jeff McAffer, The Linux Foundation,
+  March 2023.
+  [PDF](https://www.linuxfoundation.org/hubfs/LF%20Research/Recommended%20Practices%20for%20Hosting%20and%20Managing%20OS%20Projects%20on%20Github%20-%20Report.pdf)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,50 @@
+# Shumoku Roadmap
+
+This is a living, best-effort view of where Shumoku is heading. It is **not a
+commitment or a delivery schedule** — priorities and timing change as we learn.
+For *how* roadmap decisions are made (and how partners/enterprise requests are
+handled), see [GOVERNANCE.md](GOVERNANCE.md#roadmap).
+
+Last updated: <!-- TODO: YYYY-MM -->
+
+## Themes
+
+What the project is broadly trying to achieve. <!-- TODO: confirm / edit -->
+
+- **Trustworthy diagrams** — keep generated topology close to the source of truth.
+- **Live operations** — overlay real-time metrics and alerts on the map.
+- **Easy adoption** — smooth setup for NetBox, Zabbix, Prometheus, and friends.
+
+## Now (in progress)
+
+<!-- TODO: list what's actively being worked on. Link issues/PRs where useful. -->
+
+- _e.g._ … <!-- #123 -->
+
+## Next (near-term)
+
+<!-- TODO: the next things we intend to pick up. -->
+
+- _e.g._ …
+
+## Later / exploring
+
+<!-- TODO: ideas under consideration, not yet scheduled. -->
+
+- _e.g._ …
+
+## Recently shipped
+
+<!-- TODO (optional): a short list of notable things already delivered, for context. -->
+
+- _e.g._ …
+
+## How to influence the roadmap
+
+- 💡 **Share an idea or use case** → [Discussions](https://github.com/konoe-akitoshi/shumoku/discussions)
+- 🐛 **Concrete bug or feature request** → [Issues](https://github.com/konoe-akitoshi/shumoku/issues)
+
+Feedback from users — including enterprise users and partners — is welcome and
+genuinely valued. As noted in [GOVERNANCE.md](GOVERNANCE.md#roadmap), a request
+being filed does not guarantee it will be scheduled or implemented; prioritization
+is at the discretion of the maintainers and Project Lead.


### PR DESCRIPTION
## Summary

Maturity follow-ups after the OSS-docs and CodeQL work.

- **OpenSSF Scorecard** — `.github/workflows/scorecard.yml`. Scores the project's
  security posture and publishes to **Security → Code scanning** + the public
  OpenSSF API (enables a Scorecard badge later). A low initial score is expected;
  findings are a hardening to-do list.
- **ROADMAP.md** — a living, best-effort roadmap that complements the roadmap
  *process* in `GOVERNANCE.md`. Sections are scaffolded with `TODO` placeholders
  to be filled in.
- **GOVERNANCE.md references** — cites the Linux Foundation report
  (*Recommended Practices for Hosting and Managing Open Source Projects on GitHub*,
  Ibrahim Haddad, March 2023) that informed these community/governance docs.

Also done outside this PR (repo settings):
- **Wiki disabled** (was enabled but empty/unused).

## Type of Change

- [x] Documentation update
- [x] Other: CI / security tooling

## Notes

- Scorecard's `publish_results: true` posts to the public OpenSSF API — standard
  for public repos and required for the badge.
- Pinning actions to commit SHAs would raise the Scorecard "Pinned-Dependencies"
  score; tags are used for readability and kept current by Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
