### PR TITLE
fix(ci): pin scorecard-action to v2.4.3

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

The Scorecard workflow was failing on every run with:

```
Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
```

`ossf/scorecard-action` does not publish a moving `v2` major tag — only full versions. This pins it to the latest release **v2.4.3**. Dependabot (github-actions) will keep it current.

Once merged, the Scorecard run on `main` should succeed and publish a score, after which a Scorecard badge can be added to the README.

## Type of Change

- [x] Bug fix (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
