### PR TITLE
docs: add OpenSSF Scorecard badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Shumoku turns YAML, NetBox, LLDP, SNMP, and other topology data into diagrams th
 [![npm version](https://img.shields.io/npm/v/shumoku.svg)](https://www.npmjs.com/package/shumoku)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](./LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13294/badge)](https://www.bestpractices.dev/projects/13294)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/konoe-akitoshi/shumoku/badge)](https://scorecard.dev/viewer/?uri=github.com/konoe-akitoshi/shumoku)
 [![Discord](https://img.shields.io/discord/1476527182669938720?logo=discord&logoColor=white&label=Discord)](https://discord.gg/dyYbEsDZYr)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow?logo=buy-me-a-coffee&logoColor=white)](https://buymeacoffee.com/akitoshi)
 


### PR DESCRIPTION
## Summary

The Scorecard workflow now runs successfully on `main` (after #510) and publishes a score (**currently 6.8/10**). This adds the Scorecard badge to the README, next to the OpenSSF Best Practices badge.

```
[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/konoe-akitoshi/shumoku/badge)](https://scorecard.dev/viewer/?uri=github.com/konoe-akitoshi/shumoku)
```

The score is a live hardening indicator — it will rise as items like SHA-pinned actions, signed releases, and required-checks coverage are addressed.

## Type of Change

- [x] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
