### PR TITLE
feat(server/web): secret field reveal toggle + configured/replace state

### DIFF
--- a/apps/server/web/src/lib/components/SchemaForm.svelte
+++ b/apps/server/web/src/lib/components/SchemaForm.svelte
@@ -11,6 +11,7 @@
   // Dynamic `optionsSource` candidates degrade to free entry (the documented F2
   // fallback); wiring getConfigOptions is a later step.
   import type { PluginConfigProperty, PluginConfigSchema } from '@shumoku/core'
+  import { EyeIcon, EyeSlashIcon, LockIcon } from 'phosphor-svelte'
   import SchemaForm from './SchemaForm.svelte'
 
   let {
@@ -30,6 +31,53 @@
   } = $props()
 
   const entries = $derived(Object.entries(schema.properties))
+
+  // --- Secret (password) widget state -------------------------------------
+  // A configured secret arrives from the API as a masked sentinel containing
+  // '•' (datasources API maskConfigSecrets). We keep it in `value` for display
+  // and treat it as "unchanged" on submit (the parent strips it).
+  const MASK_CHAR = '•'
+  function isMasked(v: unknown): boolean {
+    return typeof v === 'string' && v.includes(MASK_CHAR)
+  }
+
+  // Per-field UI state, keyed by schema key.
+  let revealed = $state<Record<string, boolean>>({})
+  let replacing = $state<Record<string, boolean>>({})
+  // The masked sentinel for an already-configured secret, kept so we can restore
+  // it when a replace is cancelled.
+  let storedSecret = $state<Record<string, string>>({})
+
+  // When the server (re)sends a masked secret — on load or after a save — show
+  // the "Configured" view and drop any stale replace/reveal state. Guarded
+  // writes keep this from looping.
+  $effect(() => {
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      if (prop.format !== 'password') continue
+      const v = value[key]
+      if (isMasked(v)) {
+        if (storedSecret[key] !== v) storedSecret[key] = v as string
+        if (replacing[key]) replacing[key] = false
+        if (revealed[key]) revealed[key] = false
+      }
+    }
+  })
+
+  function isConfigured(key: string): boolean {
+    return !replacing[key] && isMasked(value[key])
+  }
+  function startReplace(key: string) {
+    replacing[key] = true
+    revealed[key] = false
+    value[key] = ''
+    onChange?.()
+  }
+  function cancelReplace(key: string) {
+    replacing[key] = false
+    revealed[key] = false
+    value[key] = storedSecret[key] ?? ''
+    onChange?.()
+  }
 
   // Dynamic candidates for optionsSource array fields, fetched lazily.
   let candidates = $state<Record<string, { value: string; label: string }[]>>({})
@@ -226,6 +274,62 @@
               {onChange}
             />
           </fieldset>
+        {:else if prop.format === 'password'}
+          {#if isConfigured(key)}
+            <div class="secret-set">
+              <span class="secret-badge"><LockIcon size={14} /> Configured</span>
+              <button
+                type="button"
+                class="secret-action"
+                {disabled}
+                onclick={() => startReplace(key)}
+              >
+                Replace
+              </button>
+            </div>
+          {:else}
+            <div class="secret-edit">
+              <input
+                id={`sf-${key}`}
+                class="input secret-field"
+                type={revealed[key] ? 'text' : 'password'}
+                autocomplete="off"
+                autocapitalize="off"
+                spellcheck="false"
+                placeholder={prop.placeholder}
+                {disabled}
+                value={(value[key] ?? '') as string}
+                oninput={(e) => onText(key, e)}
+              >
+              <button
+                type="button"
+                class="secret-toggle"
+                {disabled}
+                aria-pressed={revealed[key] ? 'true' : 'false'}
+                aria-label={revealed[key] ? 'Hide value' : 'Show value'}
+                title={revealed[key] ? 'Hide' : 'Show'}
+                onclick={() => {
+                  revealed[key] = !revealed[key]
+                }}
+              >
+                {#if revealed[key]}
+                  <EyeSlashIcon size={16} />
+                {:else}
+                  <EyeIcon size={16} />
+                {/if}
+              </button>
+              {#if storedSecret[key] !== undefined}
+                <button
+                  type="button"
+                  class="secret-action"
+                  {disabled}
+                  onclick={() => cancelReplace(key)}
+                >
+                  Cancel
+                </button>
+              {/if}
+            </div>
+          {/if}
         {:else if prop.optionsSource && (candidates[prop.optionsSource]?.length ?? 0) > 0}
           <!-- Single-select from dynamic candidates (e.g. a Zabbix map). When no
                candidates are available (connection not ready), this falls through
@@ -322,5 +426,47 @@
     outline: none;
     background: transparent;
     font: inherit;
+  }
+  .secret-set {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .secret-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+    color: var(--muted-foreground, #6b7280);
+  }
+  .secret-edit {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  .secret-field {
+    flex: 1;
+  }
+  .secret-toggle,
+  .secret-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border, #e5e7eb);
+    border-radius: 0.375rem;
+    background: var(--muted, #f3f4f6);
+    cursor: pointer;
+    font-size: 0.8125rem;
+  }
+  .secret-toggle {
+    padding: 0.4rem;
+  }
+  .secret-action {
+    padding: 0.25rem 0.6rem;
+  }
+  .secret-toggle:disabled,
+  .secret-action:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 </style>

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -175,7 +175,7 @@
     // Manual has no connection config — its graph is recorded as an observation
     // (see manualGraphFromEditor / handleSave), not stored in config_json.
     if (type === 'manual') return '{}'
-    return JSON.stringify(pruneEmpty(config))
+    return JSON.stringify(pruneEmpty(stripMaskedSecrets(config, configSchemaFor(type))))
   }
 
   /** Parse the active editor pane (YAML or JSON) into a NetworkGraph. */
@@ -209,18 +209,24 @@
   }
 
   /**
-   * Blank password fields so the masked secret loaded from the API isn't
-   * re-submitted; the server preserves the stored secret when a field is
-   * omitted (and re-generates grafana's webhookSecret as needed).
+   * Drop password fields whose value is still the server's masked sentinel
+   * (contains '•') at submit time. An untouched secret is "unchanged" — omitting
+   * it makes the server preserve the stored value (and re-generate grafana's
+   * webhookSecret as needed). A field the user actually replaced holds real text
+   * and is kept. The masked value stays in `config` for display so the form can
+   * show a "Configured" state (see SchemaForm's password widget).
    */
-  function blankSecrets(
+  function stripMaskedSecrets(
     cfg: Record<string, unknown>,
     schema?: PluginConfigSchema,
   ): Record<string, unknown> {
     if (!schema) return cfg
     const out = { ...cfg }
     for (const [key, prop] of Object.entries(schema.properties)) {
-      if (prop.format === 'password') out[key] = ''
+      const v = out[key]
+      if (prop.format === 'password' && typeof v === 'string' && v.includes('•')) {
+        delete out[key]
+      }
     }
     return out
   }
@@ -246,8 +252,9 @@
           pluginTypes = await api.dataSources.getPluginTypes()
           if (cancelled) return
         }
-        const parsed = parseConfig(ds.configJson) as Record<string, unknown>
-        config = blankSecrets(parsed, configSchemaFor(ds.type))
+        // Keep the server's masked secrets in `config` so the form shows a
+        // "Configured" state; they're stripped at submit time (stripMaskedSecrets).
+        config = parseConfig(ds.configJson) as Record<string, unknown>
 
         await loadConnectionInfo()
 
@@ -343,11 +350,9 @@
       }
 
       dataSource = await dataSources.update(id, updates)
-      // Re-seed from the saved (masked) config so password fields blank again.
-      config = blankSecrets(
-        parseConfig(dataSource.configJson) as Record<string, unknown>,
-        configSchemaFor(dataSource.type),
-      )
+      // Re-seed from the saved (masked) config; SchemaForm shows the masked
+      // secrets as "Configured" again.
+      config = parseConfig(dataSource.configJson) as Record<string, unknown>
 
       // Refresh derived connection info after save (e.g. a webhook secret may
       // have just been generated server-side).


### PR DESCRIPTION
## What

Reworks how `format: 'password'` fields (NetBox/Zabbix/Grafana tokens, etc.) render in the generic `SchemaForm`, so secrets are verifiable on input and clearly indicated when already set.

### Before
- The token field was a bare `<input type="password">`, blanked on load. No reveal, no "is a secret set?" indication, no replace affordance.
- A pasted value couldn't be eyeballed → e.g. NetBox's UI copies the **full Authorization header** `Token <token>`, and the extra `Token ` prefix slipped in unnoticed → `Authorization: Token Token …` → HTTP 403.

### After
- **Reveal (eye) toggle** to verify the pasted value before saving.
- **"Configured" indicator + Replace/Cancel** for already-set secrets, driven by the server's masked sentinel — no plaintext is ever round-tripped (write-only preserved).
- `autocomplete` / `autocapitalize` / `spellcheck` off on the input.
- Edit page keeps the masked value for display and strips still-masked secrets **only at submit time** (`stripMaskedSecrets`): an untouched secret is omitted (preserved server-side); a replaced one is sent.

## Why
Removes the "blank field — is it even set?" confusion and makes the copy-paste-a-scheme-prefix footgun visible at input time.

## Scope / release
- Touches only `@shumoku/server-web` (private). No public-package change → **no changeset** (verified `changeset status` is clean).
- Renders generically from `configSchema` — no per-plugin branch (keeps #270 invariant).

## Verification
- `biome check` clean
- `svelte-check` — 0 errors / 0 warnings
- `bun run build` — success
- pre-commit hooks (biome + monorepo typecheck) green

## Behavior
| Case | UI |
|---|---|
| New source | editable input + reveal |
| Existing, untouched | `🔒 Configured` + Replace (omitted on submit → preserved) |
| Replace clicked | empty input + reveal + Cancel |

A follow-up PR will harden NetBox auth itself (v1/v2 scheme detection + leading-scheme stripping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)