### PR TITLE
fix(server/web): dashboard "+ Add Widget" silently drops widgets

### DIFF
--- a/apps/server/web/src/routes/(app)/dashboards/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/dashboards/[id]/+page.svelte
@@ -13,7 +13,7 @@
     TreeStructureIcon,
     XIcon,
   } from 'phosphor-svelte'
-  import { mount, onMount, tick, unmount } from 'svelte'
+  import { mount, onMount, tick, unmount, untrack } from 'svelte'
   import { browser } from '$app/environment'
   import { goto } from '$app/navigation'
   import { api } from '$lib/api'
@@ -62,11 +62,19 @@
     const currentId = id
     if (!currentId) return
     // Tear down the existing grid so the next layout rebuilds cleanly.
-    cleanupAllWidgets()
-    if (grid) {
-      grid.destroy(true)
-      grid = null
-    }
+    // Only `id` should trigger this effect — read/mutate `grid` inside
+    // untrack() so the grid signal is NOT captured as a dependency. Otherwise
+    // initGrid()'s `grid = GridStack.init(...)` re-fires this effect, which
+    // destroys the freshly-created grid (and refetches), ping-ponging with the
+    // init effect forever and leaving `grid` null — so Add Widget's
+    // `if (!grid) return` guard silently drops every widget.
+    untrack(() => {
+      cleanupAllWidgets()
+      if (grid) {
+        grid.destroy(true)
+        grid = null
+      }
+    })
     dashboardStore.get(currentId)
   })
 


### PR DESCRIPTION
## 症状

Dashboard の **「+ Add Widget」** で topology などを選んでも、ウィジェットがグリッドに追加されへん（無反応）。

## 原因（回帰）

`688e7bff` で入った「route id 変更時に GridStack を破棄する `$effect`」が犯人です。

```js
$effect(() => {
  const currentId = id
  if (!currentId) return
  cleanupAllWidgets()
  if (grid) {          // ← grid ($state) を読んでいる
    grid.destroy(true)
    grid = null
  }
  dashboardStore.get(currentId)
})
```

この effect は `if (grid)` で `grid`(`$state`) を読むため、Svelte 5 が **`grid` を依存として捕捉** してしまう。結果、layout ロード時に `grid = GridStack.init(...)` する別 effect と無限 ping-pong する:

1. grid を生成 (null→obj)
2. grid が変化 → **この route-id effect が再発火** → 生成直後の grid を `destroy()` ＋ API 再 fetch
3. grid が null → init effect が再発火 → また grid 生成 → 1 へ…

`tick()` / `get()` を挟むため同期の depth guard には引っかからず、**非同期の無限ループ** になり `grid` が常時 null/破壊済みになる。そこへ Add Widget を押すと:

```js
async function addWidgetToGrid(type: string) {
  if (!grid || !$currentLayout) return   // ← grid が null で即 return
```

で弾かれ、何も追加されへんかった（裏で API も叩き続ける）。

## 修正

grid の teardown を `untrack()` で包み、この effect が **`id` の変化だけ** に反応するようにした。grid 生成のたびに自滅する連鎖を断ち切る。

## 確認

- [x] `biome check` / pre-commit hook 通過
- [ ] 実機 (web + API:8080) で edit → Add Widget → topology がグリッドに乗ることを確認

> 公開パッケージ (`libs/@shumoku/*` / `apps/cli`) の変更ではないため changeset は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)