### PR TITLE
feat(server): first-class secret config field with in-field reveal toggle

### DIFF
--- a/.changeset/secret-field-flag.md
+++ b/.changeset/secret-field-flag.md
@@ -4,7 +4,6 @@
 'shumoku-plugin-grafana': patch
 'shumoku-plugin-prometheus': patch
 'shumoku-plugin-zabbix': patch
-'shumoku-plugin-aruba-instant-on': patch
 ---
 
 Add a first-class `secret` flag to plugin config schemas.

--- a/.changeset/secret-field-flag.md
+++ b/.changeset/secret-field-flag.md
@@ -1,0 +1,20 @@
+---
+'@shumoku/core': minor
+'shumoku-plugin-netbox': patch
+'shumoku-plugin-grafana': patch
+'shumoku-plugin-prometheus': patch
+'shumoku-plugin-zabbix': patch
+'shumoku-plugin-aruba-instant-on': patch
+---
+
+Add a first-class `secret` flag to plugin config schemas.
+
+`PluginConfigProperty` gains `secret?: boolean`, and `@shumoku/core/plugin-kit`
+exports `isSecretProp`. Secret-ness is declared once on the schema
+(`secret: true`; `format: 'password'` is still honoured for back-compat), so the
+host can render token/password fields masked with a show/hide reveal toggle and
+suppress password-manager autofill from a single definition — no per-plugin
+branches, no hard-coded field-name lists.
+
+Bundled plugins mark their token/password/webhook-secret fields with
+`secret: true`.

--- a/apps/server/api/src/api/datasources.ts
+++ b/apps/server/api/src/api/datasources.ts
@@ -13,31 +13,12 @@ import { getSignalStreams } from '../services/signal-streams.js'
 import type { DataSourceInput } from '../types.js'
 import { getTopologyService } from './topologies.js'
 
-/**
- * Mask sensitive fields in config JSON
- */
-const SECRET_KEYS = new Set(['token', 'password', 'secret', 'apikey', 'apiKey'])
-
-function maskConfigSecrets(configJson: string): string {
-  try {
-    const config = JSON.parse(configJson)
-    maskSecrets(config)
-    return JSON.stringify(config)
-  } catch {
-    return configJson
-  }
-}
-
-function maskSecrets(obj: Record<string, unknown>): void {
-  for (const key of Object.keys(obj)) {
-    const value = obj[key]
-    if (SECRET_KEYS.has(key) && typeof value === 'string') {
-      obj[key] = '••••••••'
-    } else if (value && typeof value === 'object' && !Array.isArray(value)) {
-      maskSecrets(value as Record<string, unknown>)
-    }
-  }
-}
+// Secret fields (token / password / webhookSecret) are returned to the client
+// in full. The config UI is admin-only (single-session auth — there is no
+// non-admin role that can reach it), and the admin can already read the same
+// values straight from the database, so the form masks them with a reveal
+// toggle rather than withholding them. Revisit toward a gated reveal-on-demand
+// endpoint if Shumoku ever gains multi-user roles or at-rest config encryption.
 
 /**
  * Validate a config_json string against the plugin's configSchema using core's
@@ -140,12 +121,7 @@ export function createDataSourcesApi(): Hono {
   // existing topology) so the list can be noisy at first; users can
   // rename them from each detail page.
   app.get('/', (c) => {
-    const dataSources = service.list()
-    const sanitized = dataSources.map((ds) => ({
-      ...ds,
-      configJson: maskConfigSecrets(ds.configJson),
-    }))
-    return c.json(sanitized)
+    return c.json(service.list())
   })
 
   // List data sources by capability. Manual has no capabilities so it
@@ -158,12 +134,7 @@ export function createDataSourcesApi(): Hono {
         400,
       )
     }
-    const dataSources = service.listByCapability(capability)
-    const sanitized = dataSources.map((ds) => ({
-      ...ds,
-      configJson: maskConfigSecrets(ds.configJson),
-    }))
-    return c.json(sanitized)
+    return c.json(service.listByCapability(capability))
   })
 
   // Topologies that this data source is currently attached to.
@@ -194,10 +165,7 @@ export function createDataSourcesApi(): Hono {
     if (!dataSource) {
       return c.json({ error: 'Data source not found' }, 404)
     }
-    return c.json({
-      ...dataSource,
-      configJson: maskConfigSecrets(dataSource.configJson),
-    })
+    return c.json(dataSource)
   })
 
   // Create new data source
@@ -215,13 +183,7 @@ export function createDataSourcesApi(): Hono {
       }
 
       const dataSource = await service.create(body)
-      return c.json(
-        {
-          ...dataSource,
-          configJson: maskConfigSecrets(dataSource.configJson),
-        },
-        201,
-      )
+      return c.json(dataSource, 201)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 400)
@@ -253,10 +215,7 @@ export function createDataSourcesApi(): Hono {
       // A config edit can change resolve inputs (priority / connection) →
       // invalidate attached topologies so they recompute.
       getTopologyService().clearCacheForDataSource(id)
-      return c.json({
-        ...dataSource,
-        configJson: maskConfigSecrets(dataSource.configJson),
-      })
+      return c.json(dataSource)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 400)

--- a/apps/server/api/src/services/datasource.ts
+++ b/apps/server/api/src/services/datasource.ts
@@ -24,9 +24,6 @@ import type {
 } from '../plugins/types.js'
 import type { DataSource, DataSourceInput, DataSourceStatus, DataSourceType } from '../types.js'
 
-/** Config keys that should be preserved on update when not explicitly provided */
-const SECRET_KEYS = ['token', 'password', 'secret', 'apikey', 'apiKey']
-
 interface DataSourceRow {
   id: string
   name: string
@@ -200,34 +197,20 @@ export class DataSourceService {
       values.push(input.type)
     }
     if (input.configJson !== undefined) {
-      let configJson = input.configJson
-      const newConfig = JSON.parse(configJson)
-      const existingConfig = JSON.parse(existing.configJson)
-
-      // Preserve sensitive fields (token, password, etc.) when not provided in update
-      for (const key of SECRET_KEYS) {
-        if (newConfig[key] === undefined && existingConfig[key] !== undefined) {
-          newConfig[key] = existingConfig[key]
-        }
-      }
-
-      // Handle Grafana-specific fields
+      const newConfig = JSON.parse(input.configJson)
       const type = input.type ?? existing.type
-      if (type === 'grafana') {
-        // Preserve existing webhook secret
-        if (!newConfig.webhookSecret && existingConfig.webhookSecret) {
-          newConfig.webhookSecret = existingConfig.webhookSecret
-        }
-        // Generate secret when useWebhook is enabled and no secret exists
-        if (newConfig.useWebhook && !newConfig.webhookSecret) {
-          const { nanoid } = await import('nanoid')
-          newConfig.webhookSecret = nanoid(32)
-        }
+
+      // The form submits the full config including secret values (they are
+      // returned to the admin-only UI and masked there), so there's nothing to
+      // preserve here — store as provided. Still auto-provision a Grafana
+      // webhook secret when the webhook is enabled and none was supplied.
+      if (type === 'grafana' && newConfig.useWebhook && !newConfig.webhookSecret) {
+        const { nanoid } = await import('nanoid')
+        newConfig.webhookSecret = nanoid(32)
       }
 
-      configJson = JSON.stringify(newConfig)
       updates.push('config_json = ?')
-      values.push(configJson)
+      values.push(JSON.stringify(newConfig))
     }
 
     if (updates.length === 0) {

--- a/apps/server/web/src/lib/components/SchemaForm.svelte
+++ b/apps/server/web/src/lib/components/SchemaForm.svelte
@@ -10,7 +10,8 @@
   // $effect, not during render, to avoid Svelte's state_unsafe_mutation.
   // Dynamic `optionsSource` candidates degrade to free entry (the documented F2
   // fallback); wiring getConfigOptions is a later step.
-  import type { PluginConfigProperty, PluginConfigSchema } from '@shumoku/core'
+  import { isSecretProp, type PluginConfigProperty, type PluginConfigSchema } from '@shumoku/core'
+  import { EyeIcon, EyeSlashIcon } from 'phosphor-svelte'
   import SchemaForm from './SchemaForm.svelte'
 
   let {
@@ -28,6 +29,11 @@
     /** Called after any field mutation — for save-on-change consumers. */
     onChange?: () => void
   } = $props()
+
+  // Per-field reveal toggle for secret inputs. Default masked (type=password);
+  // the eye reveals the value, including a stored secret the server returns to
+  // the admin-only config UI.
+  let revealed = $state<Record<string, boolean>>({})
 
   const entries = $derived(Object.entries(schema.properties))
 
@@ -242,6 +248,45 @@
               <option value={o.value}>{o.label}</option>
             {/each}
           </select>
+        {:else if isSecretProp(prop)}
+          <div class="relative" class:opacity-50={disabled}>
+            <input
+              id={`sf-${key}`}
+              class="input"
+              style="padding-right: 2.5rem"
+              type={revealed[key] ? 'text' : 'password'}
+              autocomplete="new-password"
+              autocapitalize="off"
+              autocorrect="off"
+              spellcheck="false"
+              data-1p-ignore
+              data-lpignore="true"
+              data-bwignore="true"
+              placeholder={prop.placeholder}
+              {disabled}
+              value={(value[key] ?? prop.default ?? '') as string}
+              oninput={(e) => onText(key, e)}
+            >
+            <!-- Eye sits inside the field's right edge. Stable accessible name +
+                 aria-pressed conveys state; the icon swaps for sighted users. -->
+            <button
+              type="button"
+              class="absolute inset-y-0 right-0 flex w-9 items-center justify-center text-theme-text-muted transition-colors hover:text-theme-text disabled:opacity-60"
+              aria-label="Toggle secret visibility"
+              aria-pressed={revealed[key] ? 'true' : 'false'}
+              title={revealed[key] ? 'Hide' : 'Show'}
+              {disabled}
+              onclick={() => {
+                revealed[key] = !revealed[key]
+              }}
+            >
+              {#if revealed[key]}
+                <EyeSlashIcon size={16} />
+              {:else}
+                <EyeIcon size={16} />
+              {/if}
+            </button>
+          </div>
         {:else}
           <input
             id={`sf-${key}`}

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -208,23 +208,6 @@
     return out
   }
 
-  /**
-   * Blank password fields so the masked secret loaded from the API isn't
-   * re-submitted; the server preserves the stored secret when a field is
-   * omitted (and re-generates grafana's webhookSecret as needed).
-   */
-  function blankSecrets(
-    cfg: Record<string, unknown>,
-    schema?: PluginConfigSchema,
-  ): Record<string, unknown> {
-    if (!schema) return cfg
-    const out = { ...cfg }
-    for (const [key, prop] of Object.entries(schema.properties)) {
-      if (prop.format === 'password') out[key] = ''
-    }
-    return out
-  }
-
   // Re-fetch whenever the route id changes (the component is reused across
   // /datasources/[id] navigations).
   $effect(() => {
@@ -246,8 +229,9 @@
           pluginTypes = await api.dataSources.getPluginTypes()
           if (cancelled) return
         }
-        const parsed = parseConfig(ds.configJson) as Record<string, unknown>
-        config = blankSecrets(parsed, configSchemaFor(ds.type))
+        // Config includes secret values (returned to the admin-only UI); the
+        // form masks them with a reveal toggle.
+        config = parseConfig(ds.configJson) as Record<string, unknown>
 
         await loadConnectionInfo()
 
@@ -343,11 +327,9 @@
       }
 
       dataSource = await dataSources.update(id, updates)
-      // Re-seed from the saved (masked) config so password fields blank again.
-      config = blankSecrets(
-        parseConfig(dataSource.configJson) as Record<string, unknown>,
-        configSchemaFor(dataSource.type),
-      )
+      // Re-seed from the saved config (a server-generated webhook secret may now
+      // be present).
+      config = parseConfig(dataSource.configJson) as Record<string, unknown>
 
       // Refresh derived connection info after save (e.g. a webhook secret may
       // have just been generated server-side).

--- a/libs/@shumoku/core/src/plugin-kit/index.ts
+++ b/libs/@shumoku/core/src/plugin-kit/index.ts
@@ -16,6 +16,7 @@
 export * from './alertmanager.js'
 export * from './concurrency.js'
 export * from './metrics-flatten.js'
+export * from './secrets.js'
 export * from './severity.js'
 export * from './stamp.js'
 export * from './validate-schema.js'

--- a/libs/@shumoku/core/src/plugin-kit/secrets.test.ts
+++ b/libs/@shumoku/core/src/plugin-kit/secrets.test.ts
@@ -1,0 +1,15 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import { isSecretProp } from './secrets.js'
+
+describe('isSecretProp', () => {
+  it('treats secret:true and format:password as secret, nothing else', () => {
+    expect(isSecretProp({ type: 'string', secret: true })).toBe(true)
+    expect(isSecretProp({ type: 'string', format: 'password' })).toBe(true)
+    expect(isSecretProp({ type: 'string', format: 'uri' })).toBe(false)
+    expect(isSecretProp({ type: 'string' })).toBe(false)
+  })
+})

--- a/libs/@shumoku/core/src/plugin-kit/secrets.ts
+++ b/libs/@shumoku/core/src/plugin-kit/secrets.ts
@@ -1,0 +1,24 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Secret field identification, schema-driven.
+ *
+ * Secret-ness is declared once on the schema (`secret: true`, or legacy
+ * `format: 'password'`). The host renders such fields masked with a reveal
+ * toggle and suppresses password-manager autofill — a single definition both
+ * the web form and any plugin can share, with no per-plugin branches and no
+ * hard-coded field-name lists.
+ */
+
+import type { PluginConfigProperty } from '../plugin-types.js'
+
+/**
+ * A field is a write-only secret if it declares `secret: true`. `format:
+ * 'password'` is honoured too so external plugins that predate the flag keep
+ * working; new schemas should set `secret: true`.
+ */
+export function isSecretProp(prop: PluginConfigProperty): boolean {
+  return prop.secret === true || prop.format === 'password'
+}

--- a/libs/@shumoku/core/src/plugin-types.ts
+++ b/libs/@shumoku/core/src/plugin-types.ts
@@ -709,6 +709,13 @@ export interface PluginConfigProperty {
   description?: string
   /** String formatting hint (masked password / URL / email). */
   format?: 'password' | 'uri' | 'email'
+  /**
+   * Marks this field as a secret (API token, password, webhook secret). The
+   * host renders it masked with a reveal (show/hide) toggle and suppresses
+   * password-manager autofill. `format: 'password'` is treated as `secret`
+   * for back-compat, but new schemas should set `secret: true` directly.
+   */
+  secret?: boolean
   /** Placeholder shown in an empty input. */
   placeholder?: string
   default?: unknown

--- a/libs/plugins/aruba-instant-on/src/index.ts
+++ b/libs/plugins/aruba-instant-on/src/index.ts
@@ -15,7 +15,7 @@ const configSchema: PluginConfigSchema = {
       title: 'Portal email',
       warning: 'The account must NOT have MFA enabled.',
     },
-    password: { type: 'string', format: 'password', title: 'Password' },
+    password: { type: 'string', secret: true, title: 'Password' },
     siteId: {
       type: 'string',
       title: 'Site ID',

--- a/libs/plugins/grafana/src/index.ts
+++ b/libs/plugins/grafana/src/index.ts
@@ -15,7 +15,7 @@ const configSchema: PluginConfigSchema = {
   required: ['url', 'token'],
   properties: {
     url: { type: 'string', format: 'uri', title: 'Grafana URL' },
-    token: { type: 'string', format: 'password', title: 'API token' },
+    token: { type: 'string', secret: true, title: 'API token' },
     useWebhook: {
       type: 'boolean',
       title: 'Receive alerts via webhook',
@@ -24,7 +24,7 @@ const configSchema: PluginConfigSchema = {
     },
     webhookSecret: {
       type: 'string',
-      format: 'password',
+      secret: true,
       title: 'Webhook secret',
       visibleWhen: { field: 'useWebhook', equals: true },
       help: 'Leave blank to auto-generate on save.',

--- a/libs/plugins/netbox/src/index.ts
+++ b/libs/plugins/netbox/src/index.ts
@@ -82,7 +82,7 @@ const configSchema: PluginConfigSchema = {
   required: ['url', 'token'],
   properties: {
     url: { type: 'string', format: 'uri', title: 'NetBox URL' },
-    token: { type: 'string', format: 'password', title: 'API token' },
+    token: { type: 'string', secret: true, title: 'API token' },
     insecure: {
       type: 'boolean',
       title: 'Skip TLS verification',

--- a/libs/plugins/prometheus/src/index.ts
+++ b/libs/plugins/prometheus/src/index.ts
@@ -61,7 +61,7 @@ const configSchema: PluginConfigSchema = {
       title: 'Basic auth (optional)',
       properties: {
         username: { type: 'string', title: 'Username' },
-        password: { type: 'string', format: 'password', title: 'Password' },
+        password: { type: 'string', secret: true, title: 'Password' },
       },
     },
   },

--- a/libs/plugins/zabbix/src/index.ts
+++ b/libs/plugins/zabbix/src/index.ts
@@ -15,7 +15,7 @@ const configSchema: PluginConfigSchema = {
       title: 'Zabbix URL',
       placeholder: 'https://zabbix.example.com',
     },
-    token: { type: 'string', format: 'password', title: 'API token' },
+    token: { type: 'string', secret: true, title: 'API token' },
     insecure: {
       type: 'boolean',
       title: 'Skip TLS verification',


### PR DESCRIPTION
## Why

Secret-ness for plugin config fields was expressed three different ways and they had to stay in sync by convention:

- server masking/preservation keyed on a hard-coded name list (`['token','password','secret','apikey','apiKey']`)
- the web form keyed on `format: 'password'`
- a `type === 'grafana'` branch in the service preserved `webhookSecret`

The list and the form had drifted: `webhookSecret` was `format: 'password'` but **not** in the server name list, so it was returned to the browser unmasked and only kept-on-update by the grafana-specific branch. There was also no first-class way to say "this field is a secret."

## What

- **`@shumoku/core`**: add `secret?: boolean` to `PluginConfigProperty` and export `isSecretProp` from `plugin-kit`. Secret-ness is declared once on the schema (`format: 'password'` still honoured for back-compat).
- **Bundled plugins** (netbox / grafana / prometheus / zabbix / aruba-instant-on): mark token / password / webhook-secret fields with `secret: true`.
- **Web `SchemaForm`**: secret fields render masked with an **in-field eye reveal toggle** (phosphor `Eye`/`EyeSlash`, Tailwind utilities, stable `aria-label` + `aria-pressed`) and **password-manager autofill suppressed** (`autocomplete="new-password"` + 1Password / LastPass / Bitwarden ignore attrs). No per-plugin branches.
- **Server**: the datasource config UI is admin-only (single-session auth — no non-admin role can reach it) and the admin can already read these values straight from the DB, so the server returns secret values to the form (masked + revealable client-side) rather than withholding them.

A code comment marks the revisit trigger: move to a gated reveal-on-demand endpoint if Shumoku gains multi-user roles or at-rest config encryption.

## Test

- core: `plugin-kit/secrets.test.ts` (isSecretProp), full core suite green
- server-api: typecheck + 28 unit + 71 db tests green
- web: `svelte-check` 0 errors / 0 warnings
- biome: clean on all changed files
- Manually verified on the dev server: existing source shows the stored token masked with a working eye toggle; editing other fields keeps the token; new source masks + suppresses autofill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)