### PR TITLE
ci(docker): publish a rolling `edge` tag on every server release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,7 @@ jobs:
             type=raw,value=${{ steps.build.outputs.version }},enable=${{ steps.build.outputs.release == 'true' }}
             type=raw,value=latest,enable=${{ steps.build.outputs.channel == 'stable' }}
             type=raw,value=beta,enable=${{ steps.build.outputs.channel == 'beta' }}
+            type=raw,value=edge,enable=${{ steps.build.outputs.release == 'true' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -83,12 +83,14 @@ The Docker workflow verifies that the tag matches
 
 | Release | GHCR tags changed | GitHub Release |
 |---------|-------------------|----------------|
-| Beta | `X.Y.Z-beta.N`, `beta` | prerelease |
-| Stable | `X.Y.Z`, `latest` | stable release |
+| Beta | `X.Y.Z-beta.N`, `beta`, `edge` | prerelease |
+| Stable | `X.Y.Z`, `latest`, `edge` | stable release |
 
 Pushes to `main` and pull requests build the image for verification but do not
 publish it. Stable releases never move `beta`, and beta releases never move
-`latest`.
+`latest`. `edge` moves on every release — stable or beta — so it always points
+at the most recently published image (the bleeding-edge channel); pin an
+immutable `X.Y.Z` / `X.Y.Z-beta.N` tag for reproducibility.
 
 The running Server checks GitHub Releases whose tags begin with `server-v`.
 Stable builds ignore beta releases. Beta builds can report a newer beta or the


### PR DESCRIPTION
## Why

`:latest` only tracks the newest **stable** and `:beta` only the newest **beta** — there's no single tag for "newest of either channel". A user who wants to always run the most recent build (prereleases included) had no rolling tag to follow.

## What

Add an `edge` tag to the Docker metadata, enabled on every release (`release == 'true'`, i.e. any `server-v*` tag — stable or beta). It moves on each publish, so `:edge` always points at the most recently published image.

- `:latest` → newest stable (unchanged)
- `:beta` → newest beta (unchanged)
- `:edge` → newest of either (new)

Immutable `X.Y.Z` / `X.Y.Z-beta.N` tags remain for reproducible pins. `main`/PR builds still don't publish, so `edge` only ever reflects tagged releases. Docs (`releasing.md`) updated.

```bash
docker pull ghcr.io/konoe-akitoshi/shumoku:edge
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)