### PR TITLE
fix(zabbix): exclude resolved problems from active alerts + Server 0.1.3-beta.2

### DIFF
--- a/.changeset/zabbix-active-alerts-only.md
+++ b/.changeset/zabbix-active-alerts-only.md
@@ -1,0 +1,14 @@
+---
+'shumoku-plugin-zabbix': patch
+---
+
+Fix the Zabbix alerts widget showing already-resolved problems when
+`activeOnly` is requested.
+
+`event.get` was filtered with a top-level `value` parameter, which Zabbix
+ignores (value filtering must go through `filter`), so recovery events leaked
+through. Even with that fixed, a problem that has since recovered still carries
+its original `value=1` event, so active-only queries now also drop events whose
+`r_eventid` points at a recovery event. The mapped `status` uses the same
+recovery check, so resolved-but-recent problems are no longer reported as
+active.

--- a/apps/server/chart/shumoku/Chart.yaml
+++ b/apps/server/chart/shumoku/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: shumoku
 description: Network topology visualization server
 type: application
-version: 0.1.3-beta.1
-appVersion: "0.1.3-beta.1"
+version: 0.1.3-beta.2
+appVersion: "0.1.3-beta.2"
 home: https://www.shumoku.dev/
 sources:
   - https://github.com/konoe-akitoshi/shumoku

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shumoku/server",
-  "version": "0.1.3-beta.1",
+  "version": "0.1.3-beta.2",
   "private": true,
   "description": "Real-time network topology visualization server with Zabbix integration",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -96,7 +96,7 @@
     },
     "apps/server": {
       "name": "@shumoku/server",
-      "version": "0.1.3-beta.1",
+      "version": "0.1.3-beta.2",
       "dependencies": {
         "@shumoku/server-api": "workspace:*",
         "@shumoku/server-web": "workspace:*",

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -507,8 +507,13 @@ export class ZabbixPlugin
       name: string
       severity: string
       clock: string
-      /** '1' = problem (active), '0' = recovery (resolved) */
+      /** '1' = problem, '0' = recovery */
       value: string
+      /**
+       * Recovery event id. '0' means the problem has *not* recovered yet
+       * (still active); any other id means a recovery event closed it.
+       */
+      r_eventid?: string
       hosts?: Array<{ hostid: string; host: string; name: string }>
     }
 
@@ -516,7 +521,7 @@ export class ZabbixPlugin
     // Zabbix 3.x–7.x and continues to accept selectHosts, while problem.get
     // dropped selectHosts in 7.0 and tightened sortfield to 'eventid' only.
     const params: Record<string, unknown> = {
-      output: ['eventid', 'objectid', 'name', 'severity', 'clock', 'value'],
+      output: ['eventid', 'objectid', 'name', 'severity', 'clock', 'value', 'r_eventid'],
       selectHosts: ['hostid', 'host', 'name'],
       source: 0, // EVENT_SOURCE_TRIGGERS
       object: 0, // EVENT_OBJECT_TRIGGER
@@ -535,21 +540,31 @@ export class ZabbixPlugin
       params['hostids'] = options.hostIds
     }
 
-    // Active-only: ask Zabbix for problem events only (value=1)
+    // Active-only: keep only problem events (value=1). event.get filters values
+    // via `filter`, not a top-level `value` param. Note this alone is not enough
+    // — a problem that has since recovered still carries its original value=1
+    // event, so we additionally drop recovered ones by r_eventid below.
     if (options?.activeOnly) {
-      params['value'] = 1
+      params['filter'] = { value: 1 }
     }
 
     const events = await this.apiRequest<ZabbixEvent[]>('event.get', params)
 
-    return events.map((e) => ({
+    // A value=1 event whose r_eventid is set has already been closed by a
+    // recovery event — exclude those when the caller wants active alerts only.
+    const visible = options?.activeOnly
+      ? events.filter((e) => !e.r_eventid || e.r_eventid === '0')
+      : events
+
+    return visible.map((e) => ({
       id: e.eventid,
       severity: this.mapZabbixSeverity(e.severity),
       title: e.name,
       host: e.hosts?.[0]?.host,
       hostId: e.hosts?.[0]?.hostid,
       startTime: Number.parseInt(e.clock, 10) * 1000,
-      status: e.value === '1' ? 'active' : 'resolved',
+      // value=1 with no recovery event = active; otherwise resolved.
+      status: e.value === '1' && (!e.r_eventid || e.r_eventid === '0') ? 'active' : 'resolved',
       source: 'zabbix' as const,
       url: this.config
         ? `${this.config.url.replace(/\/$/, '')}/tr_events.php?triggerid=${e.objectid}&eventid=${e.eventid}`


### PR DESCRIPTION
## 問題

Alert ウィジェットで Zabbix の障害一覧に、最新のアクティブな障害だけやなく**終了済み(解決済み)の障害も表示されてしまう**。AlertWidget はデフォルトで `activeOnly: true` をリクエストしとるのに効いてへんかった。

## 原因

`shumoku-plugin-zabbix` の `getAlerts` に2つのバグがあった:

1. **`params['value'] = 1` が効いてへん** — Zabbix の `event.get` には top-level の `value` パラメータが存在せえへん。value で絞るには `filter: { value: 1 }` にする必要があり、今までは無視されて recovery イベント(value=0)も返ってきとった。
2. **`value=1` だけでは「今アクティブ」にならへん** — Zabbix では障害が解決すると別の recovery イベント(value=0)が記録されるだけで、元の problem イベント(value=1)は残る。せやから value=1 で絞っても、既に解決済みやのに時間枠内に発生した障害が混ざる。

## 修正

- `output` に `r_eventid`(recovery イベントへの参照。`'0'` = 未解決)を追加
- `activeOnly` 時は `filter: { value: 1 }` で正しく絞る
- さらに `r_eventid === '0'` のものだけ残すよう後段でフィルタ
- `status` の判定も同じ recovery チェックを使い、最近解決した障害が `active` 扱いされへんように

## リリース

この修正は Server が `workspace:*` で bundle する plugin やから、配布は **Server の docker image** 経由になる。本 PR に Server beta の version bump を同梱した:

- `@shumoku/server` / Helm chart を **0.1.3-beta.2** に bump(`bun run version:server`)
- npm 利用者向けに `shumoku-plugin-zabbix: patch` の changeset も同梱

### マージ後の手順(beta image を出す)

```bash
git switch main && git pull
git tag -a server-v0.1.3-beta.2 -m "Shumoku Server 0.1.3-beta.2"
git push origin server-v0.1.3-beta.2
```

→ `docker.yml` が version 一致を検証して `ghcr.io/konoe-akitoshi/shumoku:0.1.3-beta.2` / `:beta` / `:edge` をビルド&push(`latest` は動かさへん)。

## テスト

- `shumoku-plugin-zabbix` の vitest 10件 pass / biome clean
- `bun run version:products:check` 整合 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)