### PR TITLE
feat(server): Rebuild action — blank topology + re-sync from scratch

### DIFF
--- a/apps/server/api/src/api/discovery-policy.ts
+++ b/apps/server/api/src/api/discovery-policy.ts
@@ -29,11 +29,6 @@
  *       without being deleted (it can't be — the source keeps seeing it).
  *   DELETE /discovery-policy/exclusions   (same body) → Unhide.
  *
- *   POST   /discovery-policy/rebuild
- *     → Discard the WHOLE authored overlay (every node/subgraph/topology-
- *       default attachment + all exclusions). Pair with a Sync-all to refresh
- *       observed afterwards. Destructive; the UI confirms first.
- *
  * Reset (drop one node's human contribution) reuses PATCH with
  * attachments=null, label=null, suppressedAttachments=null — no dedicated
  * route. A node with any remaining human claim (attachment OR suppression) is
@@ -479,32 +474,6 @@ export function createDiscoveryPolicyApi(): Hono {
     await service.writeProjectOverlay(topologyId, { ...authored, exclusions })
     service.clearCacheEntry(topologyId)
     return c.json({ exclusions })
-  })
-
-  // Rebuild: discard the entire authored overlay — every node's attachments,
-  // the topology-default attachments, and all exclusions — so the topology
-  // falls back to "purely what the sources observed". Callers pair this with a
-  // Sync-all to refresh observed afterwards. Destructive; UI confirms first.
-  app.post('/:id/discovery-policy/rebuild', async (c) => {
-    const topologyId = c.req.param('id')
-    const topology = service.get(topologyId)
-    if (!topology) return c.json({ error: 'Topology not found' }, 404)
-    const authored = service.readProjectOverlay(topologyId)
-    if (!authored) return c.json({ cleared: false, reason: 'no authored graph' })
-    // Strip overlay: drop attachments from every node/subgraph, the topology
-    // default, and all exclusions. Keep the nodes themselves out entirely —
-    // a node that exists only as an overlay has nothing to keep once cleared,
-    // and observation-backed ones re-resolve from their snapshots.
-    const cleared = {
-      ...authored,
-      nodes: [],
-      subgraphs: (authored.subgraphs ?? []).map(({ attachments: _a, ...sg }) => sg),
-      attachments: undefined,
-      exclusions: undefined,
-    }
-    await service.writeProjectOverlay(topologyId, cleared)
-    service.clearCacheEntry(topologyId)
-    return c.json({ cleared: true })
   })
 
   return app

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -605,6 +605,48 @@ export function createTopologiesApi(): Hono {
     return c.json({ job: syncJobView(job) }, 202)
   })
 
+  /**
+   * Rebuild = blank, then re-sync. Delete every syncable source's observed data
+   * and invalidate the cached layout, then run the same sync job. On the blank
+   * slate every fetch is entirely "new", so the no-change gate passes and the
+   * layout re-derives from scratch — no force needed. Drives the same progress
+   * modal as Sync all. The human curation overlay is kept (it is a separate
+   * layer from observed data; use the discovery-policy reset to drop that).
+   */
+  app.post('/:id/rebuild', async (c) => {
+    const id = c.req.param('id')
+    const topology = service.get(id)
+    if (!topology) {
+      return c.json({ error: 'Topology not found' }, 404)
+    }
+    const running = getSyncJob(id)
+    if (running && running.state === 'running') {
+      return c.json({ job: syncJobView(running) }, 409)
+    }
+    const sourcesToSync = getTopologySourcesService()
+      .listByPurpose(id, 'topology')
+      .filter((s) => s.dataSource?.type !== 'manual')
+
+    // Blank: drop each source's observed data, then invalidate the artifact.
+    const observationsService = new ObservationsService()
+    for (const source of sourcesToSync) {
+      observationsService.deleteForSource(id, source.dataSourceId)
+    }
+    service.clearCacheEntry(id)
+    console.log(`[rebuild] ${id}: blanked ${sourcesToSync.length} source(s), re-syncing`)
+
+    const job = startSyncJob(id, sourcesToSync, {
+      topologyService: service,
+      topologySourcesService: getTopologySourcesService(),
+      dataSourceService,
+      observationsService,
+    })
+    if (!job) {
+      return c.json({ error: 'No topology sources attached' }, 400)
+    }
+    return c.json({ job: syncJobView(job) }, 202)
+  })
+
   // Current (or last finished) sync job — the progress modal polls this, and
   // a freshly-loaded page uses it to re-attach to a run already in flight.
   app.get('/:id/sync-job', (c) => {

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -454,6 +454,16 @@ export const topologies = {
         method: 'POST',
       }),
 
+    /**
+     * Rebuild = blank then re-sync: delete all observed source data + the cached
+     * layout, then run a Sync-all so the diagram is re-derived from scratch.
+     * Same tracked job + progress modal as syncAll (202; 409 = one running).
+     */
+    rebuild: (topologyId: string) =>
+      request<{ job: SyncJob }>(`/topologies/${topologyId}/rebuild`, {
+        method: 'POST',
+      }),
+
     /** Current (or last finished) sync job — drives the progress modal + reload re-attach. */
     getSyncJob: (topologyId: string) =>
       request<{ job: SyncJob | null }>(`/topologies/${topologyId}/sync-job`),
@@ -630,13 +640,6 @@ export const topologies = {
       request<{ exclusions: NodeExclusion[] }>(
         `/topologies/${topologyId}/discovery-policy/exclusions`,
         { method: 'DELETE', body: JSON.stringify(identity) },
-      ),
-
-    /** Rebuild: discard the whole authored overlay (attachments + exclusions). */
-    rebuild: (topologyId: string) =>
-      request<{ cleared: boolean; reason?: string }>(
-        `/topologies/${topologyId}/discovery-policy/rebuild`,
-        { method: 'POST' },
       ),
   },
 }

--- a/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
@@ -62,7 +62,6 @@
     >
   >({})
   let syncingSourceId = $state<string | null>(null)
-  let rebuilding = $state(false)
 
   // Sync-all job (server-tracked): drives the progress modal. State lives on
   // the server, so a reload mid-sync re-attaches to the same job.
@@ -544,27 +543,34 @@
     return Math.min(100, Math.round(((settled + running) / total) * 100))
   })
 
-  /** Reset the human curation layer only (authored attachments, names, hidden
-   *  nodes). Does NOT re-sync — that's a separate, explicit Sync all. Splitting
-   *  the old combined "Rebuild" keeps data-reset and override-reset independent. */
-  async function handleResetOverrides() {
+  /** Rebuild = blank, then re-sync. Delete every source's observed data and the
+   *  cached layout, then run a normal Sync all. On the blank slate every fetch
+   *  is entirely "new", so the no-change gate passes naturally and the layout
+   *  re-derives — no force needed. Reuses the sync job + progress modal. (Manual
+   *  overrides are kept; they live in a separate overlay, not the source data.) */
+  async function handleRebuild() {
     const ok = confirm(
-      'Reset overrides discards every manual change you made (names, community, ' +
-        'hidden nodes) and falls back to what the sources observe. The source data ' +
-        'itself is kept. This cannot be undone. Continue?',
+      'Rebuild blanks this topology — deletes all observed source data and the ' +
+        'cached layout — then re-syncs every source from scratch and re-derives ' +
+        'the diagram. This cannot be undone. Continue?',
     )
     if (!ok) return
-    rebuilding = true
+    localError = ''
     try {
-      await api.topologies.discoveryPolicy.rebuild(ctx.topologyId)
-      const updated = await api.topologies.get(ctx.topologyId)
-      ctx.topology = updated
-      topologies.upsert(updated)
+      const res = await api.topologies.sources.rebuild(ctx.topologyId)
+      attachSyncJob(res.job)
+      // Blanked server-side already — show the empty diagram while the re-sync
+      // repopulates it (the visible "white-out → rebuild").
       ctx.bumpRevision()
     } catch (e) {
-      localError = e instanceof Error ? e.message : 'Reset overrides failed'
-    } finally {
-      rebuilding = false
+      // 409 = a job is already running — attach to it instead of failing.
+      const status = (e as { status?: number }).status
+      if (status === 409) {
+        const { job } = await api.topologies.sources.getSyncJob(ctx.topologyId)
+        if (job) attachSyncJob(job)
+        return
+      }
+      localError = e instanceof Error ? e.message : 'Rebuild failed'
     }
   }
 
@@ -624,23 +630,18 @@
       <h2 class="font-medium text-theme-text-emphasis">Topology Sources</h2>
       <div class="flex items-center gap-1.5">
         {#if topologySources.length > 0}
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={syncingAll || rebuilding}
-            onclick={handleSyncAll}
-          >
+          <Button variant="outline" size="sm" disabled={syncingAll} onclick={handleSyncAll}>
             {syncingAll ? 'Syncing…' : '⟳ Sync all'}
           </Button>
           <Button
             variant="ghost"
             size="sm"
             class="text-muted-foreground hover:text-destructive"
-            disabled={rebuilding || syncingAll}
-            title="Discard manual overrides (names, hidden nodes); keeps source data"
-            onclick={handleResetOverrides}
+            disabled={syncingAll}
+            title="Blank the topology (delete observed data + cached layout) and re-sync from scratch."
+            onclick={handleRebuild}
           >
-            {rebuilding ? 'Resetting…' : 'Reset overrides'}
+            ↻ Rebuild
           </Button>
         {/if}
         <DropdownMenu.Root>


### PR DESCRIPTION
## What

Rebuild now deletes every syncable source's observed data **and** the cached layout, then runs the standard sync job. On the blank slate every fetch is "new", so the no-change gate passes and the layout always re-derives — no `force` flag. Reuses the Sync-all progress modal.

## Changes

- `POST /:id/rebuild`: blank observed data + `clearCacheEntry`, then `startSyncJob`.
- Drop `POST /:id/discovery-policy/rebuild` — its name said "rebuild" but it only discarded the human-curation overlay (a different op), and nothing called it once the button moved to blank+re-sync.
- web: "↻ Rebuild" button → `/rebuild`, driving the shared sync modal.

## Testing

- server-api: 71 tests pass; typecheck + biome clean.
- Verified live: `/rebuild` → 202, `fetch` + `derive` both run (no "No changes"); old endpoint → 404.

## Notes

- Server-only (private package) — no changeset required.
- Independent of #layout PR (no file overlap; either merge order works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj