### PR TITLE
docs: formalize the OSS community vs commercial support boundary

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,7 @@ contact_links:
   - name: 🔒 Report a security vulnerability
     url: https://github.com/konoe-akitoshi/shumoku/security/advisories/new
     about: Please report security issues privately — not as a public issue. See SECURITY.md.
-  - name: 🏢 Commercial / implementation support
+  # TODO: enterprise/commercial contact will move to support@shumoku.dev
+  - name: 🏢 Commercial / implementation support (paid)
     url: mailto:contact@shumoku.dev
-    about: Implementation, NetBox/Zabbix integration, PoC, or custom development help.
+    about: Implementation, NetBox/Zabbix integration, PoC, or custom development help — see COMMERCIAL_SUPPORT.md.

--- a/COMMERCIAL_SUPPORT.md
+++ b/COMMERCIAL_SUPPORT.md
@@ -38,8 +38,8 @@ Commercial support is paid work, scoped and agreed individually. It can cover:
   mappings to your network and conventions.
 - **Custom plugin development** — building integrations for data sources that
   the open-source project does not cover (see [Plugin policy](#plugin-policy)).
-- **Priority handling and deadline-bound work** — guaranteed attention to
-  specific bugs or features within an agreed timeframe.
+- **Priority handling and deadline-bound work** — prioritized work on specific
+  bugs or features within a timeframe agreed in an individual contract.
 - **Proof-of-concept (PoC) support** — helping you evaluate Shumoku against
   your requirements.
 - **Operational design and ongoing support** — consulting on how to run Shumoku

--- a/COMMERCIAL_SUPPORT.md
+++ b/COMMERCIAL_SUPPORT.md
@@ -1,0 +1,93 @@
+# Commercial Support
+
+Shumoku is free and open-source software under **AGPL-3.0**. Using it never
+requires a commercial relationship, and community support is available to
+everyone on GitHub — see [SUPPORT.md](SUPPORT.md).
+
+Commercial support is a **separate, paid service** for organizations that need
+help beyond what public, best-effort community support covers: hands-on work in
+their specific environment, guaranteed attention, or custom development. Paying
+for support buys services — it does not change the AGPL-3.0 terms of the
+software, and it does not buy influence over the project (see
+[GOVERNANCE.md](GOVERNANCE.md)).
+
+## Community or commercial?
+
+The line between the two is not *who you are* but *what the work is*:
+
+| The work is… | Route |
+|---|---|
+| A reproducible bug report, a general question, a feature request, a docs improvement — anything that can be discussed publicly and benefits the project as a whole | **Community** — [GitHub Issues / Discussions](SUPPORT.md) |
+| Investigation of your specific environment, private support, guaranteed response, a deadline, priority implementation, or development for your requirements | **Commercial** — email [contact@shumoku.dev](mailto:contact@shumoku.dev) |
+
+Feature requests posted on GitHub are always welcome, but whether, when, and in
+what order they are implemented is decided by the Shumoku Project based on the
+project's direction, roadmap, and maintainability. If your organization needs a
+specific outcome on a specific timeline, that is commercial work.
+
+## What commercial support covers
+
+Commercial support is paid work, scoped and agreed individually. It can cover:
+
+- **Implementation and deployment support** — installing and operating the
+  Shumoku Server (and Editor) in your environment.
+- **Data source integration** — investigating and configuring connections to
+  NetBox, Zabbix, Prometheus, Grafana, and similar systems, including reviewing
+  the configuration on the monitoring side.
+- **Environment-specific mapping** — adapting topology, metrics, and alert
+  mappings to your network and conventions.
+- **Custom plugin development** — building integrations for data sources that
+  the open-source project does not cover (see [Plugin policy](#plugin-policy)).
+- **Priority handling and deadline-bound work** — guaranteed attention to
+  specific bugs or features within an agreed timeframe.
+- **Proof-of-concept (PoC) support** — helping you evaluate Shumoku against
+  your requirements.
+- **Operational design and ongoing support** — consulting on how to run Shumoku
+  as part of your operations, and continued technical support after rollout.
+
+## Plugin policy
+
+Shumoku is extensible through data source plugins. Not all plugins are — or
+will be — part of the open-source project. There are three kinds:
+
+1. **Bundled open-source plugins** — maintained in this repository under
+   [`libs/plugins/`](libs/plugins) (currently `zabbix`, `prometheus`, `netbox`,
+   `grafana`, `aruba-instant-on`, `network-scan`). These are part of the OSS
+   project and covered by community support.
+2. **Community plugins** — plugins anyone can build and publish independently
+   using the public plugin contract (see
+   [docs/plugin-authoring.md](docs/plugin-authoring.md)). They are maintained by
+   their authors, not by the Shumoku Project.
+3. **Commercially developed plugins** — plugins built as commercial work for a
+   specific organization. These may remain private to that customer. Whether
+   such a plugin is later open-sourced, bundled, or offered as a paid add-on is
+   decided case by case by the Shumoku Project together with the customer.
+
+## Commercial support partner
+
+<!-- TODO: enterprise/commercial contact will move to support@shumoku.dev -->
+
+Commercial support and implementation services are provided by the Project Lead
+in collaboration with our commercial support partner:
+
+> **TelHi Corporation（輝日株式会社）** — Commercial Support Partner
+
+This partnership is **non-exclusive**: there is no sole agent, exclusive
+distributor, or single official reseller of Shumoku, and other partners may
+offer services as well. Partners provide services around Shumoku; they do not
+own, control, or speak for the open-source project. Technical direction, the
+roadmap, releases, and community governance remain with the Shumoku Project —
+see [GOVERNANCE.md](GOVERNANCE.md) and [TRADEMARK.md](TRADEMARK.md).
+
+## Case studies and PoC
+
+If your deployment can be published as a case study, PoC and implementation
+support terms can be discussed individually — mention it when you reach out.
+
+## Contact
+
+<!-- TODO: enterprise/commercial contact will move to support@shumoku.dev -->
+
+Email **[contact@shumoku.dev](mailto:contact@shumoku.dev)** with a short
+description of your environment and what you need. We will scope the work and,
+where appropriate, involve our partner.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -72,8 +72,9 @@ status to contribute — see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 
 A **partner** is an organization or individual that provides commercial services
 around Shumoku — for example implementation support, integration help, or
-first-line support for enterprise users. See [SUPPORT.md](SUPPORT.md) for what
-such services may cover.
+first-line support for enterprise users. See
+[COMMERCIAL_SUPPORT.md](COMMERCIAL_SUPPORT.md) for what such services may cover
+and for the current commercial support partners.
 
 Partners are an important part of making Shumoku usable in production
 environments, but their role is deliberately bounded:

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Contributions are welcome under the AGPL-3.0 license.
 
 - [Contributing](CONTRIBUTING.md) — dev setup, pull requests, DCO sign-off
 - [Governance](GOVERNANCE.md) — roles, decision-making, releases
-- [Support](SUPPORT.md) — community help and commercial / implementation support
+- [Support](SUPPORT.md) — community help on GitHub · [Commercial support](COMMERCIAL_SUPPORT.md) — paid implementation / integration services
 - [Code of Conduct](CODE_OF_CONDUCT.md) · [Security](SECURITY.md) · [Brand guidelines](TRADEMARK.md)
 
 ## License
@@ -302,8 +302,10 @@ Contributions are welcome under the AGPL-3.0 license.
 Shumoku is free and open-source software, licensed under **AGPL-3.0**
 ([LICENSE](./LICENSE)).
 
-For enterprise use, we can provide commercial **support and implementation
-services** (deployment, NetBox/Zabbix integration, PoC, custom development) —
-separate from the open-source license. See [SUPPORT.md](SUPPORT.md), or reach out
-at [contact@shumoku.dev](mailto:contact@shumoku.dev). If AGPL-3.0 does not fit your
+For enterprise use, we provide paid commercial **support and implementation
+services** (deployment, NetBox/Zabbix integration, PoC, custom plugin
+development, priority handling) — separate from the open-source license, in
+collaboration with our commercial support partner. See
+[COMMERCIAL_SUPPORT.md](COMMERCIAL_SUPPORT.md), or reach out at
+[contact@shumoku.dev](mailto:contact@shumoku.dev). If AGPL-3.0 does not fit your
 use case, contact us to discuss the options.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,8 +1,9 @@
 # Getting Support
 
 There are two kinds of support around Shumoku: free **community support** for
-everyone, and optional **commercial / partner support** for organizations that
-want hands-on help. This page explains the difference and where to go.
+everyone, in public, on GitHub — and paid **commercial support** for
+organizations that need hands-on help in their own environment. This page
+explains the difference and where to go.
 
 ## Where to ask what
 
@@ -12,36 +13,61 @@ want hands-on help. This page explains the difference and where to go.
 | Request a feature | [Feature request](https://github.com/konoe-akitoshi/shumoku/issues/new?template=feature_request.yml) |
 | Ask a question / share an idea | [GitHub Discussions](https://github.com/konoe-akitoshi/shumoku/discussions) · [Discord](https://discord.gg/dyYbEsDZYr) |
 | Report a security issue | [SECURITY.md](SECURITY.md) (do **not** open a public issue) |
-| Get commercial / hands-on help | Email [contact@shumoku.dev](mailto:contact@shumoku.dev) |
+| Get paid, hands-on help for my organization | [COMMERCIAL_SUPPORT.md](COMMERCIAL_SUPPORT.md) · [contact@shumoku.dev](mailto:contact@shumoku.dev) |
 
 ## Community support
 
-Community support is free and open to everyone:
+Community support is free, open to everyone, and happens **in public**:
 
 - **GitHub Issues** — for bugs and feature requests.
 - **GitHub Discussions** and **Discord** — for questions, usage help, and ideas.
 
+### What community support includes
+
+- Bug reports — ideally reproducible ones (see [CONTRIBUTING.md](CONTRIBUTING.md)
+  for what makes a good report).
+- General questions about using Shumoku.
+- Feature requests and improvement proposals that benefit the project as a whole.
+- Documentation feedback and improvement suggestions.
+
+Because community support is public, please post content that can be shared
+publicly. If your situation involves confidential details (internal hostnames,
+addressing plans, customer names), summarize or anonymize them first.
+
+### What community support does not include
+
 Community support is provided on a **best-effort basis by maintainers and the
-community**. There is **no guaranteed response time** and no service-level
-agreement. The friendliest, fastest path to help is a clear, reproducible report
-and a searchable question — see [CONTRIBUTING.md](CONTRIBUTING.md) for tips on
-filing good issues.
+community**. It comes with:
 
-## Commercial / partner support
+- **No guaranteed response** — questions and reports may go unanswered.
+- **No guaranteed implementation** — feature requests are welcome, but whether,
+  when, and in what order they are implemented is decided by the Shumoku
+  Project based on the project's direction, roadmap, and maintainability (see
+  [GOVERNANCE.md](GOVERNANCE.md)).
+- **No investigation of your specific environment** — debugging a problem that
+  only reproduces in your network, reviewing your configuration, or tuning your
+  deployment is hands-on work, not community support.
+- **No private support** — support outside the public channels above is not
+  part of community support.
 
-For production deployments, some organizations want more than best-effort
-community help. Commercial support and services may be available — provided by the
-Project Lead and/or by partner companies — and can cover things like:
+If you need any of those, that is exactly what
+[commercial support](COMMERCIAL_SUPPORT.md) is for.
 
-- Implementation and deployment support for the Shumoku Server and Editor.
-- **NetBox integration** support (topology and host discovery).
-- **Zabbix integration** support (metrics, LLDP topology, alerts).
-- Investigation of specific bugs or issues affecting your environment.
-- **Proof-of-concept (PoC)** assistance.
-- Consulting on custom development and integrations.
+## Commercial support
 
-To discuss commercial support, email **[contact@shumoku.dev](mailto:contact@shumoku.dev)**.
-We can scope what you need and, where appropriate, involve a partner.
+For production deployments, some organizations need more than best-effort
+public help: implementation and deployment support, data source integration
+work, environment-specific investigation, custom plugin development, priority
+or deadline-bound handling, PoC assistance, or ongoing support.
+
+These are provided as **paid services**, by the Project Lead in collaboration
+with our commercial support partner — see
+**[COMMERCIAL_SUPPORT.md](COMMERCIAL_SUPPORT.md)** for the full scope, the
+plugin policy, and partner details.
+
+<!-- TODO: enterprise/commercial contact will move to support@shumoku.dev -->
+To discuss commercial support, email
+**[contact@shumoku.dev](mailto:contact@shumoku.dev)**.
 
 ### Important boundaries
 

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -8,7 +8,10 @@ On, …). Plugins surface **hosts**, **metrics**, **alerts**, or
 they only know the capability contracts.
 
 This document is the contract reference for authors of bundled and
-external plugins.
+external plugins. "Bundled" vs "external" is a purely technical
+distinction; which plugins ship with the open-source project and how
+custom plugin development is handled commercially is described in the
+[plugin policy](../COMMERCIAL_SUPPORT.md#plugin-policy).
 
 ## Contents
 


### PR DESCRIPTION
## Summary

Formalizes the boundary between OSS community support and paid commercial support, following the policy decided after the recent partner meeting.

- **SUPPORT.md** — rewritten around explicit includes/excludes: community support is public, best-effort, on GitHub only; no response/implementation/priority guarantees; no environment-specific investigation or private support.
- **COMMERCIAL_SUPPORT.md (new)** — scope of paid services, a community-vs-commercial routing table ("the line is not who you are but what the work is"), a plugin policy (bundled OSS / community / commercially developed), and names **TelHi Corporation（輝日株式会社）** as the non-exclusive Commercial Support Partner. Roadmap, releases, and governance stay with the Shumoku Project (GOVERNANCE.md unchanged in substance).
- Pointers updated in README, GOVERNANCE.md, the issue-template contact links, and docs/plugin-authoring.md.
- Contact stays `contact@shumoku.dev` for now; TODO comments mark the planned move of enterprise contact to `support@shumoku.dev`.

Website copy is intentionally untouched — tracked in #538 (includes the "MIT licensed" FAQ correction).

## Conventions check

- SUPPORT.md is the GitHub-recognized community health file and keeps the routing-table-first shape.
- Naming a commercial support partner in project docs follows established precedent (e.g. curl: "Commercial curl support is offered via wolfSSL"), while GOVERNANCE/TRADEMARK keep the non-exclusive, project-led framing.
- "Guaranteed" wording was avoided in the commercial scope so nothing reads as an SLA before individual contracts define one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgbYHemjtc53nKnf4gJFK