### PR TITLE
fix(server): stamp ifName on identity-less ports so link mappings persist

### DIFF
--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -487,16 +487,18 @@ export function createTopologiesApi(): Hono {
     }
   })
 
-  // Update mapping
+  // Update mapping. Returns the topology PLUS `skipped` — how many node/link
+  // bindings couldn't be persisted (the source didn't provide identity to anchor
+  // them). The UI warns on skipped > 0 instead of reporting a clean save.
   app.put('/:id/mapping', async (c) => {
     const id = c.req.param('id')
     try {
       const mapping = (await c.req.json()) as MetricsMapping
-      const topology = await service.updateMapping(id, mapping)
+      const { topology, skipped } = await service.updateMapping(id, mapping)
       if (!topology) {
         return c.json({ error: 'Topology not found' }, 404)
       }
-      return c.json(topology)
+      return c.json({ ...topology, skipped })
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 400)
@@ -543,7 +545,7 @@ export function createTopologiesApi(): Hono {
       }
 
       // Save updated mapping
-      const updated = await service.updateMapping(id, mapping)
+      const { topology: updated } = await service.updateMapping(id, mapping)
       return c.json({
         success: true,
         topology: updated,

--- a/apps/server/api/src/services/contribution-store.ts
+++ b/apps/server/api/src/services/contribution-store.ts
@@ -13,7 +13,7 @@
  *
  * Nodes round-trip as `presence='present'`, `exclusions` as `presence='hide'`.
  *
- * Three defined equivalences (the round-trip is lossless modulo these, matching how
+ * Four defined equivalences (the round-trip is lossless modulo these, matching how
  * every consumer already treats them):
  *  - **empty collection ≡ absent** — an empty `ports`/`attachments`/`via`/… is stored
  *    as zero rows and rebuilt as an absent key (no consumer distinguishes `[]` from
@@ -25,6 +25,10 @@
  *    `resolve()` onto its OUTPUT; a contribution is an INPUT, so they are stripped on
  *    ingest and re-derived on every resolve. Storing one would let a stale value (e.g.
  *    an old `provenance.source`) leak through a recompute.
+ *  - **an identity-less port gains `identity.ifName = <port id>` on ingest** — port ids
+ *    ARE interface names here, so a port with no port-identity key is stamped with one
+ *    (`portIdentityWithIfNameFallback`) so a metrics binding can anchor to it. A port
+ *    that already carries a port key is untouched.
  */
 
 import type { Database } from 'bun:sqlite'
@@ -75,6 +79,24 @@ function identityFromRows(rows: IdRow[]): Identity | undefined {
     }
   }
   return id
+}
+
+/**
+ * Port ids in Shumoku ARE interface names (NetBox interface name, Zabbix ifName,
+ * LLDP localIf). When a port carries no port-identity key (ifName/ifIndex/mac) —
+ * either a link-endpoint stub the source never enumerated, or a plugin-enumerated
+ * port that came without one — default its id in as `ifName` so a metrics binding
+ * has a port to anchor onto. Without this the port is identity-less, so
+ * `buildLinkBindingDesired` skips the link binding and the mapping silently
+ * vanishes on reload (Phase 0 stop-the-bleeding — see
+ * apps/server/docs/design/topology-foundation-entity-registry.md). Plugin-provided
+ * identity always wins: we DEFAULT the key, never overwrite or duplicate one.
+ */
+function portIdentityWithIfNameFallback(identity: Identity | undefined, portId: string): Identity {
+  if (identity && (identity.ifName || identity.ifIndex !== undefined || identity.mac)) {
+    return identity
+  }
+  return { ...identity, ifName: portId }
 }
 
 /** A shallow copy of `obj` without `keys` — becomes the payload document. */
@@ -244,7 +266,10 @@ export function ingestGraph(
     const ensurePortElement = (nodeId: string, portId: string): string => {
       const lid = portLocalId(nodeId, portId)
       if (!portLocalIds.has(lid)) {
-        elementId(lid, 'port', nodeId, 'present', {})
+        const pid = elementId(lid, 'port', nodeId, 'present', {})
+        // A link referenced a port the node never enumerated → this stub carries
+        // no identity. Stamp its id as ifName so a metrics binding can anchor.
+        writeIdentity(pid, portIdentityWithIfNameFallback(undefined, portId))
         portLocalIds.add(lid)
       }
       return lid
@@ -286,7 +311,9 @@ export function ingestGraph(
         const portLid = portLocalId(node.id, port.id)
         const pid = elementId(portLid, 'port', node.id, 'present', portPayload)
         portLocalIds.add(portLid)
-        writeIdentity(pid, port.identity)
+        // A port the plugin enumerated without a port-identity key still needs
+        // one to anchor a metrics binding; its id is its interface name.
+        writeIdentity(pid, portIdentityWithIfNameFallback(port.identity, port.id))
         writeAttachments(pid, 'port', port.attachments)
         writeSuppressions(pid, 'port', port.suppressedAttachments)
       }

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -322,6 +322,17 @@ interface LinkBindingDesired {
 }
 
 /**
+ * `updateMapping` result: the updated topology, plus how many bindings could NOT
+ * be persisted because the element lacked identity to anchor to (node: no node
+ * key; link: no port key). Returned so callers stop reporting a clean success
+ * when part of the mapping was silently dropped — the UI surfaces a warning.
+ */
+export interface UpdateMappingResult {
+  topology: Topology | null
+  skipped: { nodes: number; links: number }
+}
+
+/**
  * A source's composition for one topology. node/link contribution are per-source
  * (how THIS source behaves here); `closeScope` is derived from the TOPOLOGY's
  * scope policy (which source's regions close the world) — see computeScopeSources.
@@ -681,10 +692,15 @@ export class TopologyService {
    * monitored port), folded by `resolve()` so they follow re-sync. There is no
    * `mapping_json` residual — `reconcileBindings` makes the overlay hold EXACTLY
    * the given mapping for this metrics source (so clearing an entry removes it).
+   *
+   * Returns the updated topology AND the count of bindings that couldn't be
+   * anchored (see `UpdateMappingResult`) so the route/UI can warn instead of
+   * reporting a clean success when part of the mapping was dropped.
    */
-  async updateMapping(id: string, mapping: MetricsMapping): Promise<Topology | null> {
+  async updateMapping(id: string, mapping: MetricsMapping): Promise<UpdateMappingResult> {
+    const noneSkipped = { nodes: 0, links: 0 }
     const existing = this.get(id)
-    if (!existing) return null
+    if (!existing) return { topology: null, skipped: noneSkipped }
 
     const sourceId = this.metricsSourceIdFor(id)
     const parsed = await this.getParsed(id)
@@ -697,7 +713,7 @@ export class TopologyService {
       )
     }
     // Without a metrics source there's nowhere to bind (and nothing to poll).
-    if (!sourceId) return this.get(id)
+    if (!sourceId) return { topology: this.get(id), skipped: noneSkipped }
 
     const { desired: nodeDesired, skipped: nodeSkipped } = this.buildNodeBindingDesired(
       parsed.graph,
@@ -711,13 +727,14 @@ export class TopologyService {
       // Surface dropped bindings rather than silently losing them (no-silent-caps):
       // an element with no identity (node) or no port identity (link) can't be
       // anchored so the binding would create a duplicate overlay instead of
-      // folding. These need source-emitted identity (Phase 1) to bind.
+      // folding. These need source-emitted identity (Phase 1) to bind. The count
+      // also rides back on the result so the UI can warn (not just this log).
       console.warn(
         `[Mapping] topology ${id}: skipped ${nodeSkipped} node + ${linkSkipped} link binding(s) lacking identity to anchor`,
       )
     }
     await this.reconcileBindings(id, sourceId, nodeDesired, linkDesired)
-    return this.get(id)
+    return { topology: this.get(id), skipped: { nodes: nodeSkipped, links: linkSkipped } }
   }
 
   /**

--- a/apps/server/api/test/db/contribution-codec.test.ts
+++ b/apps/server/api/test/db/contribution-codec.test.ts
@@ -113,12 +113,15 @@ describe('contribution codec — round-trip', () => {
   })
 
   test('links with ports, plug/ip/pin, via, and a link without id', () => {
+    // Ports carry a port-identity key so the round-trip stays strictly lossless
+    // (an identity-less port would gain `identity.ifName = <id>` on ingest — that
+    // enrichment path is covered by the dedicated tests below).
     expectLossless({
       version: '1',
       name: 'links',
       nodes: [
-        { id: 'a', label: 'A', ports: [{ id: 'a-1', label: 'p' }] },
-        { id: 'b', label: 'B', ports: [{ id: 'b-1', label: 'p' }] },
+        { id: 'a', label: 'A', ports: [{ id: 'a-1', label: 'p', identity: { ifName: 'a-1' } }] },
+        { id: 'b', label: 'B', ports: [{ id: 'b-1', label: 'p', identity: { ifName: 'b-1' } }] },
       ],
       terminations: [{ id: 'eps1', label: 'EPS', role: 'eps', position: { x: 1, y: 2 } }],
       links: [
@@ -157,7 +160,42 @@ describe('contribution codec — round-trip', () => {
     // undeclared port synthesized as a stub on 'a'; empty port ≡ no port on 'b'
     expect(out.links[0]?.from.port).toBe('ge-0/0/1')
     expect(out.links[0]?.to.port).toBeUndefined()
-    expect(out.nodes.find((n) => n.id === 'a')?.ports?.some((p) => p.id === 'ge-0/0/1')).toBe(true)
+    const stub = out.nodes.find((n) => n.id === 'a')?.ports?.find((p) => p.id === 'ge-0/0/1')
+    expect(stub).toBeDefined()
+    // The stub carries no source identity, so its id (an interface name) is
+    // stamped as ifName — a metrics binding needs this to anchor (issue #548).
+    expect(stub?.identity?.ifName).toBe('ge-0/0/1')
+  })
+
+  test('identity-less ports gain ifName=<id>; ports with a port key keep it (no dup)', () => {
+    const out = roundTrip({
+      version: '1',
+      name: 'port-identity-stamp',
+      nodes: [
+        // Plugin-enumerated port with NO identity → stamped with ifName=<id>.
+        { id: 'a', label: 'A', ports: [{ id: 'ge-0/0/1', label: 'p' }] },
+        // Port already carrying ifName (e.g. Zabbix) → untouched, no duplication.
+        {
+          id: 'b',
+          label: 'B',
+          ports: [{ id: 'p2', label: 'p', identity: { ifName: 'Gi0/2', ifIndex: 3 } }],
+        },
+        // Port carrying only a mac (a port key, but no ifName) → NOT stamped.
+        {
+          id: 'c',
+          label: 'C',
+          ports: [{ id: 'p3', label: 'p', identity: { mac: '00:11:22:33:44:55' } }],
+        },
+      ],
+      links: [],
+    } as NetworkGraph)
+    const portOf = (nodeId: string) => out.nodes.find((n) => n.id === nodeId)?.ports?.[0]
+    // (a) identity-less enumerated port → ifName defaulted to its id.
+    expect(portOf('a')?.identity?.ifName).toBe('ge-0/0/1')
+    // (b) existing port identity preserved exactly (plugin identity takes precedence).
+    expect(portOf('b')?.identity).toEqual({ ifName: 'Gi0/2', ifIndex: 3 })
+    // (c) a port with a non-ifName port key is not given a spurious ifName.
+    expect(portOf('c')?.identity).toEqual({ mac: '00:11:22:33:44:55' })
   })
 
   test('node-scoped duplicate port ids round-trip (two nodes both have "eth0")', () => {
@@ -165,8 +203,16 @@ describe('contribution codec — round-trip', () => {
       version: '1',
       name: 'dup-ports',
       nodes: [
-        { id: 'sw-a', label: 'A', ports: [{ id: 'eth0', label: 'eth0' }] },
-        { id: 'sw-b', label: 'B', ports: [{ id: 'eth0', label: 'eth0' }] },
+        {
+          id: 'sw-a',
+          label: 'A',
+          ports: [{ id: 'eth0', label: 'eth0', identity: { ifName: 'eth0' } }],
+        },
+        {
+          id: 'sw-b',
+          label: 'B',
+          ports: [{ id: 'eth0', label: 'eth0', identity: { ifName: 'eth0' } }],
+        },
       ],
       links: [
         { id: 'l', from: { node: 'sw-a', port: 'eth0' }, to: { node: 'sw-b', port: 'eth0' } },

--- a/apps/server/api/test/db/metrics-binding.test.ts
+++ b/apps/server/api/test/db/metrics-binding.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
-import type { NetworkGraph } from '@shumoku/core'
+import type { Identity, NetworkGraph } from '@shumoku/core'
 import { TopologyService } from '../../src/services/topology.ts'
 import { attachSource, getDatabase, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
 
@@ -78,5 +78,69 @@ describe('metrics binding write path (identity-keyed attachments)', () => {
       .run(metricsId)
     svc.clearCacheEntry(topoId)
     expect((await svc.getParsed(topoId))?.mapping?.nodes?.[nodeAId]).toBeUndefined()
+  })
+})
+
+/**
+ * A NetBox-style topology: nodes with NO enumerated ports, ports referenced only
+ * by link endpoint names. The contribution store synthesizes stub ports and (as of
+ * #548) stamps each with `identity.ifName = <port id>`, so a link metrics binding
+ * can anchor. Before the fix the binding was silently skipped and vanished on
+ * reload. `writeProjectOverlay` runs through `ingestGraph`, so the stub-port stamp
+ * applies here.
+ */
+async function netboxishFixture(
+  name: string,
+  // Required (no default): a default object would be substituted when a test
+  // passes `undefined` explicitly, defeating the identity-less case.
+  nodeAIdentity: Identity | undefined,
+): Promise<{ topoId: string; nodeAId: string }> {
+  const topo = await svc.create({ name })
+  const graph: NetworkGraph = {
+    version: '1',
+    name,
+    nodes: [
+      { id: 'a', label: 'A', shape: 'rect', ...(nodeAIdentity ? { identity: nodeAIdentity } : {}) },
+      { id: 'b', label: 'B', shape: 'rect', identity: { mgmtIp: '10.5.0.2' } },
+    ],
+    links: [
+      { id: 'L1', from: { node: 'a', port: 'ge-0/0/1' }, to: { node: 'b', port: 'ge-0/0/2' } },
+    ],
+  } as NetworkGraph
+  await svc.writeProjectOverlay(topo.id, graph)
+  attachSource(topo.id, insertDataSource('netbox', `nb_${name}`), 'metrics')
+  const parsed = await svc.getParsed(topo.id)
+  // Use the resolved endpoint id (resolve may re-key the node) so the mapping's
+  // monitoredNodeId matches an actual endpoint of the link.
+  const nodeAId = parsed?.graph.links.find((l) => l.id === 'L1')?.from.node ?? 'a'
+  return { topoId: topo.id, nodeAId }
+}
+
+describe('link bindings to identity-less ports (issue #548)', () => {
+  test('a link-only-referenced port anchors its binding (skipped=0) and derives back', async () => {
+    const { topoId, nodeAId } = await netboxishFixture('mb-nb', { mgmtIp: '10.5.0.1' })
+    const { skipped } = await svc.updateMapping(topoId, {
+      nodes: {},
+      links: { L1: { monitoredNodeId: nodeAId, interface: 'ge-0/0/1', bandwidth: 1000 } },
+    })
+    // The stub port got identity.ifName at ingest → nothing is dropped.
+    expect(skipped).toEqual({ nodes: 0, links: 0 })
+
+    // And it survives reload (the reported bug was this returning empty).
+    const m = (await svc.getParsed(topoId))?.mapping
+    expect(m?.links?.['L1']?.monitoredNodeId).toBe(nodeAId)
+    expect(m?.links?.['L1']?.interface).toBe('ge-0/0/1')
+    expect(m?.links?.['L1']?.bandwidth).toBe(1000)
+  })
+
+  test('updateMapping reports link bindings it cannot anchor (skipped is honest)', async () => {
+    // Node 'a' has no node identity, so even a stamped port can't anchor the
+    // binding — it must be counted, not silently dropped.
+    const { topoId, nodeAId } = await netboxishFixture('mb-skip', undefined)
+    const { skipped } = await svc.updateMapping(topoId, {
+      nodes: {},
+      links: { L1: { monitoredNodeId: nodeAId, interface: 'ge-0/0/1' } },
+    })
+    expect(skipped.links).toBe(1)
   })
 })

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -247,8 +247,10 @@ export const topologies = {
   // misses node bindings stored as attachments.
   getMapping: (id: string) => request<MetricsMapping>(`/topologies/${id}/mapping`),
 
+  // Response is the topology PLUS `skipped`: node/link bindings the server could
+  // not persist because the source didn't provide identity to anchor them.
   updateMapping: (id: string, mapping: MetricsMapping) =>
-    request<Topology>(`/topologies/${id}/mapping`, {
+    request<Topology & { skipped: { nodes: number; links: number } }>(`/topologies/${id}/mapping`, {
       method: 'PUT',
       body: JSON.stringify(mapping),
     }),

--- a/apps/server/web/src/lib/stores/index.ts
+++ b/apps/server/web/src/lib/stores/index.ts
@@ -26,6 +26,7 @@ export {
   mappingHosts,
   mappingLoading,
   mappingStore,
+  mappingWarning,
   metricsSources,
   nodeMapping,
 } from './mapping'

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -63,6 +63,12 @@ interface MappingState {
   loading: boolean
   hostsLoading: boolean
   error: string | null
+  /**
+   * Non-fatal notice, distinct from `error`. Set when a save succeeded but some
+   * bindings couldn't be persisted (the source lacked port identity to anchor
+   * them) — the save itself didn't fail, so this must not read as an error.
+   */
+  warning: string | null
 }
 
 const initialState: MappingState = {
@@ -76,6 +82,7 @@ const initialState: MappingState = {
   loading: false,
   hostsLoading: false,
   error: null,
+  warning: null,
 }
 
 /**
@@ -180,7 +187,7 @@ function createMappingStore() {
       // hydrated left hosts empty → auto-map matched nothing).
       const alreadyOnTopology = current.topologyId === topologyId && !current.loading
       if (forceReload || !alreadyOnTopology) {
-        update((s) => ({ ...s, loading: true, error: null, topologyId }))
+        update((s) => ({ ...s, loading: true, error: null, warning: null, topologyId }))
         try {
           // The RESOLVED mapping (bindings ∪ residual), not topo.mappingJson.
           const [mapping, sources] = await Promise.all([
@@ -348,8 +355,22 @@ function createMappingStore() {
       if (!current.topologyId) return
 
       try {
-        const updated = await api.topologies.updateMapping(current.topologyId, current.mapping)
+        const { skipped, ...updated } = await api.topologies.updateMapping(
+          current.topologyId,
+          current.mapping,
+        )
         topologies.upsert(updated)
+        // The save succeeded, but the server may have been unable to anchor some
+        // bindings because the source doesn't expose port identity — surface that
+        // as a non-fatal warning rather than silently losing the mappings.
+        const dropped = skipped.nodes + skipped.links
+        update((s) => ({
+          ...s,
+          warning:
+            dropped > 0
+              ? `${dropped} link mapping(s) could not be persisted: the source does not provide port identity. Re-sync after upgrading, or check the data source.`
+              : null,
+        }))
       } catch (e) {
         update((s) => ({
           ...s,
@@ -430,6 +451,7 @@ export const mappingStore = createMappingStore()
 // Derived stores for convenience
 export const mappingLoading = derived(mappingStore, ($s) => $s.loading)
 export const mappingError = derived(mappingStore, ($s) => $s.error)
+export const mappingWarning = derived(mappingStore, ($s) => $s.warning)
 export const nodeMapping = derived(mappingStore, ($s) => $s.mapping.nodes)
 export const linkMapping = derived(mappingStore, ($s) => $s.mapping.links)
 export const mappingHosts = derived(mappingStore, ($s) => $s.hosts)

--- a/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
@@ -22,6 +22,7 @@
     linkMapping,
     mappingHosts,
     mappingStore,
+    mappingWarning,
     nodeMapping,
   } from '$lib/stores'
   import type { MetricsData } from '$lib/stores/metrics'
@@ -426,6 +427,14 @@
   {#if localError}
     <div class="p-3 bg-danger/10 border border-danger/20 rounded-lg text-danger text-sm">
       {localError}
+    </div>
+  {/if}
+
+  <!-- Non-fatal: the save landed, but the source lacked port identity to anchor
+       some bindings, so they weren't persisted. Warn instead of a silent drop. -->
+  {#if $mappingWarning}
+    <div class="p-3 bg-warning/10 border border-warning/20 rounded-lg text-warning text-sm">
+      {$mappingWarning}
     </div>
   {/if}
 


### PR DESCRIPTION
Closes #548 (Phase 0 of #547 — Entity Registry plan, design: #546).

## Bug

Auto-map + save on the mapping tab's links section → reload → 0. Link mappings persist only as `metrics-binding` attachments anchored to the monitored **port's identity**, but NetBox-derived graphs had ports with no identity (0/198 in the demo — the ports are stubs synthesized from link endpoints). `updateMapping` skipped every link binding with only a console.warn, returned 200, and the UI showed success.

## Fix (stop-the-bleeding; registry lands in later phases)

- **Ingest chokepoint**: any port recorded without a port-identity key gets `identity.ifName = <port id>` (`portIdentityWithIfNameFallback`) — port ids ARE interface names (NetBox interface name / Zabbix ifName / LLDP localIf). Covers both link-endpoint stubs and plugin-enumerated identity-less ports; plugin-provided identity always wins. All plugins benefit, not just NetBox.
- **Honesty**: `updateMapping` returns `skipped: { nodes, links }`; the web mapping page shows a non-fatal warning instead of pretending the save succeeded.

Ingest-time only — no RESOLVER_VERSION bump; existing topologies pick it up on the next Sync/Rebuild.

## Verified end-to-end (local, NetBox demo topology)

| | before | after (+ Rebuild) |
|---|---|---|
| ports with identity | 0/198 | **198/198** |
| PUT /mapping | 200, silently dropped | 200, `skipped: 0/0` |
| GET after reload | links: **0** | links: **1**, round-trips intact |

Tests: API DB 74 pass (+3 new), vitest 28 pass, svelte-check clean, biome clean.

Implemented by a Sonnet subagent from the Phase 0 spec; reviewed + live-verified by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj