### PR TITLE
perf(zabbix): batch metrics polling and cache itemid resolution

### DIFF
--- a/.changeset/zabbix-poll-batching.md
+++ b/.changeset/zabbix-poll-batching.md
@@ -1,0 +1,17 @@
+---
+'shumoku-plugin-zabbix': patch
+---
+
+Batch Zabbix metrics polling and cache interface→itemid resolution.
+
+`pollMetrics` previously made up to two `item.get` round-trips per link every
+cycle: one to resolve the interface's traffic itemids, then one to fetch their
+values. On a large weathermap this was O(2 × links) calls per poll.
+
+Now a per-instance cache keyed by `hostId|interface` remembers the resolved
+itemids (stable between polls), so steady-state polling resolves entirely from
+cache. Cache misses are resolved together in host-id-batched `item.get`
+searches, and the values for every link's itemids are fetched in a single
+`item.get` (chunked only past 500 ids). A cached itemid the value fetch stops
+returning (item deleted/disabled) is evicted so the host re-resolves next
+cycle. Utilization/freshness semantics are unchanged.

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -293,7 +293,10 @@ function createMappingStore() {
       const sourceId = sourceIdForHost(current.hosts, hostId)
       if (!sourceId) return
 
-      // Skip if already loaded or loading
+      // Skip only if already loaded (key present, even as an empty array) or a
+      // load is in flight. A PAST FAILURE leaves neither set — the catch below
+      // does not record the host as loaded — so a failed host is retried on the
+      // next call (e.g. the next auto-map press), never permanently skipped.
       if (current.hostInterfaces[hostId] || current.hostInterfacesLoading[hostId]) {
         return
       }
@@ -340,6 +343,8 @@ function createMappingStore() {
           hostInterfacesLoading: { ...s.hostInterfacesLoading, [hostId]: false },
         }))
       } catch {
+        // Only clear the in-flight flag; deliberately do NOT set hostInterfaces
+        // for this host, so the failure isn't cached and the next call retries.
         update((s) => ({
           ...s,
           hostInterfacesLoading: { ...s.hostInterfacesLoading, [hostId]: false },

--- a/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
@@ -73,6 +73,11 @@
     kind: 'nodes' | 'links'
     byIdentity?: number
     byName?: number
+    // Link auto-map only: how many of the hosts it needs already have their
+    // interfaces loaded. Present only on a PARTIAL load, so the message can be
+    // honest that a second press (or a wait) will match the remaining links.
+    hostsLoaded?: number
+    hostsTotal?: number
   } | null>(null)
   let singleCandidateFallback = $state(true)
   let customBandwidthLinks = $state(new Set<string>())
@@ -190,7 +195,9 @@
     return [info.interfaceName, info.label, ...(info.aliases ?? [])].filter((n): n is string => !!n)
   }
 
-  async function loadInterfacesForMappedNodes() {
+  /** Host ids referenced by a mapped endpoint of any link — what link auto-map
+   *  needs interfaces loaded for. */
+  function mappedLinkHostIds(): Set<string> {
     const hostIds = new Set<string>()
     for (const edge of edges) {
       const fromHostId = $nodeMapping[edge.from.nodeId]?.hostId
@@ -198,6 +205,11 @@
       if (fromHostId) hostIds.add(fromHostId)
       if (toHostId) hostIds.add(toHostId)
     }
+    return hostIds
+  }
+
+  async function loadInterfacesForMappedNodes() {
+    const hostIds = mappedLinkHostIds()
     await Promise.all([...hostIds].map((hostId) => mappingStore.loadHostInterfaces(hostId)))
   }
 
@@ -415,9 +427,26 @@
   // hosts first (they load lazily), so it works right after a bulk node auto-map.
   async function handleLinkAutoMap() {
     await loadInterfacesForMappedNodes()
+
+    // Be honest about partial loads. Interfaces load lazily and a metrics
+    // source can be slow or fail (loadHostInterfaces leaves failed hosts
+    // absent so they retry on the next press), so a link may go unmatched
+    // simply because its host's interfaces aren't in yet — not because no
+    // interface matches. Count how many needed hosts are actually loaded so
+    // the result can say "press again or wait" instead of implying the
+    // unmatched links have no candidate.
+    const hostIds = mappedLinkHostIds()
+    const loaded = [...hostIds].filter((id) => $hostInterfaces[id] !== undefined).length
+    const allLoaded = loaded >= hostIds.size
+
     const matched = handleAutoMapLinks()
-    if (matched > 0) {
-      autoMapResult = { matched, total: edges.length, kind: 'links' }
+    if (matched > 0 || !allLoaded) {
+      autoMapResult = {
+        matched,
+        total: edges.length,
+        kind: 'links',
+        ...(allLoaded ? {} : { hostsLoaded: loaded, hostsTotal: hostIds.size }),
+      }
       scheduleClearAutoMapResult()
     }
   }
@@ -475,6 +504,12 @@
           <span class="text-muted-foreground">
             ({autoMapResult.byIdentity}
             by identity, {autoMapResult.byName} by name)
+          </span>
+        {/if}
+        {#if autoMapResult.hostsTotal !== undefined}
+          <span class="text-muted-foreground">
+            (interfaces loaded for {autoMapResult.hostsLoaded}/{autoMapResult.hostsTotal}
+            hosts — press again or wait to match the rest)
           </span>
         {/if}
       </div>

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -20,6 +20,7 @@ import type {
   HostsCapable,
   Identity,
   InterfaceNeighbor,
+  LinkMetrics,
   LinkMetricsMapping,
   MetricsCapable,
   MetricsData,
@@ -103,8 +104,19 @@ export class ZabbixPlugin
   /** Shared SDK client: timeout, Node-compatible insecure TLS, no credential logging. */
   private http: HttpClient | null = null
 
+  /**
+   * Per-instance link-resolution cache: `hostId|interface` → traffic item ids.
+   * Interface→itemid is stable between polls, so caching it turns the
+   * steady-state link poll into a single value `item.get` — the expensive
+   * per-link resolution search only runs on a cache MISS. Positive hits only:
+   * an interface we couldn't resolve stays uncached so it retries next cycle.
+   * Cleared on (re)initialize since a new config may point at a different Zabbix.
+   */
+  private readonly itemIdCache = new Map<string, { in?: string; out?: string }>()
+
   initialize(config: unknown): void {
     this.config = config as ZabbixPluginConfig
+    this.itemIdCache.clear() // a new config may target a different Zabbix
     // Zabbix auth is per-method (apiinfo.version etc. must be unauthenticated),
     // so the client carries no global auth — the Bearer header is set per request.
     this.http = createHttpClient({
@@ -118,6 +130,7 @@ export class ZabbixPlugin
   dispose(): void {
     this.config = null
     this.http = null
+    this.itemIdCache.clear()
   }
 
   // ============================================
@@ -182,82 +195,241 @@ export class ZabbixPlugin
       if (result) metrics.nodes[result[0]] = result[1]
     }
 
-    // Poll link metrics. Same silence rule as nodes — emit nothing
-    // when the link doesn't resolve to a Zabbix-owned interface, so
-    // another metrics source can fill it.
-    const linkResults = await mapWithConcurrency(
-      Object.entries(mapping.links || {}),
-      POLL_CONCURRENCY,
-      async ([linkId, baseLinkMapping]) => {
-        try {
-          const linkMapping = baseLinkMapping as ZabbixLinkMapping
-          let inItemId = linkMapping.in
-          let outItemId = linkMapping.out
-
-          // Resolve item IDs from monitoredNodeId + interface if not directly set
-          if (!inItemId && !outItemId && linkMapping.monitoredNodeId && linkMapping.interface) {
-            const hostId = mapping.nodes[linkMapping.monitoredNodeId]?.hostId
-            if (hostId) {
-              const ifItems = await this.getInterfaceItems(hostId, linkMapping.interface)
-              inItemId = ifItems.in?.id
-              outItemId = ifItems.out?.id
-            }
-          }
-
-          if (!inItemId && !outItemId) return null // not a Zabbix-monitored link
-
-          const itemIds = [inItemId, outItemId].filter(Boolean) as string[]
-          const items = await this.getItemsByIds(itemIds)
-
-          // Drop stale items — when a host goes unreachable Zabbix keeps the
-          // last polled value indefinitely. Without this check we'd paint
-          // utilization bars for a dead link from values minutes/hours old.
-          const nowSec = Math.floor(Date.now() / 1000)
-          let inBps = 0
-          let outBps = 0
-          let anyFresh = false
-          for (const item of items) {
-            const lastclock = (item as ZabbixItem & { lastclock?: string }).lastclock ?? '0'
-            if (!ZabbixPlugin.isFreshClock(lastclock, nowSec)) continue
-            anyFresh = true
-            const value = Number.parseFloat(item.lastvalue) || 0
-            if (item.itemid === inItemId) inBps = value
-            else if (item.itemid === outItemId) outBps = value
-          }
-
-          // Stale data on a link Zabbix *does* own (items resolved) — emit an
-          // explicit `unknown` so the renderer drops the weathermap flow rather
-          // than animating hours-old values. Not the silence rule: a link is
-          // owned by exactly one source, so this can't clobber another source.
-          if (!anyFresh) return [linkId, { status: 'unknown' }] as const
-
-          const capacity = linkMapping.bandwidth || 1_000_000_000
-          const inUtil = (inBps / capacity) * 100
-          const outUtil = (outBps / capacity) * 100
-          const maxUtil = Math.max(inUtil, outUtil)
-
-          return [
-            linkId,
-            {
-              status: maxUtil > 0 ? 'up' : 'unknown',
-              utilization: Math.ceil(maxUtil),
-              inUtilization: Math.ceil(inUtil),
-              outUtilization: Math.ceil(outUtil),
-              inBps,
-              outBps,
-            },
-          ] as const
-        } catch {
-          // Transport / auth failure — let the absence speak.
-          return null
-        }
-      },
-    )
-    for (const result of linkResults) {
-      if (result) metrics.links[result[0]] = result[1]
-    }
+    // Poll link metrics. Same silence rule as nodes — emit nothing when the
+    // link doesn't resolve to a Zabbix-owned interface, so another metrics
+    // source can fill it. Batched + itemid-cached; see pollLinkMetrics.
+    metrics.links = await this.pollLinkMetrics(mapping)
 
     return metrics
+  }
+
+  /**
+   * Poll every link's utilization with a fixed, cache-amortized number of API
+   * calls instead of the old two-round-trips-per-link (resolve + values).
+   *
+   * Per cycle:
+   *  1. Resolve each link's traffic item ids — cache hits cost nothing; the
+   *     misses are resolved together in host-id-batched `item.get` searches.
+   *  2. Fetch the current value of every needed item id in one `item.get`
+   *     (chunked only past ITEM_VALUE_BATCH), keyed by itemid.
+   *  3. Distribute values per link (freshness + utilization math unchanged).
+   *  4. Self-heal: evict any cached item id the value fetch no longer returns
+   *     so a deleted/disabled item re-resolves next cycle.
+   *
+   * A transport failure degrades to silence (like the old per-link catch)
+   * rather than throwing, so node metrics from this same poll still survive.
+   */
+  private async pollLinkMetrics(mapping: MetricsMapping): Promise<Record<string, LinkMetrics>> {
+    const out: Record<string, LinkMetrics> = {}
+    const linkEntries = Object.entries(mapping.links || {})
+    if (linkEntries.length === 0) return out
+
+    const { perLink, usedCacheKeys } = await this.resolveLinkItemIds(linkEntries, mapping)
+
+    // One value fetch for the union of every link's item ids (was one per link).
+    const allItemIds = new Set<string>()
+    for (const ids of perLink.values()) {
+      if (ids.in) allItemIds.add(ids.in)
+      if (ids.out) allItemIds.add(ids.out)
+    }
+    let itemsById: Map<string, ZabbixItem>
+    try {
+      itemsById = await this.fetchItemsByIdMap([...allItemIds])
+    } catch {
+      // Value fetch failed — stay silent for every link (let absence speak),
+      // same as the old per-link catch. Retry next cycle.
+      return out
+    }
+
+    // Self-heal: a cached id the server didn't return is stale (item deleted /
+    // disabled) — drop it so the next cycle re-resolves. Only touches
+    // cache-derived ids, never ids stored directly on the mapping.
+    for (const key of usedCacheKeys) {
+      const ids = this.itemIdCache.get(key)
+      if (!ids) continue
+      if ((ids.in && !itemsById.has(ids.in)) || (ids.out && !itemsById.has(ids.out))) {
+        this.itemIdCache.delete(key)
+      }
+    }
+
+    const nowSec = Math.floor(Date.now() / 1000)
+    for (const [linkId, ids] of perLink) {
+      const linkMapping = mapping.links[linkId] as ZabbixLinkMapping
+      const inItem = ids.in ? itemsById.get(ids.in) : undefined
+      const outItem = ids.out ? itemsById.get(ids.out) : undefined
+
+      // Drop stale items — when a host goes unreachable Zabbix keeps the last
+      // polled value indefinitely; without this we'd paint a dead link's bar
+      // from values minutes/hours old.
+      let inBps = 0
+      let outBps = 0
+      let anyFresh = false
+      if (inItem && ZabbixPlugin.isFreshClock(inItem.lastclock, nowSec)) {
+        anyFresh = true
+        inBps = Number.parseFloat(inItem.lastvalue) || 0
+      }
+      if (outItem && ZabbixPlugin.isFreshClock(outItem.lastclock, nowSec)) {
+        anyFresh = true
+        outBps = Number.parseFloat(outItem.lastvalue) || 0
+      }
+
+      // Stale data on a link Zabbix *does* own (items resolved) — emit an
+      // explicit `unknown` so the renderer drops the weathermap flow rather
+      // than animating hours-old values. Not the silence rule: a link is owned
+      // by exactly one source, so this can't clobber another source.
+      if (!anyFresh) {
+        out[linkId] = { status: 'unknown' }
+        continue
+      }
+
+      const capacity = linkMapping.bandwidth || 1_000_000_000
+      const inUtil = (inBps / capacity) * 100
+      const outUtil = (outBps / capacity) * 100
+      const maxUtil = Math.max(inUtil, outUtil)
+      out[linkId] = {
+        status: maxUtil > 0 ? 'up' : 'unknown',
+        utilization: Math.ceil(maxUtil),
+        inUtilization: Math.ceil(inUtil),
+        outUtilization: Math.ceil(outUtil),
+        inBps,
+        outBps,
+      }
+    }
+
+    return out
+  }
+
+  /**
+   * Resolve each link's `{in,out}` traffic item ids, preferring cheapest:
+   *  1. Item ids stored directly on the mapping (`in`/`out`) — nothing to do.
+   *  2. The per-instance resolution cache (`hostId|interface`) — a hit avoids
+   *     any API call.
+   *  3. A single bulk `item.get` search across every host with an unresolved
+   *     interface, matched locally by the same key/name logic as
+   *     `getInterfaceItems`. Positive hits are cached; misses retry next cycle.
+   *
+   * Returns the resolved ids per link plus the cache keys touched this cycle
+   * (so the caller can self-heal stale ids after the value fetch).
+   */
+  private async resolveLinkItemIds(
+    linkEntries: Array<[string, LinkMetricsMapping]>,
+    mapping: MetricsMapping,
+  ): Promise<{
+    perLink: Map<string, { in?: string; out?: string }>
+    usedCacheKeys: Set<string>
+  }> {
+    const perLink = new Map<string, { in?: string; out?: string }>()
+    const usedCacheKeys = new Set<string>()
+    // hostId → interfaces still needing a bulk resolve (deduped across links).
+    const missHostIds = new Set<string>()
+    // linkId → the (hostId, interface) it's waiting on, to copy ids back post-fetch.
+    const pending = new Map<string, { hostId: string; interface: string }>()
+
+    for (const [linkId, base] of linkEntries) {
+      const linkMapping = base as ZabbixLinkMapping
+      // (1) Ids stored on the mapping win outright.
+      if (linkMapping.in || linkMapping.out) {
+        const ids: { in?: string; out?: string } = {}
+        if (linkMapping.in) ids.in = linkMapping.in
+        if (linkMapping.out) ids.out = linkMapping.out
+        perLink.set(linkId, ids)
+        continue
+      }
+      if (!linkMapping.monitoredNodeId || !linkMapping.interface) continue
+      const hostId = mapping.nodes[linkMapping.monitoredNodeId]?.hostId
+      if (!hostId) continue
+
+      const cacheKey = `${hostId}|${linkMapping.interface}`
+      // (2) Cache hit — no API call.
+      const cached = this.itemIdCache.get(cacheKey)
+      if (cached) {
+        perLink.set(linkId, { ...cached })
+        usedCacheKeys.add(cacheKey)
+        continue
+      }
+      // (3) Defer to the bulk resolve below.
+      pending.set(linkId, { hostId, interface: linkMapping.interface })
+      missHostIds.add(hostId)
+    }
+
+    if (missHostIds.size > 0) {
+      let found: Map<string, { in?: string; out?: string }>
+      try {
+        found = await this.bulkResolveTrafficItems([...missHostIds])
+      } catch {
+        // Resolution round failed — cache hits (already in perLink) still poll;
+        // the unresolved links stay silent and retry next cycle.
+        return { perLink, usedCacheKeys }
+      }
+      // Cache every positive hit we saw (each has an in and/or out id).
+      for (const [key, ids] of found) this.itemIdCache.set(key, ids)
+      // Copy resolved ids onto the links that were waiting; an interface that
+      // wasn't found stays absent (a miss) and simply retries next cycle.
+      for (const [linkId, need] of pending) {
+        const key = `${need.hostId}|${need.interface}`
+        const ids = this.itemIdCache.get(key)
+        if (!ids) continue
+        perLink.set(linkId, { ...ids })
+        usedCacheKeys.add(key)
+      }
+    }
+
+    return { perLink, usedCacheKeys }
+  }
+
+  /**
+   * Resolve traffic item ids for every interface on the given hosts in as few
+   * `item.get` calls as possible (host-id batches of LLDP_HOST_BATCH). Shares
+   * `trafficDirection` + `interfaceNameOf` with `getInterfaceItems` so the
+   * single-link and bulk paths match interfaces identically.
+   */
+  private async bulkResolveTrafficItems(
+    hostIds: string[],
+  ): Promise<Map<string, { in?: string; out?: string }>> {
+    const out = new Map<string, { in?: string; out?: string }>()
+    if (hostIds.length === 0) return out
+
+    const batches = ZabbixPlugin.chunk(hostIds, LLDP_HOST_BATCH)
+    const itemArrays = await mapWithConcurrency(batches, POLL_CONCURRENCY, (batch) =>
+      this.apiRequest<ZabbixItem[]>('item.get', {
+        output: ['itemid', 'hostid', 'name', 'key_', 'lastvalue'],
+        hostids: batch,
+        search: { key_: ZabbixPlugin.TRAFFIC_KEY_SEARCH },
+        searchByAny: true,
+        filter: { status: '0', state: '0' },
+      }),
+    )
+
+    for (const items of itemArrays) {
+      for (const item of items) {
+        const direction = ZabbixPlugin.trafficDirection(item.key_)
+        if (!direction) continue // search is substring — drop incidental hits
+        const ifName = ZabbixPlugin.interfaceNameOf(item.key_, item.name)
+        if (!ifName) continue
+        const key = `${item.hostid}|${ifName}`
+        const entry = out.get(key) ?? {}
+        entry[direction] = item.itemid
+        out.set(key, entry)
+      }
+    }
+    return out
+  }
+
+  /**
+   * Current value of many item ids in as few `item.get` calls as possible
+   * (one when ≤ ITEM_VALUE_BATCH), returned itemid → item for O(1) lookup.
+   */
+  private async fetchItemsByIdMap(itemIds: string[]): Promise<Map<string, ZabbixItem>> {
+    const byId = new Map<string, ZabbixItem>()
+    if (itemIds.length === 0) return byId
+    const batches = ZabbixPlugin.chunk(itemIds, ZabbixPlugin.ITEM_VALUE_BATCH)
+    const arrays = await mapWithConcurrency(batches, POLL_CONCURRENCY, (batch) =>
+      this.getItemsByIds(batch),
+    )
+    for (const items of arrays) {
+      for (const item of items) byId.set(item.itemid, item)
+    }
+    return byId
   }
 
   // ============================================
@@ -698,9 +870,7 @@ export class ZabbixPlugin
     ]
     // the host's OWN sysDescr (NOT the per-neighbor lldp.rem.sys.desc)
     const sysDescrKeys = new Set(['lldp.sys.desc', 'lldp.loc.sys.desc'])
-    const batches = Array.from({ length: Math.ceil(hostIds.length / LLDP_HOST_BATCH) }, (_, i) =>
-      hostIds.slice(i * LLDP_HOST_BATCH, (i + 1) * LLDP_HOST_BATCH),
-    )
+    const batches = ZabbixPlugin.chunk(hostIds, LLDP_HOST_BATCH)
     const ifSuffix = /\[([^\]]+)\]\s*$/
 
     const itemArrays = await mapWithConcurrency(batches, POLL_CONCURRENCY, (batch) =>
@@ -986,6 +1156,16 @@ export class ZabbixPlugin
       output: ['itemid', 'hostid', 'name', 'key_', 'lastvalue', 'lastclock'],
       itemids: itemIds,
     })
+  }
+
+  /** Max item ids per value `item.get`; Zabbix params bloat past a few hundred. */
+  private static readonly ITEM_VALUE_BATCH = 500
+
+  /** Split into fixed-size chunks (matches the `fetchLldpData` batching idiom). */
+  private static chunk<T>(items: T[], size: number): T[][] {
+    return Array.from({ length: Math.ceil(items.length / size) }, (_, i) =>
+      items.slice(i * size, (i + 1) * size),
+    )
   }
 
   /**

--- a/libs/plugins/zabbix/src/poll-metrics.test.ts
+++ b/libs/plugins/zabbix/src/poll-metrics.test.ts
@@ -1,0 +1,219 @@
+import type { MetricsMapping } from '@shumoku/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ZabbixPlugin } from './plugin.js'
+
+/**
+ * pollMetrics is the hot path — it runs every poll cycle for every attached
+ * topology. These tests pin the API-call budget the batching + itemid cache
+ * are meant to deliver:
+ *
+ *  - cycle 1 (cold): ONE bulk `item.get` search to resolve interface→itemid
+ *    for every host, then ONE `item.get` for the values of all links' items.
+ *  - cycle 2 (warm): ZERO resolution calls (cache hit) and still ONE value call.
+ *  - a cached itemid the value fetch stops returning is evicted, so the host
+ *    re-resolves on the following cycle.
+ *
+ * We intercept the private `apiRequest` (the single JSON-RPC chokepoint) and
+ * classify calls by shape: an `item.get` with `search` is a resolution, one
+ * with `itemids` is a value fetch. Node-health calls (`host.get` + an
+ * `item.get` with neither) are left to return empty and are not counted.
+ */
+
+interface FakeItem {
+  itemid: string
+  hostid: string
+  name: string
+  key_: string
+  lastvalue: string
+  lastclock: string
+}
+
+function mkTraffic(itemid: string, hostid: string, key: string, name: string): FakeItem {
+  return { itemid, hostid, key_: key, name, lastvalue: '', lastclock: '' }
+}
+
+// hostid → its traffic items (Agent-style `net.if.{in,out}[<if>]` keys).
+const TRAFFIC_ITEMS: Record<string, FakeItem[]> = {
+  '10': [
+    mkTraffic('100', '10', 'net.if.in[eth0]', 'Interface eth0: Bits received'),
+    mkTraffic('101', '10', 'net.if.out[eth0]', 'Interface eth0: Bits sent'),
+  ],
+  '20': [
+    mkTraffic('200', '20', 'net.if.in[eth1]', 'Interface eth1: Bits received'),
+    mkTraffic('201', '20', 'net.if.out[eth1]', 'Interface eth1: Bits sent'),
+  ],
+}
+
+// itemid → its current value + owning host, for the value `item.get`.
+const VALUES: Record<string, { hostid: string; lastvalue: string }> = {
+  '100': { hostid: '10', lastvalue: '100000000' }, // 100 Mbps in on 1G link → 10%
+  '101': { hostid: '10', lastvalue: '50000000' }, //   50 Mbps out            →  5%
+  '200': { hostid: '20', lastvalue: '0' },
+  '201': { hostid: '20', lastvalue: '0' },
+}
+
+// Freshness window is 300s; a clock at "now" is always fresh within a test run.
+const NOW_CLOCK = String(Math.floor(Date.now() / 1000))
+
+const MAPPING: MetricsMapping = {
+  nodes: {
+    nodeA: { hostId: '10' },
+    nodeB: { hostId: '20' },
+  },
+  links: {
+    linkA: { monitoredNodeId: 'nodeA', interface: 'eth0', bandwidth: 1_000_000_000 },
+    linkB: { monitoredNodeId: 'nodeB', interface: 'eth1', bandwidth: 1_000_000_000 },
+  },
+}
+
+describe('ZabbixPlugin.pollMetrics link batching + itemid cache', () => {
+  let plugin: ZabbixPlugin
+  let apiRequest: ReturnType<typeof vi.fn>
+  // Item ids the value fetch should pretend no longer exist (simulates a
+  // deleted/disabled item), driving the self-heal eviction test.
+  let missingItemIds: Set<string>
+
+  beforeEach(() => {
+    missingItemIds = new Set<string>()
+    apiRequest = vi.fn(async (method: string, params: Record<string, unknown> = {}) => {
+      if (method === 'item.get') {
+        if (Array.isArray(params.itemids)) {
+          // Value fetch: return each requested item unless it's been "deleted".
+          const out: FakeItem[] = []
+          for (const id of params.itemids as string[]) {
+            if (missingItemIds.has(id)) continue
+            const v = VALUES[id]
+            if (!v) continue
+            out.push({
+              itemid: id,
+              hostid: v.hostid,
+              name: '',
+              key_: '',
+              lastvalue: v.lastvalue,
+              lastclock: NOW_CLOCK,
+            })
+          }
+          return out
+        }
+        if (params.search) {
+          // Resolution search: traffic items for exactly the requested hosts.
+          const out: FakeItem[] = []
+          for (const h of (params.hostids as string[]) ?? []) {
+            const items = TRAFFIC_ITEMS[h]
+            if (items) out.push(...items)
+          }
+          return out
+        }
+        // Node-health item.get (hostids + filter, no search/itemids).
+        return []
+      }
+      // host.get (node-health meta) and anything else.
+      return []
+    })
+
+    plugin = new ZabbixPlugin()
+    plugin.initialize({ url: 'http://zabbix.test', token: 'tok' })
+    // Replace the single JSON-RPC chokepoint with the fake. An own property
+    // shadows the prototype method, so every internal `this.apiRequest(...)`
+    // routes here.
+    ;(plugin as unknown as { apiRequest: typeof apiRequest }).apiRequest = apiRequest
+  })
+
+  /** `item.get` calls that carry a `search` param — interface resolutions. */
+  const resolutionCalls = () =>
+    apiRequest.mock.calls.filter(
+      (args) => args[0] === 'item.get' && !!args[1] && 'search' in args[1],
+    )
+
+  /** `item.get` calls that carry `itemids` — value fetches. */
+  const valueCalls = () =>
+    apiRequest.mock.calls.filter(
+      (args) => args[0] === 'item.get' && !!args[1] && 'itemids' in args[1],
+    )
+
+  it('cold cycle: one bulk resolution + one value fetch, correct utilization', async () => {
+    const data = await plugin.pollMetrics(MAPPING)
+
+    // Both hosts fit one batch → a single resolution search, a single value get.
+    expect(resolutionCalls()).toHaveLength(1)
+    expect(valueCalls()).toHaveLength(1)
+
+    expect(data.links.linkA).toEqual({
+      status: 'up',
+      utilization: 10,
+      inUtilization: 10,
+      outUtilization: 5,
+      inBps: 100_000_000,
+      outBps: 50_000_000,
+    })
+    // Fresh but idle link → explicit `unknown` with zeroed utilization.
+    expect(data.links.linkB).toEqual({
+      status: 'unknown',
+      utilization: 0,
+      inUtilization: 0,
+      outUtilization: 0,
+      inBps: 0,
+      outBps: 0,
+    })
+  })
+
+  it('warm cycle: zero resolution calls, exactly one value call, identical values', async () => {
+    const first = await plugin.pollMetrics(MAPPING)
+
+    apiRequest.mockClear()
+    const second = await plugin.pollMetrics(MAPPING)
+
+    expect(resolutionCalls()).toHaveLength(0) // served entirely from the cache
+    expect(valueCalls()).toHaveLength(1)
+    expect(second.links).toEqual(first.links) // semantics unchanged cycle-to-cycle
+  })
+
+  it('evicts a vanished cached itemid and re-resolves that host next cycle', async () => {
+    await plugin.pollMetrics(MAPPING) // warm the cache (1 resolution)
+
+    // Item 100 (host 10, eth0 in) disappears from Zabbix.
+    missingItemIds.add('100')
+    apiRequest.mockClear()
+    await plugin.pollMetrics(MAPPING)
+    // The ids still came from cache this cycle, so no resolution yet — but the
+    // missing id must have triggered an eviction of the `10|eth0` entry.
+    expect(resolutionCalls()).toHaveLength(0)
+    expect(valueCalls()).toHaveLength(1)
+
+    // Item comes back. Only host 10 was evicted, so exactly one host re-resolves.
+    missingItemIds.delete('100')
+    apiRequest.mockClear()
+    const healed = await plugin.pollMetrics(MAPPING)
+    expect(resolutionCalls()).toHaveLength(1)
+    expect(valueCalls()).toHaveLength(1)
+    // ...and linkA is whole again with the same utilization as the cold cycle.
+    expect(healed.links.linkA).toEqual({
+      status: 'up',
+      utilization: 10,
+      inUtilization: 10,
+      outUtilization: 5,
+      inBps: 100_000_000,
+      outBps: 50_000_000,
+    })
+  })
+
+  it('caches directly-stored item ids are not needed — resolves purely by cache key', async () => {
+    // A second warm poll must not re-hit resolution even as new link entries
+    // referencing an already-resolved host+interface appear.
+    await plugin.pollMetrics(MAPPING)
+    apiRequest.mockClear()
+
+    const extended: MetricsMapping = {
+      nodes: MAPPING.nodes,
+      links: {
+        ...MAPPING.links,
+        // Same host+interface as linkA → should resolve from cache, no new call.
+        linkC: { monitoredNodeId: 'nodeA', interface: 'eth0', bandwidth: 1_000_000_000 },
+      },
+    }
+    const data = await plugin.pollMetrics(extended)
+    expect(resolutionCalls()).toHaveLength(0)
+    expect(valueCalls()).toHaveLength(1)
+    expect(data.links.linkC).toEqual(data.links.linkA)
+  })
+})


### PR DESCRIPTION
Closes #554 (metrics Phase A — stop-the-bleeding; Phase B #555, Phase C #556 follow).

## Root cause

`pollMetrics` re-resolved interface→itemid via up to 2 Zabbix API calls **per link per cycle** (~200 calls/cycle at 99 links, × several topologies). One cycle took minutes; the global "skip if previous poll still running" guard then starved everything — after saving a mapping, the weathermap animation appeared minutes later, and the mapping page's link auto-map converged only over repeated presses (interface lists loading slowly per host).

## Fix

- Per-instance `itemIdCache` (hostId|interface → in/out itemids); misses retry next cycle, never cached negatively.
- Bulk resolution: host-batched `item.get` searches (reuses the LLDP batching idiom + the same matching logic as `getInterfaceItems`, extracted, not duplicated).
- ONE `item.get` for all cached itemids per cycle (chunked at 500). Freshness/utilization semantics unchanged.
- Self-heal: cached itemid absent from the value response → evicted → re-resolved next cycle.
- Web: link auto-map now reports partial interface loading ("interfaces loaded for X/Y hosts — press again…") instead of silently part-matching.

## Measured (local, 99-link NetBox demo + remote Zabbix)

| | before | after |
|---|---|---|
| API calls / warm cycle | ≤ 2 × links | **0 resolves + 1 value fetch** (pinned by tests) |
| poll log over ~90s | 13+ consecutive skips per completion | **8 completions vs 7 skips** |
| WS snapshot | stale for minutes | 99/99 links live, shape unchanged |

Tests: zabbix 14/14 (4 new pinning call counts), svelte-check clean, biome clean. Changeset included (public package).

Implemented by a Sonnet subagent; reviewed + live-verified by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj