### PR TITLE
feat(server): Entity Registry Phase 1 — adopt-or-mint + stable entityId on the resolved graph

### DIFF
--- a/.changeset/entity-registry-core-types.md
+++ b/.changeset/entity-registry-core-types.md
@@ -1,0 +1,5 @@
+﻿---
+'@shumoku/core': patch
+---
+
+Add optional `entityId` field to Node, NodePort, and Link for server-side entity registry stamping.

--- a/.changeset/entity-registry-core-types.md
+++ b/.changeset/entity-registry-core-types.md
@@ -1,4 +1,4 @@
-﻿---
+---
 '@shumoku/core': patch
 ---
 

--- a/apps/server/api/src/db/migrations/025_entity_registry.sql
+++ b/apps/server/api/src/db/migrations/025_entity_registry.sql
@@ -1,0 +1,51 @@
+-- Phase 1: Entity Registry (topology-foundation-entity-registry.md §2.1)
+-- Stable entity IDs minted at ingest time, surviving re-scans and cross-source adoption.
+-- Three tables:
+--   entity_registry      — one row per logical entity (node / port / link)
+--   entity_identity_key  — identity keys associated with each entity
+--   entity_alias         — merge tombstones (absorbed old_id → survivor new_id)
+--
+-- Design note: entity_identity_key.parent_id uses '' (empty string, NOT NULL) for
+-- node and link entities to satisfy UNIQUE constraints under SQLite's
+-- NULL-is-distinct semantics.  Port entities use the parent node entity id.
+
+CREATE TABLE IF NOT EXISTS entity_registry (
+  id            TEXT PRIMARY KEY,
+  topology_id   TEXT NOT NULL
+                REFERENCES topologies(id) ON DELETE CASCADE,
+  kind          TEXT NOT NULL
+                CHECK (kind IN ('node', 'port', 'link')),
+  parent_id     TEXT
+                REFERENCES entity_registry(id),
+  status        TEXT NOT NULL DEFAULT 'active'
+                CHECK (status IN ('active', 'retired')),
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at  INTEGER NOT NULL,
+  retired_at    INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_registry_topology
+  ON entity_registry(topology_id, kind);
+
+CREATE TABLE IF NOT EXISTS entity_identity_key (
+  topology_id TEXT NOT NULL,
+  entity_id   TEXT NOT NULL REFERENCES entity_registry(id) ON DELETE CASCADE,
+  kind        TEXT NOT NULL,
+  parent_id   TEXT NOT NULL DEFAULT '',
+  key         TEXT NOT NULL,
+  value       TEXT NOT NULL,
+  UNIQUE (topology_id, kind, parent_id, key, value)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_identity_lookup
+  ON entity_identity_key(topology_id, kind, parent_id, key, value);
+
+CREATE TABLE IF NOT EXISTS entity_alias (
+  old_id TEXT PRIMARY KEY
+         REFERENCES entity_registry(id) ON DELETE CASCADE,
+  new_id TEXT NOT NULL
+         REFERENCES entity_registry(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_alias_new
+  ON entity_alias(new_id);

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -29,6 +29,7 @@ import migration021 from './migrations/021_topology_scope_criteria.sql'
 import migration022 from './migrations/022_topology_composition_mode.sql'
 import migration023 from './migrations/023_contribution_content_hash.sql'
 import migration024 from './migrations/024_signal_streams.sql'
+import migration025 from './migrations/025_entity_registry.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -54,6 +55,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '022_topology_composition_mode.sql', sql: migration022 },
   { name: '023_contribution_content_hash.sql', sql: migration023 },
   { name: '024_signal_streams.sql', sql: migration024 },
+  { name: '025_entity_registry.sql', sql: migration025 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/entity-registry.ts
+++ b/apps/server/api/src/services/entity-registry.ts
@@ -29,6 +29,7 @@ import type { Database } from 'bun:sqlite'
 import { randomBytes } from 'node:crypto'
 import type { Identity, Link, NetworkGraph, Node, NodePort } from '@shumoku/core'
 import { timestamp } from '../db/index.js'
+import { buildGraph } from './contribution-store.js'
 
 // ---------------------------------------------------------------------------
 // ULID generator (synchronous — safe to call inside bun:sqlite transactions)
@@ -300,21 +301,25 @@ function adoptOrMintEntity(
 // ---------------------------------------------------------------------------
 
 /**
- * Walk a source's NetworkGraph and adopt-or-mint entity_registry rows for
- * every node, port, and link.  Must be called after `ingestGraph` within
- * the same DB connection.
+ * Adopt-or-mint entity_registry rows for every node, port, and link in a
+ * source's contribution.  Must be called after `ingestGraph` on the same DB
+ * connection: it registers from the POST-INGEST contribution rows (read back
+ * via `buildGraph`), never from the raw source graph.  This is deliberate —
+ * NetBox-shaped sources enumerate no `ports[]` at all; their ports exist only
+ * as link-endpoint strings and are synthesized as stub elements (with
+ * `identity.ifName`, Phase 0) inside `ingestGraph`.  Reading back keeps that
+ * synthesis the single source of truth instead of duplicating it here; a raw
+ * graph would yield zero port entities and therefore zero link entities.
  *
  * Execution order:
  *   1. Nodes  — establishes node entityIds needed by ports.
  *   2. Ports  — parent-scoped; requires node entityId.
  *   3. Links  — endpoint port entityIds must be known first.
  */
-export function adoptOrMintForGraph(
-  topologyId: string,
-  sourceId: string,
-  graph: NetworkGraph,
-  db: Database,
-): void {
+export function adoptOrMintForGraph(topologyId: string, sourceId: string, db: Database): void {
+  // No contribution rows for this (topology, source) → nothing to register.
+  const graph = buildGraph(topologyId, sourceId, db)
+  if (!graph) return
   const now = timestamp()
 
   // --- Nodes ---

--- a/apps/server/api/src/services/entity-registry.ts
+++ b/apps/server/api/src/services/entity-registry.ts
@@ -1,0 +1,447 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Entity Registry — adopt-or-mint and entityId stamping.
+ *
+ * Called at **ingest time** (inside ObservationsService.record) to assign
+ * stable ULIDs to every observed node / port / link.
+ *
+ * `stampEntityIds` is called in the host process after the derive worker
+ * returns its resolved graph; it reads the registry (no writes) and adds
+ * `entityId` to nodes, ports, and links.
+ *
+ * Key normalisation rules (documented for audit / test clarity):
+ *   mgmtIp, mac, sysName → lowercase + trim
+ *   chassisId, ifName    → trim only (preserve case — vendor strings / OS names)
+ *   ifIndex              → string(number) (no case change)
+ *   vendor:*, endpoints  → trim
+ *   manual:<sourceId>    → trim (value is an element local id)
+ *
+ * parent_id sentinel: entity_identity_key.parent_id uses '' (empty string)
+ * for node and link entities so UNIQUE constraints work under SQLite's
+ * NULL-is-distinct behaviour.  Port entities use the parent node entity id.
+ *
+ * See apps/server/docs/design/topology-foundation-entity-registry.md §2.
+ */
+
+import type { Database } from 'bun:sqlite'
+import { randomBytes } from 'node:crypto'
+import type { Identity, Link, NetworkGraph, Node, NodePort } from '@shumoku/core'
+import { timestamp } from '../db/index.js'
+
+// ---------------------------------------------------------------------------
+// ULID generator (synchronous — safe to call inside bun:sqlite transactions)
+// ---------------------------------------------------------------------------
+
+const BASE32_CHARS = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+
+/**
+ * Generate a ULID (Universally Unique Lexicographically Sortable Identifier).
+ * Uses crypto.randomBytes so it is safe to call within a DB transaction.
+ */
+function generateUlid(): string {
+  const t = Date.now()
+  // Time part: 48-bit timestamp encoded as 10 Crockford base32 chars (50 bits, top 2 always 0)
+  const timeChars: string[] = new Array(10)
+  let ts = t
+  for (let i = 9; i >= 0; i--) {
+    timeChars[i] = BASE32_CHARS[ts % 32] ?? '0'
+    ts = Math.floor(ts / 32)
+  }
+  // Random part: 80 bits → 16 Crockford base32 chars
+  const rand = randomBytes(10)
+  let r = 0n
+  for (const byte of rand) r = (r << 8n) | BigInt(byte)
+  const randChars: string[] = new Array(16)
+  for (let i = 15; i >= 0; i--) {
+    randChars[i] = BASE32_CHARS[Number(r & 31n)] ?? '0'
+    r >>= 5n
+  }
+  return timeChars.join('') + randChars.join('')
+}
+
+// ---------------------------------------------------------------------------
+// Key normalisation
+// ---------------------------------------------------------------------------
+
+/** Normalise an identity key value for storage and lookup. */
+function normalizeKeyValue(key: string, value: string): string {
+  const trimmed = value.trim()
+  switch (key) {
+    case 'mgmtIp':
+    case 'mac':
+    case 'sysName':
+      return trimmed.toLowerCase()
+    // chassisId, ifName, ifIndex, vendor:*, manual:*, endpoints → trim only
+    default:
+      return trimmed
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Identity key gathering
+// ---------------------------------------------------------------------------
+
+interface IdentityKey {
+  key: string
+  value: string
+}
+
+/**
+ * Gather node identity keys in priority order: chassisId > mgmtIp > sysName > vendorIds.
+ * Falls back to `manual:<sourceId>` when no network identity is available so
+ * manually-authored nodes always get an entity.
+ */
+function gatherNodeKeys(
+  identity: Identity | undefined,
+  sourceId: string,
+  nodeId: string,
+): IdentityKey[] {
+  const keys: IdentityKey[] = []
+  if (identity?.chassisId) {
+    keys.push({ key: 'chassisId', value: normalizeKeyValue('chassisId', identity.chassisId) })
+  }
+  if (identity?.mgmtIp) {
+    keys.push({ key: 'mgmtIp', value: normalizeKeyValue('mgmtIp', identity.mgmtIp) })
+  }
+  if (identity?.sysName) {
+    keys.push({ key: 'sysName', value: normalizeKeyValue('sysName', identity.sysName) })
+  }
+  for (const [ns, v] of Object.entries(identity?.vendorIds ?? {})) {
+    keys.push({ key: `vendor:${ns}`, value: normalizeKeyValue(`vendor:${ns}`, v) })
+  }
+  if (keys.length === 0) {
+    // No network identity — fall back to source-local id so manual nodes
+    // can still be tracked across re-ingests of the same source.
+    keys.push({ key: `manual:${sourceId}`, value: nodeId })
+  }
+  return keys
+}
+
+/**
+ * Gather port identity keys in priority order: ifName > mac > ifIndex.
+ * Falls back to `manual:<sourceId>` when no port identity is available.
+ */
+function gatherPortKeys(
+  identity: Identity | undefined,
+  sourceId: string,
+  portId: string,
+): IdentityKey[] {
+  const keys: IdentityKey[] = []
+  if (identity?.ifName) {
+    keys.push({ key: 'ifName', value: normalizeKeyValue('ifName', identity.ifName) })
+  }
+  if (identity?.mac) {
+    keys.push({ key: 'mac', value: normalizeKeyValue('mac', identity.mac) })
+  }
+  if (identity?.ifIndex !== undefined) {
+    keys.push({ key: 'ifIndex', value: String(identity.ifIndex) })
+  }
+  if (keys.length === 0) {
+    keys.push({ key: `manual:${sourceId}`, value: portId })
+  }
+  return keys
+}
+
+// ---------------------------------------------------------------------------
+// Alias resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Follow the alias chain for an entity id.  Caps at depth 8 to prevent
+ * infinite loops from malformed data; in practice the chain is at most
+ * 1-deep (one merge produces one alias row).
+ */
+function resolveAlias(entityId: string, db: Database, depth = 0): string {
+  if (depth >= 8) return entityId
+  const row = db
+    .query<{ new_id: string }, [string]>('SELECT new_id FROM entity_alias WHERE old_id = ?')
+    .get(entityId)
+  if (!row) return entityId
+  return resolveAlias(row.new_id, db, depth + 1)
+}
+
+// ---------------------------------------------------------------------------
+// Lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the unique survivor entity ids for the given keys.  Resolves aliases
+ * so the returned set never contains a merged-away id.
+ *
+ * parentId is '' for node/link entities and the node entity id for port entities
+ * (see the parent_id sentinel note at the top of this file).
+ */
+function lookupByKeys(
+  topologyId: string,
+  kind: string,
+  parentId: string,
+  keys: IdentityKey[],
+  db: Database,
+): string[] {
+  if (keys.length === 0) return []
+  const conditions = keys.map(() => '(key = ? AND value = ?)').join(' OR ')
+  const params: (string | number)[] = [
+    topologyId,
+    kind,
+    parentId,
+    ...keys.flatMap((k) => [k.key, k.value]),
+  ]
+  const rows = db
+    .query<{ entity_id: string }, (string | number)[]>(
+      `SELECT DISTINCT entity_id FROM entity_identity_key
+       WHERE topology_id = ? AND kind = ? AND parent_id = ?
+       AND (${conditions})`,
+    )
+    .all(...params)
+
+  const resolved = new Set<string>()
+  for (const { entity_id } of rows) {
+    resolved.add(resolveAlias(entity_id, db))
+  }
+  return [...resolved]
+}
+
+// ---------------------------------------------------------------------------
+// Core adopt-or-mint
+// ---------------------------------------------------------------------------
+
+/**
+ * Adopt an existing entity (update last_seen_at, union new keys) or mint a
+ * new one (INSERT + register keys).  When multiple entities match via
+ * different keys, merge them: keep the oldest by first_seen_at, alias the
+ * others, and union all keys onto the survivor.
+ *
+ * `parentId`       — empty string for node/link; node entity id for port
+ *                    (stored in entity_identity_key.parent_id).
+ * `entityParentId` — null for node/link; node entity id for port
+ *                    (stored in entity_registry.parent_id, a nullable FK).
+ */
+function adoptOrMintEntity(
+  topologyId: string,
+  kind: string,
+  parentId: string,
+  entityParentId: string | null,
+  keys: IdentityKey[],
+  now: number,
+  db: Database,
+): string {
+  const matchedIds = lookupByKeys(topologyId, kind, parentId, keys, db)
+
+  if (matchedIds.length === 0) {
+    // Mint
+    const entityId = generateUlid()
+    db.query(
+      `INSERT INTO entity_registry
+         (id, topology_id, kind, parent_id, status, first_seen_at, last_seen_at)
+       VALUES (?, ?, ?, ?, 'active', ?, ?)`,
+    ).run(entityId, topologyId, kind, entityParentId, now, now)
+    for (const { key, value } of keys) {
+      db.query(
+        `INSERT OR IGNORE INTO entity_identity_key
+           (topology_id, entity_id, kind, parent_id, key, value)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(topologyId, entityId, kind, parentId, key, value)
+    }
+    return entityId
+  }
+
+  if (matchedIds.length === 1) {
+    // Adopt: update freshness + union new keys
+    const entityId = matchedIds[0] as string
+    db.query('UPDATE entity_registry SET last_seen_at = ? WHERE id = ?').run(now, entityId)
+    for (const { key, value } of keys) {
+      db.query(
+        `INSERT OR IGNORE INTO entity_identity_key
+           (topology_id, entity_id, kind, parent_id, key, value)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(topologyId, entityId, kind, parentId, key, value)
+    }
+    return entityId
+  }
+
+  // Merge: keep oldest (min first_seen_at, then lex id for determinism)
+  const placeholders = matchedIds.map(() => '?').join(', ')
+  const entities = db
+    .query<{ id: string; first_seen_at: number }, string[]>(
+      `SELECT id, first_seen_at FROM entity_registry
+       WHERE id IN (${placeholders})
+       ORDER BY first_seen_at ASC, id ASC`,
+    )
+    .all(...matchedIds)
+
+  const survivor = entities[0]
+  if (!survivor) {
+    // Defensive: should never happen if lookupByKeys found entries
+    return matchedIds[0] as string
+  }
+  const survivorId = survivor.id
+  for (const other of entities.slice(1)) {
+    db.query('INSERT OR IGNORE INTO entity_alias (old_id, new_id) VALUES (?, ?)').run(
+      other.id,
+      survivorId,
+    )
+  }
+  // Refresh survivor + union ALL keys from the new observation
+  db.query('UPDATE entity_registry SET last_seen_at = ? WHERE id = ?').run(now, survivorId)
+  for (const { key, value } of keys) {
+    db.query(
+      `INSERT OR IGNORE INTO entity_identity_key
+         (topology_id, entity_id, kind, parent_id, key, value)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(topologyId, survivorId, kind, parentId, key, value)
+  }
+  return survivorId
+}
+
+// ---------------------------------------------------------------------------
+// Public API — adopt-or-mint for a whole graph
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk a source's NetworkGraph and adopt-or-mint entity_registry rows for
+ * every node, port, and link.  Must be called after `ingestGraph` within
+ * the same DB connection.
+ *
+ * Execution order:
+ *   1. Nodes  — establishes node entityIds needed by ports.
+ *   2. Ports  — parent-scoped; requires node entityId.
+ *   3. Links  — endpoint port entityIds must be known first.
+ */
+export function adoptOrMintForGraph(
+  topologyId: string,
+  sourceId: string,
+  graph: NetworkGraph,
+  db: Database,
+): void {
+  const now = timestamp()
+
+  // --- Nodes ---
+  const nodeEntityIds = new Map<string, string>() // nodeLocalId → entityId
+  for (const node of graph.nodes ?? []) {
+    const keys = gatherNodeKeys(node.identity, sourceId, node.id)
+    const entityId = adoptOrMintEntity(topologyId, 'node', '', null, keys, now, db)
+    nodeEntityIds.set(node.id, entityId)
+  }
+
+  // --- Ports ---
+  const portEntityIds = new Map<string, string>() // `${nodeId}:${portId}` → entityId
+  for (const node of graph.nodes ?? []) {
+    const nodeEntityId = nodeEntityIds.get(node.id)
+    if (!nodeEntityId) continue
+    for (const port of node.ports ?? []) {
+      const keys = gatherPortKeys(port.identity, sourceId, port.id)
+      const entityId = adoptOrMintEntity(
+        topologyId,
+        'port',
+        nodeEntityId,
+        nodeEntityId,
+        keys,
+        now,
+        db,
+      )
+      portEntityIds.set(`${node.id}:${port.id}`, entityId)
+    }
+  }
+
+  // --- Links (canonical sorted endpoint pair → link entity) ---
+  for (const link of graph.links ?? []) {
+    const fromComposite = link.from.port ? `${link.from.node}:${link.from.port}` : undefined
+    const toComposite = link.to.port ? `${link.to.node}:${link.to.port}` : undefined
+    const fromPortEntityId = fromComposite ? portEntityIds.get(fromComposite) : undefined
+    const toPortEntityId = toComposite ? portEntityIds.get(toComposite) : undefined
+    if (!fromPortEntityId || !toPortEntityId) continue
+    const [pA, pB] = [fromPortEntityId, toPortEntityId].sort()
+    const linkKey: IdentityKey[] = [{ key: 'endpoints', value: `${pA}|${pB}` }]
+    adoptOrMintEntity(topologyId, 'link', '', null, linkKey, now, db)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API — stamp entityId onto a resolved graph (read-only registry access)
+// ---------------------------------------------------------------------------
+
+function lookupNodeEntityId(
+  topologyId: string,
+  identity: Identity | undefined,
+  db: Database,
+): string | undefined {
+  if (!identity) return undefined
+  // Use gatherNodeKeys but strip manual fallback keys (source-specific, not useful for lookup)
+  const keys = gatherNodeKeys(identity, '', '').filter((k) => !k.key.startsWith('manual:'))
+  if (keys.length === 0) return undefined
+  return lookupByKeys(topologyId, 'node', '', keys, db)[0]
+}
+
+function lookupPortEntityId(
+  topologyId: string,
+  nodeEntityId: string,
+  identity: Identity | undefined,
+  db: Database,
+): string | undefined {
+  if (!identity) return undefined
+  const keys = gatherPortKeys(identity, '', '').filter((k) => !k.key.startsWith('manual:'))
+  if (keys.length === 0) return undefined
+  return lookupByKeys(topologyId, 'port', nodeEntityId, keys, db)[0]
+}
+
+function lookupLinkEntityId(
+  topologyId: string,
+  portAEntityId: string,
+  portBEntityId: string,
+  db: Database,
+): string | undefined {
+  const [pA, pB] = [portAEntityId, portBEntityId].sort()
+  const keys: IdentityKey[] = [{ key: 'endpoints', value: `${pA}|${pB}` }]
+  return lookupByKeys(topologyId, 'link', '', keys, db)[0]
+}
+
+/**
+ * Stamp `entityId` on nodes, their ports, and links in the resolved graph.
+ * Read-only: never writes to the registry.  Elements whose identity cannot
+ * be resolved in the registry are returned unchanged (entityId omitted).
+ *
+ * Called by TopologyService.completeDerivation in the host process after the
+ * derive worker returns its result.
+ */
+export function stampEntityIds(
+  topologyId: string,
+  graph: NetworkGraph,
+  db: Database,
+): NetworkGraph {
+  const portEntityByNodePort = new Map<string, string>() // `${nodeId}:${portId}` → entityId
+
+  const stampedNodes: Node[] = graph.nodes.map((node) => {
+    const nodeEntityId = lookupNodeEntityId(topologyId, node.identity, db)
+
+    const stampedPorts: NodePort[] | undefined = node.ports?.map((port) => {
+      if (!nodeEntityId) return port
+      const portEntityId = lookupPortEntityId(topologyId, nodeEntityId, port.identity, db)
+      if (!portEntityId) return port
+      portEntityByNodePort.set(`${node.id}:${port.id}`, portEntityId)
+      return { ...port, entityId: portEntityId }
+    })
+
+    if (!nodeEntityId) {
+      if (stampedPorts) return { ...node, ports: stampedPorts }
+      return node
+    }
+    const withEntity: Node = { ...node, entityId: nodeEntityId }
+    if (stampedPorts) withEntity.ports = stampedPorts
+    return withEntity
+  })
+
+  const stampedLinks: Link[] = graph.links.map((link) => {
+    const fromKey = link.from.port ? `${link.from.node}:${link.from.port}` : undefined
+    const toKey = link.to.port ? `${link.to.node}:${link.to.port}` : undefined
+    const fromPortEntityId = fromKey ? portEntityByNodePort.get(fromKey) : undefined
+    const toPortEntityId = toKey ? portEntityByNodePort.get(toKey) : undefined
+    if (!fromPortEntityId || !toPortEntityId) return link
+    const linkEntityId = lookupLinkEntityId(topologyId, fromPortEntityId, toPortEntityId, db)
+    if (!linkEntityId) return link
+    return { ...link, entityId: linkEntityId }
+  })
+
+  return { ...graph, nodes: stampedNodes, links: stampedLinks }
+}

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -25,6 +25,7 @@ import { createHash } from 'node:crypto'
 import type { NetworkGraph } from '@shumoku/core'
 import { generateId, getDatabase, timestamp } from '../db/index.js'
 import { ingestGraph } from './contribution-store.js'
+import { adoptOrMintForGraph } from './entity-registry.js'
 
 /**
  * Hash of a contribution's STRUCTURAL content: volatile per-scan fields
@@ -278,6 +279,7 @@ export class ObservationsService {
       },
       this.db,
     )
+    adoptOrMintForGraph(input.topologyId, input.sourceId, graph, this.db)
     return true
   }
 

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -279,7 +279,9 @@ export class ObservationsService {
       },
       this.db,
     )
-    adoptOrMintForGraph(input.topologyId, input.sourceId, graph, this.db)
+    // Registers from the post-ingest contribution rows (NOT `graph`) so ports
+    // synthesized from link endpoints get entities too — see adoptOrMintForGraph.
+    adoptOrMintForGraph(input.topologyId, input.sourceId, this.db)
     return true
   }
 

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -1660,7 +1660,7 @@ export class TopologyService {
       { attachmentId: null, lastStatus: 'ok', lastOkAt: timestamp() },
       this.db,
     )
-    adoptOrMintForGraph(topologyId, PROJECT_SOURCE, graph, this.db)
+    adoptOrMintForGraph(topologyId, PROJECT_SOURCE, this.db)
     this.clearCacheEntry(topologyId)
   }
 

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -64,6 +64,7 @@ import type {
 } from '../types.js'
 import { buildGraph, ingestGraph } from './contribution-store.js'
 import { isDeriving, kickDerivation } from './derivation.js'
+import { adoptOrMintForGraph, stampEntityIds } from './entity-registry.js'
 
 /**
  * How long `getParsed` waits for an in-flight bake before falling back to
@@ -144,7 +145,8 @@ interface ScopeCriterionRow {
 // longer emits y-backtracking bends.
 // v14: role-driven ranks use directed topology dependencies first; soft
 // device tiers no longer place firewalls above upstream routers.
-const RESOLVER_VERSION = 17
+// v18: entity registry Phase 1 — entityId field added to nodes/ports/links
+const RESOLVER_VERSION = 18
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {
@@ -1211,10 +1213,11 @@ export class TopologyService {
   completeDerivation(id: string, builtRevision: number, result: DeriveResult): void {
     const topology = this.get(id)
     if (!topology) return
+    const stampedGraph = stampEntityIds(id, result.graph, this.db)
     const parsed: ParsedTopology = {
       id: topology.id,
       name: topology.name,
-      graph: result.graph,
+      graph: stampedGraph,
       layout: result.layout,
       resolved: result.resolved,
       iconDimensions: result.iconDimensions,
@@ -1657,6 +1660,7 @@ export class TopologyService {
       { attachmentId: null, lastStatus: 'ok', lastOkAt: timestamp() },
       this.db,
     )
+    adoptOrMintForGraph(topologyId, PROJECT_SOURCE, graph, this.db)
     this.clearCacheEntry(topologyId)
   }
 

--- a/apps/server/api/test/db/entity-registry.test.ts
+++ b/apps/server/api/test/db/entity-registry.test.ts
@@ -11,6 +11,7 @@ import type { Database } from 'bun:sqlite'
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import type { NetworkGraph } from '@shumoku/core'
 import { getDatabase, timestamp } from '../../src/db/index.ts'
+import { ingestGraph } from '../../src/services/contribution-store.ts'
 import { adoptOrMintForGraph, stampEntityIds } from '../../src/services/entity-registry.ts'
 import { attachSource, insertDataSource, setupTempDb } from './helper.ts'
 
@@ -28,6 +29,30 @@ function makeTopology(db: Database): string {
     now,
   )
   return id
+}
+
+/**
+ * Mirror the production order: ingest into the contribution store first, then
+ * register.  adoptOrMintForGraph reads the post-ingest rows back itself — the
+ * raw graph is never handed to the registry (link-endpoint ports only exist
+ * after ingest synthesizes them).
+ */
+function ingestAndRegister(
+  db: Database,
+  topologyId: string,
+  sourceId: string,
+  graph: NetworkGraph,
+): void {
+  // Own the contribution via the attach row, like materializeContribution does —
+  // a NULL attachment_id means "intrinsic" and is unique per topology.
+  const attach = db
+    .query<{ id: string }, [string, string]>(
+      `SELECT id FROM topology_data_sources
+       WHERE topology_id = ? AND data_source_id = ? AND purpose = 'topology'`,
+    )
+    .get(topologyId, sourceId)
+  ingestGraph(topologyId, sourceId, graph, { attachmentId: attach?.id ?? null }, db)
+  adoptOrMintForGraph(topologyId, sourceId, db)
 }
 
 function registryCount(
@@ -53,6 +78,15 @@ function entityIdOf(db: Database, topologyId: string, kind: string): string | un
       )
       .get(topologyId, kind) ?? undefined
   )?.id
+}
+
+function entityIdsOf(db: Database, topologyId: string, kind: string): string[] {
+  return db
+    .query<{ id: string }, [string, string]>(
+      'SELECT id FROM entity_registry WHERE topology_id = ? AND kind = ? ORDER BY id',
+    )
+    .all(topologyId, kind)
+    .map((r) => r.id)
 }
 
 // ---------------------------------------------------------------------------
@@ -103,6 +137,28 @@ const GRAPH_SIMPLE: NetworkGraph = {
   ],
 }
 
+// NetBox-shaped: nodes enumerate NO ports[] — ports exist only as link-endpoint
+// strings, exactly what the NetBox plugin emits. ingestGraph synthesizes stub
+// port elements (with identity.ifName, Phase 0) for these; the registry must
+// register from that post-ingest state, not from this raw graph.
+const GRAPH_NETBOX_SHAPE: NetworkGraph = {
+  name: 'netbox-shape',
+  nodes: [
+    { id: 'rtr-1', label: 'rtr-1', identity: { mgmtIp: '10.9.0.1' } },
+    { id: 'sw-9', label: 'sw-9', identity: { mgmtIp: '10.9.0.2' } },
+  ],
+  links: [
+    {
+      from: { node: 'rtr-1', port: 'ge-0/0/0' },
+      to: { node: 'sw-9', port: 'GigabitEthernet1/0/1' },
+    },
+    {
+      from: { node: 'rtr-1', port: 'ge-0/0/1' },
+      to: { node: 'sw-9', port: 'GigabitEthernet1/0/2' },
+    },
+  ],
+}
+
 // ---------------------------------------------------------------------------
 // Test suite
 // ---------------------------------------------------------------------------
@@ -125,11 +181,11 @@ describe('entity registry', () => {
       const src = insertDataSource('netbox')
       attachSource(topologyId, src, 'topology')
 
-      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      ingestAndRegister(db, topologyId, src, GRAPH_SIMPLE)
       const after1 = registryCount(db, topologyId)
       const nodeId1 = entityIdOf(db, topologyId, 'node')
 
-      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      ingestAndRegister(db, topologyId, src, GRAPH_SIMPLE)
       const after2 = registryCount(db, topologyId)
       const nodeId2 = entityIdOf(db, topologyId, 'node')
 
@@ -171,9 +227,9 @@ describe('entity registry', () => {
         links: [],
       }
 
-      adoptOrMintForGraph(topologyId, src1, g1, db)
+      ingestAndRegister(db, topologyId, src1, g1)
       const id1 = entityIdOf(db, topologyId, 'node')
-      adoptOrMintForGraph(topologyId, src2, g2, db)
+      ingestAndRegister(db, topologyId, src2, g2)
       const id2 = entityIdOf(db, topologyId, 'node')
 
       // Should resolve to the same entity (not a second row)
@@ -194,7 +250,7 @@ describe('entity registry', () => {
         nodes: [{ id: 'n1', label: 'n1', identity: { chassisId: 'ab:cd:ef:01:02:03' }, ports: [] }],
         links: [],
       }
-      adoptOrMintForGraph(topologyId, src, g1, db)
+      ingestAndRegister(db, topologyId, src, g1)
       const id1 = entityIdOf(db, topologyId, 'node')
 
       // Second scan adds sysName (new key)
@@ -210,7 +266,7 @@ describe('entity registry', () => {
         ],
         links: [],
       }
-      adoptOrMintForGraph(topologyId, src, g2, db)
+      ingestAndRegister(db, topologyId, src, g2)
       const id2 = entityIdOf(db, topologyId, 'node')
 
       // Still the same entity
@@ -237,51 +293,36 @@ describe('entity registry', () => {
       attachSource(topologyId, src2, 'topology')
 
       // Mint via sysName only
-      adoptOrMintForGraph(
-        topologyId,
-        src1,
-        {
-          name: 'g1',
-          nodes: [{ id: 'a', label: 'a', identity: { sysName: 'spine-1' }, ports: [] }],
-          links: [],
-        },
-        db,
-      )
+      ingestAndRegister(db, topologyId, src1, {
+        name: 'g1',
+        nodes: [{ id: 'a', label: 'a', identity: { sysName: 'spine-1' }, ports: [] }],
+        links: [],
+      })
 
       // Mint via chassisId only
-      adoptOrMintForGraph(
-        topologyId,
-        src2,
-        {
-          name: 'g2',
-          nodes: [{ id: 'b', label: 'b', identity: { chassisId: 'ff:ee:dd:cc:bb:aa' }, ports: [] }],
-          links: [],
-        },
-        db,
-      )
+      ingestAndRegister(db, topologyId, src2, {
+        name: 'g2',
+        nodes: [{ id: 'b', label: 'b', identity: { chassisId: 'ff:ee:dd:cc:bb:aa' }, ports: [] }],
+        links: [],
+      })
 
       // Two entities exist
       const before = registryCount(db, topologyId)
       expect(before.nodes).toBe(2)
 
       // Now ingest with BOTH keys → merge
-      adoptOrMintForGraph(
-        topologyId,
-        src1,
-        {
-          name: 'g3',
-          nodes: [
-            {
-              id: 'c',
-              label: 'c',
-              identity: { sysName: 'spine-1', chassisId: 'ff:ee:dd:cc:bb:aa' },
-              ports: [],
-            },
-          ],
-          links: [],
-        },
-        db,
-      )
+      ingestAndRegister(db, topologyId, src1, {
+        name: 'g3',
+        nodes: [
+          {
+            id: 'c',
+            label: 'c',
+            identity: { sysName: 'spine-1', chassisId: 'ff:ee:dd:cc:bb:aa' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
 
       // Should have collapsed to 1 entity (+ 1 alias)
       const after = registryCount(db, topologyId)
@@ -303,7 +344,7 @@ describe('entity registry', () => {
       const src = insertDataSource('snmp')
       attachSource(topologyId, src, 'topology')
 
-      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      ingestAndRegister(db, topologyId, src, GRAPH_SIMPLE)
 
       const portRows = db
         .query<{ id: string; parent_id: string }, string>(
@@ -326,7 +367,7 @@ describe('entity registry', () => {
       const src = insertDataSource('lldp')
       attachSource(topologyId, src, 'topology')
 
-      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      ingestAndRegister(db, topologyId, src, GRAPH_SIMPLE)
 
       const counts = registryCount(db, topologyId)
       expect(counts.links).toBe(1)
@@ -337,13 +378,104 @@ describe('entity registry', () => {
       const src = insertDataSource('lldp')
       attachSource(topologyId, src, 'topology')
 
-      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      ingestAndRegister(db, topologyId, src, GRAPH_SIMPLE)
       const linkId1 = entityIdOf(db, topologyId, 'link')
 
-      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      ingestAndRegister(db, topologyId, src, GRAPH_SIMPLE)
       const linkId2 = entityIdOf(db, topologyId, 'link')
 
       expect(linkId2).toBe(linkId1)
+    })
+  })
+
+  describe('NetBox-shaped ingest (no ports[] arrays)', () => {
+    test('link-endpoint ports yield port entities and link entities', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('netbox')
+      attachSource(topologyId, src, 'topology')
+
+      ingestAndRegister(db, topologyId, src, GRAPH_NETBOX_SHAPE)
+
+      const counts = registryCount(db, topologyId)
+      expect(counts.nodes).toBe(2)
+      // Every port referenced by a link endpoint (synthesized at ingest) gets an entity
+      expect(counts.ports).toBe(4)
+      expect(counts.links).toBe(2)
+    })
+
+    test('port and link entity ids are stable across re-ingest', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('netbox')
+      attachSource(topologyId, src, 'topology')
+
+      ingestAndRegister(db, topologyId, src, GRAPH_NETBOX_SHAPE)
+      const ports1 = entityIdsOf(db, topologyId, 'port')
+      const links1 = entityIdsOf(db, topologyId, 'link')
+
+      // Blank + rebuild: ingest fully replaces the contribution rows, then registers again
+      ingestAndRegister(db, topologyId, src, GRAPH_NETBOX_SHAPE)
+      const ports2 = entityIdsOf(db, topologyId, 'port')
+      const links2 = entityIdsOf(db, topologyId, 'link')
+
+      expect(ports2).toEqual(ports1)
+      expect(links2).toEqual(links1)
+    })
+
+    test('stampEntityIds stamps ports and links on the resolved shape', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('netbox')
+      attachSource(topologyId, src, 'topology')
+
+      ingestAndRegister(db, topologyId, src, GRAPH_NETBOX_SHAPE)
+
+      // The RESOLVED graph (unlike the raw NetBox graph) carries materialized
+      // ports[] with identity.ifName — stamping must find the ingest-minted entities.
+      const resolvedShape: NetworkGraph = {
+        name: 'resolved',
+        nodes: [
+          {
+            id: 'rtr-1',
+            label: 'rtr-1',
+            identity: { mgmtIp: '10.9.0.1' },
+            ports: [
+              { id: 'ge-0/0/0', connectors: [], identity: { ifName: 'ge-0/0/0' } },
+              { id: 'ge-0/0/1', connectors: [], identity: { ifName: 'ge-0/0/1' } },
+            ],
+          },
+          {
+            id: 'sw-9',
+            label: 'sw-9',
+            identity: { mgmtIp: '10.9.0.2' },
+            ports: [
+              {
+                id: 'GigabitEthernet1/0/1',
+                connectors: [],
+                identity: { ifName: 'GigabitEthernet1/0/1' },
+              },
+              {
+                id: 'GigabitEthernet1/0/2',
+                connectors: [],
+                identity: { ifName: 'GigabitEthernet1/0/2' },
+              },
+            ],
+          },
+        ],
+        links: GRAPH_NETBOX_SHAPE.links,
+      }
+
+      const stamped = stampEntityIds(topologyId, resolvedShape, db)
+
+      for (const node of stamped.nodes) {
+        expect(node.entityId).toBeTruthy()
+        expect(node.ports?.length).toBeGreaterThan(0)
+        for (const port of node.ports ?? []) {
+          expect(port.entityId).toBeTruthy()
+        }
+      }
+      expect(stamped.links.length).toBe(2)
+      for (const link of stamped.links) {
+        expect(link.entityId).toBeTruthy()
+      }
     })
   })
 
@@ -353,7 +485,7 @@ describe('entity registry', () => {
       const src = insertDataSource('netbox')
       attachSource(topologyId, src, 'topology')
 
-      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      ingestAndRegister(db, topologyId, src, GRAPH_SIMPLE)
 
       const stamped = stampEntityIds(topologyId, GRAPH_SIMPLE, db)
 
@@ -370,7 +502,7 @@ describe('entity registry', () => {
       const src = insertDataSource('netbox')
       attachSource(topologyId, src, 'topology')
 
-      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      ingestAndRegister(db, topologyId, src, GRAPH_SIMPLE)
 
       const stamped = stampEntityIds(topologyId, GRAPH_SIMPLE, db)
 

--- a/apps/server/api/test/db/entity-registry.test.ts
+++ b/apps/server/api/test/db/entity-registry.test.ts
@@ -1,0 +1,404 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Tests for the entity registry (adopt-or-mint + stampEntityIds).
+ *
+ * Run with: cd apps/server/api && bun test test/db/entity-registry.test.ts
+ */
+
+import type { Database } from 'bun:sqlite'
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { NetworkGraph } from '@shumoku/core'
+import { getDatabase, timestamp } from '../../src/db/index.ts'
+import { adoptOrMintForGraph, stampEntityIds } from '../../src/services/entity-registry.ts'
+import { attachSource, insertDataSource, setupTempDb } from './helper.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTopology(db: Database): string {
+  const id = `topo-${Math.random().toString(36).slice(2)}`
+  const now = timestamp()
+  db.query('INSERT INTO topologies (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(
+    id,
+    id,
+    now,
+    now,
+  )
+  return id
+}
+
+function registryCount(
+  db: Database,
+  topologyId: string,
+): { nodes: number; ports: number; links: number } {
+  const countOf = (kind: string) =>
+    (
+      db
+        .query<{ n: number }, [string, string]>(
+          'SELECT COUNT(*) AS n FROM entity_registry WHERE topology_id = ? AND kind = ?',
+        )
+        .get(topologyId, kind) ?? { n: 0 }
+    ).n
+  return { nodes: countOf('node'), ports: countOf('port'), links: countOf('link') }
+}
+
+function entityIdOf(db: Database, topologyId: string, kind: string): string | undefined {
+  return (
+    db
+      .query<{ id: string }, [string, string]>(
+        'SELECT id FROM entity_registry WHERE topology_id = ? AND kind = ? LIMIT 1',
+      )
+      .get(topologyId, kind) ?? undefined
+  )?.id
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const GRAPH_SIMPLE: NetworkGraph = {
+  name: 'simple',
+  nodes: [
+    {
+      id: 'sw-1',
+      label: 'sw-1',
+      identity: { chassisId: 'aa:bb:cc:dd:ee:01', mgmtIp: '10.0.0.1' },
+      ports: [
+        {
+          id: 'p1',
+          label: 'Gi0/1',
+          connectors: [],
+          identity: { ifName: 'GigabitEthernet0/1', ifIndex: 1 },
+        },
+        {
+          id: 'p2',
+          label: 'Gi0/2',
+          connectors: [],
+          identity: { ifName: 'GigabitEthernet0/2', ifIndex: 2 },
+        },
+      ],
+    },
+    {
+      id: 'sw-2',
+      label: 'sw-2',
+      identity: { chassisId: 'aa:bb:cc:dd:ee:02', mgmtIp: '10.0.0.2' },
+      ports: [
+        {
+          id: 'p1',
+          label: 'Gi0/1',
+          connectors: [],
+          identity: { ifName: 'GigabitEthernet0/1' },
+        },
+      ],
+    },
+  ],
+  links: [
+    {
+      from: { node: 'sw-1', port: 'p1' },
+      to: { node: 'sw-2', port: 'p1' },
+    },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('entity registry', () => {
+  let teardown: () => void
+  let db: Database
+
+  beforeAll(() => {
+    const tmp = setupTempDb()
+    teardown = tmp.teardown
+    db = getDatabase()
+  })
+
+  afterAll(() => teardown())
+
+  describe('adopt (same graph twice)', () => {
+    test('second ingest reuses entity ids', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('netbox')
+      attachSource(topologyId, src, 'topology')
+
+      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      const after1 = registryCount(db, topologyId)
+      const nodeId1 = entityIdOf(db, topologyId, 'node')
+
+      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      const after2 = registryCount(db, topologyId)
+      const nodeId2 = entityIdOf(db, topologyId, 'node')
+
+      // Row counts must not grow on re-ingest
+      expect(after2.nodes).toBe(after1.nodes)
+      expect(after2.ports).toBe(after1.ports)
+      expect(after2.links).toBe(after1.links)
+      // Entity id must be stable
+      expect(nodeId2).toBe(nodeId1)
+    })
+  })
+
+  describe('cross-source adopt', () => {
+    test('two sources with shared chassisId → same entity', () => {
+      const topologyId = makeTopology(db)
+      const src1 = insertDataSource('netbox')
+      const src2 = insertDataSource('zabbix')
+      attachSource(topologyId, src1, 'topology')
+      attachSource(topologyId, src2, 'topology')
+
+      const g1: NetworkGraph = {
+        name: 'g1',
+        nodes: [
+          {
+            id: 'n1',
+            label: 'r1',
+            identity: { chassisId: 'cc:dd:ee:ff:00:01', mgmtIp: '192.168.1.1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      }
+      const g2: NetworkGraph = {
+        name: 'g2',
+        // Same chassisId, different sourceId/local-id — should adopt the same entity
+        nodes: [
+          { id: 'router-1', label: 'r1', identity: { chassisId: 'cc:dd:ee:ff:00:01' }, ports: [] },
+        ],
+        links: [],
+      }
+
+      adoptOrMintForGraph(topologyId, src1, g1, db)
+      const id1 = entityIdOf(db, topologyId, 'node')
+      adoptOrMintForGraph(topologyId, src2, g2, db)
+      const id2 = entityIdOf(db, topologyId, 'node')
+
+      // Should resolve to the same entity (not a second row)
+      const counts = registryCount(db, topologyId)
+      expect(counts.nodes).toBe(1)
+      expect(id2).toBe(id1)
+    })
+  })
+
+  describe('evidence accretion', () => {
+    test('new keys accumulate on same entity', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('snmp')
+      attachSource(topologyId, src, 'topology')
+
+      const g1: NetworkGraph = {
+        name: 'g1',
+        nodes: [{ id: 'n1', label: 'n1', identity: { chassisId: 'ab:cd:ef:01:02:03' }, ports: [] }],
+        links: [],
+      }
+      adoptOrMintForGraph(topologyId, src, g1, db)
+      const id1 = entityIdOf(db, topologyId, 'node')
+
+      // Second scan adds sysName (new key)
+      const g2: NetworkGraph = {
+        name: 'g2',
+        nodes: [
+          {
+            id: 'n1',
+            label: 'n1',
+            identity: { chassisId: 'ab:cd:ef:01:02:03', sysName: 'core-sw-1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      }
+      adoptOrMintForGraph(topologyId, src, g2, db)
+      const id2 = entityIdOf(db, topologyId, 'node')
+
+      // Still the same entity
+      expect(id2).toBe(id1)
+
+      // sysName key now registered
+      const keyCount = (
+        db
+          .query<{ n: number }, string[]>(
+            'SELECT COUNT(*) AS n FROM entity_identity_key WHERE entity_id = ? AND key = ?',
+          )
+          .get(id1 ?? '', 'sysName') ?? { n: 0 }
+      ).n
+      expect(keyCount).toBe(1)
+    })
+  })
+
+  describe('merge', () => {
+    test('two entities that acquire a shared key merge into one', () => {
+      const topologyId = makeTopology(db)
+      const src1 = insertDataSource('lldp')
+      const src2 = insertDataSource('netbox')
+      attachSource(topologyId, src1, 'topology')
+      attachSource(topologyId, src2, 'topology')
+
+      // Mint via sysName only
+      adoptOrMintForGraph(
+        topologyId,
+        src1,
+        {
+          name: 'g1',
+          nodes: [{ id: 'a', label: 'a', identity: { sysName: 'spine-1' }, ports: [] }],
+          links: [],
+        },
+        db,
+      )
+
+      // Mint via chassisId only
+      adoptOrMintForGraph(
+        topologyId,
+        src2,
+        {
+          name: 'g2',
+          nodes: [{ id: 'b', label: 'b', identity: { chassisId: 'ff:ee:dd:cc:bb:aa' }, ports: [] }],
+          links: [],
+        },
+        db,
+      )
+
+      // Two entities exist
+      const before = registryCount(db, topologyId)
+      expect(before.nodes).toBe(2)
+
+      // Now ingest with BOTH keys → merge
+      adoptOrMintForGraph(
+        topologyId,
+        src1,
+        {
+          name: 'g3',
+          nodes: [
+            {
+              id: 'c',
+              label: 'c',
+              identity: { sysName: 'spine-1', chassisId: 'ff:ee:dd:cc:bb:aa' },
+              ports: [],
+            },
+          ],
+          links: [],
+        },
+        db,
+      )
+
+      // Should have collapsed to 1 entity (+ 1 alias)
+      const after = registryCount(db, topologyId)
+      expect(after.nodes).toBe(2) // registry row count doesn't change (alias still points to retired id)
+      const aliasCount = (
+        db
+          .query<{ n: number }, string>(
+            'SELECT COUNT(*) AS n FROM entity_alias WHERE new_id IN (SELECT id FROM entity_registry WHERE topology_id = ?)',
+          )
+          .get(topologyId) ?? { n: 0 }
+      ).n
+      expect(aliasCount).toBe(1)
+    })
+  })
+
+  describe('port parent scoping', () => {
+    test('ports with same ifName on different nodes get different entities', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('snmp')
+      attachSource(topologyId, src, 'topology')
+
+      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+
+      const portRows = db
+        .query<{ id: string; parent_id: string }, string>(
+          'SELECT id, parent_id FROM entity_registry WHERE topology_id = ? AND kind = ?',
+        )
+        .all(topologyId, 'port')
+
+      // sw-1 has 2 ports (p1, p2), sw-2 has 1 port → 3 port entities
+      expect(portRows.length).toBe(3)
+      // All port entities should have a non-null parent_id
+      for (const row of portRows) {
+        expect(row.parent_id).toBeTruthy()
+      }
+    })
+  })
+
+  describe('link entity', () => {
+    test('link entity is created keyed by sorted endpoint port ids', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('lldp')
+      attachSource(topologyId, src, 'topology')
+
+      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+
+      const counts = registryCount(db, topologyId)
+      expect(counts.links).toBe(1)
+    })
+
+    test('link entity is stable across re-ingests (same port pair)', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('lldp')
+      attachSource(topologyId, src, 'topology')
+
+      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      const linkId1 = entityIdOf(db, topologyId, 'link')
+
+      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+      const linkId2 = entityIdOf(db, topologyId, 'link')
+
+      expect(linkId2).toBe(linkId1)
+    })
+  })
+
+  describe('stampEntityIds', () => {
+    test('adds entityId to nodes with known identity', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('netbox')
+      attachSource(topologyId, src, 'topology')
+
+      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+
+      const stamped = stampEntityIds(topologyId, GRAPH_SIMPLE, db)
+
+      // Nodes with network identity should have entityId
+      for (const node of stamped.nodes) {
+        if (node.identity?.chassisId ?? node.identity?.mgmtIp) {
+          expect(node.entityId).toBeTruthy()
+        }
+      }
+    })
+
+    test('adds entityId to ports and links', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('netbox')
+      attachSource(topologyId, src, 'topology')
+
+      adoptOrMintForGraph(topologyId, src, GRAPH_SIMPLE, db)
+
+      const stamped = stampEntityIds(topologyId, GRAPH_SIMPLE, db)
+
+      const sw1 = stamped.nodes.find((n) => n.id === 'sw-1')
+      expect(sw1?.entityId).toBeTruthy()
+      // Ports with ifName should have entityId
+      const p1 = sw1?.ports?.find((p) => p.id === 'p1')
+      expect(p1?.entityId).toBeTruthy()
+
+      // Links with resolved endpoints should have entityId
+      const link = stamped.links[0]
+      expect(link?.entityId).toBeTruthy()
+    })
+
+    test('nodes without network identity get no entityId (manual fallback requires source)', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('netbox')
+      attachSource(topologyId, src, 'topology')
+
+      const graphWithManual: NetworkGraph = {
+        name: 'manual',
+        nodes: [{ id: 'n1', label: 'unnamed', ports: [] }], // no identity
+        links: [],
+      }
+
+      // stampEntityIds should NOT find an entity (manual key is source-scoped, stripped by stamp)
+      const stamped = stampEntityIds(topologyId, graphWithManual, db)
+      expect(stamped.nodes[0]?.entityId).toBeUndefined()
+    })
+  })
+})

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/cli": {
       "name": "@shumoku/cli",
-      "version": "0.2.25",
+      "version": "0.2.26",
       "bin": {
         "shumoku": "./dist/shumoku.js",
       },

--- a/libs/@shumoku/core/src/models/types.ts
+++ b/libs/@shumoku/core/src/models/types.ts
@@ -241,6 +241,11 @@ export interface NodePort {
    * a re-supplied binding won't resurrect a deleted one.
    */
   suppressedAttachments?: string[]
+  /**
+   * Stable entity id from the server-side entity registry; absent for
+   * graphs not resolved through it.
+   */
+  entityId?: string
 }
 
 /**
@@ -648,6 +653,11 @@ export interface Node {
    * the resolved node so the UI can round-trip it.
    */
   suppressedAttachments?: string[]
+  /**
+   * Stable entity id from the server-side entity registry; absent for
+   * graphs not resolved through it.
+   */
+  entityId?: string
 }
 
 // ============================================
@@ -904,6 +914,11 @@ export interface Link {
    * than by a stable identity record, so no `identity` field here.
    */
   provenance?: Provenance
+  /**
+   * Stable entity id from the server-side entity registry; absent for
+   * graphs not resolved through it.
+   */
+  entityId?: string
 }
 
 /**


### PR DESCRIPTION
Closes #549 (Phase 1 of #547 — Entity Registry; design doc #546).

## What

The persistent entity registry: identity matching centralized at ingest, ULID entity IDs stable across blank+rebuild.

- Migration `025_entity_registry.sql`: `entity_registry` / `entity_identity_key` (UNIQUE per topology+kind+parent+key+value) / `entity_alias`.
- **adopt-or-mint** runs at `materializeContribution` (the single ingest chokepoint, behind the content-hash change gate). Matching precedence per the identity design doc (node: chassisId > mgmtIp > sysName > vendor:*; port: ifName > mac > ifIndex; link: canonical endpoint-port-entity pair). Evidence accretion unions keys onto the adopted entity; ≥2 matches merge into the oldest with `entity_alias` rows (depth-capped resolution). Manual elements register under `manual:<sourceId>`.
- **Registration reads the post-ingest contribution back** (`buildGraph`) instead of the raw source graph — NetBox-shaped sources emit ports only as link-endpoint strings, synthesized as stubs during ingest; reading back makes ingest's synthesis + Phase 0's ifName stamping the single source of truth, and the no-graph-parameter signature makes the bug class unreproducible by call-site.
- **`entityId` exposed (additive)** on `Node`/`NodePort`/`Link` (core patch + changeset); stamped host-side in `completeDerivation` (derive worker stays pure). `RESOLVER_VERSION` 17→18.

## Live verification (NetBox demo, 50 nodes / 198 ports / 99 links)

Two full blank+rebuild cycles:

| | run 1 | run 2 |
|---|---|---|
| coverage | nodes 50/50 · ports 198/198 · links 99/99 | same |
| **ID stability across rebuild** | — | **347/347 identical, 0 diffs** |

Tests: server-api 87/87 (13 registry tests incl. NetBox-shape regressions: no `ports[]` arrays, links by endpoint strings), core 373/373, typecheck/biome clean.

## Known limitation (deliberate, documented)

Registration sits behind the content-hash no-change gate: an in-place upgrade on an existing DB won't populate the registry until the next content change or Rebuild. Remedy is trivial with the read-back design (also call on the no-change path — idempotent, would refresh `last_seen_at` too) — deferred to Phase 2/4 (#550/#552) rather than expanding this change.

Implemented by a Sonnet subagent (incl. one live-verification-found gap fixed structurally); reviewed + live-verified by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj