### PR TITLE
fix(renderer): split weathermap in/out lanes on routed polyline edges

### DIFF
--- a/.changeset/polyline-weathermap-lanes.md
+++ b/.changeset/polyline-weathermap-lanes.md
@@ -1,0 +1,5 @@
+---
+'@shumoku/renderer': patch
+---
+
+add routePoints to LinkOverlayContext and polylineOffsetPath helper for weathermap lane rendering

--- a/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
+++ b/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { LinkOverlayContext } from '@shumoku/renderer'
-  import { bezierOffsetPath } from '@shumoku/renderer'
+  import { bezierOffsetPath, polylineOffsetPath } from '@shumoku/renderer'
   import {
     bpsToDurationMs,
     DOWN_COLOR,
@@ -52,21 +52,19 @@
   // edges) we collapse to a single combined overlay — see template —
   // because there's no geometric anchor to split lanes from.
   const hasPorts = $derived(!!(context.fromPort && context.toPort))
-  // Routed (octilinear polyline) edges: the flow dashes must follow the
-  // routed path, not a port-to-port Bezier — otherwise every routed link
-  // grows a phantom diagonal dash line across the diagram. Polyline path
-  // data contains no 'C' command; both lanes share the path, and the
-  // opposite dash directions keep in/out distinguishable.
-  const isRoutedPolyline = $derived(!context.pathD.includes('C'))
   const inPathD = $derived(
-    !isRoutedPolyline && hasPorts && context.fromPort && context.toPort
-      ? bezierOffsetPath(context.fromPort, context.toPort, laneOffset)
-      : context.pathD,
+    context.routePoints && context.routePoints.length >= 2
+      ? polylineOffsetPath(context.routePoints, laneOffset)
+      : hasPorts && context.fromPort && context.toPort
+        ? bezierOffsetPath(context.fromPort, context.toPort, laneOffset)
+        : context.pathD,
   )
   const outPathD = $derived(
-    !isRoutedPolyline && hasPorts && context.fromPort && context.toPort
-      ? bezierOffsetPath(context.fromPort, context.toPort, -laneOffset)
-      : context.pathD,
+    context.routePoints && context.routePoints.length >= 2
+      ? polylineOffsetPath(context.routePoints, -laneOffset)
+      : hasPorts && context.fromPort && context.toPort
+        ? bezierOffsetPath(context.fromPort, context.toPort, -laneOffset)
+        : context.pathD,
   )
   // Combined-lane duration for the port-less fallback: pick whichever
   // direction is moving fastest so the user still sees activity.
@@ -172,8 +170,8 @@
   }
 
   /* Down: no lane overlay; the base link itself is the indicator —
-                         solid red dashed line, full opacity, so it can never be confused
-                         with the animated red lanes of a 90-100% utilized link. */
+                           solid red dashed line, full opacity, so it can never be confused
+                           with the animated red lanes of a 90-100% utilized link. */
   :global(.wm-active.wm-down > path.link) {
     opacity: 1;
     stroke-dasharray: 8 4;

--- a/libs/@shumoku/renderer/package.json
+++ b/libs/@shumoku/renderer/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "svelte-package -i src && vite build --outDir dist/wc --emptyOutDir",
+    "test": "vitest run --passWithNoTests",
     "typecheck": "svelte-check --tsconfig ./tsconfig.json",
     "lint": "biome check .",
     "format": "biome check --write ."

--- a/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgEdge.svelte
@@ -2,7 +2,12 @@
   import type { ResolvedEdge } from '@shumoku/core'
   import type { LinkOverlaySnippet } from '../../lib/overlays'
   import type { RenderColors } from '../../lib/render-colors'
-  import { bezierEdgePath, computePortLabelPosition, getVlanStroke } from '../../lib/svg-coords'
+  import {
+    bezierEdgePath,
+    computePortLabelPosition,
+    getVlanStroke,
+    polylinePath,
+  } from '../../lib/svg-coords'
 
   let {
     edge,
@@ -49,43 +54,6 @@
         : `M ${edge.points[0]?.x ?? 0} ${edge.points[0]?.y ?? 0} L ${edge.points[1]?.x ?? 0} ${edge.points[1]?.y ?? 0}`,
   )
 
-  /**
-   * Polyline path with optional corner rounding. Standard SVG L
-   * segments at every joint give a hard 90° look; in practice
-   * network-diagram convention prefers a small radius so the eye
-   * registers the corner without it being aggressively crisp.
-   */
-  function polylinePath(pts: { x: number; y: number }[]): string {
-    if (pts.length === 0) return ''
-    if (pts.length === 1) return `M ${pts[0]?.x ?? 0} ${pts[0]?.y ?? 0}`
-    const r = 6
-    let d = `M ${pts[0]?.x ?? 0} ${pts[0]?.y ?? 0}`
-    for (let i = 1; i < pts.length - 1; i++) {
-      const prev = pts[i - 1]
-      const curr = pts[i]
-      const next = pts[i + 1]
-      if (!prev || !curr || !next) continue
-      const dxIn = curr.x - prev.x
-      const dyIn = curr.y - prev.y
-      const dxOut = next.x - curr.x
-      const dyOut = next.y - curr.y
-      const lenIn = Math.hypot(dxIn, dyIn)
-      const lenOut = Math.hypot(dxOut, dyOut)
-      if (lenIn < 1 || lenOut < 1) {
-        d += ` L ${curr.x} ${curr.y}`
-        continue
-      }
-      const ri = Math.min(r, lenIn / 2, lenOut / 2)
-      const inX = curr.x - (dxIn / lenIn) * ri
-      const inY = curr.y - (dyIn / lenIn) * ri
-      const outX = curr.x + (dxOut / lenOut) * ri
-      const outY = curr.y + (dyOut / lenOut) * ri
-      d += ` L ${inX} ${inY} Q ${curr.x} ${curr.y} ${outX} ${outY}`
-    }
-    const last = pts[pts.length - 1]
-    if (last) d += ` L ${last.x} ${last.y}`
-    return d
-  }
   const link = $derived(edge.link)
   const linkType = $derived(link?.type ?? 'solid')
   const dasharray = $derived(() => {
@@ -160,6 +128,7 @@
     toPortPosition: edge.toPort?.absolutePosition ?? null,
     fromPortLabelPosition: edge.fromPort ? computePortLabelPosition(edge.fromPort) : null,
     toPortLabelPosition: edge.toPort ? computePortLabelPosition(edge.toPort) : null,
+    routePoints: edge.route?.points ?? null,
   })
 
   function onclick(e: MouseEvent) {

--- a/libs/@shumoku/renderer/src/index.ts
+++ b/libs/@shumoku/renderer/src/index.ts
@@ -31,6 +31,8 @@ export {
   computePortLabelPosition,
   getNodeLabel,
   getVlanStroke,
+  polylineOffsetPath,
+  polylinePath,
   screenToSvg,
   svgPointToContainer,
   svgRectToContainer,

--- a/libs/@shumoku/renderer/src/lib/overlays.ts
+++ b/libs/@shumoku/renderer/src/lib/overlays.ts
@@ -1,4 +1,4 @@
-import type { Node, ResolvedEdge, ResolvedPort, Subgraph } from '@shumoku/core'
+﻿import type { Node, ResolvedEdge, ResolvedPort, Subgraph } from '@shumoku/core'
 import type { Snippet } from 'svelte'
 
 export interface SubgraphOverlayContext {
@@ -25,6 +25,14 @@ export interface LinkOverlayContext {
   toPortPosition: { x: number; y: number } | null
   fromPortLabelPosition: { x: number; y: number; textAnchor: string } | null
   toPortLabelPosition: { x: number; y: number; textAnchor: string } | null
+  /**
+   * Routed polyline points when this edge was routed orthogonally by the
+   * layout engine. `null` for Bezier edges (port-anchored default).
+   * Overlays that draw parallel lanes (e.g. weathermap in/out streams)
+   * should call `polylineOffsetPath(routePoints, ±offset)` when this
+   * field is non-null rather than offsetting from port positions.
+   */
+  routePoints: { x: number; y: number }[] | null
 }
 
 export interface NodeOverlayContext {

--- a/libs/@shumoku/renderer/src/lib/svg-coords.test.ts
+++ b/libs/@shumoku/renderer/src/lib/svg-coords.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import { polylineOffsetPath, polylinePath } from './svg-coords.js'
+
+// ============================================================================
+// polylinePath (smoke tests — the function is also tested indirectly via
+// polylineOffsetPath which calls it on the resulting offset points)
+// ============================================================================
+
+describe('polylinePath', () => {
+  it('returns empty string for empty input', () => {
+    expect(polylinePath([])).toBe('')
+  })
+
+  it('returns M command for single point', () => {
+    expect(polylinePath([{ x: 10, y: 20 }])).toBe('M 10 20')
+  })
+
+  it('returns M + L for two points', () => {
+    const d = polylinePath([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ])
+    expect(d).toMatch(/^M 0 0/)
+    expect(d).toContain('L 100 0')
+  })
+})
+
+// ============================================================================
+// polylineOffsetPath
+// ============================================================================
+
+describe('polylineOffsetPath', () => {
+  // Helper to parse the first M x y from a path string
+  function parseFirstM(d: string): { x: number; y: number } {
+    const m = /M ([\d.e+-]+) ([\d.e+-]+)/.exec(d)
+    if (!m) throw new Error(`No M command in: ${d}`)
+    return { x: Number(m[1]), y: Number(m[2]) }
+  }
+
+  // Helper to parse the last L x y (or last coord) from a path string
+  function parseLastPoint(d: string): { x: number; y: number } {
+    // Find the last L or final numbers in the path
+    const matches = [...d.matchAll(/[ML] ([\d.e+-]+) ([\d.e+-]+)/g)]
+    const last = matches[matches.length - 1]
+    if (!last) throw new Error(`No L/M commands in: ${d}`)
+    return { x: Number(last[1]), y: Number(last[2]) }
+  }
+
+  it('returns base polylinePath for offset=0', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    expect(polylineOffsetPath(pts, 0)).toBe(polylinePath(pts))
+  })
+
+  it('returns base polylinePath for non-finite offset', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    expect(polylineOffsetPath(pts, Number.NaN)).toBe(polylinePath(pts))
+    expect(polylineOffsetPath(pts, Number.POSITIVE_INFINITY)).toBe(polylinePath(pts))
+  })
+
+  it('returns base polylinePath for fewer than 2 points', () => {
+    const single = [{ x: 5, y: 5 }]
+    expect(polylineOffsetPath(single, 10)).toBe(polylinePath(single))
+  })
+
+  // 1. Straight horizontal segment — +offset shifts y downward
+  it('offsets a horizontal segment correctly in y', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]
+    const offset = 5
+    const d = polylineOffsetPath(pts, offset)
+    // For rightward travel (dx=100, dy=0), right-hand normal = (-dy/len, dx/len) * offset
+    // = (0, 1) * 5 = (0, 5) → start and end shift from y=0 to y=5
+    const start = parseFirstM(d)
+    const end = parseLastPoint(d)
+    expect(start.y).toBeCloseTo(5, 5)
+    expect(start.x).toBeCloseTo(0, 5)
+    expect(end.y).toBeCloseTo(5, 5)
+    expect(end.x).toBeCloseTo(100, 5)
+  })
+
+  // 2. L-shaped polyline: corner joins at intersection of offset lines
+  it('miters an L-shaped (right then down) polyline correctly', () => {
+    // Segment 1: (0,0) → (100,0) rightward
+    //   offset normal: (0, +offset) → start (0, offset), end (100, offset)
+    //   offset line 1: horizontal at y = offset
+    // Segment 2: (100,0) → (100,100) downward
+    //   direction: (0,1), right-hand normal: (-1,0)*offset = (-offset, 0)
+    //   start (100-offset, 0), end (100-offset, 100)
+    //   offset line 2: vertical at x = 100-offset
+    // Intersection: (100-offset, offset)
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ]
+    const offset = 10
+    const d = polylineOffsetPath(pts, offset)
+    // Start point should be (0, 10)
+    const start = parseFirstM(d)
+    expect(start.x).toBeCloseTo(0, 4)
+    expect(start.y).toBeCloseTo(10, 4)
+    // End point should be (90, 100)
+    const end = parseLastPoint(d)
+    expect(end.x).toBeCloseTo(90, 4)
+    expect(end.y).toBeCloseTo(100, 4)
+  })
+
+  // 3. +offset and -offset produce mirror images
+  it('positive and negative offset are y-axis mirrors for horizontal segment', () => {
+    const pts = [
+      { x: 0, y: 50 },
+      { x: 100, y: 50 },
+    ]
+    const offset = 8
+    const pos = polylineOffsetPath(pts, offset)
+    const neg = polylineOffsetPath(pts, -offset)
+    const posStart = parseFirstM(pos)
+    const negStart = parseFirstM(neg)
+    // Positive offset goes to y=50+8=58, negative to y=50-8=42
+    expect(posStart.y).toBeCloseTo(50 + offset, 4)
+    expect(negStart.y).toBeCloseTo(50 - offset, 4)
+    // x should be the same
+    expect(posStart.x).toBeCloseTo(negStart.x, 4)
+  })
+
+  // 4. Degenerate: two identical points must not throw
+  it('does not throw for two identical points', () => {
+    const pts = [
+      { x: 50, y: 50 },
+      { x: 50, y: 50 },
+    ]
+    expect(() => polylineOffsetPath(pts, 5)).not.toThrow()
+  })
+
+  // 5. Lane separation on horizontal segment
+  it('two lanes on a horizontal segment are at least 2.5px apart', () => {
+    // With laneWidth=2 (min), laneOffset = laneWidth/2 + 0.5 = 1.5
+    // The two lanes are offset by +1.5 and -1.5 → separation = 3 ≥ 2.5
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 200, y: 0 },
+    ]
+    const laneWidth = 2
+    const laneOffset = laneWidth / 2 + 0.5
+    const inPath = polylineOffsetPath(pts, laneOffset)
+    const outPath = polylineOffsetPath(pts, -laneOffset)
+    const inY = parseFirstM(inPath).y
+    const outY = parseFirstM(outPath).y
+    expect(Math.abs(inY - outY)).toBeGreaterThanOrEqual(2.5)
+  })
+
+  // 6. Single-segment vertical line
+  it('offsets a vertical segment correctly in x', () => {
+    // Upward travel: (0,100) → (0,0), direction (0,-1)
+    // Right-hand normal: (-(-1)/1, 0/1) * offset = (1, 0) * offset
+    // So +offset shifts x by +offset
+    const pts = [
+      { x: 0, y: 100 },
+      { x: 0, y: 0 },
+    ]
+    const offset = 7
+    const d = polylineOffsetPath(pts, offset)
+    const start = parseFirstM(d)
+    expect(start.x).toBeCloseTo(offset, 4)
+    expect(start.y).toBeCloseTo(100, 4)
+  })
+})

--- a/libs/@shumoku/renderer/src/lib/svg-coords.ts
+++ b/libs/@shumoku/renderer/src/lib/svg-coords.ts
@@ -148,3 +148,178 @@ export function svgPointToContainer(
     left: screen.x - containerRect.left,
   }
 }
+
+// ============================================================================
+// Polyline path helpers
+// ============================================================================
+
+type Point = { x: number; y: number }
+
+/**
+ * Build an SVG path `d` string for an orthogonal polyline with optional
+ * rounded corners. Uses quadratic-Bezier arcs (Q command) at each interior
+ * joint so the right-angle turns read cleanly without being aggressively
+ * crisp. Extracted from `SvgEdge.svelte` so weathermap overlays and
+ * other consumers can reuse the exact same rounding logic.
+ */
+export function polylinePath(pts: Point[]): string {
+  if (pts.length === 0) return ''
+  if (pts.length === 1) return `M ${pts[0]?.x ?? 0} ${pts[0]?.y ?? 0}`
+  const r = 6
+  let d = `M ${pts[0]?.x ?? 0} ${pts[0]?.y ?? 0}`
+  for (let i = 1; i < pts.length - 1; i++) {
+    const prev = pts[i - 1]
+    const curr = pts[i]
+    const next = pts[i + 1]
+    if (!prev || !curr || !next) continue
+    const dxIn = curr.x - prev.x
+    const dyIn = curr.y - prev.y
+    const dxOut = next.x - curr.x
+    const dyOut = next.y - curr.y
+    const lenIn = Math.hypot(dxIn, dyIn)
+    const lenOut = Math.hypot(dxOut, dyOut)
+    if (lenIn < 1 || lenOut < 1) {
+      d += ` L ${curr.x} ${curr.y}`
+      continue
+    }
+    const ri = Math.min(r, lenIn / 2, lenOut / 2)
+    const inX = curr.x - (dxIn / lenIn) * ri
+    const inY = curr.y - (dyIn / lenIn) * ri
+    const outX = curr.x + (dxOut / lenOut) * ri
+    const outY = curr.y + (dyOut / lenOut) * ri
+    d += ` L ${inX} ${inY} Q ${curr.x} ${curr.y} ${outX} ${outY}`
+  }
+  const last = pts[pts.length - 1]
+  if (last) d += ` L ${last.x} ${last.y}`
+  return d
+}
+
+/**
+ * Build a laterally-offset polyline SVG path `d` string.
+ *
+ * Each segment of the polyline is shifted perpendicular to its direction
+ * by `offset` pixels. Sign convention — matches `bezierOffsetPath`:
+ * positive = right-hand side of the travel direction in screen coords
+ * (y-down). So for a rightward segment `+offset` shifts the lane downward.
+ *
+ * Interior corners are mitered: the join point is the intersection of the
+ * two adjacent offset-segment lines, so the path remains continuous and
+ * gap-free. Pathological miters (angle close to 180° or degenerate
+ * segments) fall back to the average of the two per-segment translations.
+ * Miters that land further than 4×|offset| from the original corner are
+ * also clamped to the average-translation fallback.
+ *
+ * The resulting offset points are passed to `polylinePath` so the output
+ * has the same rounded-corner style as the base edge.
+ */
+export function polylineOffsetPath(pts: Point[], offset: number): string {
+  if (pts.length < 2) return polylinePath(pts)
+  if (offset === 0 || !Number.isFinite(offset)) return polylinePath(pts)
+
+  const n = pts.length
+
+  // Per-segment perpendicular offset vector.
+  // Convention: right-hand side of travel (dx,dy) → normal (-dy/len, dx/len) × offset.
+  const segNormals: Point[] = []
+  for (const [i] of pts.entries()) {
+    if (i >= n - 1) break
+    const p0 = pts[i]
+    const p1 = pts[i + 1]
+    if (!p0 || !p1) {
+      segNormals.push({ x: 0, y: 0 })
+      continue
+    }
+    const dx = p1.x - p0.x
+    const dy = p1.y - p0.y
+    const len = Math.hypot(dx, dy)
+    if (len < 0.001) {
+      segNormals.push({ x: 0, y: 0 })
+    } else {
+      segNormals.push({ x: (-dy / len) * offset, y: (dx / len) * offset })
+    }
+  }
+
+  const offsetPts: Point[] = new Array(n)
+
+  // First point: shift by first segment's normal.
+  const first = pts[0]
+  const n0 = segNormals[0]
+  if (!first || !n0) return polylinePath(pts)
+  offsetPts[0] = { x: first.x + n0.x, y: first.y + n0.y }
+
+  // Last point: shift by last segment's normal.
+  const last = pts[n - 1]
+  const nLast = segNormals[n - 2]
+  if (!last || !nLast) return polylinePath(pts)
+  offsetPts[n - 1] = { x: last.x + nLast.x, y: last.y + nLast.y }
+
+  // Interior corners: miter join (line-line intersection of adjacent offset lines).
+  for (const [i] of pts.entries()) {
+    if (i === 0 || i >= n - 1) continue
+    const pi = pts[i]
+    const nm1 = segNormals[i - 1] // normal of segment ending at corner
+    const ni = segNormals[i] // normal of segment starting at corner
+    const prev = pts[i - 1]
+    const next = pts[i + 1]
+
+    if (!pi || !nm1 || !ni || !prev || !next) {
+      offsetPts[i] = pi ?? { x: 0, y: 0 }
+      continue
+    }
+
+    // Fallback: translate by average of the two per-segment normals.
+    const fallback: Point = {
+      x: pi.x + (nm1.x + ni.x) / 2,
+      y: pi.y + (nm1.y + ni.y) / 2,
+    }
+
+    // Line 1: passes through (pi + nm1) with direction d(i-1).
+    const Ax = pi.x + nm1.x
+    const Ay = pi.y + nm1.y
+    const dx1 = pi.x - prev.x
+    const dy1 = pi.y - prev.y
+    const len1 = Math.hypot(dx1, dy1)
+
+    // Line 2: passes through (pi + ni) with direction d(i).
+    const Bx = pi.x + ni.x
+    const By = pi.y + ni.y
+    const dx2 = next.x - pi.x
+    const dy2 = next.y - pi.y
+    const len2 = Math.hypot(dx2, dy2)
+
+    if (len1 < 0.001 || len2 < 0.001) {
+      offsetPts[i] = fallback
+      continue
+    }
+
+    const Dx = dx1 / len1
+    const Dy = dy1 / len1
+    const Ex = dx2 / len2
+    const Ey = dy2 / len2
+
+    // Solve: (Ax,Ay) + t*(Dx,Dy) = (Bx,By) + s*(Ex,Ey)
+    // Cross-product of directions to find t.
+    const cross = Dx * Ey - Dy * Ex
+
+    if (Math.abs(cross) < 0.001) {
+      // Near-parallel segments (collinear or nearly so): use fallback.
+      offsetPts[i] = fallback
+      continue
+    }
+
+    const t = ((Ay - By) * Ex - (Ax - Bx) * Ey) / cross
+    const miterX = Ax + t * Dx
+    const miterY = Ay + t * Dy
+
+    // Clamp pathological miters: if the join is further than 4×|offset|
+    // from the original corner, fall back to the average-translation point.
+    const dist = Math.hypot(miterX - pi.x, miterY - pi.y)
+    if (dist > 4 * Math.abs(offset)) {
+      offsetPts[i] = fallback
+    } else {
+      offsetPts[i] = { x: miterX, y: miterY }
+    }
+  }
+
+  return polylinePath(offsetPts)
+}

--- a/libs/@shumoku/renderer/vitest.config.ts
+++ b/libs/@shumoku/renderer/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+const dir = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@shumoku/core': path.resolve(dir, '../core/src/index.ts'),
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+})


### PR DESCRIPTION
## Bug

The weathermap draws two directional flow lanes (in/out) per link, offset ±laneOffset via `bezierOffsetPath` — but routed octilinear polyline edges fell back to sharing `context.pathD`, drawing BOTH lanes on the exact same path. Since the composite engine now routes every edge as a polyline, this was universal: verified in live DOM, 99/99 links had byte-identical lane `d` attributes — one visible line, and the out lane (rendered second) hid the in lane's color entirely.

Root cause of the root cause: overlays only received the path *string*; the polyline's points were never passed, and no polyline equivalent of `bezierOffsetPath` existed.

## Fix

- `LinkOverlayContext.routePoints` — SvgEdge passes `edge.route?.points ?? null` to overlays.
- New `polylineOffsetPath(points, offset)` in the renderer lib: per-segment perpendicular offset, true miter joins via line-line intersection, average-normal fallback for near-collinear/degenerate joints, 4×|offset| miter clamp for hairpins. Output rounded through the same (now shared/exported) `polylinePath` radius-6 corner rounding as the base edge.
- `WeathermapLinkOverlay` uses it when routePoints exist; bezier and port-less branches unchanged; lanes keep independent in/out colors and opposite dash animation.

## Verified

- Live DOM after: **99/99 links render two offset lanes** (0 identical), start-point gaps match ±(laneWidth/2+0.5).
- Renderer unit tests: 12/12 (straight offset, L-corner intersection, ± mirror symmetry, degenerate input, ≥2.5px lane separation at realistic sizes).
- Web svelte-check: 0 errors (requires the renderer dist rebuild — CI builds via turbo).
- biome clean. Changeset included (`@shumoku/renderer` patch). Also adds the renderer package's first vitest setup.

Implemented by a Sonnet subagent; reviewed + live-verified by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj