### PR TITLE
fix(layout): restore log display widths; separate vertical risers by ink width

### DIFF
--- a/.changeset/composite-log-widths-risers.md
+++ b/.changeset/composite-log-widths-risers.md
@@ -1,0 +1,9 @@
+---
+'@shumoku/core': patch
+---
+
+Composite layout draws bandwidth pipes again (log widths) and separates vertical risers by actual stroke width.
+
+The composite search engine was overwriting `ResolvedEdge.width` with the 'linear' routing experiment (10G→1px), collapsing access links to hairlines and starving the weathermap flow lanes. This patch restores the log-curve widths that `route-edges.ts` seeds and the renderers draw.
+
+Vertical risers now use a width-aware shift search: the reach scales to the widest ribbon already placed in the corridor so two 100G ribbons (34px each, needing ≥37px separation) always find room — the fixed ±32px ceiling was 5px short.

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -154,7 +154,8 @@ interface MetricsMappingRow {
 // v14: role-driven ranks use directed topology dependencies first; soft
 // device tiers no longer place firewalls above upstream routers.
 // v18: entity registry Phase 1 — entityId field added to nodes/ports/links
-const RESOLVER_VERSION = 18
+// v19: composite edges return to log display widths; vertical risers separate by ink width
+const RESOLVER_VERSION = 19
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {

--- a/libs/@shumoku/core/src/layout/composite/composite.test.ts
+++ b/libs/@shumoku/core/src/layout/composite/composite.test.ts
@@ -351,9 +351,9 @@ describe('applyOctilinearRoutes', () => {
     const result = layoutComposite(graph)
     const ports = placePorts(result.nodes, graph.links, 'TB')
     const edges = await routeEdges(result.nodes, ports, graph.links, result.subgraphs)
-    // mirror the engine: composite pairs with linear widths before routing
+    // mirror the engine: display (log) widths drive routing separation
     for (const edge of edges.values()) {
-      edge.width = Math.max(1, getLinkWidthForMode(edge.link, 'linear'))
+      edge.width = Math.max(1, getLinkWidthForMode(edge.link, 'log'))
     }
     const routed = applyOctilinearRoutes(edges)
     expect(routed).toBeGreaterThan(0)

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -13,10 +13,13 @@
  *   1. NO TWO LINES SHARE A TRACK — every horizontal run gets its own y
  *      via a single GLOBAL greedy allocator (per-edge floor/ceil bounds,
  *      bidirectional search; separating by stroke half-widths, so wide
- *      ribbons claim wide berths). Separate allocators collide with each
- *      other; per-edge clamping after allocation silently re-stacks
- *      tracks — both were real bugs, hence one allocator and bounds
- *      inside it.
+ *      ribbons claim wide berths); vertical risers follow the same
+ *      discipline — a global registry of placed columns, width-aware
+ *      shift search whose reach scales to the widest ribbon already in
+ *      the corridor so two 100G pipes never collapse. Separate allocators
+ *      collide with each other; per-edge clamping after allocation
+ *      silently re-stacks tracks — both were real bugs, hence one
+ *      allocator and bounds inside it.
  *   2. Crossings should be ~90° — long shallow diagonals crossing at
  *      grazing angles were the dominant residual unreadability.
  *
@@ -1005,10 +1008,20 @@ export function applyOctilinearRoutes(
   const allocate = (route: OrthRoute, kind: 'straight' | 'orth'): void => {
     const runs = verticalRuns(route, kind)
     const ownNodes = new Set(endpointsOf.get(route.id) ?? [])
+    // Width-aware reach: the fixed ±32 array can't resolve two 34px (100G)
+    // bands that need ≥37px separation. Scale the search to the widest
+    // already-placed ribbon plus this ribbon's half-width plus clearance
+    // — the same intuition as the horizontal allocator's 240px ceiling but
+    // calibrated per corridor (log widths top out at 34px / half=17).
+    const widestPlacedHalf =
+      placedVerticals.length > 0 ? Math.max(...placedVerticals.map((p) => p.half)) : 0
+    const reach = Math.max(48, widestPlacedHalf + route.half + clearance + 8)
+    const shiftCandidates: number[] = [0]
+    for (const step of Array.from({ length: Math.ceil(reach / 4) }, (_, i) => (i + 1) * 4)) {
+      shiftCandidates.push(step, -step)
+    }
     let chosen = 0
-    candidate: for (const shift of [
-      0, 4, -4, 8, -8, 12, -12, 16, -16, 20, -20, 24, -24, 28, -28, 32, -32,
-    ]) {
+    candidate: for (const shift of shiftCandidates) {
       for (const run of runs) {
         for (const placed of placedVerticals) {
           const overlap =

--- a/libs/@shumoku/core/src/layout/composite/search.ts
+++ b/libs/@shumoku/core/src/layout/composite/search.ts
@@ -103,7 +103,12 @@ async function evaluate(
   const edges = await routeEdges(comp.nodes, ports, graph.links, comp.subgraphs)
   const routingPlan = buildCompositeRoutingPlan(problem, comp, edges)
   for (const edge of edges.values()) {
-    edge.width = Math.max(1, getLinkWidthForMode(edge.link, 'linear'))
+    // Display width (log pipes) — the SAME width route-edges seeded and the
+    // renderers draw. Routing spacing/scoring must be calibrated to the ink
+    // that actually lands on the page; the composite engine briefly overwrote
+    // this with the 'linear' routing experiment, which collapsed access links
+    // to 1px and starved the weathermap lanes (they split this width in two).
+    edge.width = Math.max(1, getLinkWidthForMode(edge.link, 'log'))
     // v3 grammar: HA heartbeats are couplings, not wires — explicit
     // (link.redundancy) and inferred (direct link between detected pair
     // members) alike. Couplings skip port seating, routing, and scoring.


### PR DESCRIPTION
## What

- `ResolvedEdge.width` returns to the display contract (log pipes: 10G→14px, 25G→20, 100G→34) — the composite engine's 'linear' routing experiment had collapsed access links to 1px hairlines and starved the weathermap lanes (they split this width in two, #559).
- Vertical risers now separate by actual stroke width: the router's conflict check was already width-aware, but the shift-candidate search radius was a fixed ±32px — two 34px ribbons need ≥37px. The radius is now computed from the widest placed riser + the candidate's half-width (min 48px), extending the existing single-allocator discipline (no second mechanism).
- `RESOLVER_VERSION` 18→19; changeset (@shumoku/core patch).

## Verified

- The previously-failing invariant "routes vertical edges as track-separated polylines" passes: 3 collinear riser overlaps → **0**. Full core suite 373/373, determinism test green.
- Live demo rebuild: stroke widths 14/20/34 restored, weathermap lanes at width 7 with 8px separation (two clearly parallel flows), mapping survived the resolver bump (50/99), figure size ~unchanged (aspect 3.07).

Implemented by a Sonnet subagent; reviewed + live-verified by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj