### PR TITLE
feat(server): per-topology poll scheduler with demand-driven cadence

### DIFF
--- a/apps/server/api/src/config.ts
+++ b/apps/server/api/src/config.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Configuration loader
  */
 
@@ -72,6 +72,15 @@ export function loadConfig(configPath?: string): Config {
   }
   if (process.env['POLL_INTERVAL']) {
     config.server.pollInterval = Number.parseInt(process.env['POLL_INTERVAL'], 10)
+  }
+  if (process.env['BACKGROUND_POLL_INTERVAL']) {
+    config.server.backgroundPollInterval = Number.parseInt(
+      process.env['BACKGROUND_POLL_INTERVAL'],
+      10,
+    )
+  }
+  if (process.env['POLL_CONCURRENCY_LIMIT']) {
+    config.server.concurrencyLimit = Number.parseInt(process.env['POLL_CONCURRENCY_LIMIT'], 10)
   }
 
   // Handle ${VAR} syntax in config values

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * HTTP + WebSocket Server using Hono + Bun
  */
 
@@ -24,8 +24,13 @@ import { isSetupComplete, SESSION_COOKIE, validateSession } from './services/aut
 import { DataSourceService } from './services/datasource.js'
 import { startDiscoveryScheduler, stopDiscoveryScheduler } from './services/discovery-scheduler.js'
 import { startHealthChecker, stopHealthChecker } from './services/health-checker.js'
-import { publishMetrics } from './services/metrics-hub.js'
+import {
+  getSubscriberCount,
+  publishMetrics,
+  setWatchChangeCallback,
+} from './services/metrics-hub.js'
 import { ObservationsService } from './services/observations.js'
+import { PollScheduler } from './services/poll-scheduler.js'
 import { getSignalStreams } from './services/signal-streams.js'
 import type { ParsedTopology, TopologyService } from './services/topology.js'
 import { TopologySourcesService } from './services/topology-sources.js'
@@ -87,7 +92,7 @@ export class Server {
   private dataSourceService: DataSourceService | null = null
   private metricsProvider: MockMetricsProvider
   private clients: Map<ServerWebSocket<ClientState>, ClientState> = new Map()
-  private pollInterval: ReturnType<typeof setInterval> | null = null
+  private pollScheduler: PollScheduler | null = null
   private housekeepingInterval: ReturnType<typeof setInterval> | null = null
   private bunServer: BunServer<ClientState> | null = null
   private dbTopologyMetrics: Map<string, MetricsData> = new Map()
@@ -201,11 +206,19 @@ export class Server {
       if (!state) return
 
       switch (message.type) {
-        case 'subscribe':
+        case 'subscribe': {
+          const prevTopology = state.subscribedTopology
           state.subscribedTopology = message.topology || null
           console.log(`[WebSocket] Client subscribed to: ${state.subscribedTopology}`)
           this.sendInitialMetrics(ws, state)
+          // Notify scheduler: previous topology may now be unwatched
+          if (prevTopology) this.pollScheduler?.notifyWatchChanged(prevTopology)
+          // Notify scheduler: new topology is now watched
+          if (state.subscribedTopology) {
+            this.pollScheduler?.notifyWatchChanged(state.subscribedTopology)
+          }
           break
+        }
 
         case 'setInterval':
           console.log(
@@ -226,8 +239,13 @@ export class Server {
   }
 
   private handleWebSocketClose(ws: ServerWebSocket<ClientState>): void {
+    const state = this.clients.get(ws)
     this.clients.delete(ws)
     console.log(`[WebSocket] Client disconnected (remaining: ${this.clients.size})`)
+    // Notify scheduler: this topology may now be unwatched
+    if (state?.subscribedTopology) {
+      this.pollScheduler?.notifyWatchChanged(state.subscribedTopology)
+    }
   }
 
   private sendInitialMetrics(ws: ServerWebSocket<ClientState>, state: ClientState): void {
@@ -333,28 +351,75 @@ export class Server {
     }
   }
 
-  private async startMetricsPolling(): Promise<void> {
-    await this.updateAllMetrics()
-    this.broadcastMetrics()
-
-    const interval = this.config.server.pollInterval || 5000
-    let isPolling = false
-
-    this.pollInterval = setInterval(async () => {
-      // Skip if previous poll is still running
-      if (isPolling) {
-        console.log('[Server] Skipping metrics poll - previous poll still running')
+  /**
+   * Poll metrics for a single topology ID. Handles both legacy file-based
+   * topologies and DB topologies. Called by the PollScheduler for each
+   * topology independently.
+   */
+  private async pollTopology(topologyId: string): Promise<void> {
+    // DB topology path
+    if (this.topologyService) {
+      const topologies = this.topologyService.list()
+      const topology = topologies.find((t) => t.id === topologyId)
+      if (topology) {
+        await this.updateSingleDbTopologyMetrics(topology)
+        this.broadcastMetrics()
         return
       }
+    }
 
-      isPolling = true
-      try {
-        await this.updateAllMetrics()
-        this.broadcastMetrics()
-      } finally {
-        isPolling = false
+    // Legacy file-based topology path
+    const instance = this.topologyManager.getTopology(topologyId)
+    if (instance) {
+      instance.metrics = this.metricsProvider.generateMetrics(instance.graph)
+      this.broadcastMetrics()
+    }
+  }
+
+  private async startMetricsPolling(): Promise<void> {
+    const fastInterval = this.config.server.pollInterval || 5000
+    const slowInterval = this.config.server.backgroundPollInterval || 60_000
+    const concurrencyLimit = this.config.server.concurrencyLimit || 3
+
+    const getTopologyIds = (): string[] => {
+      const ids: string[] = []
+      // DB topologies
+      if (this.topologyService) {
+        for (const t of this.topologyService.list()) {
+          ids.push(t.id)
+        }
       }
-    }, interval)
+      // Legacy file-based topologies
+      for (const name of this.topologyManager.listTopologies()) {
+        ids.push(name)
+      }
+      return ids
+    }
+
+    const isWatched = (topologyId: string): boolean => {
+      // Check SSE subscribers via the hub
+      if (getSubscriberCount(topologyId) > 0) return true
+      // Check WS clients
+      for (const state of this.clients.values()) {
+        if (state.subscribedTopology === topologyId) return true
+      }
+      return false
+    }
+
+    this.pollScheduler = new PollScheduler(
+      { fastInterval, slowInterval, concurrencyLimit, jitterMax: 1000 },
+      (topologyId) => this.pollTopology(topologyId),
+      getTopologyIds,
+      isWatched,
+    )
+
+    // Wire the hub's SSE watch-change callback so SSE subscribers trigger
+    // immediate polls just like WS subscribe events do.
+    setWatchChangeCallback((topologyId) => {
+      this.pollScheduler?.notifyWatchChanged(topologyId)
+    })
+
+    this.pollScheduler.start()
 
     // Signal-stream housekeeping (signal-streams.md retentions): once at
     // startup, then every 6h. Cheap deletes; never let it crash the server.
@@ -375,138 +440,123 @@ export class Server {
     this.housekeepingInterval = setInterval(runHousekeeping, 6 * 3600_000)
   }
 
-  private async updateAllMetrics(): Promise<void> {
-    // Update legacy file-based topologies
-    for (const name of this.topologyManager.listTopologies()) {
-      const instance = this.topologyManager.getTopology(name)
-      if (instance) {
-        instance.metrics = this.metricsProvider.generateMetrics(instance.graph)
-      }
+  private async updateSingleDbTopologyMetrics(topology: {
+    id: string
+    name: string
+  }): Promise<void> {
+    if (!this.topologySourcesService || !this.dataSourceService || !this.topologyService) return
+
+    let parsed: ParsedTopology | null = null
+    try {
+      parsed = await this.topologyService.getParsed(topology.id)
+    } catch (err) {
+      console.error(
+        `[Server] Unexpected error parsing topology "${topology.name}":`,
+        err instanceof Error ? err.message : err,
+      )
     }
+    if (!parsed) return
 
-    // Update DB topologies
-    if (this.topologyService) {
-      await this.updateDbTopologyMetrics()
-    }
-  }
+    let metrics: MetricsData | null = null
 
-  private async updateDbTopologyMetrics(): Promise<void> {
-    if (!this.topologyService || !this.topologySourcesService || !this.dataSourceService) return
+    // Poll every attached metrics source and merge their results.
+    // Plugin host-id namespaces are structurally disjoint in practice
+    // (Zabbix numeric ids vs Aruba serials vs NetBox integers), so
+    // each plugin naturally answers for the subset of mapped nodes
+    // it recognizes and ignores the rest.
+    const metricsSources = this.topologySourcesService.listByPurpose(topology.id, 'metrics')
+    if (metricsSources.length > 0) {
+      // Use the resolved mapping (metrics-binding attachments ∪ residual
+      // mapping_json), NOT the raw mapping_json blob — after the binding
+      // backfill, node bindings live as attachments and mapping_json holds
+      // only the residual, so reading the blob alone would starve pollers of
+      // node bindings. `parseTopology` already produced this view.
+      const mapping: MetricsMapping = parsed.mapping
+        ? { nodes: { ...parsed.mapping.nodes }, links: { ...parsed.mapping.links } }
+        : { nodes: {}, links: {} }
 
-    const topologies = this.topologyService.list()
-    for (const topology of topologies) {
-      let parsed: ParsedTopology | null = null
-      try {
-        parsed = await this.topologyService.getParsed(topology.id)
-      } catch (err) {
-        console.error(
-          `[Server] Unexpected error parsing topology "${topology.name}":`,
-          err instanceof Error ? err.message : err,
-        )
-      }
-      if (!parsed) continue
-
-      let metrics: MetricsData | null = null
-
-      // Poll every attached metrics source and merge their results.
-      // Plugin host-id namespaces are structurally disjoint in practice
-      // (Zabbix numeric ids vs Aruba serials vs NetBox integers), so
-      // each plugin naturally answers for the subset of mapped nodes
-      // it recognizes and ignores the rest.
-      const metricsSources = this.topologySourcesService.listByPurpose(topology.id, 'metrics')
-      if (metricsSources.length > 0) {
-        // Use the resolved mapping (metrics-binding attachments ∪ residual
-        // mapping_json), NOT the raw mapping_json blob — after the binding
-        // backfill, node bindings live as attachments and mapping_json holds
-        // only the residual, so reading the blob alone would starve pollers of
-        // node bindings. `parseTopology` already produced this view.
-        const mapping: MetricsMapping = parsed.mapping
-          ? { nodes: { ...parsed.mapping.nodes }, links: { ...parsed.mapping.links } }
-          : { nodes: {}, links: {} }
-
-        // Backfill link bandwidth from the topology spec exactly once.
-        // The plugin sees a single authoritative bps per link.
-        if (parsed?.graph?.links) {
-          for (const [i, link] of parsed.graph.links.entries()) {
-            const linkId = link.id || `link-${i}`
-            const linkMapping = mapping.links?.[linkId]
-            if (linkMapping && linkMapping.bandwidth === undefined) {
-              const bps = linkSpeedBps(link)
-              // Copy-on-write: the link object is shared with the cached
-              // parsed.mapping, so replace it rather than mutate in place.
-              if (bps !== undefined) mapping.links[linkId] = { ...linkMapping, bandwidth: bps }
-            }
+      // Backfill link bandwidth from the topology spec exactly once.
+      // The plugin sees a single authoritative bps per link.
+      if (parsed?.graph?.links) {
+        for (const [i, link] of parsed.graph.links.entries()) {
+          const linkId = link.id || `link-${i}`
+          const linkMapping = mapping.links?.[linkId]
+          if (linkMapping && linkMapping.bandwidth === undefined) {
+            const bps = linkSpeedBps(link)
+            // Copy-on-write: the link object is shared with the cached
+            // parsed.mapping, so replace it rather than mutate in place.
+            if (bps !== undefined) mapping.links[linkId] = { ...linkMapping, bandwidth: bps }
           }
         }
+      }
 
-        // Poll all sources concurrently — they're independent plugin
-        // instances hitting independent upstreams, so a poll cycle
-        // should cost max(source latency), not the sum. `allSettled`
-        // keeps one source's failure from sinking the others.
-        const polled = await Promise.allSettled(
-          metricsSources.map(async (source) => {
-            const dataSource = this.dataSourceService?.get(source.dataSourceId)
-            if (!dataSource) return null
-            const config = JSON.parse(dataSource.configJson)
-            const plugin = pluginRegistry.getInstance(dataSource.id, dataSource.type, config)
-            if (!hasMetricsCapability(plugin)) return null
-            const data = await plugin.pollMetrics(mapping)
-            return { type: dataSource.type, data }
-          }),
-        )
+      // Poll all sources concurrently — they're independent plugin
+      // instances hitting independent upstreams, so a poll cycle
+      // should cost max(source latency), not the sum. `allSettled`
+      // keeps one source's failure from sinking the others.
+      const polled = await Promise.allSettled(
+        metricsSources.map(async (source) => {
+          const dataSource = this.dataSourceService?.get(source.dataSourceId)
+          if (!dataSource) return null
+          const config = JSON.parse(dataSource.configJson)
+          const plugin = pluginRegistry.getInstance(dataSource.id, dataSource.type, config)
+          if (!hasMetricsCapability(plugin)) return null
+          const data = await plugin.pollMetrics(mapping)
+          return { type: dataSource.type, data }
+        }),
+      )
 
-        // Merge in source order. `metricsSources` is priority-sorted
-        // (low number = high precedence) and `allSettled` preserves
-        // input order, so on the rare nodeId/linkId conflict the
-        // higher-priority source wins (see `mergeMetricsData`).
-        const polledFrom: string[] = []
-        for (const [i, result] of polled.entries()) {
-          if (result.status === 'rejected') {
-            const type = metricsSources[i]
-              ? (this.dataSourceService.get(metricsSources[i].dataSourceId)?.type ?? 'unknown')
-              : 'unknown'
-            console.error(
-              `[Server] Failed to poll metrics from ${type} for topology "${topology.name}":`,
-              result.reason instanceof Error ? result.reason.message : result.reason,
-            )
-            continue
-          }
-          if (!result.value) continue
-          metrics = mergeMetricsData(metrics, result.value.data)
-          polledFrom.push(result.value.type)
-        }
-        // One line per topology per poll cycle, not one per source —
-        // keeps the log readable when many topologies × sources poll.
-        if (polledFrom.length > 0) {
-          console.log(
-            `[Server] Polled metrics for topology "${topology.name}" from ${polledFrom.join(', ')}`,
+      // Merge in source order. `metricsSources` is priority-sorted
+      // (low number = high precedence) and `allSettled` preserves
+      // input order, so on the rare nodeId/linkId conflict the
+      // higher-priority source wins (see `mergeMetricsData`).
+      const polledFrom: string[] = []
+      for (const [i, result] of polled.entries()) {
+        if (result.status === 'rejected') {
+          const type = metricsSources[i]
+            ? (this.dataSourceService.get(metricsSources[i].dataSourceId)?.type ?? 'unknown')
+            : 'unknown'
+          console.error(
+            `[Server] Failed to poll metrics from ${type} for topology "${topology.name}":`,
+            result.reason instanceof Error ? result.reason.message : result.reason,
           )
+          continue
         }
+        if (!result.value) continue
+        metrics = mergeMetricsData(metrics, result.value.data)
+        polledFrom.push(result.value.type)
       }
-
-      // DEMO mode fallback: when no real metrics source is wired up
-      // (sample-network in DEMO_MODE has none), generate mock metrics
-      // so every overlay (weathermap flow, node status, etc.) actually
-      // shows live values in the UI. The mock sees the merged
-      // bandwidth so its bps numbers match what the renderer draws.
-      if (!metrics && process.env['DEMO_MODE'] === 'true') {
-        const mergedGraph = applyMappingBandwidth(parsed.graph, parsed.mapping)
-        metrics = this.metricsProvider.generateMetrics(mergedGraph)
+      // One line per topology per poll cycle, not one per source —
+      // keeps the log readable when many topologies × sources poll.
+      if (polledFrom.length > 0) {
+        console.log(
+          `[Server] Polled metrics for topology "${topology.name}" from ${polledFrom.join(', ')}`,
+        )
       }
+    }
 
-      if (metrics) {
-        this.dbTopologyMetrics.set(topology.id, metrics)
-        this.topologyService.updateMetrics(topology.id, metrics)
-        // Feed the hub so token-scoped share SSE streams can read/observe live
-        // metrics off the same central poll (no second poll loop).
-        publishMetrics(topology.id, metrics)
-        // Metrics stream (signal-streams.md): raw history + hourly trends.
-        // Best-effort — a stream write must never break the poll loop.
-        try {
-          getSignalStreams().recordMetrics(topology.id, metrics)
-        } catch (err) {
-          console.error('[Server] metrics stream record failed:', err)
-        }
+    // DEMO mode fallback: when no real metrics source is wired up
+    // (sample-network in DEMO_MODE has none), generate mock metrics
+    // so every overlay (weathermap flow, node status, etc.) actually
+    // shows live values in the UI. The mock sees the merged
+    // bandwidth so its bps numbers match what the renderer draws.
+    if (!metrics && process.env['DEMO_MODE'] === 'true') {
+      const mergedGraph = applyMappingBandwidth(parsed.graph, parsed.mapping)
+      metrics = this.metricsProvider.generateMetrics(mergedGraph)
+    }
+
+    if (metrics) {
+      this.dbTopologyMetrics.set(topology.id, metrics)
+      this.topologyService.updateMetrics(topology.id, metrics)
+      // Feed the hub so token-scoped share SSE streams can read/observe live
+      // metrics off the same central poll (no second poll loop).
+      publishMetrics(topology.id, metrics)
+      // Metrics stream (signal-streams.md): raw history + hourly trends.
+      // Best-effort — a stream write must never break the poll loop.
+      try {
+        getSignalStreams().recordMetrics(topology.id, metrics)
+      } catch (err) {
+        console.error('[Server] metrics stream record failed:', err)
       }
     }
   }
@@ -626,9 +676,12 @@ export class Server {
     stopDiscoveryScheduler()
     stopHealthChecker()
 
-    if (this.pollInterval) {
-      clearInterval(this.pollInterval)
-      this.pollInterval = null
+    // Clear the hub watch-change callback so it doesn't fire after shutdown.
+    setWatchChangeCallback(null)
+
+    if (this.pollScheduler) {
+      this.pollScheduler.stop()
+      this.pollScheduler = null
     }
     if (this.housekeepingInterval) {
       clearInterval(this.housekeepingInterval)

--- a/apps/server/api/src/services/metrics-hub.ts
+++ b/apps/server/api/src/services/metrics-hub.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Metrics hub — a tiny in-process pub/sub bridging the central metrics poll loop
  * (in `Server`, server.ts) to the route layer (the share SSE endpoint).
  *
@@ -17,6 +17,22 @@ const listeners = new Map<string, Set<Listener>>()
 
 /** Total live SSE subscribers across all topologies (for a global connection cap). */
 let subscriberCount = 0
+
+/**
+ * Optional callback invoked when a topology's SSE subscriber count changes
+ * (first subscriber arrived, or last subscriber left). Used by the PollScheduler
+ * so SSE arrivals trigger a cadence switch without requiring a direct reference
+ * between the route layer and the Server class.
+ */
+let watchChangeCallback: ((topologyId: string) => void) | null = null
+
+/**
+ * Register (or clear) the watch-change callback. Called once at server startup;
+ * the PollScheduler supplies its `notifyWatchChanged` method here.
+ */
+export function setWatchChangeCallback(cb: ((topologyId: string) => void) | null): void {
+  watchChangeCallback = cb
+}
 
 /** Poll loop → hub: cache the latest snapshot and fan out to live subscribers. */
 export function publishMetrics(topologyId: string, data: MetricsData): void {
@@ -42,18 +58,28 @@ export function liveSubscriberCount(): number {
   return subscriberCount
 }
 
+/** Number of live SSE subscribers for a specific topology. */
+export function getSubscriberCount(topologyId: string): number {
+  return listeners.get(topologyId)?.size ?? 0
+}
+
 /**
  * Subscribe to a topology's metric ticks. Returns an unsubscribe function; call it
  * on stream abort/close so dead clients are cleaned up and the count stays honest.
  */
 export function subscribeMetrics(topologyId: string, listener: Listener): () => void {
   let set = listeners.get(topologyId)
+  const wasEmpty = !set || set.size === 0
   if (!set) {
     set = new Set()
     listeners.set(topologyId, set)
   }
   set.add(listener)
   subscriberCount++
+  // Notify scheduler that this topology is now watched (first SSE subscriber)
+  if (wasEmpty && watchChangeCallback) {
+    watchChangeCallback(topologyId)
+  }
   let active = true
   return () => {
     if (!active) return
@@ -62,7 +88,11 @@ export function subscribeMetrics(topologyId: string, listener: Listener): () => 
     const s = listeners.get(topologyId)
     if (s) {
       s.delete(listener)
-      if (s.size === 0) listeners.delete(topologyId)
+      if (s.size === 0) {
+        listeners.delete(topologyId)
+        // Notify scheduler that this topology is now unwatched (last SSE subscriber left)
+        if (watchChangeCallback) watchChangeCallback(topologyId)
+      }
     }
   }
 }

--- a/apps/server/api/src/services/poll-scheduler.test.ts
+++ b/apps/server/api/src/services/poll-scheduler.test.ts
@@ -1,0 +1,290 @@
+﻿// Copyright (C) 2026-present Akitoshi Saeki
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PollSchedulerConfig } from './poll-scheduler.js'
+import { PollScheduler } from './poll-scheduler.js'
+
+/** A config with jitter=0 so tests have deterministic timing. */
+function makeConfig(overrides: Partial<PollSchedulerConfig> = {}): PollSchedulerConfig {
+  return {
+    fastInterval: 100,
+    slowInterval: 1000,
+    concurrencyLimit: 3,
+    jitterMax: 0, // deterministic in tests
+    ...overrides,
+  }
+}
+
+describe('PollScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // -------------------------------------------------------------------------
+  // 1. Watched topology polls at fast cadence
+  // -------------------------------------------------------------------------
+  it('polls watched topology at fastInterval', async () => {
+    const calls: string[] = []
+    const pollFn = vi.fn(async (id: string) => {
+      calls.push(id)
+    })
+    const watched = new Set(['topo-a'])
+    const scheduler = new PollScheduler(
+      makeConfig({ fastInterval: 50, slowInterval: 5000 }),
+      pollFn,
+      () => ['topo-a'],
+      (id) => watched.has(id),
+    )
+    scheduler.start()
+
+    // Fire the initial timer (delay=0, jitter=0)
+    await vi.advanceTimersByTimeAsync(5)
+    const countAfterFirst = calls.length
+    expect(countAfterFirst).toBeGreaterThanOrEqual(1)
+
+    // Advance by 3 fast intervals (50ms each = 150ms)
+    await vi.advanceTimersByTimeAsync(160)
+    const countAfterThree = calls.length
+    // Should have fired ~3 more times
+    expect(countAfterThree - countAfterFirst).toBeGreaterThanOrEqual(2)
+
+    scheduler.stop()
+  })
+
+  // -------------------------------------------------------------------------
+  // 2. Unwatched topology polls at slow cadence
+  // -------------------------------------------------------------------------
+  it('polls unwatched topology at slowInterval', async () => {
+    const calls: string[] = []
+    const pollFn = vi.fn(async (id: string) => {
+      calls.push(id)
+    })
+    const scheduler = new PollScheduler(
+      makeConfig({ fastInterval: 50, slowInterval: 500 }),
+      pollFn,
+      () => ['topo-b'],
+      () => false, // never watched
+    )
+    scheduler.start()
+
+    // Fire initial poll
+    await vi.advanceTimersByTimeAsync(5)
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+
+    const countBefore = calls.length
+    // Advance 200ms — less than one slow interval (500ms)
+    await vi.advanceTimersByTimeAsync(200)
+    // Should NOT have fired again yet
+    expect(calls.length).toBe(countBefore)
+
+    // Advance another 350ms to cross the 500ms slow interval
+    await vi.advanceTimersByTimeAsync(350)
+    expect(calls.length).toBeGreaterThan(countBefore)
+
+    scheduler.stop()
+  })
+
+  // -------------------------------------------------------------------------
+  // 3. Per-topology overlap guard: other topologies unaffected by a slow poll;
+  //    in-flight guard prevents double-start via notifyWatchChanged
+  // -------------------------------------------------------------------------
+  it('overlap guard: notifyWatchChanged does not double-start an in-flight poll', async () => {
+    const inflightResolvers: Array<() => void> = []
+    const pollStarted: string[] = []
+
+    const pollFn = vi.fn(async (id: string) => {
+      pollStarted.push(id)
+      if (id === 'topo-a') {
+        // Block until manually resolved
+        await new Promise<void>((resolve) => inflightResolvers.push(resolve))
+      }
+    })
+
+    const watched = new Set(['topo-a'])
+    const scheduler = new PollScheduler(
+      makeConfig({ fastInterval: 50, slowInterval: 5000, concurrencyLimit: 10 }),
+      pollFn,
+      () => ['topo-a'],
+      (id) => watched.has(id),
+    )
+    scheduler.start()
+
+    // Fire initial timer → topo-a is now in-flight
+    await vi.advanceTimersByTimeAsync(5)
+    expect(pollStarted.filter((id) => id === 'topo-a').length).toBe(1)
+
+    // While in-flight, notify watch change → schedules an immediate timer
+    scheduler.notifyWatchChanged('topo-a')
+
+    // Fire that immediate timer — the inFlight guard should block it
+    await vi.advanceTimersByTimeAsync(5)
+
+    // topo-a poll still only called once (inFlight guard fired)
+    expect(pollStarted.filter((id) => id === 'topo-a').length).toBe(1)
+
+    // Resolve the in-flight poll
+    for (const resolve of inflightResolvers) resolve()
+    await vi.advanceTimersByTimeAsync(10)
+
+    scheduler.stop()
+  })
+
+  it('overlap guard: other topologies poll independently while one is in flight', async () => {
+    const inflightResolvers: Array<() => void> = []
+    const pollCounts: Record<string, number> = { a: 0, b: 0 }
+
+    const pollFn = vi.fn(async (id: string) => {
+      if (id === 'topo-a') {
+        await new Promise<void>((resolve) => inflightResolvers.push(resolve))
+      } else {
+        pollCounts['b'] = (pollCounts['b'] ?? 0) + 1
+      }
+    })
+
+    const scheduler = new PollScheduler(
+      makeConfig({ fastInterval: 50, slowInterval: 50, concurrencyLimit: 10 }),
+      pollFn,
+      () => ['topo-a', 'topo-b'],
+      () => true,
+    )
+    scheduler.start()
+
+    // Let topo-a get stuck, topo-b polls freely for ~300ms
+    await vi.advanceTimersByTimeAsync(305)
+
+    // topo-b should have polled several times independently
+    expect(pollCounts['b']).toBeGreaterThanOrEqual(3)
+
+    // Resolve topo-a to let the scheduler clean up
+    for (const resolve of inflightResolvers) resolve()
+    await vi.advanceTimersByTimeAsync(10)
+
+    scheduler.stop()
+  })
+
+  // -------------------------------------------------------------------------
+  // 4. Concurrency cap: with cap=2, 3rd concurrent poll is queued
+  // -------------------------------------------------------------------------
+  it('concurrency cap: queues 3rd poll until a slot opens', async () => {
+    const resolvers: Array<() => void> = []
+    const started: string[] = []
+
+    const pollFn = vi.fn(async (id: string) => {
+      started.push(id) // synchronous — before any await
+      await new Promise<void>((resolve) => resolvers.push(resolve))
+    })
+
+    const scheduler = new PollScheduler(
+      makeConfig({ fastInterval: 50, slowInterval: 50, concurrencyLimit: 2 }),
+      pollFn,
+      () => ['t1', 't2', 't3'],
+      () => true,
+    )
+    scheduler.start()
+
+    // Fire all three t=0 timers
+    await vi.advanceTimersByTimeAsync(5)
+
+    // Only 2 should be in flight (concurrency cap = 2); t3 is queued
+    expect(started.length).toBe(2)
+
+    // Resolve one slot — the queued t3 poll should start synchronously in drainQueue
+    const r = resolvers.shift()
+    r?.()
+    // Flush microtasks: resolve → finally → drainQueue → pollFn (started.push synchronous)
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Now all 3 should have started
+    expect(started.length).toBe(3)
+
+    // Clean up
+    for (const r2 of resolvers) r2()
+    await vi.advanceTimersByTimeAsync(10)
+
+    scheduler.stop()
+  })
+
+  // -------------------------------------------------------------------------
+  // 5. Watch transition triggers immediate poll (with debounce)
+  // -------------------------------------------------------------------------
+  it('notifyWatchChanged triggers immediate poll when topology becomes watched', async () => {
+    const calls: string[] = []
+    const pollFn = vi.fn(async (id: string) => {
+      calls.push(id)
+    })
+
+    const watched = new Set<string>()
+    const scheduler = new PollScheduler(
+      makeConfig({ fastInterval: 100, slowInterval: 5000 }),
+      pollFn,
+      () => ['topo-x'],
+      (id) => watched.has(id),
+    )
+    scheduler.start()
+
+    // Fire initial slow poll
+    await vi.advanceTimersByTimeAsync(5)
+    expect(calls.length).toBeGreaterThanOrEqual(1)
+
+    // Advance well past fastInterval so lastPollAt is stale
+    await vi.advanceTimersByTimeAsync(200)
+    const countBefore = calls.length
+
+    // Now add a watcher — lastPollAt is ~205ms ago, fastInterval=100, so >= threshold
+    watched.add('topo-x')
+    scheduler.notifyWatchChanged('topo-x')
+
+    // The immediate poll should have fired (delay=0)
+    await vi.advanceTimersByTimeAsync(5)
+    expect(calls.length).toBeGreaterThan(countBefore)
+
+    scheduler.stop()
+  })
+
+  it('notifyWatchChanged does NOT re-poll if last poll was very recent (debounce)', async () => {
+    const calls: string[] = []
+    const pollFn = vi.fn(async (id: string) => {
+      calls.push(id)
+    })
+
+    const watched = new Set<string>()
+    const scheduler = new PollScheduler(
+      makeConfig({ fastInterval: 2000, slowInterval: 10000 }),
+      pollFn,
+      () => ['topo-y'],
+      (id) => watched.has(id),
+    )
+    scheduler.start()
+
+    // Fire the initial poll
+    await vi.advanceTimersByTimeAsync(5)
+    // Flush so the finally block runs and lastPollAt is set
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+    const countAfterInit = calls.length
+    expect(countAfterInit).toBeGreaterThanOrEqual(1)
+
+    // Immediately notify watch change — lastPollAt was just set, < fastInterval(2000) ago
+    watched.add('topo-y')
+    scheduler.notifyWatchChanged('topo-y')
+
+    // Only advance a tiny bit — not enough for a normal slow poll
+    await vi.advanceTimersByTimeAsync(10)
+    // Should NOT have fired another immediate poll (debounce: last poll < fastInterval ago)
+    expect(calls.length).toBe(countAfterInit)
+
+    scheduler.stop()
+  })
+})

--- a/apps/server/api/src/services/poll-scheduler.ts
+++ b/apps/server/api/src/services/poll-scheduler.ts
@@ -1,0 +1,236 @@
+﻿/**
+ * PollScheduler — per-topology demand-driven metrics polling.
+ *
+ * Replaces the single global `setInterval` in `Server.startMetricsPolling()`.
+ * Each topology gets its own recursive-setTimeout loop so we can individually
+ * adjust cadence based on whether anyone is watching:
+ *
+ *   - Watched (>0 WS/SSE subscribers): poll every `fastInterval` (default 5 s)
+ *   - Unwatched: poll every `slowInterval` (default 60 s — "background" cadence)
+ *
+ * Key design choices:
+ *
+ *   - `inFlight` guard per topology: a slow poll doesn't double-start for that
+ *     topology. Other topologies are completely unaffected — no global lock.
+ *   - Global concurrency cap (`concurrencyLimit`): total simultaneous polls across
+ *     all topologies. Excess requests are queued and run as slots open.
+ *   - Jitter (`jitterMax`): small random offset on every rescheduled timer to
+ *     break thundering-herd alignment when many topologies share a cadence.
+ *   - `notifyWatchChanged`: immediate debounced poll when a topology becomes
+ *     watched. Skipped if the last poll was < `fastInterval` ago (already fresh).
+ */
+
+export interface PollSchedulerConfig {
+  /** Fast poll interval in ms — used when the topology has active subscribers. */
+  fastInterval: number
+  /** Slow poll interval in ms — used when no subscribers are watching. */
+  slowInterval: number
+  /** Maximum simultaneous in-flight polls across all topologies. Default 3. */
+  concurrencyLimit: number
+  /** Maximum random jitter added to each reschedule in ms. Default 1000. */
+  jitterMax: number
+}
+
+export interface TopologyScheduleState {
+  topologyId: string
+  isWatched: boolean
+  lastPollAt: number
+  inFlight: boolean
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+/**
+ * PollScheduler with injected dependencies so it can be tested without a
+ * real database or HTTP server.
+ */
+export class PollScheduler {
+  private config: PollSchedulerConfig
+  private pollFn: (topologyId: string) => Promise<void>
+  private getTopologyIds: () => string[]
+  private isWatched: (topologyId: string) => boolean
+
+  private states: Map<string, TopologyScheduleState> = new Map()
+  /** Slots in use (active concurrent polls). */
+  private activeCount = 0
+  /** Queue of pending poll calls that are waiting for a concurrency slot. */
+  private queue: Array<() => void> = []
+  private started = false
+
+  constructor(
+    config: PollSchedulerConfig,
+    pollFn: (topologyId: string) => Promise<void>,
+    getTopologyIds: () => string[],
+    isWatched: (topologyId: string) => boolean,
+  ) {
+    this.config = config
+    this.pollFn = pollFn
+    this.getTopologyIds = getTopologyIds
+    this.isWatched = isWatched
+  }
+
+  /** Start polling for all current topology IDs. */
+  start(): void {
+    if (this.started) return
+    this.started = true
+    const ids = this.getTopologyIds()
+    for (const id of ids) {
+      this.ensureState(id)
+      this.scheduleNext(id, 0) // immediate first poll
+    }
+  }
+
+  /** Stop all per-topology timers and drain the queue. */
+  stop(): void {
+    this.started = false
+    for (const state of this.states.values()) {
+      if (state.timer !== null) {
+        clearTimeout(state.timer)
+        state.timer = null
+      }
+    }
+    this.queue = []
+    this.states.clear()
+  }
+
+  /**
+   * Call when a topology's watch status changes (subscriber added or removed,
+   * or a new topology is registered). If the topology is newly watched and was
+   * not recently polled, an immediate poll is triggered and the cadence switches
+   * to fast. If unwatched, the cadence switches to slow on next reschedule.
+   */
+  notifyWatchChanged(topologyId: string): void {
+    if (!this.started) return
+    const watched = this.isWatched(topologyId)
+    const state = this.ensureState(topologyId)
+    const wasWatched = state.isWatched
+    state.isWatched = watched
+
+    if (watched && !wasWatched) {
+      // Newly watched — trigger immediate poll if last poll was not recent
+      const sinceLastPoll = Date.now() - state.lastPollAt
+      if (sinceLastPoll >= this.config.fastInterval) {
+        // Cancel the pending slow timer and fire right away
+        if (state.timer !== null) {
+          clearTimeout(state.timer)
+          state.timer = null
+        }
+        this.scheduleNext(topologyId, 0)
+      }
+      // If the last poll was < fastInterval ago, the data is already fresh —
+      // let the existing timer run (it'll use the fast cadence on next tick).
+    }
+  }
+
+  /**
+   * Register a new topology that was added after `start()` was called.
+   * Starts its timer loop immediately.
+   */
+  addTopology(topologyId: string): void {
+    if (!this.started) return
+    if (this.states.has(topologyId)) return
+    this.ensureState(topologyId)
+    this.scheduleNext(topologyId, 0)
+  }
+
+  /** Remove a topology — cancel its timer and forget its state. */
+  removeTopology(topologyId: string): void {
+    const state = this.states.get(topologyId)
+    if (!state) return
+    if (state.timer !== null) {
+      clearTimeout(state.timer)
+      state.timer = null
+    }
+    this.states.delete(topologyId)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+
+  private ensureState(topologyId: string): TopologyScheduleState {
+    const existing = this.states.get(topologyId)
+    if (existing) return existing
+    const state: TopologyScheduleState = {
+      topologyId,
+      isWatched: this.isWatched(topologyId),
+      lastPollAt: 0,
+      inFlight: false,
+      timer: null,
+    }
+    this.states.set(topologyId, state)
+    return state
+  }
+
+  private scheduleNext(topologyId: string, delay: number): void {
+    const state = this.states.get(topologyId)
+    if (!state || !this.started) return
+
+    // Cancel any existing pending timer before setting a new one
+    if (state.timer !== null) {
+      clearTimeout(state.timer)
+      state.timer = null
+    }
+
+    const jitter = Math.floor(Math.random() * (this.config.jitterMax + 1))
+    const actualDelay = Math.max(0, delay + jitter)
+
+    state.timer = setTimeout(() => {
+      state.timer = null
+      this.runPoll(topologyId)
+    }, actualDelay)
+  }
+
+  private runPoll(topologyId: string): void {
+    const state = this.states.get(topologyId)
+    if (!state || !this.started) return
+
+    if (state.inFlight) {
+      // Overlap guard: this topology's previous poll is still running.
+      // Reschedule at current cadence without starting a second poll.
+      const cadence = state.isWatched ? this.config.fastInterval : this.config.slowInterval
+      this.scheduleNext(topologyId, cadence)
+      return
+    }
+
+    if (this.activeCount >= this.config.concurrencyLimit) {
+      // Global concurrency cap — queue this poll until a slot opens
+      this.queue.push(() => this.runPoll(topologyId))
+      return
+    }
+
+    this.startPoll(state)
+  }
+
+  private startPoll(state: TopologyScheduleState): void {
+    if (!this.started) return
+    state.inFlight = true
+    this.activeCount++
+
+    const { topologyId } = state
+
+    this.pollFn(topologyId)
+      .catch((err) => {
+        console.error(`[PollScheduler] Poll failed for topology "${topologyId}":`, err)
+      })
+      .finally(() => {
+        const s = this.states.get(topologyId)
+        if (s) {
+          s.inFlight = false
+          s.lastPollAt = Date.now()
+        }
+        this.activeCount--
+        this.drainQueue()
+        // Reschedule for this topology
+        if (s && this.started) {
+          const cadence = s.isWatched ? this.config.fastInterval : this.config.slowInterval
+          this.scheduleNext(topologyId, cadence)
+        }
+      })
+  }
+
+  private drainQueue(): void {
+    while (this.queue.length > 0 && this.activeCount < this.config.concurrencyLimit) {
+      const next = this.queue.shift()
+      if (next) next()
+    }
+  }
+}

--- a/apps/server/api/src/types.ts
+++ b/apps/server/api/src/types.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Type definitions for the Shumoku real-time server
  */
 
@@ -22,6 +22,10 @@ export interface ServerConfig {
   host: string
   dataDir: string
   pollInterval?: number
+  /** Background poll interval in ms for topologies with no active subscribers (default 60000). */
+  backgroundPollInterval?: number
+  /** Maximum simultaneous metrics polls across all topologies (default 3). */
+  concurrencyLimit?: number
 }
 
 export interface TopologyConfig {


### PR DESCRIPTION
Closes #555 (metrics Phase B; Phase A was #557).

## What

Replaces the single global poll loop (one `setInterval` + one global "skip if running" mutex — one slow topology starved every other topology's metrics) with a dependency-injected `PollScheduler`:

- **Per-topology recursive `setTimeout` loops** — a topology structurally cannot overlap itself; cadence re-evaluates every tick.
- **Demand-driven cadence**: watched (live WS subscriber or SSE subscriber) → `pollInterval` (5s); unwatched → `backgroundPollInterval` (default 60s, env `BACKGROUND_POLL_INTERVAL`). Background polling never stops — verified `metrics_history`/`metrics_trends` are written from the poll path (signal-streams.ts), so history continuity depends on it.
- **Global concurrency cap** (default 3, env `POLL_CONCURRENCY_LIMIT`) + per-schedule jitter.
- **Immediate poll on watch-transition** (debounced by fast-interval) — opening a diagram doesn't wait up to 60s.
- Per-poll semantics unchanged (mapping view, source merge order, publish fan-out, log style).

## Scope note (issue amendment)

Issue #555 also mentioned materializing resolved itemids to DB; skipped deliberately — Phase A's in-process cache makes it moot (cold start = one extra bulk call).

## Verified

- Tests 95/95 (7 new scheduler tests: cadences, overlap guard, concurrency cap + queueing, watch-debounce). Typecheck/biome clean.
- Live: watched topology (open diagram) polls at 5s cadence; unwatched topologies drop to 60s background cadence (log-verified).

Implemented by a Sonnet subagent; reviewed + live-verified by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj