### PR TITLE
feat(server): Entity Registry Phase 3 — resolved element ids are entity ids

### DIFF
--- a/apps/server/api/src/api/discovery-policy.ts
+++ b/apps/server/api/src/api/discovery-policy.ts
@@ -40,7 +40,7 @@ import {
   computeEffectivePolicy,
   type DiscoveryMode,
   type EffectiveDiscoveryPolicy,
-  type Node,
+  type Identity,
   type NodeExclusion,
   RUNTIME_DEFAULT,
 } from '@shumoku/core'
@@ -63,6 +63,30 @@ const VALID_ATTACHMENT_KEYS: ReadonlySet<string> = new Set([
 
 function isValidAttachmentKey(k: string): boolean {
   return VALID_ATTACHMENT_KEYS.has(k) || k.startsWith('metrics-binding:')
+}
+
+/**
+ * Whether two node identities share a strong anchor key — mirrors the entity
+ * registry's clustering keys (chassisId case-preserving; mgmtIp / sysName
+ * case-insensitive). Used to locate an existing overlay entry by identity when
+ * its authored local id no longer matches the resolved node id — which is the
+ * case after the Phase 3 entity-id flip, where the resolved id is a ULID but a
+ * pre-existing overlay entry is still keyed by the old source-local id. The
+ * overlay anchors by identity, so identity is the durable way to find it.
+ */
+function nodeIdentitiesMatch(a: Identity | undefined, b: Identity | undefined): boolean {
+  if (!a || !b) return false
+  const eq = (x: string | undefined, y: string | undefined, lower: boolean): boolean => {
+    if (!x || !y) return false
+    const nx = lower ? x.trim().toLowerCase() : x.trim()
+    const ny = lower ? y.trim().toLowerCase() : y.trim()
+    return nx === ny
+  }
+  return (
+    eq(a.chassisId, b.chassisId, false) ||
+    eq(a.mgmtIp, b.mgmtIp, true) ||
+    eq(a.sysName, b.sysName, true)
+  )
 }
 
 interface PatchBody {
@@ -257,6 +281,10 @@ export function createDiscoveryPolicyApi(): Hono {
       links: [],
     }
     const next = { ...authored }
+    // Identity of the resolved node addressed by a node-scope PATCH (if any), so
+    // the response can re-find the overlay entry the same way the mutation did —
+    // by id then by identity (see the node branch below).
+    let resolvedNodeIdentity: Identity | undefined
 
     if (body.scope === 'topology') {
       if (attachments) next.attachments = attachments
@@ -282,19 +310,21 @@ export function createDiscoveryPolicyApi(): Hono {
       // scope === 'node' — attachments and/or an authored label override.
       const id = body.id as string
       const nodes = [...next.nodes]
-      const idx = nodes.findIndex((n) => n.id === id)
 
       // Resolved (observed) node — needed to materialize a discovered-only
-      // entry and to revert a cleared label to the observed name. Loaded once.
-      let discoveredNode: Node | undefined
-      let discoveredLoaded = false
-      const loadDiscovered = async (): Promise<Node | undefined> => {
-        if (!discoveredLoaded) {
-          const resolved = await service.getParsed(topologyId)
-          discoveredNode = resolved?.graph.nodes.find((n) => n.id === id)
-          discoveredLoaded = true
-        }
-        return discoveredNode
+      // entry, to revert a cleared label to the observed name, AND to locate an
+      // existing overlay entry by identity when its authored local id no longer
+      // matches the resolved id (post Phase 3 entity-id flip the resolved id is a
+      // ULID; a pre-existing overlay entry may still be keyed by the old
+      // source-local id). Loaded once, up front, so the lookup can fall back to
+      // identity — the overlay's actual anchor.
+      const resolved = await service.getParsed(topologyId)
+      const discoveredNode = resolved?.graph.nodes.find((n) => n.id === id)
+      resolvedNodeIdentity = discoveredNode?.identity
+
+      let idx = nodes.findIndex((n) => n.id === id)
+      if (idx === -1 && discoveredNode?.identity) {
+        idx = nodes.findIndex((n) => nodeIdentitiesMatch(n.identity, discoveredNode.identity))
       }
 
       if (idx === -1) {
@@ -311,7 +341,7 @@ export function createDiscoveryPolicyApi(): Hono {
         const wantLabel = labelProvided && labelTrimmed !== ''
         const wantSuppress = suppressedProvided && suppressed
         if (wantAttach || wantLabel || wantSuppress) {
-          const discovered = await loadDiscovered()
+          const discovered = discoveredNode
           if (!discovered) return c.json({ error: `node '${id}' not found` }, 404)
           if (!discovered.identity) {
             return c.json(
@@ -365,8 +395,7 @@ export function createDiscoveryPolicyApi(): Hono {
             const hasAttach = Array.isArray(target.attachments) && target.attachments.length > 0
             const hasSuppress =
               Array.isArray(target.suppressedAttachments) && target.suppressedAttachments.length > 0
-            const discovered = await loadDiscovered()
-            const observationBacked = discovered?.provenance?.state === 'confirmed'
+            const observationBacked = discoveredNode?.provenance?.state === 'confirmed'
             if (!hasAttach && !hasSuppress && observationBacked) {
               nodes.splice(idx, 1)
               removed = true
@@ -406,7 +435,9 @@ export function createDiscoveryPolicyApi(): Hono {
         topologyDefault: next.attachments,
       })
     } else {
-      const node = next.nodes.find((n) => n.id === body.id)
+      const node =
+        next.nodes.find((n) => n.id === body.id) ??
+        next.nodes.find((n) => nodeIdentitiesMatch(n.identity, resolvedNodeIdentity))
       effective = computeEffectivePolicy({
         node: { attachments: node?.attachments, parent: node?.parent },
         subgraphs: subgraphLookup,

--- a/apps/server/api/src/api/discovery-policy.ts
+++ b/apps/server/api/src/api/discovery-policy.ts
@@ -73,8 +73,10 @@ function isValidAttachmentKey(k: string): boolean {
  * case after the Phase 3 entity-id flip, where the resolved id is a ULID but a
  * pre-existing overlay entry is still keyed by the old source-local id. The
  * overlay anchors by identity, so identity is the durable way to find it.
+ *
+ * Exported for unit testing (the normalization is the load-bearing part).
  */
-function nodeIdentitiesMatch(a: Identity | undefined, b: Identity | undefined): boolean {
+export function nodeIdentitiesMatch(a: Identity | undefined, b: Identity | undefined): boolean {
   if (!a || !b) return false
   const eq = (x: string | undefined, y: string | undefined, lower: boolean): boolean => {
     if (!x || !y) return false

--- a/apps/server/api/src/services/entity-registry.ts
+++ b/apps/server/api/src/services/entity-registry.ts
@@ -27,7 +27,21 @@
 
 import type { Database } from 'bun:sqlite'
 import { randomBytes } from 'node:crypto'
-import type { Identity, Link, NetworkGraph, Node, NodePort } from '@shumoku/core'
+import type {
+  Identity,
+  LayoutLink,
+  LayoutNode,
+  LayoutPort,
+  LayoutResult,
+  Link,
+  LinkEndpoint,
+  NetworkGraph,
+  Node,
+  NodePort,
+  ResolvedEdge,
+  ResolvedLayout,
+  ResolvedPort,
+} from '@shumoku/core'
 import { timestamp } from '../db/index.js'
 import { buildGraph } from './contribution-store.js'
 
@@ -457,4 +471,219 @@ export function stampEntityIds(
   })
 
   return { ...graph, nodes: stampedNodes, links: stampedLinks }
+}
+
+// ---------------------------------------------------------------------------
+// Public API — flip resolved element ids to their entity ids (Phase 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical, order-independent endpoint signature for a link.  Used to
+ * correlate a laid-out edge back to the (entityId-stamped) graph link WITHOUT
+ * depending on the layout engine's positional `__link_${i}` keying -- that index
+ * differs between the simple and composite engines, so an endpoint match is the
+ * only engine-independent correlation.  Control-char separators (U+0000 /
+ * U+0001) keep a node id or port name that contains ':' from colliding.
+ */
+const SIG_FIELD_SEP = String.fromCharCode(0)
+const SIG_PAIR_SEP = String.fromCharCode(1)
+function endpointSignature(from: LinkEndpoint, to: LinkEndpoint): string {
+  const a = `${from.node}${SIG_FIELD_SEP}${from.port ?? ''}`
+  const b = `${to.node}${SIG_FIELD_SEP}${to.port ?? ''}`
+  return a <= b ? `${a}${SIG_PAIR_SEP}${b}` : `${b}${SIG_PAIR_SEP}${a}`
+}
+
+/**
+ * Rewrite the node-id prefix of a resolved port id (`${nodeId}:${portName}`)
+ * when the node was flipped.  `port.id` (the port's own local name) is NEVER
+ * flipped — only the composite resolved port id's node prefix moves, so the
+ * `resolved.ports` keys and `edge.fromPortId`/`toPortId` still resolve after the
+ * node flip.  Uses the known old node id to strip exactly its prefix, so a port
+ * name containing ':' survives intact.
+ */
+function remapPortId(portId: string, oldNodeId: string, newNodeId: string): string {
+  if (oldNodeId === newNodeId) return portId
+  const prefix = `${oldNodeId}:`
+  return portId.startsWith(prefix) ? `${newNodeId}:${portId.slice(prefix.length)}` : portId
+}
+
+interface FlipMaps {
+  /** old node id → new node id (entity id); only entries that actually change */
+  nodeIdMap: Map<string, string>
+  /** endpoint signature → new link id (entity id), for links that carry one */
+  linkEntityByEndpoints: Map<string, string>
+}
+
+/** Build the flip maps from an already entityId-stamped graph. */
+function buildFlipMaps(graph: NetworkGraph): FlipMaps {
+  const nodeIdMap = new Map<string, string>()
+  for (const n of graph.nodes) {
+    if (n.entityId && n.entityId !== n.id) nodeIdMap.set(n.id, n.entityId)
+  }
+  const linkEntityByEndpoints = new Map<string, string>()
+  for (const l of graph.links) {
+    if (l.entityId) linkEntityByEndpoints.set(endpointSignature(l.from, l.to), l.entityId)
+  }
+  return { nodeIdMap, linkEntityByEndpoints }
+}
+
+const mapNodeId = (maps: FlipMaps, id: string): string => maps.nodeIdMap.get(id) ?? id
+
+/** Flip a link's `id` (to its entity id) and its endpoint node references. */
+function flipEmbeddedLink(link: Link, newId: string | undefined, maps: FlipMaps): Link {
+  const fromNode = mapNodeId(maps, link.from.node)
+  const toNode = mapNodeId(maps, link.to.node)
+  const idChanges = newId !== undefined && link.id !== newId
+  if (!idChanges && fromNode === link.from.node && toNode === link.to.node) return link
+  const next: Link = { ...link }
+  if (newId !== undefined) next.id = newId
+  if (fromNode !== link.from.node) next.from = { ...link.from, node: fromNode }
+  if (toNode !== link.to.node) next.to = { ...link.to, node: toNode }
+  return next
+}
+
+/**
+ * Flip a graph's `node.id` / `link.id` to their entity ids and rewrite every
+ * `link.from.node` / `link.to.node` accordingly.  `port.id`, subgraph ids and
+ * `node.parent` (a subgraph id) are deliberately left untouched.  Elements
+ * without an entity id keep their existing id.  Pure — never mutates input.
+ */
+function flipGraph(graph: NetworkGraph, maps: FlipMaps): NetworkGraph {
+  const nodes = graph.nodes.map((n) =>
+    n.entityId && n.entityId !== n.id ? { ...n, id: n.entityId } : n,
+  )
+  const links = graph.links.map((l) => {
+    const newId = l.entityId
+    return flipEmbeddedLink(l, newId, maps)
+  })
+  return { ...graph, nodes, links }
+}
+
+/** Flip the legacy LayoutResult (node/link map keys + embedded refs). */
+function flipLayout(layout: LayoutResult, maps: FlipMaps): LayoutResult {
+  const nodes = new Map<string, LayoutNode>()
+  for (const [id, ln] of layout.nodes) {
+    const nid = mapNodeId(maps, id)
+    let ports = ln.ports
+    if (ln.ports) {
+      const remapped = new Map<string, LayoutPort>()
+      for (const [pid, lp] of ln.ports) {
+        const npid = remapPortId(pid, id, nid)
+        remapped.set(npid, npid === pid ? lp : { ...lp, id: npid })
+      }
+      ports = remapped
+    }
+    const node = ln.node.id === nid ? ln.node : { ...ln.node, id: nid }
+    nodes.set(nid, { ...ln, id: nid, node, ...(ports ? { ports } : {}) })
+  }
+  const links = new Map<string, LayoutLink>()
+  for (const [key, ll] of layout.links) {
+    const fromNode = mapNodeId(maps, ll.from)
+    const toNode = mapNodeId(maps, ll.to)
+    const newId = maps.linkEntityByEndpoints.get(endpointSignature(ll.fromEndpoint, ll.toEndpoint))
+    const nkey = newId ?? key
+    const fromEndpoint =
+      ll.fromEndpoint.node === fromNode ? ll.fromEndpoint : { ...ll.fromEndpoint, node: fromNode }
+    const toEndpoint =
+      ll.toEndpoint.node === toNode ? ll.toEndpoint : { ...ll.toEndpoint, node: toNode }
+    links.set(nkey, {
+      ...ll,
+      id: nkey,
+      from: fromNode,
+      to: toNode,
+      fromEndpoint,
+      toEndpoint,
+      link: flipEmbeddedLink(ll.link, newId, maps),
+    })
+  }
+  // Subgraphs are keyed by subgraph id and hold no node-id references → as-is.
+  return { ...layout, nodes, links }
+}
+
+/** Flip a resolved port's composite id + nodeId when its node was flipped. */
+function flipResolvedPort(rp: ResolvedPort, maps: FlipMaps): ResolvedPort {
+  const nid = mapNodeId(maps, rp.nodeId)
+  if (nid === rp.nodeId) return rp
+  return { ...rp, id: remapPortId(rp.id, rp.nodeId, nid), nodeId: nid }
+}
+
+/** Flip the ResolvedLayout (node/port/edge map keys + embedded refs). */
+function flipResolved(resolved: ResolvedLayout, maps: FlipMaps): ResolvedLayout {
+  const nodes = new Map<string, Node>()
+  for (const [id, n] of resolved.nodes) {
+    const nid = mapNodeId(maps, id)
+    nodes.set(nid, nid === n.id ? n : { ...n, id: nid })
+  }
+  const ports = new Map<string, ResolvedPort>()
+  for (const [pid, rp] of resolved.ports) {
+    const nid = mapNodeId(maps, rp.nodeId)
+    const npid = remapPortId(pid, rp.nodeId, nid)
+    ports.set(npid, npid === pid ? rp : flipResolvedPort(rp, maps))
+  }
+  const edges = new Map<string, ResolvedEdge>()
+  for (const [key, re] of resolved.edges) {
+    const fromNodeId = mapNodeId(maps, re.fromNodeId)
+    const toNodeId = mapNodeId(maps, re.toNodeId)
+    const newId = maps.linkEntityByEndpoints.get(endpointSignature(re.fromEndpoint, re.toEndpoint))
+    const nkey = newId ?? key
+    const fromEndpoint =
+      re.fromEndpoint.node === fromNodeId
+        ? re.fromEndpoint
+        : { ...re.fromEndpoint, node: fromNodeId }
+    const toEndpoint =
+      re.toEndpoint.node === toNodeId ? re.toEndpoint : { ...re.toEndpoint, node: toNodeId }
+    edges.set(nkey, {
+      ...re,
+      id: nkey,
+      fromNodeId,
+      toNodeId,
+      fromPortId: remapPortId(re.fromPortId, re.fromNodeId, fromNodeId),
+      toPortId: remapPortId(re.toPortId, re.toNodeId, toNodeId),
+      fromPort: flipResolvedPort(re.fromPort, maps),
+      toPort: flipResolvedPort(re.toPort, maps),
+      fromEndpoint,
+      toEndpoint,
+      link: flipEmbeddedLink(re.link, newId, maps),
+    })
+  }
+  // Subgraphs (+ their boundary ports) are keyed by subgraph id → untouched.
+  return { ...resolved, nodes, ports, edges }
+}
+
+/**
+ * Flip a graph-only structure's element ids to their entity ids.  Used to
+ * migrate the project overlay's authored node/link local ids so they line up
+ * with the post-flip resolved ids (the overlay anchors by identity, so the
+ * local id is free to move).  The graph MUST already be entityId-stamped.
+ */
+export function flipGraphToEntityIds(graph: NetworkGraph): NetworkGraph {
+  return flipGraph(graph, buildFlipMaps(graph))
+}
+
+/**
+ * The Phase 3 flip: rewrite `node.id` / `link.id` on the resolved graph — AND
+ * the layout + resolved artifact that share those ids — to the stable entity
+ * ids stamped by {@link stampEntityIds}.  After this, `node.id === node.entityId`
+ * and `link.id === link.entityId` for every element the registry knows, so all
+ * downstream references (metrics mapping, weathermap data-ids, the client
+ * viewer's graph↔resolved join) key on a stable id.  `port.id` is preserved;
+ * only the composite resolved port id's node prefix moves so the maps stay
+ * consistent.  Graph, layout, and resolved are flipped with ONE shared id map
+ * so the baked artifact never disagrees with itself.  Pure — never mutates.
+ */
+export function flipToEntityIds(
+  graph: NetworkGraph,
+  layout: LayoutResult,
+  resolved: ResolvedLayout | undefined,
+): { graph: NetworkGraph; layout: LayoutResult; resolved?: ResolvedLayout } {
+  const maps = buildFlipMaps(graph)
+  if (maps.nodeIdMap.size === 0 && maps.linkEntityByEndpoints.size === 0) {
+    // Nothing stamped → nothing to flip (avoids needless copies of a big layout).
+    return { graph, layout, resolved }
+  }
+  return {
+    graph: flipGraph(graph, maps),
+    layout: flipLayout(layout, maps),
+    resolved: resolved ? flipResolved(resolved, maps) : undefined,
+  }
 }

--- a/apps/server/api/src/services/signal-streams.ts
+++ b/apps/server/api/src/services/signal-streams.ts
@@ -65,6 +65,14 @@ export class SignalStreamsService {
    * (gzip) keyed by capture time; layer 2 accumulates per-entity hour
    * buckets in RAM and flushes them when the hour rolls over (a process
    * restart loses at most the open hour — accepted, no interpolation).
+   *
+   * The `metrics_trends.entity_id` (and the keys inside the `metrics_history`
+   * blob) are the resolved graph's `node.id` / `link.id`. Since the Phase 3
+   * entity-id flip those ARE the stable registry entity ids — so this stream is
+   * now keyed by the true entity id (as the column name always implied), and a
+   * device keeps its trend history across re-scans / id churn. Rows written by a
+   * pre-flip server stay keyed by the old element ids; they are not migrated
+   * (no id-keyed reader exists yet) and simply age out under retention.
    */
   recordMetrics(topologyId: string, data: MetricsData): void {
     const at = data.timestamp || Date.now()

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -64,7 +64,12 @@ import type {
 } from '../types.js'
 import { buildGraph, ingestGraph } from './contribution-store.js'
 import { isDeriving, kickDerivation } from './derivation.js'
-import { adoptOrMintForGraph, resolveEntityAlias, stampEntityIds } from './entity-registry.js'
+import {
+  adoptOrMintForGraph,
+  flipToEntityIds,
+  resolveEntityAlias,
+  stampEntityIds,
+} from './entity-registry.js'
 
 /**
  * How long `getParsed` waits for an in-flight bake before falling back to
@@ -155,7 +160,10 @@ interface MetricsMappingRow {
 // device tiers no longer place firewalls above upstream routers.
 // v18: entity registry Phase 1 — entityId field added to nodes/ports/links
 // v19: composite edges return to log display widths; vertical risers separate by ink width
-const RESOLVER_VERSION = 19
+// v20: entity registry Phase 3 — node.id/link.id ON the resolved graph (+ layout
+// + resolved artifact) are flipped to their stable entity ids; old-id artifacts
+// must rebake so persisted references (metrics mapping, weathermap) key on ULIDs.
+const RESOLVER_VERSION = 20
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {
@@ -1199,20 +1207,28 @@ export class TopologyService {
   completeDerivation(id: string, builtRevision: number, result: DeriveResult): void {
     const topology = this.get(id)
     if (!topology) return
+    // Phase 3: stamp entity ids, then FLIP node.id/link.id (on the graph AND the
+    // layout + resolved artifact that share those ids) to the stable entity ids.
+    // Graph, layout and resolved are flipped with one shared id map so the baked
+    // artifact never disagrees with itself; the client viewer joins graph↔resolved
+    // by these ids, and metrics/weathermap key on them, so all three must move
+    // together. Elements the registry doesn't know keep their id.
     const stampedGraph = stampEntityIds(id, result.graph, this.db)
+    const flipped = flipToEntityIds(stampedGraph, result.layout, result.resolved)
     const parsed: ParsedTopology = {
       id: topology.id,
       name: topology.name,
-      graph: stampedGraph,
-      layout: result.layout,
-      resolved: result.resolved,
+      graph: flipped.graph,
+      layout: flipped.layout,
+      resolved: flipped.resolved,
       iconDimensions: result.iconDimensions,
-      metrics: this.createEmptyMetrics(result.graph),
+      metrics: this.createEmptyMetrics(flipped.graph),
       topologySourceId: this.topologySourceIdFor(topology.id),
       metricsSourceId: this.metricsSourceIdFor(topology.id),
-      // buildMapping projects entity-keyed rows back through the graph's stamped
-      // entityIds, so it MUST get the stamped graph (result.graph has none yet).
-      mapping: this.buildMapping(topology.id, stampedGraph),
+      // buildMapping projects entity-keyed rows back through the graph's ids —
+      // which ARE the entity ids post-flip — so the mapping keys line up with the
+      // element ids the client sees and sends back.
+      mapping: this.buildMapping(topology.id, flipped.graph),
     }
     // Persist even if the revision moved mid-bake: built_revision marks it
     // stale, and stale-but-newer beats the previous artifact for stale-serving.

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -30,6 +30,7 @@ import type {
   Attachment,
   IconDimensions,
   LayoutResult,
+  Link,
   MembershipCriterion,
   NetworkGraph,
   Node,
@@ -140,6 +141,20 @@ interface MetricsMappingRow {
 }
 
 /**
+ * Persisted payload of a `link` metrics_mapping row. The monitored node is
+ * referenced by its stable entity id (`monitoredNodeEntityId`) so it survives the
+ * Phase 3 element-id flip. `monitoredNodeId` only appears in legacy rows written
+ * before the flip and is treated as a stale element id on read.
+ */
+interface StoredLinkMapping {
+  monitoredNodeEntityId?: string
+  /** Legacy (pre-Phase-3) rows only: a now-stale resolved element id. */
+  monitoredNodeId?: string
+  interface?: string
+  bandwidth?: number
+}
+
+/**
  * Bump when the resolve/layout algorithms change shape, so persisted
  * `topology_resolved_graph` artifacts built by an older version are treated as
  * stale and recomputed without a manual purge.
@@ -184,6 +199,25 @@ interface ResolvedGraphRow {
  * binding can never delete unrelated authored content. Only `id` + `label:''` +
  * `identity` may remain for it to be dropped.
  */
+/**
+ * Does a link endpoint's port correspond to the given interface name? Matches
+ * the port id (interface names ARE port ids for inventory sources), its
+ * `identity.ifName`, or its label — so a legacy link mapping can recover which
+ * endpoint it monitored from the interface alone.
+ */
+function endpointMatchesInterface(
+  nodeById: ReadonlyMap<string, Node>,
+  endpoint: { node: string; port: string },
+  iface: string,
+): boolean {
+  if (endpoint.port === iface) return true
+  const port = nodeById.get(endpoint.node)?.ports?.find((p) => p.id === endpoint.port)
+  if (!port) return false
+  if (port.identity?.ifName === iface) return true
+  const label = Array.isArray(port.label) ? port.label[0] : port.label
+  return label === iface
+}
+
 function isPureEmptyOverlay(n: Node): boolean {
   const label = Array.isArray(n.label) ? n.label.join('') : (n.label ?? '')
   // Allow-list the fields a bare binding overlay legitimately carries; any other
@@ -748,7 +782,17 @@ export class TopologyService {
           skipped.links++
           continue
         }
-        upsert.run(topologyId, entityId, 'link', sourceId, JSON.stringify(lm), now, now)
+        // Persist the monitored node by its STABLE entity id, never the element
+        // id: resolved element ids change across the Phase 3 flip, so a stored
+        // element id would dangle after an upgrade (the poller would look it up
+        // in mapping.nodes and miss). `buildMapping` re-derives the current
+        // element id from this on read.
+        const stored: StoredLinkMapping = {
+          monitoredNodeEntityId: nodeById.get(lm.monitoredNodeId)?.entityId,
+          interface: lm.interface,
+          bandwidth: lm.bandwidth,
+        }
+        upsert.run(topologyId, entityId, 'link', sourceId, JSON.stringify(stored), now, now)
       }
     })
     run()
@@ -1495,7 +1539,8 @@ export class TopologyService {
       .all(topologyId) as MetricsMappingRow[]
     if (rows.length === 0) return undefined
 
-    const { nodeByEntity, linkKeyByEntity } = this.indexGraphEntities(graph)
+    const { nodeByEntity, linkKeyByEntity, linkByEntity } = this.indexGraphEntities(graph)
+    const nodeById = new Map(graph.nodes.map((n) => [n.id, n]))
     const nodes: Record<string, NodeMetricsMapping> = {}
     const links: Record<string, LinkMetricsMapping> = {}
     for (const row of rows) {
@@ -1506,7 +1551,19 @@ export class TopologyService {
         if (node) nodes[node.id] = JSON.parse(row.payload_json) as NodeMetricsMapping
       } else if (row.kind === 'link') {
         const linkKey = linkKeyByEntity.get(eid)
-        if (linkKey) links[linkKey] = JSON.parse(row.payload_json) as LinkMetricsMapping
+        const link = linkByEntity.get(eid)
+        if (!linkKey || !link) continue
+        const stored = JSON.parse(row.payload_json) as StoredLinkMapping
+        // Re-derive the monitored node's CURRENT element id — never emit the
+        // stored value, which after the Phase 3 id flip is a stale reference the
+        // poller can't resolve.
+        const monitoredNodeId = this.resolveMonitoredNodeId(stored, link, nodeByEntity, nodeById)
+        if (!monitoredNodeId) continue // can't anchor → orphan, not a dangling ref
+        links[linkKey] = {
+          monitoredNodeId,
+          interface: stored.interface,
+          bandwidth: stored.bandwidth,
+        }
       }
     }
     const has = Object.keys(nodes).length > 0 || Object.keys(links).length > 0
@@ -1522,10 +1579,12 @@ export class TopologyService {
   private indexGraphEntities(graph: NetworkGraph): {
     nodeByEntity: Map<string, Node>
     linkKeyByEntity: Map<string, string>
+    linkByEntity: Map<string, Link>
     presentEntityIds: Set<string>
   } {
     const nodeByEntity = new Map<string, Node>()
     const linkKeyByEntity = new Map<string, string>()
+    const linkByEntity = new Map<string, Link>()
     const presentEntityIds = new Set<string>()
     for (const node of graph.nodes) {
       if (node.entityId) {
@@ -1536,10 +1595,45 @@ export class TopologyService {
     graph.links.forEach((link, i) => {
       if (link.entityId) {
         linkKeyByEntity.set(link.entityId, link.id || `link-${i}`)
+        linkByEntity.set(link.entityId, link)
         presentEntityIds.add(link.entityId)
       }
     })
-    return { nodeByEntity, linkKeyByEntity, presentEntityIds }
+    return { nodeByEntity, linkKeyByEntity, linkByEntity, presentEntityIds }
+  }
+
+  /**
+   * Resolve a stored link mapping to the monitored node's CURRENT resolved
+   * element id. Prefers the persisted entity id (alias-followed → current id).
+   * Legacy rows (written before the Phase 3 id flip) stored a now-stale element
+   * id instead: the monitored node is one of the link's two endpoints, so the
+   * monitored interface name picks which end, and a still-current id (unstamped
+   * element that never flipped) matches an endpoint directly. Returns undefined
+   * when nothing anchors, so the caller surfaces an orphan rather than emitting a
+   * dangling reference the poller would silently drop.
+   */
+  private resolveMonitoredNodeId(
+    stored: StoredLinkMapping,
+    link: Link,
+    nodeByEntity: ReadonlyMap<string, Node>,
+    nodeById: ReadonlyMap<string, Node>,
+  ): string | undefined {
+    if (stored.monitoredNodeEntityId) {
+      const node = nodeByEntity.get(resolveEntityAlias(stored.monitoredNodeEntityId, this.db))
+      if (node) return node.id
+    }
+    // Legacy row (pre-Phase-3): the monitored node is one of the link's two
+    // endpoints. The stored interface name identifies which end (matched against
+    // the endpoint port's id / ifName / label), and a still-current node id
+    // (an unstamped element that never flipped) matches an endpoint directly.
+    const iface = stored.interface
+    if (iface) {
+      if (endpointMatchesInterface(nodeById, link.from, iface)) return link.from.node
+      if (endpointMatchesInterface(nodeById, link.to, iface)) return link.to.node
+    }
+    if (stored.monitoredNodeId === link.from.node) return link.from.node
+    if (stored.monitoredNodeId === link.to.node) return link.to.node
+    return undefined
   }
 
   /**

--- a/apps/server/api/test/db/discovery-policy.test.ts
+++ b/apps/server/api/test/db/discovery-policy.test.ts
@@ -1,0 +1,49 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * The discovery-policy PATCH locates an existing overlay entry by identity when
+ * its authored local id no longer matches the resolved id (post Phase 3 entity-id
+ * flip). `nodeIdentitiesMatch` is the anchor predicate; its normalization must
+ * mirror the entity registry (chassisId case-preserving; mgmtIp / sysName
+ * case-insensitive) so the match agrees with clustering.
+ *
+ * Lives under test/db (bun test) because importing the route module transitively
+ * pulls in `bun:sqlite`; the predicate itself needs no database.
+ *
+ * Run with: cd apps/server/api && bun test test/db/discovery-policy.test.ts
+ */
+
+import { describe, expect, test } from 'bun:test'
+import type { Identity } from '@shumoku/core'
+import { nodeIdentitiesMatch } from '../../src/api/discovery-policy.ts'
+
+describe('nodeIdentitiesMatch', () => {
+  test('matches on a shared mgmtIp (case-insensitive)', () => {
+    const a: Identity = { mgmtIp: '10.0.0.1' }
+    const b: Identity = { mgmtIp: '10.0.0.1', sysName: 'core-1' }
+    expect(nodeIdentitiesMatch(a, b)).toBe(true)
+  })
+
+  test('matches sysName case-insensitively (registry lowercases it)', () => {
+    expect(nodeIdentitiesMatch({ sysName: 'Core-SW-1' }, { sysName: 'core-sw-1' })).toBe(true)
+  })
+
+  test('matches chassisId case-sensitively (registry preserves case)', () => {
+    expect(nodeIdentitiesMatch({ chassisId: 'AA:BB:CC' }, { chassisId: 'AA:BB:CC' })).toBe(true)
+    // Different case → chassisId does not match (and no other shared key).
+    expect(nodeIdentitiesMatch({ chassisId: 'AA:BB:CC' }, { chassisId: 'aa:bb:cc' })).toBe(false)
+  })
+
+  test('does not match when no strong key is shared', () => {
+    expect(nodeIdentitiesMatch({ mgmtIp: '10.0.0.1' }, { mgmtIp: '10.0.0.2' })).toBe(false)
+    expect(nodeIdentitiesMatch({ sysName: 'a' }, { chassisId: 'AA' })).toBe(false)
+  })
+
+  test('is false when either identity is missing or empty', () => {
+    expect(nodeIdentitiesMatch(undefined, { mgmtIp: '10.0.0.1' })).toBe(false)
+    expect(nodeIdentitiesMatch({ mgmtIp: '10.0.0.1' }, undefined)).toBe(false)
+    // Empty-string keys make no claim.
+    expect(nodeIdentitiesMatch({ mgmtIp: '' }, { mgmtIp: '' })).toBe(false)
+  })
+})

--- a/apps/server/api/test/db/entity-id-flip.test.ts
+++ b/apps/server/api/test/db/entity-id-flip.test.ts
@@ -1,0 +1,238 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Phase 3 (entity registry): the resolved graph's `node.id` / `link.id` are
+ * flipped to their stable entity ids, and the layout + resolved artifact that
+ * share those ids are flipped in lockstep. These tests cover:
+ *   - the pure flip mechanics (graph + layout + resolved stay internally
+ *     consistent; `port.id` is preserved; only the composite resolved port id's
+ *     node prefix moves);
+ *   - the integration path (getParsed serves a graph whose node/link ids are
+ *     ULIDs, stable across re-bakes, and round-trips through the metrics mapping).
+ *
+ * Run with: cd apps/server/api && bun test test/db/entity-id-flip.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { computeNetworkLayout, type NetworkGraph } from '@shumoku/core'
+import { flipGraphToEntityIds, flipToEntityIds } from '../../src/services/entity-registry.ts'
+import { TopologyService } from '../../src/services/topology.ts'
+import { attachSource, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
+
+// A ULID: 26 Crockford base32 chars (excludes I, L, O, U).
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/
+
+/** A 2-node + 1-link graph with port identities so every element gets an entity. */
+function sampleGraph(name: string): NetworkGraph {
+  return {
+    version: '1',
+    name,
+    nodes: [
+      {
+        id: 'a',
+        label: 'A',
+        shape: 'rect',
+        identity: { mgmtIp: '10.0.0.1' },
+        ports: [{ id: 'pa', label: 'Gi0/1', connectors: ['rj45'], identity: { ifName: 'Gi0/1' } }],
+      },
+      {
+        id: 'b',
+        label: 'B',
+        shape: 'rect',
+        identity: { mgmtIp: '10.0.0.2' },
+        ports: [{ id: 'pb', label: 'Gi0/2', connectors: ['rj45'], identity: { ifName: 'Gi0/2' } }],
+      },
+    ],
+    links: [{ id: 'L1', from: { node: 'a', port: 'pa' }, to: { node: 'b', port: 'pb' } }],
+  } as NetworkGraph
+}
+
+describe('flip mechanics (pure)', () => {
+  test('graph + layout + resolved flip together; port.id preserved', async () => {
+    // Lay out the ORIGINAL-id graph exactly like the derive worker does.
+    const base = sampleGraph('flip-pure')
+    const { layout, resolved } = await computeNetworkLayout(base)
+
+    // Stamp entity ids by hand (no registry needed for the pure flip): the flip
+    // reads whatever `entityId` the graph carries.
+    const stamped: NetworkGraph = {
+      ...base,
+      nodes: [
+        { ...base.nodes[0], entityId: 'AAAAAAAAAAAAAAAAAAAAAAAAAA' },
+        { ...base.nodes[1], entityId: 'BBBBBBBBBBBBBBBBBBBBBBBBBB' },
+      ] as NetworkGraph['nodes'],
+      links: [
+        { ...base.links[0], entityId: 'LLLLLLLLLLLLLLLLLLLLLLLLLL' },
+      ] as NetworkGraph['links'],
+    }
+
+    const flipped = flipToEntityIds(stamped, layout, resolved)
+
+    // --- graph ---
+    const [na, nb] = flipped.graph.nodes
+    expect(na?.id).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+    expect(nb?.id).toBe('BBBBBBBBBBBBBBBBBBBBBBBBBB')
+    // port.id is NOT flipped
+    expect(na?.ports?.[0]?.id).toBe('pa')
+    const link = flipped.graph.links[0]
+    expect(link?.id).toBe('LLLLLLLLLLLLLLLLLLLLLLLLLL')
+    expect(link?.from.node).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+    expect(link?.to.node).toBe('BBBBBBBBBBBBBBBBBBBBBBBBBB')
+    // link endpoint PORT names are untouched
+    expect(link?.from.port).toBe('pa')
+
+    // --- layout (keyed by the new ids) ---
+    expect(flipped.layout.nodes.has('AAAAAAAAAAAAAAAAAAAAAAAAAA')).toBe(true)
+    expect(flipped.layout.nodes.has('a')).toBe(false)
+    const layoutLink = flipped.layout.links.get('LLLLLLLLLLLLLLLLLLLLLLLLLL')
+    expect(layoutLink?.from).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+    expect(layoutLink?.to).toBe('BBBBBBBBBBBBBBBBBBBBBBBBBB')
+
+    // --- resolved (nodes / ports / edges keyed consistently) ---
+    const r = flipped.resolved
+    expect(r).toBeDefined()
+    if (!r) return
+    expect(r.nodes.has('AAAAAAAAAAAAAAAAAAAAAAAAAA')).toBe(true)
+    expect(r.nodes.get('AAAAAAAAAAAAAAAAAAAAAAAAAA')?.id).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+    // resolved port id keeps its port-name suffix, only the node prefix moves
+    expect(r.ports.has('AAAAAAAAAAAAAAAAAAAAAAAAAA:pa')).toBe(true)
+    const port = r.ports.get('AAAAAAAAAAAAAAAAAAAAAAAAAA:pa')
+    expect(port?.nodeId).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+    expect(port?.id).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA:pa')
+    // edge keyed + wired by the new ids
+    const edge = r.edges.get('LLLLLLLLLLLLLLLLLLLLLLLLLL')
+    expect(edge).toBeDefined()
+    expect(edge?.fromNodeId).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+    expect(edge?.toNodeId).toBe('BBBBBBBBBBBBBBBBBBBBBBBBBB')
+    expect(edge?.fromPortId).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA:pa')
+    expect(edge?.toPortId).toBe('BBBBBBBBBBBBBBBBBBBBBBBBBB:pb')
+    expect(edge?.fromPort.nodeId).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+    expect(edge?.link.from.node).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+  })
+
+  test('no entityId stamped → nothing changes (identity flip)', async () => {
+    const base = sampleGraph('flip-noop')
+    const { layout, resolved } = await computeNetworkLayout(base)
+    const flipped = flipToEntityIds(base, layout, resolved)
+    expect(flipped.graph.nodes[0]?.id).toBe('a')
+    expect(flipped.graph.links[0]?.id).toBe('L1')
+    expect(flipped.layout).toBe(layout)
+    expect(flipped.resolved).toBe(resolved)
+  })
+
+  test('flipGraphToEntityIds flips a graph-only structure', () => {
+    const base = sampleGraph('flip-graph-only')
+    const stamped: NetworkGraph = {
+      ...base,
+      nodes: [
+        { ...base.nodes[0], entityId: 'AAAAAAAAAAAAAAAAAAAAAAAAAA' },
+        { ...base.nodes[1], entityId: 'BBBBBBBBBBBBBBBBBBBBBBBBBB' },
+      ] as NetworkGraph['nodes'],
+      links: [
+        { ...base.links[0], entityId: 'LLLLLLLLLLLLLLLLLLLLLLLLLL' },
+      ] as NetworkGraph['links'],
+    }
+    const g = flipGraphToEntityIds(stamped)
+    expect(g.nodes[0]?.id).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+    expect(g.links[0]?.from.node).toBe('AAAAAAAAAAAAAAAAAAAAAAAAAA')
+    expect(g.links[0]?.id).toBe('LLLLLLLLLLLLLLLLLLLLLLLLLL')
+  })
+})
+
+describe('flip integration (via the derive worker)', () => {
+  let db_: TempDb
+  let svc: TopologyService
+  beforeAll(() => {
+    db_ = setupTempDb()
+    svc = new TopologyService()
+  })
+  afterAll(() => db_.teardown())
+
+  async function makeTopo(name: string): Promise<string> {
+    const topo = await svc.create({ name })
+    await svc.writeProjectOverlay(topo.id, sampleGraph(name))
+    attachSource(topo.id, insertDataSource('zabbix', `zbx_${name}`), 'metrics')
+    return topo.id
+  }
+
+  test('resolved graph node/link ids are ULIDs (entity ids)', async () => {
+    const topoId = await makeTopo('flip-int')
+    const parsed = await svc.getParsed(topoId)
+    expect(parsed).not.toBeNull()
+    if (!parsed) return
+
+    for (const node of parsed.graph.nodes) {
+      // Both nodes have a network identity → each gets a ULID id === its entityId.
+      expect(node.id).toMatch(ULID_RE)
+      expect(node.id).toBe(node.entityId)
+      // port.id stays the human-facing local name.
+      expect(node.ports?.[0]?.id).not.toMatch(ULID_RE)
+    }
+    const link = parsed.graph.links[0]
+    expect(link?.id).toMatch(ULID_RE)
+    expect(link?.id).toBe(link?.entityId)
+    // endpoints reference the flipped node ids
+    expect(link?.from.node).toBe(parsed.graph.nodes.find((n) => n.entityId === link?.from.node)?.id)
+  })
+
+  test('graph ↔ resolved stay consistent after the flip', async () => {
+    const topoId = await makeTopo('flip-consistent')
+    const parsed = await svc.getParsed(topoId)
+    expect(parsed?.resolved).toBeDefined()
+    if (!parsed?.resolved) return
+
+    const graphNodeIds = new Set(parsed.graph.nodes.map((n) => n.id))
+    for (const key of parsed.resolved.nodes.keys()) {
+      expect(graphNodeIds.has(key)).toBe(true)
+    }
+    // layout node keys match the graph node ids too
+    for (const key of parsed.layout.nodes.keys()) {
+      expect(graphNodeIds.has(key)).toBe(true)
+    }
+    // every resolved edge keys on a graph link id, and its endpoints are graph nodes
+    const graphLinkIds = new Set(parsed.graph.links.map((l) => l.id))
+    for (const [key, edge] of parsed.resolved.edges) {
+      expect(graphLinkIds.has(key)).toBe(true)
+      expect(graphNodeIds.has(edge.fromNodeId)).toBe(true)
+      expect(graphNodeIds.has(edge.toNodeId)).toBe(true)
+    }
+    // resolved port keys are prefixed with a flipped (graph) node id
+    for (const port of parsed.resolved.ports.values()) {
+      expect(graphNodeIds.has(port.nodeId)).toBe(true)
+    }
+  })
+
+  test('ids are stable across a re-bake (resolve twice → same ids)', async () => {
+    const topoId = await makeTopo('flip-stable')
+    const first = await svc.getParsed(topoId)
+    const firstNodeIds = first?.graph.nodes.map((n) => n.id).sort()
+    const firstLinkId = first?.graph.links[0]?.id
+
+    // Force a fresh derive (drops the artifact + bumps revision) and re-serve.
+    await svc.rebake(topoId)
+    const second = await svc.getParsed(topoId)
+    const secondNodeIds = second?.graph.nodes.map((n) => n.id).sort()
+    const secondLinkId = second?.graph.links[0]?.id
+
+    expect(secondNodeIds).toEqual(firstNodeIds)
+    expect(secondLinkId).toBe(firstLinkId)
+  })
+
+  test('the (entity-id) node/link ids round-trip through the metrics mapping', async () => {
+    const topoId = await makeTopo('flip-mapping')
+    const parsed = await svc.getParsed(topoId)
+    const nodeId = parsed?.graph.nodes[0]?.id ?? ''
+    const linkKey = parsed?.graph.links[0]?.id ?? ''
+    expect(nodeId).toMatch(ULID_RE)
+    expect(linkKey).toMatch(ULID_RE)
+
+    await svc.updateMapping(topoId, {
+      nodes: { [nodeId]: { hostId: '1' } },
+      links: { [linkKey]: { monitoredNodeId: nodeId, interface: 'Gi0/1' } },
+    })
+    const m = (await svc.getParsed(topoId))?.mapping
+    expect(m?.nodes?.[nodeId]?.hostId).toBe('1')
+    expect(m?.links?.[linkKey]?.monitoredNodeId).toBe(nodeId)
+  })
+})

--- a/apps/server/api/test/db/metrics-binding.test.ts
+++ b/apps/server/api/test/db/metrics-binding.test.ts
@@ -17,7 +17,7 @@ afterAll(() => db_.teardown())
 /** Topology with a Manual graph (2 nodes + a link, port identities) and a metrics source. */
 async function fixture(
   name: string,
-): Promise<{ topoId: string; nodeAId: string; metricsId: string }> {
+): Promise<{ topoId: string; nodeAId: string; linkKey: string; metricsId: string }> {
   const topo = await svc.create({ name })
   const graph: NetworkGraph = {
     version: '1',
@@ -45,26 +45,29 @@ async function fixture(
   attachSource(topo.id, metricsId, 'metrics')
   const parsed = await svc.getParsed(topo.id)
   const nodeAId = parsed?.graph.nodes.find((n) => n.identity?.mgmtIp === '10.0.0.1')?.id ?? ''
-  return { topoId: topo.id, nodeAId, metricsId }
+  // Phase 3: the resolved link id IS the entity id, so the wire key is derived
+  // from the flipped resolved graph, not the authored 'L1'.
+  const linkKey = parsed?.graph.links[0]?.id ?? 'link-0'
+  return { topoId: topo.id, nodeAId, linkKey, metricsId }
 }
 
 describe('metrics binding write path (identity-keyed attachments)', () => {
   test('node + link bindings derive back; clearing removes them', async () => {
-    const { topoId, nodeAId } = await fixture('mb1')
+    const { topoId, nodeAId, linkKey } = await fixture('mb1')
     await svc.updateMapping(topoId, {
       nodes: { [nodeAId]: { hostId: '42', hostName: 'hostA' } },
-      links: { L1: { monitoredNodeId: nodeAId, interface: 'Gi0/1', bandwidth: 1000 } },
+      links: { [linkKey]: { monitoredNodeId: nodeAId, interface: 'Gi0/1', bandwidth: 1000 } },
     })
     let m = (await svc.getParsed(topoId))?.mapping
     expect(m?.nodes?.[nodeAId]).toEqual({ hostId: '42', hostName: 'hostA' })
-    expect(m?.links?.['L1']?.monitoredNodeId).toBe(nodeAId)
-    expect(m?.links?.['L1']?.interface).toBe('Gi0/1')
-    expect(m?.links?.['L1']?.bandwidth).toBe(1000)
+    expect(m?.links?.[linkKey]?.monitoredNodeId).toBe(nodeAId)
+    expect(m?.links?.[linkKey]?.interface).toBe('Gi0/1')
+    expect(m?.links?.[linkKey]?.bandwidth).toBe(1000)
 
     await svc.updateMapping(topoId, { nodes: {}, links: {} })
     m = (await svc.getParsed(topoId))?.mapping
     expect(m?.nodes?.[nodeAId]).toBeUndefined()
-    expect(m?.links?.['L1']).toBeUndefined()
+    expect(m?.links?.[linkKey]).toBeUndefined()
   })
 
   test('a binding from a detached metrics source stops driving the mapping', async () => {
@@ -94,7 +97,7 @@ async function netboxishFixture(
   // Required (no default): a default object would be substituted when a test
   // passes `undefined` explicitly, defeating the identity-less case.
   nodeAIdentity: Identity | undefined,
-): Promise<{ topoId: string; nodeAId: string }> {
+): Promise<{ topoId: string; nodeAId: string; linkKey: string }> {
   const topo = await svc.create({ name })
   const graph: NetworkGraph = {
     version: '1',
@@ -110,36 +113,39 @@ async function netboxishFixture(
   await svc.writeProjectOverlay(topo.id, graph)
   attachSource(topo.id, insertDataSource('netbox', `nb_${name}`), 'metrics')
   const parsed = await svc.getParsed(topo.id)
-  // Use the resolved endpoint id (resolve may re-key the node) so the mapping's
-  // monitoredNodeId matches an actual endpoint of the link.
-  const nodeAId = parsed?.graph.links.find((l) => l.id === 'L1')?.from.node ?? 'a'
-  return { topoId: topo.id, nodeAId }
+  // Use the resolved endpoint id + link key (resolve re-keys the node, and Phase 3
+  // flips the link id to its entity id) so the mapping's monitoredNodeId + key
+  // match an actual endpoint/id of the sole resolved link.
+  const link0 = parsed?.graph.links[0]
+  const nodeAId = link0?.from.node ?? 'a'
+  const linkKey = link0?.id ?? 'link-0'
+  return { topoId: topo.id, nodeAId, linkKey }
 }
 
 describe('link bindings to identity-less ports (issue #548)', () => {
   test('a link-only-referenced port anchors its binding (skipped=0) and derives back', async () => {
-    const { topoId, nodeAId } = await netboxishFixture('mb-nb', { mgmtIp: '10.5.0.1' })
+    const { topoId, nodeAId, linkKey } = await netboxishFixture('mb-nb', { mgmtIp: '10.5.0.1' })
     const { skipped } = await svc.updateMapping(topoId, {
       nodes: {},
-      links: { L1: { monitoredNodeId: nodeAId, interface: 'ge-0/0/1', bandwidth: 1000 } },
+      links: { [linkKey]: { monitoredNodeId: nodeAId, interface: 'ge-0/0/1', bandwidth: 1000 } },
     })
     // The stub port got identity.ifName at ingest → nothing is dropped.
     expect(skipped).toEqual({ nodes: 0, links: 0 })
 
     // And it survives reload (the reported bug was this returning empty).
     const m = (await svc.getParsed(topoId))?.mapping
-    expect(m?.links?.['L1']?.monitoredNodeId).toBe(nodeAId)
-    expect(m?.links?.['L1']?.interface).toBe('ge-0/0/1')
-    expect(m?.links?.['L1']?.bandwidth).toBe(1000)
+    expect(m?.links?.[linkKey]?.monitoredNodeId).toBe(nodeAId)
+    expect(m?.links?.[linkKey]?.interface).toBe('ge-0/0/1')
+    expect(m?.links?.[linkKey]?.bandwidth).toBe(1000)
   })
 
   test('updateMapping reports link bindings it cannot anchor (skipped is honest)', async () => {
     // Node 'a' has no node identity, so even a stamped port can't anchor the
     // binding — it must be counted, not silently dropped.
-    const { topoId, nodeAId } = await netboxishFixture('mb-skip', undefined)
+    const { topoId, nodeAId, linkKey } = await netboxishFixture('mb-skip', undefined)
     const { skipped } = await svc.updateMapping(topoId, {
       nodes: {},
-      links: { L1: { monitoredNodeId: nodeAId, interface: 'ge-0/0/1' } },
+      links: { [linkKey]: { monitoredNodeId: nodeAId, interface: 'ge-0/0/1' } },
     })
     expect(skipped.links).toBe(1)
   })

--- a/apps/server/api/test/db/metrics-mapping.test.ts
+++ b/apps/server/api/test/db/metrics-mapping.test.ts
@@ -29,6 +29,7 @@ afterAll(() => db_.teardown())
 async function fixture(name: string): Promise<{
   topoId: string
   nodeAId: string
+  linkKey: string
   metricsId: string
 }> {
   const topo = await svc.create({ name })
@@ -58,7 +59,11 @@ async function fixture(name: string): Promise<{
   attachSource(topo.id, metricsId, 'metrics')
   const parsed = await svc.getParsed(topo.id)
   const nodeAId = parsed?.graph.nodes.find((n) => n.identity?.mgmtIp === '10.0.0.1')?.id ?? ''
-  return { topoId: topo.id, nodeAId, metricsId }
+  // Phase 3: the resolved link id IS the entity id now — the element-keyed wire
+  // shape keys on it, so derive the key from the (flipped) resolved graph rather
+  // than assuming the authored 'L1'.
+  const linkKey = parsed?.graph.links[0]?.id ?? 'link-0'
+  return { topoId: topo.id, nodeAId, linkKey, metricsId }
 }
 
 const rowCount = (topoId: string, kind?: string): number =>
@@ -74,10 +79,10 @@ const rowCount = (topoId: string, kind?: string): number =>
 
 describe('metrics_mapping rows (Phase 2)', () => {
   test('PUT → entity rows → GET round-trip (element-keyed in and out)', async () => {
-    const { topoId, nodeAId } = await fixture('mm-roundtrip')
+    const { topoId, nodeAId, linkKey } = await fixture('mm-roundtrip')
     await svc.updateMapping(topoId, {
       nodes: { [nodeAId]: { hostId: '42', hostName: 'hostA' } },
-      links: { L1: { monitoredNodeId: nodeAId, interface: 'Gi0/1', bandwidth: 1000 } },
+      links: { [linkKey]: { monitoredNodeId: nodeAId, interface: 'Gi0/1', bandwidth: 1000 } },
     })
 
     // Stored as entity-keyed rows (not binding attachments).
@@ -87,16 +92,16 @@ describe('metrics_mapping rows (Phase 2)', () => {
     // Projected back to element ids on read.
     const m = (await svc.getParsed(topoId))?.mapping
     expect(m?.nodes?.[nodeAId]).toEqual({ hostId: '42', hostName: 'hostA' })
-    expect(m?.links?.['L1']?.monitoredNodeId).toBe(nodeAId)
-    expect(m?.links?.['L1']?.interface).toBe('Gi0/1')
-    expect(m?.links?.['L1']?.bandwidth).toBe(1000)
+    expect(m?.links?.[linkKey]?.monitoredNodeId).toBe(nodeAId)
+    expect(m?.links?.[linkKey]?.interface).toBe('Gi0/1')
+    expect(m?.links?.[linkKey]?.bandwidth).toBe(1000)
 
     // Clearing deletes the rows.
     await svc.updateMapping(topoId, { nodes: {}, links: {} })
     expect(rowCount(topoId)).toBe(0)
     const cleared = (await svc.getParsed(topoId))?.mapping
     expect(cleared?.nodes?.[nodeAId]).toBeUndefined()
-    expect(cleared?.links?.['L1']).toBeUndefined()
+    expect(cleared?.links?.[linkKey]).toBeUndefined()
   })
 
   test('skipped counts stay honest (element with no stable entity id)', async () => {
@@ -166,8 +171,11 @@ describe('metrics_mapping rows (Phase 2)', () => {
     svc.clearCacheEntry(topo.id)
     const restamped = await svc.getParsed(topo.id)
     expect(restamped?.graph.nodes[0]?.entityId).toBe(survivorId)
-    // The mapping row still keys the pre-merge id, but alias-following surfaces it.
-    expect(restamped?.mapping?.nodes?.[nodeAId]?.hostId).toBe('5')
+    // Phase 3: node.id IS the entity id, so after the merge the node is keyed by
+    // the SURVIVOR id. The mapping row still stores the pre-merge id, but
+    // alias-following surfaces it under the node's current (survivor) id.
+    expect(restamped?.graph.nodes[0]?.id).toBe(survivorId)
+    expect(restamped?.mapping?.nodes?.[survivorId]?.hostId).toBe('5')
   })
 
   test('orphan surfacing when the mapped entity disappears from the graph', async () => {
@@ -273,11 +281,14 @@ describe('metrics binding → rows backfill (Phase 2 one-shot)', () => {
     expect(rowCount(topo.id, 'node')).toBe(1)
     expect(rowCount(topo.id, 'link')).toBe(1)
 
-    // And they derive back element-keyed, identically.
-    const m = (await svc.getParsed(topo.id))?.mapping
+    // And they derive back element-keyed, identically. The link key is the
+    // flipped resolved link id (the entity id), not the authored 'L1'.
+    const parsedAfter = await svc.getParsed(topo.id)
+    const linkKey = parsedAfter?.graph.links[0]?.id ?? 'link-0'
+    const m = parsedAfter?.mapping
     expect(m?.nodes?.[nodeAId as string]).toEqual({ hostId: '42', hostName: 'hostA' })
-    expect(m?.links?.['L1']?.interface).toBe('Gi0/1')
-    expect(m?.links?.['L1']?.bandwidth).toBe(1000)
+    expect(m?.links?.[linkKey]?.interface).toBe('Gi0/1')
+    expect(m?.links?.[linkKey]?.bandwidth).toBe(1000)
 
     // The binding attachments are stripped from the overlay (no longer read).
     const overlay = svc.readProjectOverlay(topo.id)

--- a/apps/server/api/test/db/metrics-mapping.test.ts
+++ b/apps/server/api/test/db/metrics-mapping.test.ts
@@ -104,6 +104,47 @@ describe('metrics_mapping rows (Phase 2)', () => {
     expect(cleared?.links?.[linkKey]).toBeUndefined()
   })
 
+  test('link row survives the Phase 3 id flip via the persisted entity id', async () => {
+    const { topoId, nodeAId, linkKey } = await fixture('mm-flip-link')
+    await svc.updateMapping(topoId, {
+      nodes: { [nodeAId]: { hostId: '42', hostName: 'hostA' } },
+      links: { [linkKey]: { monitoredNodeId: nodeAId, interface: 'Gi0/1', bandwidth: 1000 } },
+    })
+    // The persisted payload references the monitored node by ENTITY id, not the
+    // (flip-unstable) element id — the poller looks the projected id up in
+    // mapping.nodes, so it must be a current node id.
+    const m = (await svc.getParsed(topoId))?.mapping
+    expect(m?.links?.[linkKey]?.monitoredNodeId).toBe(nodeAId)
+    expect(Object.keys(m?.nodes ?? {})).toContain(m?.links?.[linkKey]?.monitoredNodeId)
+  })
+
+  test('legacy pre-flip link row self-heals: stale monitoredNodeId → current id via interface', async () => {
+    const { topoId, nodeAId, linkKey, metricsId } = await fixture('mm-legacy')
+    const parsed = await svc.getParsed(topoId)
+    const entityId = parsed?.graph.links.find((l) => (l.id ?? '') === linkKey)?.entityId ?? ''
+    // Simulate a row written BEFORE Phase 3: payload carries a now-stale element
+    // id and NO monitoredNodeEntityId; the interface names the monitored port
+    // (node 'a' has port ifName Gi0/1).
+    getDatabase()
+      .query(
+        `INSERT OR REPLACE INTO metrics_mapping
+           (topology_id, entity_id, kind, source_id, payload_json, created_at, updated_at)
+         VALUES (?, ?, 'link', ?, ?, 0, 0)`,
+      )
+      .run(
+        topoId,
+        entityId,
+        metricsId,
+        JSON.stringify({ monitoredNodeId: 'discovered:STALE', interface: 'Gi0/1', bandwidth: 500 }),
+      )
+    svc.clearCacheEntry(topoId)
+
+    const emitted = (await svc.getParsed(topoId))?.mapping?.links?.[linkKey]?.monitoredNodeId
+    // Recovered to the CURRENT monitored node id, never the stale reference.
+    expect(emitted).not.toBe('discovered:STALE')
+    expect(emitted).toBe(nodeAId)
+  })
+
   test('skipped counts stay honest (element with no stable entity id)', async () => {
     const topo = await svc.create({ name: 'mm-skip' })
     // A node with NO identity gets no entityId, so its mapping can't be keyed.


### PR DESCRIPTION
Closes #551 (Phase 3 of #547; design #546). Builds on Phase 1 (#558) / Phase 2 (#560).

## What

The resolved graph's `node.id` and `link.id` become their stable registry entity ids (ULIDs); `link.from/to.node` rewritten to match. **Ports keep name ids** (`ge-0/0/1`) + their `entityId` field — port ids ARE interface names and several paths (Phase 0 ifName stamping, zabbix interface matching, mapping `interface` fallback) depend on that. Unstamped elements keep their original id (graceful degradation). Naming lives in `label` (K8s name/uid split).

The flip runs after entityId stamping in `completeDerivation` (worker stays pure); graph + layout + resolved artifact are flipped in lockstep via one shared oldId→newId map, and `RESOLVER_VERSION` 19→20 forces old artifacts to rebake.

## Audit-driven migrations

- **metrics_mapping**: rows persist the monitored node by ENTITY id; `buildMapping` re-derives the current element id (alias-followed), with legacy pre-flip rows self-healing via the interface name. (This was the live-verification catch — see below.)
- **Share projections**: nothing persisted → stateless re-emit, no migration.
- **Discovery-policy overlay**: identity relookup when a stored resolved id misses (lossless vs a risky bulk rewrite).
- **metrics_history/trends**: keys rotate at the upgrade (no id-keyed reader exists; documented).

## Live verification (NetBox demo, 50 nodes / 99 links)

| check | result |
|---|---|
| node/link ids are ULIDs; ports keep names | 50/50 · 99/99 · 198/198 |
| endpoints consistent | 99/99 |
| **ids stable across blank+rebuild** | identical both runs |
| viewer renders (ULID join) | 50 nodes / 99 links |
| mapping survives + keys ULID | 50/99 |
| **poller → weathermap** (after the fix below) | **99/99 links live** |

## Live-verification catch (fixed in `d270ab59`)

First pass: the poller went dead (0 link metrics) — link rows stored the monitored node by its now-stale element id. Fixed to persist + re-derive by entity id, with legacy-row self-heal via interface matching; regression tests added (row-survives-flip, legacy-row-self-heals). Re-verified: `monitoredNodeId` misses 99→0, weathermap 99/99 live.

Tests: server-api 109/109 (flip, id-stability, mapping round-trip, discovery-policy identity anchor, + 2 new self-heal tests), web check clean, typecheck/biome clean.

Implemented by a Sonnet subagent; the flip audit + monitored-id fix reviewed and live-verified by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj