### PR TITLE
feat(server): resolve link auto-map on the server via port identity

### DIFF
--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -570,6 +570,22 @@ export function createTopologiesApi(): Hono {
     }
   })
 
+  // Server-side link auto-map: resolves interface via port identity, writes mapping rows.
+  app.post('/:id/mapping/auto-map-links', async (c) => {
+    const id = c.req.param('id')
+    try {
+      const body = (await c.req.json().catch(() => ({}))) as { overwrite?: boolean }
+      if (!service.get(id)) return c.json({ error: 'Topology not found' }, 404)
+      const result = await service.autoMapLinks(id, dataSourceService, {
+        overwrite: body.overwrite ?? false,
+      })
+      return c.json(result)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 400)
+    }
+  })
+
   /**
    * Sync ALL topology-purpose sources — as a TRACKED JOB.
    *

--- a/apps/server/api/src/services/link-automap.test.ts
+++ b/apps/server/api/src/services/link-automap.test.ts
@@ -5,11 +5,38 @@
 import type { LinkMetricsMapping } from '@shumoku/core'
 import { describe, expect, it } from 'vitest'
 import {
+  extractInterfaceNames,
   type LinkAutoMapDeps,
   matchInterface,
   type PlannableLink,
   planLinkAutoMap,
 } from './link-automap.js'
+
+describe('extractInterfaceNames', () => {
+  it('prefers the structured interfaceName over the decorated item name', () => {
+    const items = [
+      { name: 'Interface ge-0/0/1: Bits received', interfaceName: 'ge-0/0/1' },
+      { name: 'Interface ge-0/0/1: Bits sent', interfaceName: 'ge-0/0/1' },
+      { name: 'Interface ge-0/0/2: Bits received', interfaceName: 'ge-0/0/2' },
+    ]
+    // Deduped (in + out share one interface) — this is what a port identity
+    // matches against; the full item name never would.
+    expect(extractInterfaceNames(items)).toEqual(['ge-0/0/1', 'ge-0/0/2'])
+  })
+
+  it('strips the decoration when interfaceName is absent', () => {
+    expect(
+      extractInterfaceNames([
+        { name: 'Interface GigabitEthernet0/1: Bits received' },
+        { name: 'GigabitEthernet0/2 - Inbound' },
+      ]),
+    ).toEqual(['GigabitEthernet0/1', 'GigabitEthernet0/2'])
+  })
+
+  it('falls back to the raw name for an undecorated item', () => {
+    expect(extractInterfaceNames([{ name: 'eth0' }])).toEqual(['eth0'])
+  })
+})
 
 describe('matchInterface', () => {
   it('returns null for empty candidates', () => {

--- a/apps/server/api/src/services/link-automap.test.ts
+++ b/apps/server/api/src/services/link-automap.test.ts
@@ -1,0 +1,203 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import type { LinkMetricsMapping } from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import {
+  type LinkAutoMapDeps,
+  matchInterface,
+  type PlannableLink,
+  planLinkAutoMap,
+} from './link-automap.js'
+
+describe('matchInterface', () => {
+  it('returns null for empty candidates', () => {
+    expect(matchInterface(['GE0/1'], [])).toBeNull()
+  })
+
+  it('returns null for empty port names', () => {
+    expect(matchInterface([], ['GigabitEthernet0/1'])).toBeNull()
+  })
+
+  it('exact case-insensitive match', () => {
+    expect(matchInterface(['GE0/1'], ['ge0/1', 'GE0/2'])).toBe('ge0/1')
+  })
+
+  it('normalised fuzzy match: GE0/1 matches GigabitEthernet0/1', () => {
+    expect(matchInterface(['GE0/1'], ['GigabitEthernet0/1', 'GigabitEthernet0/2'])).toBe(
+      'GigabitEthernet0/1',
+    )
+  })
+
+  it('normalised fuzzy match: ifName takes priority over label', () => {
+    // port.identity.ifName is listed before port.label in the candidates array
+    expect(matchInterface(['GE0/1', 'port-A'], ['GigabitEthernet0/1', 'GigabitEthernet0/2'])).toBe(
+      'GigabitEthernet0/1',
+    )
+  })
+
+  it('number-sequence cross-vocabulary fallback: unique number match', () => {
+    // hg0/1 and Ethernet0/1 share numbers [0,1]; only one candidate
+    expect(matchInterface(['hg0/1'], ['Ethernet0/1'])).toBe('Ethernet0/1')
+  })
+
+  it('returns null when no match at threshold', () => {
+    expect(matchInterface(['GE0/1'], ['GigabitEthernet1/2', 'GigabitEthernet2/3'])).toBeNull()
+  })
+
+  it('perfect number match wins over partial', () => {
+    const candidates = ['GigabitEthernet0/0/1', 'GigabitEthernet0/1']
+    // GE0/1 should match GigabitEthernet0/1 (shorter, same numbers)
+    expect(matchInterface(['GE0/1'], candidates)).toBe('GigabitEthernet0/1')
+  })
+})
+
+// ------------------------------------------------------------------------
+// planLinkAutoMap — the pure decision core of server-side link auto-map.
+// ------------------------------------------------------------------------
+
+/** Build deps from a nodeId→hostId map, an endpoint→port-names map, and a
+ *  hostId→interface-names map. Endpoints are keyed `${nodeId}:${portId}`. */
+function makeDeps(
+  hostByNode: Record<string, string>,
+  portCandidates: Record<string, string[]>,
+  ifacesByHost: Record<string, string[]>,
+): LinkAutoMapDeps {
+  return {
+    hostForNode: (nodeId) => hostByNode[nodeId],
+    portCandidates: (nodeId, portId) => portCandidates[`${nodeId}:${portId}`] ?? [],
+    interfacesForHost: (hostId) => ifacesByHost[hostId] ?? [],
+  }
+}
+
+function link(key: string, from: [string, string], to: [string, string]): PlannableLink {
+  return {
+    key,
+    from: { node: from[0], port: from[1] },
+    to: { node: to[0], port: to[1] },
+  }
+}
+
+describe('planLinkAutoMap', () => {
+  it('resolves the monitored endpoint + interface by port identity', () => {
+    const deps = makeDeps(
+      { sw1: 'host-1', sw2: 'host-2' },
+      { 'sw1:GE0/1': ['GE0/1'], 'sw2:GE0/2': ['GE0/2'] },
+      { 'host-1': ['GigabitEthernet0/1'], 'host-2': ['GigabitEthernet0/2'] },
+    )
+    const plan = planLinkAutoMap([link('l0', ['sw1', 'GE0/1'], ['sw2', 'GE0/2'])], {}, deps)
+    expect(plan.matched).toBe(1)
+    expect(plan.skipped).toBe(0)
+    // from-endpoint (sw1) is tried first and resolves → it's the monitored node.
+    expect(plan.resolved.l0).toEqual({
+      monitoredNodeId: 'sw1',
+      interface: 'GigabitEthernet0/1',
+    })
+  })
+
+  it('falls back to the to-endpoint when the from-endpoint has no match', () => {
+    const deps = makeDeps(
+      { sw1: 'host-1', sw2: 'host-2' },
+      { 'sw1:GE0/1': ['GE0/1'], 'sw2:GE0/2': ['GE0/2'] },
+      // host-1 reports nothing matching sw1's port; host-2 matches sw2's.
+      { 'host-1': ['Loopback0'], 'host-2': ['GigabitEthernet0/2'] },
+    )
+    const plan = planLinkAutoMap([link('l0', ['sw1', 'GE0/1'], ['sw2', 'GE0/2'])], {}, deps)
+    expect(plan.matched).toBe(1)
+    expect(plan.resolved.l0?.monitoredNodeId).toBe('sw2')
+    expect(plan.resolved.l0?.interface).toBe('GigabitEthernet0/2')
+  })
+
+  it('skips a link with no mapped endpoint (not counted as skipped)', () => {
+    const deps = makeDeps({}, {}, {})
+    const plan = planLinkAutoMap([link('l0', ['sw1', 'GE0/1'], ['sw2', 'GE0/2'])], {}, deps)
+    expect(plan.matched).toBe(0)
+    expect(plan.skipped).toBe(0) // "skipped" is reserved for already-mapped links
+    expect(plan.resolved.l0).toBeUndefined()
+  })
+
+  it('leaves a link with no resolvable interface unmatched', () => {
+    const deps = makeDeps(
+      { sw1: 'host-1' },
+      { 'sw1:GE0/1': ['GE0/1'] },
+      { 'host-1': ['Serial0', 'Loopback0'] }, // nothing matches GE0/1
+    )
+    const plan = planLinkAutoMap([link('l0', ['sw1', 'GE0/1'], ['sw2', 'GE0/2'])], {}, deps)
+    expect(plan.matched).toBe(0)
+    expect(plan.resolved.l0).toBeUndefined()
+  })
+
+  it('respects overwrite:false — a fully-mapped link is skipped, not re-matched', () => {
+    const deps = makeDeps(
+      { sw1: 'host-1' },
+      { 'sw1:GE0/1': ['GE0/1'] },
+      { 'host-1': ['GigabitEthernet0/1'] },
+    )
+    const existing: Record<string, LinkMetricsMapping> = {
+      l0: { monitoredNodeId: 'sw1', interface: 'manual-choice' },
+    }
+    const plan = planLinkAutoMap([link('l0', ['sw1', 'GE0/1'], ['sw2', 'GE0/2'])], existing, deps)
+    expect(plan.matched).toBe(0)
+    expect(plan.skipped).toBe(1)
+    expect(plan.resolved.l0).toBeUndefined() // untouched
+  })
+
+  it('overwrite:true re-matches a fully-mapped link', () => {
+    const deps = makeDeps(
+      { sw1: 'host-1' },
+      { 'sw1:GE0/1': ['GE0/1'] },
+      { 'host-1': ['GigabitEthernet0/1'] },
+    )
+    const existing: Record<string, LinkMetricsMapping> = {
+      l0: { monitoredNodeId: 'sw1', interface: 'stale' },
+    }
+    const plan = planLinkAutoMap([link('l0', ['sw1', 'GE0/1'], ['sw2', 'GE0/2'])], existing, deps, {
+      overwrite: true,
+    })
+    expect(plan.matched).toBe(1)
+    expect(plan.skipped).toBe(0)
+    expect(plan.resolved.l0?.interface).toBe('GigabitEthernet0/1')
+  })
+
+  it('preserves an existing bandwidth override when it re-matches', () => {
+    const deps = makeDeps(
+      { sw1: 'host-1' },
+      { 'sw1:GE0/1': ['GE0/1'] },
+      { 'host-1': ['GigabitEthernet0/1'] },
+    )
+    // A link with a bandwidth override but no interface yet → eligible to match.
+    const existing: Record<string, LinkMetricsMapping> = { l0: { bandwidth: 10_000_000_000 } }
+    const plan = planLinkAutoMap([link('l0', ['sw1', 'GE0/1'], ['sw2', 'GE0/2'])], existing, deps)
+    expect(plan.matched).toBe(1)
+    expect(plan.resolved.l0).toEqual({
+      bandwidth: 10_000_000_000,
+      monitoredNodeId: 'sw1',
+      interface: 'GigabitEthernet0/1',
+    })
+  })
+
+  it('counts matched/skipped across a mix of links', () => {
+    const deps = makeDeps(
+      { a: 'ha', b: 'hb' },
+      { 'a:GE0/1': ['GE0/1'], 'b:GE0/2': ['GE0/2'] },
+      { ha: ['GigabitEthernet0/1'], hb: ['GigabitEthernet0/2'] },
+    )
+    const existing: Record<string, LinkMetricsMapping> = {
+      done: { monitoredNodeId: 'a', interface: 'already' },
+    }
+    const plan = planLinkAutoMap(
+      [
+        link('fresh', ['a', 'GE0/1'], ['b', 'GE0/2']),
+        link('done', ['a', 'GE0/1'], ['b', 'GE0/2']),
+        link('unmapped', ['x', 'GE9/9'], ['y', 'GE9/9']),
+      ],
+      existing,
+      deps,
+    )
+    expect(plan.matched).toBe(1) // fresh
+    expect(plan.skipped).toBe(1) // done (already mapped, overwrite false)
+    // unmapped contributes to neither counter
+    expect(Object.keys(plan.resolved)).toEqual(['fresh'])
+  })
+})

--- a/apps/server/api/src/services/link-automap.ts
+++ b/apps/server/api/src/services/link-automap.ts
@@ -116,6 +116,28 @@ function ifMatchScore(a: NormalizedIf, b: NormalizedIf): number {
  *
  * Returns the matched candidate name, or null if nothing resolves.
  */
+/**
+ * The distinct INTERFACE NAMES a host's metric items describe. Metric sources
+ * report per-direction items whose `name` is decorated ("Interface ge-0/0/1:
+ * Bits received") — matching a port identity against that full string never
+ * hits. Prefer the structured `interfaceName`; otherwise strip the
+ * "Interface …: Bits …/- Inbound/Outbound" decoration; else use the raw name.
+ * Deduped (in + out share one interface).
+ */
+export function extractInterfaceNames(
+  items: readonly { name: string; interfaceName?: string }[],
+): string[] {
+  const names = new Set<string>()
+  for (const it of items) {
+    const ifName =
+      it.interfaceName ??
+      it.name.match(/^(?:Interface\s+)?(.+?)\s*[-:]\s*(?:Bits|Inbound|Outbound)/i)?.[1]?.trim() ??
+      it.name
+    if (ifName) names.add(ifName)
+  }
+  return [...names]
+}
+
 export function matchInterface(portNames: string[], candidates: string[]): string | null {
   if (candidates.length === 0 || portNames.length === 0) return null
 

--- a/apps/server/api/src/services/link-automap.ts
+++ b/apps/server/api/src/services/link-automap.ts
@@ -1,0 +1,243 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Server-side link interface matching for auto-map-links.
+ *
+ * Mirrors the normalization logic in apps/server/web/src/lib/auto-mapping.ts
+ * but runs on the API server where browser-side stores are unavailable.
+ * Kept intentionally minimal: the primary resolution path is identity-key
+ * exact match (port.id / port.identity.ifName); fuzzy normalization is a
+ * fallback for cross-vocabulary names (e.g. NetBox "GE0/1" vs Zabbix "Gi1/0/1").
+ */
+
+import type { LinkMetricsMapping } from '@shumoku/core'
+
+// Interface-name prefix synonyms (canonical → set of synonyms including canonical).
+// Kept in sync with the browser auto-mapping.ts prefix groups.
+const PREFIX_SYNONYMS: [string[], string][] = [
+  [['eighthundredgigabitethernet', 'eighthundredgigabitether', 'eighthundredgige', 'ehg'], 'ehge'],
+  [['fourhundredgigabitethernet', 'fourhundredgigabitether', 'fourhundredgige', 'fhg'], 'fhge'],
+  [['hundredgigabitethernet', 'hundredgigabitether', 'hundredgige', 'hu', 'hg'], 'hge'],
+  [['fortygigabitethernet', 'fortygigabitether', 'fortygige', 'fo', 'fg'], 'fge'],
+  [['twentyfivegigabitethernet', 'twentyfivegige'], 'xxge'],
+  [
+    ['tengigabitethernet', 'tengigabitether', 'tengigaethernet', 'tenge', 'te', 'xge', 'xe', 'xg'],
+    'te',
+  ],
+  [['gigabitethernet', 'gigaethernet', 'gi', 'ge'], 'ge'],
+  [['fastethernet', 'fa', 'fe'], 'fe'],
+  [['ethernet', 'ens', 'enp', 'eno', 'eth', 'en'], 'eth'],
+  [['port-channel', 'portchannel', 'po', 'ae', 'bond'], 'lag'],
+  [['vlan', 'vl', 'irb'], 'vlan'],
+  [['loopback', 'lo'], 'lo'],
+  [['tunnel', 'tu', 'tun'], 'tun'],
+  [['management', 'mgmt', 'me'], 'mgmt'],
+  [['wireless', 'wifi', 'wlan'], 'wlan'],
+  [['wired'], 'wired'],
+  [['serial', 'se'], 'serial'],
+  [['bvi'], 'bvi'],
+]
+
+const SORTED_PREFIX_SYNONYMS = PREFIX_SYNONYMS.map(
+  ([synonyms, canonical]) =>
+    [synonyms.slice().sort((a, b) => b.length - a.length), canonical] as [string[], string],
+)
+
+interface NormalizedIf {
+  prefix: string
+  numbers: number[]
+}
+
+function normalizeIfName(name: string): NormalizedIf {
+  const lower = name.toLowerCase().trim()
+  let prefix = ''
+  let prefixLen = 0
+  let rest = lower
+
+  for (const [synonyms, canonical] of SORTED_PREFIX_SYNONYMS) {
+    for (const syn of synonyms) {
+      if (lower.startsWith(syn) && syn.length > prefixLen) {
+        prefix = canonical
+        prefixLen = syn.length
+        rest = lower.slice(syn.length)
+      }
+    }
+  }
+
+  if (!prefix) {
+    const m = lower.match(/^([a-z][a-z-]*)(.*)$/)
+    if (m?.[1] && m[2]) {
+      prefix = m[1]
+      rest = m[2]
+    } else {
+      return { prefix: lower, numbers: [] }
+    }
+  }
+
+  rest = rest.replace(/^[^0-9]*/, '')
+  const numbers: number[] = []
+  if (rest) {
+    for (const seg of rest.split('/')) {
+      const main = parseInt(seg.split('.')[0] ?? '', 10)
+      if (!Number.isNaN(main)) numbers.push(main)
+    }
+  }
+  return { prefix, numbers }
+}
+
+function ifMatchScore(a: NormalizedIf, b: NormalizedIf): number {
+  if (a.prefix !== b.prefix) return 0
+  if (a.numbers.length === 0 && b.numbers.length === 0) return 1.0
+  if (a.numbers.length === 0 || b.numbers.length === 0) return 0.3
+  const aRev = [...a.numbers].reverse()
+  const bRev = [...b.numbers].reverse()
+  const minLen = Math.min(aRev.length, bRev.length)
+  let matched = 0
+  for (let i = 0; i < minLen; i++) {
+    if (aRev[i] === bRev[i]) matched++
+    else break
+  }
+  if (matched === 0) return 0
+  const maxLen = Math.max(aRev.length, bRev.length)
+  return matched === maxLen ? 1.0 : 0.5 + (matched / maxLen) * 0.4
+}
+
+/**
+ * Find the best matching interface name from `candidates` for a port
+ * described by `portNames` (id / ifName / label, in preference order).
+ *
+ * Match priority:
+ *   1. Exact name match (case-insensitive) — covers identity-key matches
+ *      (port.id IS the ifName for inventory sources)
+ *   2. Normalised prefix+number match (cross-vocabulary; score >= 0.5)
+ *   3. Number-sequence match as cross-vocabulary fallback (exactly one candidate)
+ *
+ * Returns the matched candidate name, or null if nothing resolves.
+ */
+export function matchInterface(portNames: string[], candidates: string[]): string | null {
+  if (candidates.length === 0 || portNames.length === 0) return null
+
+  // 1. Exact match (case-insensitive)
+  const lowerCandidates = candidates.map((c) => c.toLowerCase())
+  for (const name of portNames) {
+    const lower = name.toLowerCase()
+    const idx = lowerCandidates.indexOf(lower)
+    if (idx !== -1) return candidates[idx] ?? null
+  }
+
+  // 2. Normalised fuzzy match
+  let bestScore = 0
+  let bestCandidate: string | null = null
+  const normCandidates = candidates.map((c) => normalizeIfName(c))
+  for (const name of portNames) {
+    const normPort = normalizeIfName(name)
+    for (const [i, normC] of normCandidates.entries()) {
+      const score = ifMatchScore(normPort, normC)
+      if (score > bestScore) {
+        bestScore = score
+        bestCandidate = candidates[i] ?? null
+      }
+    }
+  }
+  if (bestScore >= 0.5) return bestCandidate
+
+  // 3. Number-sequence fallback: if exactly one candidate shares the number
+  //    sequence with any port name candidate, accept it (cross-vocabulary).
+  for (const name of portNames) {
+    const normPort = normalizeIfName(name)
+    if (normPort.numbers.length === 0) continue
+    const want = normPort.numbers.join('/')
+    const hits = candidates.filter((c) => normalizeIfName(c).numbers.join('/') === want)
+    if (hits.length === 1) return hits[0] ?? null
+  }
+
+  return null
+}
+
+// ============================================
+// Link auto-map planning (pure)
+// ============================================
+
+/** A link the planner iterates: its stable key + both endpoints. */
+export interface PlannableLink {
+  key: string
+  from: { node: string; port: string }
+  to: { node: string; port: string }
+}
+
+/**
+ * Inputs the planner needs, injected so the decision logic is a pure function
+ * (no DB / network): which host a node is mapped to, the port-identity
+ * candidates for an endpoint, and the interface names a host reports.
+ */
+export interface LinkAutoMapDeps {
+  /** hostId a node is mapped to (undefined = not mapped). */
+  hostForNode: (nodeId: string) => string | undefined
+  /** Identity-key candidates for an endpoint port (id / ifName / label / aliases). */
+  portCandidates: (nodeId: string, portId: string) => string[]
+  /** Interface names the metrics source reports for a host. */
+  interfacesForHost: (hostId: string) => string[]
+}
+
+/** What {@link planLinkAutoMap} decided, ready to fold into a mapping + summary. */
+export interface LinkAutoMapPlan {
+  /** New/updated link mappings, keyed by link key. Only the matched links. */
+  resolved: Record<string, LinkMetricsMapping>
+  matched: number
+  /** Links skipped because already fully mapped and `overwrite` was false. */
+  skipped: number
+}
+
+/**
+ * Decide, for each link, which endpoint to monitor and which interface — the
+ * deterministic core of server-side link auto-map, kept pure so it's testable
+ * without a DB. For a link with at least one mapped endpoint it tries the
+ * from-endpoint first, then the to-endpoint; the monitored end is the first
+ * whose port identity ({@link matchInterface}) resolves to one of that host's
+ * interfaces. A link already carrying both a monitored node AND an interface is
+ * left untouched (and counted as skipped) unless `overwrite` is set. Links with
+ * no mapped endpoint, or no resolvable interface, are simply not in `resolved`.
+ */
+export function planLinkAutoMap(
+  links: readonly PlannableLink[],
+  existing: Record<string, LinkMetricsMapping>,
+  deps: LinkAutoMapDeps,
+  opts: { overwrite?: boolean } = {},
+): LinkAutoMapPlan {
+  const resolved: Record<string, LinkMetricsMapping> = {}
+  let matched = 0
+  let skipped = 0
+
+  for (const link of links) {
+    const prior = existing[link.key]
+    // Respect overwrite:false — leave a fully-mapped link alone.
+    if (!opts.overwrite && prior?.monitoredNodeId && prior.interface) {
+      skipped++
+      continue
+    }
+
+    // Ordered from-then-to; only endpoints whose node is mapped to a host.
+    const toTry: { nodeId: string; portId: string; hostId: string }[] = []
+    const fromHost = deps.hostForNode(link.from.node)
+    const toHost = deps.hostForNode(link.to.node)
+    if (fromHost) toTry.push({ nodeId: link.from.node, portId: link.from.port, hostId: fromHost })
+    if (toHost) toTry.push({ nodeId: link.to.node, portId: link.to.port, hostId: toHost })
+    if (toTry.length === 0) continue // no mapped endpoint
+
+    for (const ep of toTry) {
+      const iface = matchInterface(
+        deps.portCandidates(ep.nodeId, ep.portId),
+        deps.interfacesForHost(ep.hostId),
+      )
+      if (iface) {
+        resolved[link.key] = { ...(prior ?? {}), monitoredNodeId: ep.nodeId, interface: iface }
+        matched++
+        break
+      }
+    }
+  }
+
+  return { resolved, matched, skipped }
+}

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -64,6 +64,7 @@ import type {
   TopologyInput,
 } from '../types.js'
 import { buildGraph, ingestGraph } from './contribution-store.js'
+import type { DataSourceService } from './datasource.js'
 import { isDeriving, kickDerivation } from './derivation.js'
 import {
   adoptOrMintForGraph,
@@ -71,6 +72,8 @@ import {
   resolveEntityAlias,
   stampEntityIds,
 } from './entity-registry.js'
+import { planLinkAutoMap } from './link-automap.js'
+import { TopologySourcesService } from './topology-sources.js'
 
 /**
  * How long `getParsed` waits for an in-flight bake before falling back to
@@ -93,8 +96,6 @@ const DERIVE_WAIT_MS = 3_000
  * source. Curation never spawns a Manual source — it writes the project overlay.
  */
 const PROJECT_SOURCE = 'intrinsic'
-
-import { TopologySourcesService } from './topology-sources.js'
 
 /** Bare topology row — no content_json column post-migration-010. */
 interface TopologyRow {
@@ -1671,6 +1672,86 @@ export class TopologyService {
       })
     }
     return orphans
+  }
+
+  /**
+   * Server-side link auto-map: for each unmapped link whose endpoint nodes are
+   * mapped to hosts, resolves the monitored endpoint + interface by matching the
+   * endpoint port's identity keys (id / ifName / label) against the metrics
+   * source's reported interfaces. Writes via updateMapping so results are
+   * entity-keyed and durable. Returns a summary { matched, total, skipped }.
+   *
+   * The `overwrite` option controls whether links that already have both a
+   * monitored node and an interface set are re-matched (true) or skipped (false).
+   */
+  async autoMapLinks(
+    id: string,
+    dataSourceService: DataSourceService,
+    opts: { overwrite?: boolean } = {},
+  ): Promise<{ matched: number; total: number; skipped: number }> {
+    const parsed = await this.getParsed(id)
+    if (!parsed) throw new Error('topology not resolved; cannot auto-map links')
+    const total = parsed.graph.links.length
+    const sourceId = this.metricsSourceIdFor(id)
+    if (!sourceId) return { matched: 0, total, skipped: 0 }
+
+    const currentMapping = parsed.mapping ?? { nodes: {}, links: {} }
+    const nodeById = new Map(parsed.graph.nodes.map((n) => [n.id, n]))
+    // hostId keyed by nodeId, from the current node mapping.
+    const hostByNode = new Map<string, string>()
+    for (const [nodeId, nm] of Object.entries(currentMapping.nodes ?? {})) {
+      if (nm.hostId) hostByNode.set(nodeId, nm.hostId)
+    }
+
+    // Pre-fetch every referenced host's interface list ONCE (server-side, no
+    // per-link browser round-trips — the whole point of this endpoint). The
+    // planner then runs purely against these lists.
+    const ifacesByHost = new Map<string, string[]>()
+    for (const hostId of new Set(hostByNode.values())) {
+      const items = await dataSourceService.getHostItems(sourceId, hostId)
+      ifacesByHost.set(
+        hostId,
+        items.map((it) => it.name),
+      )
+    }
+
+    // Port identity candidates for an endpoint: id (== ifName for inventory
+    // sources), identity.ifName, label, and aliases — in preference order.
+    const portCandidates = (nodeId: string, portId: string): string[] => {
+      const port = nodeById.get(nodeId)?.ports?.find((p) => p.id === portId)
+      if (!port) return portId ? [portId] : []
+      const label = Array.isArray(port.label) ? port.label[0] : port.label
+      return [port.id, port.identity?.ifName, label, ...(port.aliases ?? [])].filter(
+        (s): s is string => typeof s === 'string' && s.length > 0,
+      )
+    }
+
+    const plan = planLinkAutoMap(
+      parsed.graph.links.map((link, i) => ({
+        key: link.id || `link-${i}`,
+        from: { node: link.from.node, port: link.from.port ?? '' },
+        to: { node: link.to.node, port: link.to.port ?? '' },
+      })),
+      currentMapping.links ?? {},
+      {
+        hostForNode: (nodeId) => hostByNode.get(nodeId),
+        portCandidates,
+        interfacesForHost: (hostId) => ifacesByHost.get(hostId) ?? [],
+      },
+      { overwrite: opts.overwrite ?? false },
+    )
+
+    // Fold the resolved links onto the current mapping and persist via
+    // updateMapping so rows are entity-keyed (Phase 2) and durable (Phase 3).
+    if (plan.matched > 0) {
+      const newMapping: MetricsMapping = {
+        nodes: { ...(currentMapping.nodes ?? {}) },
+        links: { ...(currentMapping.links ?? {}), ...plan.resolved },
+      }
+      await this.updateMapping(id, newMapping)
+    }
+
+    return { matched: plan.matched, total, skipped: plan.skipped }
   }
 
   /** Current composition revision for a topology (0 if column/row missing). */

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -72,7 +72,7 @@ import {
   resolveEntityAlias,
   stampEntityIds,
 } from './entity-registry.js'
-import { planLinkAutoMap } from './link-automap.js'
+import { extractInterfaceNames, planLinkAutoMap } from './link-automap.js'
 import { TopologySourcesService } from './topology-sources.js'
 
 /**
@@ -1709,10 +1709,9 @@ export class TopologyService {
     const ifacesByHost = new Map<string, string[]>()
     for (const hostId of new Set(hostByNode.values())) {
       const items = await dataSourceService.getHostItems(sourceId, hostId)
-      ifacesByHost.set(
-        hostId,
-        items.map((it) => it.name),
-      )
+      // The INTERFACE NAME is what port identities match — never the full,
+      // per-direction item `name` (see extractInterfaceNames).
+      ifacesByHost.set(hostId, extractInterfaceNames(items))
     }
 
     // Port identity candidates for an endpoint: id (== ifName for inventory

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -269,6 +269,15 @@ export const topologies = {
       body: JSON.stringify(mapping),
     }),
 
+  autoMapLinks: (id: string, body?: { overwrite?: boolean }) =>
+    request<{ matched: number; total: number; skipped: number }>(
+      `/topologies/${id}/mapping/auto-map-links`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body ?? {}),
+      },
+    ),
+
   renderSvg: async (id: string): Promise<string> => {
     const response = await fetch(`${BASE_URL}/topologies/${id}/render`)
     if (!response.ok) {

--- a/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
@@ -6,19 +6,18 @@
    * the per-node up/down indicators.
    *
    * Auto-map: best-effort match by name/label/alias against host
-   * interfaces. The operator can flip a "single candidate fallback"
-   * toggle to also accept "the host has exactly one interface, use it".
+   * interfaces. Link auto-map delegates to the server endpoint
+   * (POST /mapping/auto-map-links) which matches port identity keys
+   * against the metrics source's reported interfaces server-side.
    *
    * Saves through `mappingStore` so the diagram view (which reads from
    * the same store) updates without a refresh.
    */
   import { ArrowRightIcon, CheckCircleIcon, FloppyDiskIcon } from 'phosphor-svelte'
   import { api } from '$lib/api'
-  import { findBestInterfaceMatch, matchInterfaceByNeighbor } from '$lib/auto-mapping'
   import { Button } from '$lib/components/ui/button'
   import {
     hostInterfaces,
-    hostNeighbors,
     linkMapping,
     mappingHosts,
     mappingStore,
@@ -73,13 +72,7 @@
     kind: 'nodes' | 'links'
     byIdentity?: number
     byName?: number
-    // Link auto-map only: how many of the hosts it needs already have their
-    // interfaces loaded. Present only on a PARTIAL load, so the message can be
-    // honest that a second press (or a wait) will match the remaining links.
-    hostsLoaded?: number
-    hostsTotal?: number
   } | null>(null)
-  let singleCandidateFallback = $state(true)
   let customBandwidthLinks = $state(new Set<string>())
   let localError = $state('')
   let autoMapTimer: ReturnType<typeof setTimeout> | null = null
@@ -171,7 +164,6 @@
         dataSourceId: contextData.dataSourceId,
         mapping: contextData.mapping,
       }
-      loadInterfacesForMappedNodes()
     } catch (e) {
       localError = e instanceof Error ? e.message : 'Failed to load mapping data'
     }
@@ -189,30 +181,6 @@
     return ep.portInfo?.label || ep.portInfo?.interfaceName || ep.port
   }
 
-  function portMatchCandidates(ep: EdgeEndpoint): string[] {
-    const info = ep.portInfo
-    if (!info) return []
-    return [info.interfaceName, info.label, ...(info.aliases ?? [])].filter((n): n is string => !!n)
-  }
-
-  /** Host ids referenced by a mapped endpoint of any link — what link auto-map
-   *  needs interfaces loaded for. */
-  function mappedLinkHostIds(): Set<string> {
-    const hostIds = new Set<string>()
-    for (const edge of edges) {
-      const fromHostId = $nodeMapping[edge.from.nodeId]?.hostId
-      const toHostId = $nodeMapping[edge.to.nodeId]?.hostId
-      if (fromHostId) hostIds.add(fromHostId)
-      if (toHostId) hostIds.add(toHostId)
-    }
-    return hostIds
-  }
-
-  async function loadInterfacesForMappedNodes() {
-    const hostIds = mappedLinkHostIds()
-    await Promise.all([...hostIds].map((hostId) => mappingStore.loadHostInterfaces(hostId)))
-  }
-
   function handleNodeMappingChange(nodeId: string, hostId: string) {
     const host = $mappingHosts.find((h) => h.id === hostId)
     mappingStore.updateNode(
@@ -228,10 +196,6 @@
       ...mappingStore.autoMapNodes(parsedTopology.graph.nodes, { overwrite: false }),
       kind: 'nodes',
     }
-    // Load interfaces + neighbours for the freshly mapped hosts so a following
-    // link auto-map has data to match against (bulk node mapping doesn't load
-    // them the way the per-node dropdown does).
-    void loadInterfacesForMappedNodes()
     scheduleClearAutoMapResult()
   }
 
@@ -313,108 +277,6 @@
     }
   }
 
-  function nodeForMapping(nodeId: string): { identity?: Identity; label?: string | string[] } {
-    return parsedTopology?.graph.nodes.find((n) => n.id === nodeId) ?? {}
-  }
-
-  /**
-   * Resolve one endpoint's interface: LLDP neighbour first (which local
-   * interface faces the peer), then fuzzy port-name matching. A neighbour hit
-   * is only accepted when it maps to a monitored interface so the link polls.
-   */
-  function resolveLinkInterface(
-    hostId: string | undefined,
-    side: EdgeEndpoint,
-    peerNodeId: string,
-    peerPort: string | undefined,
-    interfaces: Array<{ name: string }>,
-  ): string | null {
-    if (!hostId || interfaces.length === 0) return null
-    const names = interfaces.map((i) => i.name)
-    const neighborIf = matchInterfaceByNeighbor(
-      nodeForMapping(peerNodeId),
-      peerPort,
-      $hostNeighbors[hostId] ?? [],
-    )
-    if (neighborIf) {
-      const resolved = names.includes(neighborIf)
-        ? neighborIf
-        : findBestInterfaceMatch(neighborIf, names, { singleCandidateFallback: false })
-      if (resolved) return resolved
-    }
-    return findMatchingInterface(portMatchCandidates(side), interfaces)
-  }
-
-  function handleAutoMapLinks() {
-    let matched = 0
-    for (const edge of edges) {
-      const fromHostId = $nodeMapping[edge.from.nodeId]?.hostId
-      const toHostId = $nodeMapping[edge.to.nodeId]?.hostId
-      const fromInterfaces = fromHostId ? $hostInterfaces[fromHostId] || [] : []
-      const toInterfaces = toHostId ? $hostInterfaces[toHostId] || [] : []
-      const currentMapping = $linkMapping[edge.id] || {}
-      if (currentMapping.interface) continue
-
-      let monitoredNodeId: string | null = null
-      let matchedInterface = resolveLinkInterface(
-        fromHostId,
-        edge.from,
-        edge.to.nodeId,
-        edge.to.port,
-        fromInterfaces,
-      )
-      if (matchedInterface) {
-        monitoredNodeId = edge.from.nodeId
-      } else {
-        matchedInterface = resolveLinkInterface(
-          toHostId,
-          edge.to,
-          edge.from.nodeId,
-          edge.from.port,
-          toInterfaces,
-        )
-        if (matchedInterface) monitoredNodeId = edge.to.nodeId
-      }
-      if (!matchedInterface) {
-        if (fromHostId && fromInterfaces.length > 0) monitoredNodeId = edge.from.nodeId
-        else if (toHostId && toInterfaces.length > 0) monitoredNodeId = edge.to.nodeId
-      }
-
-      if (monitoredNodeId && matchedInterface) {
-        mappingStore.updateLink(edge.id, {
-          ...currentMapping,
-          monitoredNodeId,
-          interface: matchedInterface,
-        })
-        matched++
-      } else if (monitoredNodeId && !currentMapping.monitoredNodeId) {
-        mappingStore.updateLink(edge.id, { ...currentMapping, monitoredNodeId })
-      }
-    }
-    return matched
-  }
-
-  function findMatchingInterface(
-    portNames: string[],
-    interfaces: Array<{ name: string }>,
-  ): string | null {
-    if (portNames.length === 0) {
-      return singleCandidateFallback && interfaces.length === 1
-        ? (interfaces[0]?.name ?? null)
-        : null
-    }
-    const candidateNames = interfaces.map((i) => i.name)
-    let best: string | null = null
-    for (const name of portNames) {
-      const match = findBestInterfaceMatch(name, candidateNames, { singleCandidateFallback })
-      if (match) {
-        best = match
-        break
-      }
-    }
-    return best
-  }
-
   function scheduleClearAutoMapResult() {
     if (autoMapTimer) clearTimeout(autoMapTimer)
     autoMapTimer = setTimeout(() => {
@@ -423,31 +285,17 @@
     }, 5000)
   }
 
-  // Link auto-map: ensure interfaces + neighbours are loaded for the mapped
-  // hosts first (they load lazily), so it works right after a bulk node auto-map.
+  // Link auto-map: delegates to the server endpoint which fetches host interfaces
+  // and matches port identity keys (id / ifName / label) server-side.
   async function handleLinkAutoMap() {
-    await loadInterfacesForMappedNodes()
-
-    // Be honest about partial loads. Interfaces load lazily and a metrics
-    // source can be slow or fail (loadHostInterfaces leaves failed hosts
-    // absent so they retry on the next press), so a link may go unmatched
-    // simply because its host's interfaces aren't in yet — not because no
-    // interface matches. Count how many needed hosts are actually loaded so
-    // the result can say "press again or wait" instead of implying the
-    // unmatched links have no candidate.
-    const hostIds = mappedLinkHostIds()
-    const loaded = [...hostIds].filter((id) => $hostInterfaces[id] !== undefined).length
-    const allLoaded = loaded >= hostIds.size
-
-    const matched = handleAutoMapLinks()
-    if (matched > 0 || !allLoaded) {
-      autoMapResult = {
-        matched,
-        total: edges.length,
-        kind: 'links',
-        ...(allLoaded ? {} : { hostsLoaded: loaded, hostsTotal: hostIds.size }),
-      }
+    try {
+      const result = await api.topologies.autoMapLinks(ctx.topologyId, { overwrite: false })
+      // Reload the mapping from the server so the UI reflects the persisted state.
+      await mappingStore.load(ctx.topologyId, false)
+      autoMapResult = { matched: result.matched, total: result.total, kind: 'links' }
       scheduleClearAutoMapResult()
+    } catch (e) {
+      localError = e instanceof Error ? e.message : 'Failed to auto-map links'
     }
   }
 </script>
@@ -504,12 +352,6 @@
           <span class="text-muted-foreground">
             ({autoMapResult.byIdentity}
             by identity, {autoMapResult.byName} by name)
-          </span>
-        {/if}
-        {#if autoMapResult.hostsTotal !== undefined}
-          <span class="text-muted-foreground">
-            (interfaces loaded for {autoMapResult.hostsLoaded}/{autoMapResult.hostsTotal}
-            hosts — press again or wait to match the rest)
           </span>
         {/if}
       </div>
@@ -608,12 +450,6 @@
         bind:searchValue={linkSearchQuery}
         searchPlaceholder="Search links..."
       >
-        {#snippet actions()}
-          <label class="flex items-center gap-1.5 text-xs text-theme-text-muted cursor-pointer">
-            <input type="checkbox" bind:checked={singleCandidateFallback} class="rounded">
-            Single candidate fallback
-          </label>
-        {/snippet}
         {#if filteredEdges.length === 0}
           <div class="p-4 text-center text-theme-text-muted">
             {linkSearchQuery ? 'No matching links' : 'No links'}


### PR DESCRIPTION
Closes #556 (metrics Phase C; read-path convergence of the entity-registry idea).

## What

Link auto-map moves from a chatty browser-side fuzzy-name match to a deterministic server-side identity match against the resolved graph.

- **`POST /:id/mapping/auto-map-links`** (`{ overwrite? }`, default false) → `{ matched, total, skipped }`. Pre-fetches each mapped host's interface list ONCE (no per-link browser round-trips — the cause of "converges over repeated presses"), runs a pure planner matching endpoint port identities (`port.id` / `identity.ifName` / `label` / aliases) against the source's interfaces, and persists via `updateMapping` (entity-keyed rows, durable across rebuilds).
- `matchInterface`: exact (case-insensitive) → prefix+number fuzzy → unique number-sequence fallback. `extractInterfaceNames`: interface name from the source's per-direction items.
- **Web**: the button calls the one endpoint; removed the browser round-trip machinery (`handleAutoMapLinks`/`resolveLinkInterface`/`loadInterfacesForMappedNodes`/partial-load messaging). Node auto-map stays client-side (identity-driven).
- LLDP-neighbour preference dropped deliberately (would reintroduce a per-host round-trip); parallel-link disambiguation can be added server-side later.

## Live-verification catch (fixed in `57181b99`)

First pass matched **0/99** — the planner was fed each item's full `name` ("Interface ge-0/0/1: Bits received") instead of the interface name. Extracted `interfaceName` into a pure, unit-tested helper. Re-verified:

| | result |
|---|---|
| auto-map (cleared → run) | 200, **matched 99/99**, 0 monitoredNodeId misses, ~7s single call |
| second run (overwrite:false) | matched 0, **skipped 99** (idempotent) |

Tests: server-api 112 (19 link-automap incl. 3 new extraction tests), web check clean, typecheck/biome clean.

Implemented by a Sonnet subagent; the `interfaceName` extraction bug found + fixed via live verification by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj