### PR TITLE
feat(server): Entity Registry Phase 4 — retire, orphan repair, full reset

### DIFF
--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -501,6 +501,57 @@ export function createTopologiesApi(): Hono {
     }
   })
 
+  // Reassign an orphaned mapping row to a live entity (Phase 4). Moves the
+  // metrics_mapping row to `toEntityId` after validating it exists in the
+  // current resolved graph and its kind matches — the "drift is visible, never
+  // silent" repair action.
+  app.post('/:id/mapping/orphans/:entityId/reassign', async (c) => {
+    const id = c.req.param('id')
+    const entityId = c.req.param('entityId')
+    try {
+      if (!service.get(id)) return c.json({ error: 'Topology not found' }, 404)
+      const body = (await c.req.json()) as { toEntityId?: string }
+      if (!body.toEntityId) return c.json({ error: 'toEntityId is required' }, 400)
+      const result = await service.reassignOrphan(id, entityId, body.toEntityId)
+      if (!result.ok) return c.json({ error: result.error }, 400)
+      return c.json({ success: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 400)
+    }
+  })
+
+  // Discard an orphaned mapping row (Phase 4).
+  app.delete('/:id/mapping/orphans/:entityId', (c) => {
+    const id = c.req.param('id')
+    const entityId = c.req.param('entityId')
+    try {
+      if (!service.get(id)) return c.json({ error: 'Topology not found' }, 404)
+      const deleted = service.discardOrphan(id, entityId)
+      if (!deleted) return c.json({ error: 'Orphan not found' }, 404)
+      return c.json({ success: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 400)
+    }
+  })
+
+  // Full entity-registry reset (Phase 4). DESTRUCTIVE: wipes entity_registry,
+  // its identity keys / aliases / retire counters, AND the metrics_mapping rows
+  // for this topology. The next resolve re-mints fresh entities. Distinct from
+  // Rebuild (which keeps the human/entity layer); guard with a confirm in the UI.
+  app.post('/:id/registry/reset', (c) => {
+    const id = c.req.param('id')
+    try {
+      if (!service.get(id)) return c.json({ error: 'Topology not found' }, 404)
+      service.resetRegistry(id)
+      return c.json({ success: true })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 500)
+    }
+  })
+
   // Update mapping. Returns the topology PLUS `skipped` — how many node/link
   // bindings couldn't be persisted (the source didn't provide identity to anchor
   // them). The UI warns on skipped > 0 instead of reporting a clean save.

--- a/apps/server/api/src/db/migrations/027_entity_retire_counter.sql
+++ b/apps/server/api/src/db/migrations/027_entity_retire_counter.sql
@@ -1,0 +1,13 @@
+-- Phase 4: Entity lifecycle — retire counter.
+-- Tracks consecutive miss counts per (topology, source, entity) so
+-- retireStaleEntities() can retire an entity after RETIRE_THRESHOLD_SYNCS
+-- consecutive absences from a source that DID return data.
+-- entity_id cascades on entity_registry delete so reset/merge clean it up.
+
+CREATE TABLE IF NOT EXISTS entity_retire_counter (
+  topology_id TEXT NOT NULL,
+  source_id   TEXT NOT NULL,
+  entity_id   TEXT NOT NULL REFERENCES entity_registry(id) ON DELETE CASCADE,
+  miss_count  INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (topology_id, source_id, entity_id)
+);

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -31,6 +31,7 @@ import migration023 from './migrations/023_contribution_content_hash.sql'
 import migration024 from './migrations/024_signal_streams.sql'
 import migration025 from './migrations/025_entity_registry.sql'
 import migration026 from './migrations/026_metrics_mapping.sql'
+import migration027 from './migrations/027_entity_retire_counter.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -58,6 +59,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '024_signal_streams.sql', sql: migration024 },
   { name: '025_entity_registry.sql', sql: migration025 },
   { name: '026_metrics_mapping.sql', sql: migration026 },
+  { name: '027_entity_retire_counter.sql', sql: migration027 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/entity-registry.ts
+++ b/apps/server/api/src/services/entity-registry.ts
@@ -271,9 +271,11 @@ function adoptOrMintEntity(
   }
 
   if (matchedIds.length === 1) {
-    // Adopt: update freshness + union new keys
+    // Adopt: update freshness, un-retire if needed, union new keys
     const entityId = matchedIds[0] as string
-    db.query('UPDATE entity_registry SET last_seen_at = ? WHERE id = ?').run(now, entityId)
+    db.query(
+      "UPDATE entity_registry SET last_seen_at = ?, status = 'active', retired_at = NULL WHERE id = ?",
+    ).run(now, entityId)
     for (const { key, value } of keys) {
       db.query(
         `INSERT OR IGNORE INTO entity_identity_key
@@ -306,8 +308,10 @@ function adoptOrMintEntity(
       survivorId,
     )
   }
-  // Refresh survivor + union ALL keys from the new observation
-  db.query('UPDATE entity_registry SET last_seen_at = ? WHERE id = ?').run(now, survivorId)
+  // Refresh survivor (un-retire if needed) + union ALL keys from the new observation
+  db.query(
+    "UPDATE entity_registry SET last_seen_at = ?, status = 'active', retired_at = NULL WHERE id = ?",
+  ).run(now, survivorId)
   for (const { key, value } of keys) {
     db.query(
       `INSERT OR IGNORE INTO entity_identity_key
@@ -338,11 +342,15 @@ function adoptOrMintEntity(
  *   2. Ports  — parent-scoped; requires node entityId.
  *   3. Links  — endpoint port entityIds must be known first.
  */
-export function adoptOrMintForGraph(topologyId: string, sourceId: string, db: Database): void {
+export function adoptOrMintForGraph(
+  topologyId: string,
+  sourceId: string,
+  db: Database,
+  now = timestamp(),
+): number {
   // No contribution rows for this (topology, source) → nothing to register.
   const graph = buildGraph(topologyId, sourceId, db)
-  if (!graph) return
-  const now = timestamp()
+  if (!graph) return now
 
   // --- Nodes ---
   const nodeEntityIds = new Map<string, string>() // nodeLocalId → entityId
@@ -383,6 +391,80 @@ export function adoptOrMintForGraph(topologyId: string, sourceId: string, db: Da
     const linkKey: IdentityKey[] = [{ key: 'endpoints', value: `${pA}|${pB}` }]
     adoptOrMintEntity(topologyId, 'link', '', null, linkKey, now, db)
   }
+  return now
+}
+
+// ---------------------------------------------------------------------------
+// Public API — entity retirement
+// ---------------------------------------------------------------------------
+
+/**
+ * RETIRE_THRESHOLD_SYNCS: number of consecutive source syncs (that returned
+ * data) after which an absent entity is marked 'retired'. Default 3.
+ * Retired entities keep their id — a returning device re-adopts the same id
+ * (the adopt branch resets status to 'active' and clears retired_at).
+ */
+export const RETIRE_THRESHOLD_SYNCS = 3
+
+/**
+ * Retirement pass: called after adoptOrMintForGraph when the source DID
+ * return data (status != 'failed'). Increments miss_count for every active
+ * entity of this topology whose last_seen_at < syncNow (was not adopted in
+ * this sync). Resets miss_count to 0 for entities that WERE seen. Entities
+ * reaching RETIRE_THRESHOLD_SYNCS misses flip to 'retired'.
+ *
+ * Source-failure guard: the CALLER must NOT call this when the source failed.
+ * ObservationsService.materializeContribution skips the 'failed' status path.
+ *
+ * Returns the count of entities retired in this pass.
+ */
+export function retireStaleEntities(
+  topologyId: string,
+  sourceId: string,
+  syncNow: number,
+  db: Database,
+): number {
+  // Reset miss_count to 0 for entities THIS source saw in this sync
+  // (last_seen_at was just advanced to >= syncNow by adopt-or-mint). This is
+  // also what SEEDS a counter row for an entity the first time this source
+  // observes it — so the increment below can be scoped to entities this source
+  // has actually seen before (a source only retires what it once reported;
+  // another source's exclusive entities never get a counter row here).
+  db.query(
+    `INSERT OR REPLACE INTO entity_retire_counter (topology_id, source_id, entity_id, miss_count)
+     SELECT ?, ?, er.id, 0
+     FROM entity_registry er
+     WHERE er.topology_id = ? AND er.status = 'active' AND er.last_seen_at >= ?`,
+  ).run(topologyId, sourceId, topologyId, syncNow)
+
+  // Increment miss_count for entities THIS source previously observed (they
+  // already have a counter row) but did NOT see in this sync (last_seen_at <
+  // syncNow). Scoping to existing counter rows is what keeps a multi-source
+  // topology honest: source A never counts misses against an entity only source
+  // B ever reported. A failed fetch never reaches here (the caller skips it).
+  db.query(
+    `UPDATE entity_retire_counter
+       SET miss_count = miss_count + 1
+     WHERE topology_id = ? AND source_id = ?
+       AND entity_id IN (
+         SELECT er.id FROM entity_registry er
+         WHERE er.topology_id = ? AND er.status = 'active' AND er.last_seen_at < ?
+       )`,
+  ).run(topologyId, sourceId, topologyId, syncNow)
+
+  // Retire entities that have reached the threshold for this source.
+  const result = db
+    .query(
+      `UPDATE entity_registry SET status = 'retired', retired_at = ?
+     WHERE topology_id = ? AND status = 'active'
+       AND id IN (
+         SELECT entity_id FROM entity_retire_counter
+         WHERE topology_id = ? AND source_id = ?
+           AND miss_count >= ?
+       )`,
+    )
+    .run(syncNow, topologyId, topologyId, sourceId, RETIRE_THRESHOLD_SYNCS)
+  return result.changes
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -25,7 +25,7 @@ import { createHash } from 'node:crypto'
 import type { NetworkGraph } from '@shumoku/core'
 import { generateId, getDatabase, timestamp } from '../db/index.js'
 import { ingestGraph } from './contribution-store.js'
-import { adoptOrMintForGraph } from './entity-registry.js'
+import { adoptOrMintForGraph, retireStaleEntities } from './entity-registry.js'
 
 /**
  * Hash of a contribution's STRUCTURAL content: volatile per-scan fields
@@ -271,7 +271,10 @@ export class ObservationsService {
       // that produced identical content, or a lost/never-minted registry row)
       // must be re-established. The mapping now keys off these entities, so a
       // missing one would silently orphan a live binding.
-      adoptOrMintForGraph(input.topologyId, input.sourceId, this.db)
+      const syncNowNoChange = timestamp()
+      adoptOrMintForGraph(input.topologyId, input.sourceId, this.db, syncNowNoChange)
+      // Retire pass: entities absent from this sync get their miss counter bumped.
+      retireStaleEntities(input.topologyId, input.sourceId, syncNowNoChange, this.db)
       return false
     }
     ingestGraph(
@@ -288,7 +291,10 @@ export class ObservationsService {
     )
     // Registers from the post-ingest contribution rows (NOT `graph`) so ports
     // synthesized from link endpoints get entities too — see adoptOrMintForGraph.
-    adoptOrMintForGraph(input.topologyId, input.sourceId, this.db)
+    const syncNow = timestamp()
+    adoptOrMintForGraph(input.topologyId, input.sourceId, this.db, syncNow)
+    // Retire pass: entities absent from this sync get their miss counter bumped.
+    retireStaleEntities(input.topologyId, input.sourceId, syncNow, this.db)
     return true
   }
 

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -1753,6 +1753,84 @@ export class TopologyService {
     return { matched: plan.matched, total, skipped: plan.skipped }
   }
 
+  /**
+   * Reassign an orphaned metrics_mapping row to a live entity (Phase 4).
+   * Validates that the target entity exists in the current resolved graph and
+   * that the orphan and target kinds match. Returns `ok: false` with a reason
+   * when either check fails, so the caller surfaces WHY a repair was refused.
+   */
+  async reassignOrphan(
+    topologyId: string,
+    entityId: string,
+    toEntityId: string,
+  ): Promise<{ ok: boolean; error?: string }> {
+    const parsed = await this.getParsed(topologyId)
+    if (!parsed) return { ok: false, error: 'topology not resolved' }
+
+    // Verify the orphan row exists (nothing to move otherwise).
+    const orphanRow = this.db
+      .query<MetricsMappingRow, [string, string]>(
+        'SELECT entity_id, kind, source_id, payload_json FROM metrics_mapping WHERE topology_id = ? AND entity_id = ?',
+      )
+      .get(topologyId, entityId)
+    if (!orphanRow) return { ok: false, error: 'orphan not found' }
+
+    const { presentEntityIds, nodeByEntity, linkKeyByEntity } = this.indexGraphEntities(
+      parsed.graph,
+    )
+    // Follow aliases so a caller passing a pre-merge id still lands on the survivor.
+    const resolvedTarget = resolveEntityAlias(toEntityId, this.db)
+    if (!presentEntityIds.has(resolvedTarget)) {
+      return { ok: false, error: 'target entity not in current graph' }
+    }
+
+    // Kind must match (node→node, link→link) — a link binding on a node makes
+    // no sense to the poller.
+    if (orphanRow.kind === 'node' && !nodeByEntity.has(resolvedTarget)) {
+      return { ok: false, error: 'kind mismatch: target is not a node' }
+    }
+    if (orphanRow.kind === 'link' && !linkKeyByEntity.has(resolvedTarget)) {
+      return { ok: false, error: 'kind mismatch: target is not a link' }
+    }
+
+    this.db
+      .query('UPDATE metrics_mapping SET entity_id = ? WHERE topology_id = ? AND entity_id = ?')
+      .run(resolvedTarget, topologyId, entityId)
+    // The mapping is re-derived from these rows on every read → only drop the
+    // RAM cache; no resolve/layout re-run needed.
+    this.invalidateMappingCache(topologyId)
+    return { ok: true }
+  }
+
+  /**
+   * Discard an orphaned metrics_mapping row (Phase 4). Returns true when a row
+   * was deleted, false when the entity had no row.
+   */
+  discardOrphan(topologyId: string, entityId: string): boolean {
+    const result = this.db
+      .query('DELETE FROM metrics_mapping WHERE topology_id = ? AND entity_id = ?')
+      .run(topologyId, entityId)
+    if (result.changes > 0) this.invalidateMappingCache(topologyId)
+    return result.changes > 0
+  }
+
+  /**
+   * Full registry reset (Phase 4): wipe entity_registry, entity_identity_key,
+   * entity_alias, entity_retire_counter, and metrics_mapping for this topology.
+   * The next resolve re-mints fresh entities. DISTINCT from Rebuild (which keeps
+   * the human/entity layer); this discards every stable id and mapping — the
+   * "complete re-initialization" the design mentions. Guard with a confirm in
+   * the UI (it drops durable mappings).
+   */
+  resetRegistry(topologyId: string): void {
+    // entity_identity_key, entity_alias, and entity_retire_counter all cascade
+    // on entity_registry delete (via their entity_id FKs). metrics_mapping does
+    // NOT cascade (no FK to entity_registry), so delete it explicitly first.
+    this.db.query('DELETE FROM metrics_mapping WHERE topology_id = ?').run(topologyId)
+    this.db.query('DELETE FROM entity_registry WHERE topology_id = ?').run(topologyId)
+    this.clearCacheEntry(topologyId)
+  }
+
   /** Current composition revision for a topology (0 if column/row missing). */
   /**
    * Current composition revision (bumped on every invalidation). Public:

--- a/apps/server/api/test/db/entity-lifecycle.test.ts
+++ b/apps/server/api/test/db/entity-lifecycle.test.ts
@@ -1,0 +1,370 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Phase 4 (entity registry): entity lifecycle — retirement, orphan
+ * reassignment / discard, and full registry reset.
+ *
+ * Covers:
+ *   - retire after N consecutive syncs of a source that returned data
+ *   - a failed-fetch sync does NOT retire (source outage ≠ absence)
+ *   - a retired entity re-observed → active again, SAME id
+ *   - last_seen_at advances on the no-change re-scan path
+ *   - orphan reassign moves the row and it projects onto the new element
+ *   - reassign validates the target (kind + presence)
+ *   - discard removes the orphan row
+ *   - registry reset clears the tables and a subsequent resolve re-mints
+ *
+ * Run with: cd apps/server/api && bun test test/db/entity-lifecycle.test.ts
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { NetworkGraph } from '@shumoku/core'
+import { RETIRE_THRESHOLD_SYNCS } from '../../src/services/entity-registry.ts'
+import { ObservationsService } from '../../src/services/observations.ts'
+import { TopologyService } from '../../src/services/topology.ts'
+import { attachSource, getDatabase, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
+
+let db_: TempDb
+let svc: TopologyService
+let obs: ObservationsService
+beforeAll(() => {
+  db_ = setupTempDb()
+  svc = new TopologyService()
+  obs = new ObservationsService()
+})
+afterAll(() => db_.teardown())
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A one-node graph keyed by a stable sysName identity. */
+function nodeGraph(sysName: string, extra: NetworkGraph['nodes'] = []): NetworkGraph {
+  return {
+    version: '1',
+    name: 't',
+    nodes: [{ id: sysName, label: sysName, shape: 'rect', identity: { sysName } }, ...extra],
+    links: [],
+  } as NetworkGraph
+}
+
+function entityStatus(entityId: string): { status: string; retired_at: number | null } | null {
+  return getDatabase()
+    .query('SELECT status, retired_at FROM entity_registry WHERE id = ?')
+    .get(entityId) as { status: string; retired_at: number | null } | null
+}
+
+function nodeEntityId(topologyId: string, sysName: string): string | undefined {
+  const row = getDatabase()
+    .query(
+      `SELECT er.id AS id FROM entity_registry er
+       JOIN entity_identity_key k ON k.entity_id = er.id
+       WHERE er.topology_id = ? AND k.key = 'sysName' AND k.value = ?`,
+    )
+    .get(topologyId, sysName.toLowerCase()) as { id: string } | undefined
+  return row?.id
+}
+
+/** Record an observed sync for a source (mirrors a scan landing). */
+async function sync(
+  topologyId: string,
+  sourceId: string,
+  capturedAt: number,
+  graph: NetworkGraph | null,
+  status: 'ok' | 'failed' = 'ok',
+): Promise<void> {
+  await obs.record({ topologyId, sourceId, capturedAt, status, graph })
+}
+
+// ---------------------------------------------------------------------------
+// Retirement
+// ---------------------------------------------------------------------------
+
+describe('entity retirement', () => {
+  test(`an entity missed by ${RETIRE_THRESHOLD_SYNCS} good syncs is retired (source reporting OK)`, async () => {
+    const topo = await svc.create({ name: 'retire-basic' })
+    const src = insertDataSource('zabbix', 'zbx_retire_basic')
+    attachSource(topo.id, src, 'topology')
+
+    // First sync sees A + B.
+    await sync(topo.id, src, 1000, {
+      version: '1',
+      name: 't',
+      nodes: [
+        { id: 'A', label: 'A', shape: 'rect', identity: { sysName: 'A' } },
+        { id: 'B', label: 'B', shape: 'rect', identity: { sysName: 'B' } },
+      ],
+      links: [],
+    } as NetworkGraph)
+
+    const bId = nodeEntityId(topo.id, 'B')
+    expect(bId).toBeTruthy()
+    expect(entityStatus(bId ?? '')?.status).toBe('active')
+
+    // Subsequent good syncs see ONLY A — B is absent but the source reported.
+    for (let i = 1; i <= RETIRE_THRESHOLD_SYNCS; i++) {
+      await sync(topo.id, src, 1000 + i * 1000, nodeGraph('A'))
+    }
+
+    // A stays active; B crossed the miss threshold → retired (id preserved).
+    expect(entityStatus(nodeEntityId(topo.id, 'A') ?? '')?.status).toBe('active')
+    expect(entityStatus(bId ?? '')?.status).toBe('retired')
+  })
+
+  test('a FAILED-fetch sync does NOT retire (an outage is not absence)', async () => {
+    const topo = await svc.create({ name: 'retire-failure' })
+    const src = insertDataSource('zabbix', 'zbx_retire_failure')
+    attachSource(topo.id, src, 'topology')
+
+    await sync(topo.id, src, 1000, {
+      version: '1',
+      name: 't',
+      nodes: [
+        { id: 'A', label: 'A', shape: 'rect', identity: { sysName: 'A' } },
+        { id: 'B', label: 'B', shape: 'rect', identity: { sysName: 'B' } },
+      ],
+      links: [],
+    } as NetworkGraph)
+    const bId = nodeEntityId(topo.id, 'B')
+
+    // Many FAILED fetches (source is down): the retire pass must not run at all,
+    // so B's miss counter never advances (an outage is not an absence).
+    for (let i = 1; i <= RETIRE_THRESHOLD_SYNCS + 2; i++) {
+      await sync(topo.id, src, 1000 + i * 1000, null, 'failed')
+    }
+
+    // B stays active regardless of how many fetches failed.
+    expect(entityStatus(bId ?? '')?.status).toBe('active')
+    // The initial good sync seeded a miss=0 counter row for B; failed syncs
+    // never incremented it (they short-circuit before the retire pass).
+    const bMiss = getDatabase()
+      .query(
+        'SELECT miss_count AS m FROM entity_retire_counter WHERE topology_id = ? AND entity_id = ?',
+      )
+      .get(topo.id, bId ?? '') as { m: number } | null
+    expect(bMiss?.m ?? 0).toBe(0)
+  })
+
+  test('a retired entity re-observed becomes active again with the SAME id', async () => {
+    const topo = await svc.create({ name: 'retire-unretire' })
+    const src = insertDataSource('zabbix', 'zbx_retire_unretire')
+    attachSource(topo.id, src, 'topology')
+
+    await sync(topo.id, src, 1000, {
+      version: '1',
+      name: 't',
+      nodes: [
+        { id: 'A', label: 'A', shape: 'rect', identity: { sysName: 'A' } },
+        { id: 'B', label: 'B', shape: 'rect', identity: { sysName: 'B' } },
+      ],
+      links: [],
+    } as NetworkGraph)
+    const bId = nodeEntityId(topo.id, 'B')
+    expect(bId).toBeTruthy()
+
+    // Retire B by missing it N times.
+    for (let i = 1; i <= RETIRE_THRESHOLD_SYNCS; i++) {
+      await sync(topo.id, src, 1000 + i * 1000, nodeGraph('A'))
+    }
+    expect(entityStatus(bId ?? '')?.status).toBe('retired')
+
+    // B returns — same identity → adopt re-uses the id and clears retirement.
+    await sync(topo.id, src, 100_000, {
+      version: '1',
+      name: 't',
+      nodes: [
+        { id: 'A', label: 'A', shape: 'rect', identity: { sysName: 'A' } },
+        { id: 'B', label: 'B', shape: 'rect', identity: { sysName: 'B' } },
+      ],
+      links: [],
+    } as NetworkGraph)
+
+    expect(nodeEntityId(topo.id, 'B')).toBe(bId)
+    const st = entityStatus(bId ?? '')
+    expect(st?.status).toBe('active')
+    expect(st?.retired_at).toBeNull()
+  })
+
+  test('last_seen_at advances on the no-change re-scan path', async () => {
+    const topo = await svc.create({ name: 'retire-lastseen' })
+    const src = insertDataSource('zabbix', 'zbx_retire_lastseen')
+    attachSource(topo.id, src, 'topology')
+
+    const graph = nodeGraph('LS')
+    await sync(topo.id, src, 1000, graph)
+    const id = nodeEntityId(topo.id, 'LS')
+    expect(id).toBeTruthy()
+    const before = getDatabase()
+      .query('SELECT last_seen_at AS t FROM entity_registry WHERE id = ?')
+      .get(id ?? '') as { t: number }
+
+    // Byte-identical re-scan → the no-change gate hits, but adopt still refreshes.
+    const second = await obs.record({
+      topologyId: topo.id,
+      sourceId: src,
+      capturedAt: 5000,
+      status: 'ok',
+      graph,
+    })
+    expect(second.contributionChanged).toBe(false)
+
+    const after = getDatabase()
+      .query('SELECT last_seen_at AS t FROM entity_registry WHERE id = ?')
+      .get(id ?? '') as { t: number }
+    expect(after.t).toBeGreaterThan(before.t)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Orphan reassignment / discard (via TopologyService)
+// ---------------------------------------------------------------------------
+
+/**
+ * A topology with two identity-bearing nodes + a metrics source, and a node
+ * mapping on A. Rewriting the overlay to drop A orphans that mapping.
+ */
+async function orphanFixture(name: string): Promise<{
+  topoId: string
+  metricsId: string
+  aEntityId: string
+  bEntityId: string
+}> {
+  const topo = await svc.create({ name })
+  const graph: NetworkGraph = {
+    version: '1',
+    name,
+    nodes: [
+      { id: 'a', label: 'A', shape: 'rect', identity: { mgmtIp: '10.0.0.1' } },
+      { id: 'b', label: 'B', shape: 'rect', identity: { mgmtIp: '10.0.0.2' } },
+    ],
+    links: [],
+  } as NetworkGraph
+  await svc.writeProjectOverlay(topo.id, graph)
+  const metricsId = insertDataSource('zabbix', `zbx_${name}`)
+  attachSource(topo.id, metricsId, 'metrics')
+  const parsed = await svc.getParsed(topo.id)
+  const aEntityId = parsed?.graph.nodes.find((n) => n.identity?.mgmtIp === '10.0.0.1')?.id ?? ''
+  const bEntityId = parsed?.graph.nodes.find((n) => n.identity?.mgmtIp === '10.0.0.2')?.id ?? ''
+  await svc.updateMapping(topo.id, { nodes: { [aEntityId]: { hostId: '9' } }, links: {} })
+  return { topoId: topo.id, metricsId, aEntityId, bEntityId }
+}
+
+/** Drop node A from the overlay so its mapping row orphans. B survives. */
+async function dropNodeA(topoId: string, name: string): Promise<void> {
+  await svc.writeProjectOverlay(topoId, {
+    version: '1',
+    name,
+    nodes: [{ id: 'b', label: 'B', shape: 'rect', identity: { mgmtIp: '10.0.0.2' } }],
+    links: [],
+  } as NetworkGraph)
+}
+
+describe('orphan reassignment / discard', () => {
+  test('reassign moves the row to the target and it projects onto that element', async () => {
+    const { topoId, aEntityId, bEntityId } = await orphanFixture('orphan-reassign')
+    await dropNodeA(topoId, 'orphan-reassign')
+
+    const orphans = await svc.mappingOrphans(topoId)
+    expect(orphans).toHaveLength(1)
+    expect(orphans[0]?.entityId).toBe(aEntityId)
+
+    const result = await svc.reassignOrphan(topoId, aEntityId, bEntityId)
+    expect(result.ok).toBe(true)
+
+    // No more orphans, and B now carries the reassigned host binding.
+    expect(await svc.mappingOrphans(topoId)).toHaveLength(0)
+    const m = (await svc.getParsed(topoId))?.mapping
+    expect(m?.nodes?.[bEntityId]?.hostId).toBe('9')
+  })
+
+  test('reassign refuses a target absent from the current graph', async () => {
+    const { topoId, aEntityId } = await orphanFixture('orphan-reassign-bad')
+    await dropNodeA(topoId, 'orphan-reassign-bad')
+
+    const result = await svc.reassignOrphan(topoId, aEntityId, 'NO-SUCH-ENTITY-000000000000')
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('target entity not in current graph')
+    // The orphan is untouched.
+    expect(await svc.mappingOrphans(topoId)).toHaveLength(1)
+  })
+
+  test('discard removes the orphan row', async () => {
+    const { topoId, aEntityId } = await orphanFixture('orphan-discard')
+    await dropNodeA(topoId, 'orphan-discard')
+    expect(await svc.mappingOrphans(topoId)).toHaveLength(1)
+
+    const removed = svc.discardOrphan(topoId, aEntityId)
+    expect(removed).toBe(true)
+    expect(await svc.mappingOrphans(topoId)).toHaveLength(0)
+
+    const rows = getDatabase()
+      .query('SELECT COUNT(*) AS n FROM metrics_mapping WHERE topology_id = ?')
+      .get(topoId) as { n: number }
+    expect(rows.n).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Registry reset
+// ---------------------------------------------------------------------------
+
+describe('registry reset', () => {
+  test('reset clears the registry + mapping, and the next resolve re-mints', async () => {
+    const topo = await svc.create({ name: 'reset' })
+    const graph: NetworkGraph = {
+      version: '1',
+      name: 'reset',
+      nodes: [{ id: 'a', label: 'A', shape: 'rect', identity: { mgmtIp: '10.5.0.1' } }],
+      links: [],
+    } as NetworkGraph
+    await svc.writeProjectOverlay(topo.id, graph)
+    attachSource(topo.id, insertDataSource('zabbix', 'zbx_reset'), 'metrics')
+    const before = await svc.getParsed(topo.id)
+    const oldId = before?.graph.nodes[0]?.id ?? ''
+    await svc.updateMapping(topo.id, { nodes: { [oldId]: { hostId: '3' } }, links: {} })
+
+    const db = getDatabase()
+    const entityCount = (): number =>
+      (
+        db
+          .query('SELECT COUNT(*) AS n FROM entity_registry WHERE topology_id = ?')
+          .get(topo.id) as {
+          n: number
+        }
+      ).n
+    const mappingCount = (): number =>
+      (
+        db
+          .query('SELECT COUNT(*) AS n FROM metrics_mapping WHERE topology_id = ?')
+          .get(topo.id) as {
+          n: number
+        }
+      ).n
+    expect(entityCount()).toBeGreaterThan(0)
+    expect(mappingCount()).toBe(1)
+
+    svc.resetRegistry(topo.id)
+    expect(entityCount()).toBe(0)
+    expect(mappingCount()).toBe(0)
+    // Identity keys + retire counters cascade away with the registry rows.
+    const keyCount = (
+      db
+        .query('SELECT COUNT(*) AS n FROM entity_identity_key WHERE topology_id = ?')
+        .get(topo.id) as {
+        n: number
+      }
+    ).n
+    expect(keyCount).toBe(0)
+
+    // Re-ingesting the same content (what a Sync / Rebuild does after reset)
+    // re-mints a FRESH entity for the same node — a new stable id, since the old
+    // registry was wiped. This is the "complete re-initialization" contract.
+    await svc.writeProjectOverlay(topo.id, graph)
+    expect(entityCount()).toBeGreaterThan(0)
+    const after = await svc.getParsed(topo.id)
+    const newId = after?.graph.nodes[0]?.id ?? ''
+    expect(newId).toBeTruthy()
+    expect(newId).not.toBe(oldId)
+  })
+})

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -247,6 +247,36 @@ export const topologies = {
   // misses node bindings stored as attachments.
   getMapping: (id: string) => request<MetricsMapping>(`/topologies/${id}/mapping`),
 
+  // Orphaned mapping rows (Phase 4): entities no longer present in the current
+  // resolved graph (a mapping pointing at a retired / disappeared element).
+  getOrphans: (topologyId: string) =>
+    request<{ orphans: { entityId: string; kind: string; sourceId: string; payload: unknown }[] }>(
+      `/topologies/${topologyId}/mapping/orphans`,
+    ),
+
+  // Reassign an orphaned mapping to a live entity.
+  reassignOrphan: (topologyId: string, entityId: string, toEntityId: string) =>
+    request<{ success: boolean }>(
+      `/topologies/${topologyId}/mapping/orphans/${entityId}/reassign`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ toEntityId }),
+      },
+    ),
+
+  // Discard an orphaned mapping row.
+  discardOrphan: (topologyId: string, entityId: string) =>
+    request<{ success: boolean }>(`/topologies/${topologyId}/mapping/orphans/${entityId}`, {
+      method: 'DELETE',
+    }),
+
+  // Full registry reset: discard all stable entity ids and mapping rows.
+  // DESTRUCTIVE — guard with a confirm dialog before calling.
+  resetRegistry: (topologyId: string) =>
+    request<{ success: boolean }>(`/topologies/${topologyId}/registry/reset`, {
+      method: 'POST',
+    }),
+
   // Response is the topology PLUS `skipped`: node/link bindings the server could
   // not persist because the source didn't provide identity to anchor them.
   updateMapping: (id: string, mapping: MetricsMapping) =>

--- a/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
@@ -298,6 +298,98 @@
       localError = e instanceof Error ? e.message : 'Failed to auto-map links'
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Orphaned mappings (Phase 4) — the "drift is visible, never silent" surface.
+  // A mapping row whose entity left the diagram (retired / disappeared element).
+  // The operator reassigns it to a current element or discards it. Additive
+  // section — kept self-contained so it doesn't tangle with the auto-map flow.
+  // ---------------------------------------------------------------------------
+
+  interface OrphanRow {
+    entityId: string
+    kind: string
+    sourceId: string
+    payload: unknown
+  }
+
+  let orphans = $state<OrphanRow[]>([])
+  let orphansLoaded = $state(false)
+  let orphanError = $state('')
+  // entityId → chosen target element id (= entity id after the Phase 3 flip).
+  let reassignTargets = $state<Record<string, string>>({})
+  let orphanActing = $state<Record<string, boolean>>({})
+
+  // Current node / link elements a node/link orphan can be reassigned onto. After
+  // the Phase 3 id flip, element `id` IS the entity id the server validates against.
+  let nodeTargets = $derived(
+    (parsedTopology?.graph.nodes ?? []).map((n) => ({ id: n.id, label: getNodeLabel(n) })),
+  )
+  let linkTargets = $derived(
+    edges.map((e) => ({
+      id: e.id,
+      label: `${getNodeLabelById(e.from.nodeId)} → ${getNodeLabelById(e.to.nodeId)}`,
+    })),
+  )
+
+  function orphanHint(payload: unknown): string {
+    if (payload && typeof payload === 'object') {
+      const p = payload as { hostName?: string; hostId?: string; interface?: string }
+      const parts = [p.hostName ?? p.hostId, p.interface].filter((v): v is string => !!v)
+      if (parts.length > 0) return parts.join(' · ')
+    }
+    return ''
+  }
+
+  $effect(() => {
+    if (ctx.topologyId) void loadOrphans()
+  })
+
+  async function loadOrphans() {
+    try {
+      const resp = await api.topologies.getOrphans(ctx.topologyId)
+      orphans = resp.orphans
+      orphansLoaded = true
+    } catch {
+      // Non-fatal: the orphan panel just stays hidden if the fetch fails.
+      orphansLoaded = true
+    }
+  }
+
+  async function handleReassign(entityId: string) {
+    const toEntityId = reassignTargets[entityId]
+    if (!toEntityId) return
+    orphanActing = { ...orphanActing, [entityId]: true }
+    orphanError = ''
+    try {
+      await api.topologies.reassignOrphan(ctx.topologyId, entityId, toEntityId)
+      await loadOrphans()
+      // Re-hydrate the mapping so the reassigned binding shows up on its new element.
+      await mappingStore.load(ctx.topologyId, false)
+    } catch (e) {
+      orphanError = e instanceof Error ? e.message : 'Reassign failed'
+    } finally {
+      const next = { ...orphanActing }
+      delete next[entityId]
+      orphanActing = next
+    }
+  }
+
+  async function handleDiscardOrphan(entityId: string) {
+    if (!confirm('Discard this orphaned mapping? This cannot be undone.')) return
+    orphanActing = { ...orphanActing, [entityId]: true }
+    orphanError = ''
+    try {
+      await api.topologies.discardOrphan(ctx.topologyId, entityId)
+      await loadOrphans()
+    } catch (e) {
+      orphanError = e instanceof Error ? e.message : 'Discard failed'
+    } finally {
+      const next = { ...orphanActing }
+      delete next[entityId]
+      orphanActing = next
+    }
+  }
 </script>
 
 <div class="p-4 space-y-4">
@@ -555,5 +647,60 @@
         {/if}
       </MappingPanel>
     {/if}
+  {/if}
+
+  <!-- Orphaned mappings (Phase 4): drift surface. Only rendered when the server
+       reports rows pointing at entities that left the diagram. -->
+  {#if orphansLoaded && orphans.length > 0}
+    <div class="card border-warning/30">
+      <div class="card-header">
+        <h2 class="font-medium text-warning">Orphaned mappings ({orphans.length})</h2>
+        <p class="text-xs text-theme-text-muted mt-0.5">
+          These mappings point at elements no longer in the diagram (retired or removed). Reassign
+          each to a current element, or discard it.
+        </p>
+      </div>
+      <div class="card-body space-y-3">
+        {#if orphanError}
+          <p class="text-xs text-danger">{orphanError}</p>
+        {/if}
+        {#each orphans as orphan (orphan.entityId)}
+          {@const hint = orphanHint(orphan.payload)}
+          {@const targets = orphan.kind === 'link' ? linkTargets : nodeTargets}
+          <div class="flex items-center gap-2 border border-theme-border rounded p-2">
+            <div class="flex-1 min-w-0">
+              <p class="text-xs text-theme-text truncate">{hint || orphan.entityId}</p>
+              <p class="text-xs text-theme-text-muted">{orphan.kind}</p>
+            </div>
+            <select
+              class="input text-xs"
+              style="width: 14rem;"
+              bind:value={reassignTargets[orphan.entityId]}
+            >
+              <option value="">Reassign to…</option>
+              {#each targets as t (t.id)}
+                <option value={t.id}>{t.label}</option>
+              {/each}
+            </select>
+            <Button
+              variant="outline"
+              class="text-xs px-2 py-1 h-auto"
+              disabled={orphanActing[orphan.entityId] || !reassignTargets[orphan.entityId]}
+              onclick={() => handleReassign(orphan.entityId)}
+            >
+              Reassign
+            </Button>
+            <Button
+              variant="destructive"
+              class="text-xs px-2 py-1 h-auto"
+              disabled={orphanActing[orphan.entityId]}
+              onclick={() => handleDiscardOrphan(orphan.entityId)}
+            >
+              Discard
+            </Button>
+          </div>
+        {/each}
+      </div>
+    </div>
   {/if}
 </div>

--- a/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/settings/+page.svelte
@@ -36,6 +36,7 @@
   let hideDisconnected = $state(false)
   let savingEdgeStyle = $state(false)
   let deleting = $state(false)
+  let resettingRegistry = $state(false)
 
   onMount(() => {
     void parseGraphSettings()
@@ -102,6 +103,24 @@
     } catch (e) {
       alert(e instanceof Error ? e.message : 'Failed to delete')
       deleting = false
+    }
+  }
+
+  async function handleResetRegistry() {
+    if (!ctx.topology) return
+    const msg =
+      `Reset entity registry for "${ctx.topology.name}"?\n\n` +
+      'This permanently discards all stable entity ids and metrics mappings. ' +
+      'Devices will be re-minted with new ids on the next sync. This cannot be undone.'
+    if (!confirm(msg)) return
+    resettingRegistry = true
+    try {
+      await api.topologies.resetRegistry(ctx.topology.id)
+      ctx.bumpRevision()
+    } catch (e) {
+      alert(e instanceof Error ? e.message : 'Failed to reset registry')
+    } finally {
+      resettingRegistry = false
     }
   }
 </script>
@@ -260,25 +279,50 @@
     <div class="card-header">
       <h2 class="font-medium text-danger">Danger Zone</h2>
     </div>
-    <div class="card-body">
-      <p class="text-xs text-theme-text-muted mb-3">
-        Once deleted, this topology cannot be recovered.
-      </p>
-      <Button
-        variant="destructive"
-        class="w-full justify-center"
-        onclick={handleDelete}
-        disabled={deleting}
-      >
-        {#if deleting}
-          <span
-            class="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin mr-2"
-          ></span>
-        {:else}
-          <TrashIcon size={16} class="mr-2" />
-        {/if}
-        Delete Topology
-      </Button>
+    <div class="card-body space-y-4">
+      <div>
+        <p class="text-sm text-theme-text font-medium mb-0.5">Reset Entity Registry</p>
+        <p class="text-xs text-theme-text-muted mb-2">
+          Permanently discards all stable entity ids and metrics mappings. Devices will be re-minted
+          on the next sync. Use only if the registry is in an inconsistent state.
+        </p>
+        <Button
+          variant="destructive"
+          class="w-full justify-center"
+          onclick={handleResetRegistry}
+          disabled={resettingRegistry}
+        >
+          {#if resettingRegistry}
+            <span
+              class="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin mr-2"
+            ></span>
+          {/if}
+          Reset Registry
+        </Button>
+      </div>
+
+      <hr class="border-danger/20">
+
+      <div>
+        <p class="text-xs text-theme-text-muted mb-3">
+          Once deleted, this topology cannot be recovered.
+        </p>
+        <Button
+          variant="destructive"
+          class="w-full justify-center"
+          onclick={handleDelete}
+          disabled={deleting}
+        >
+          {#if deleting}
+            <span
+              class="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin mr-2"
+            ></span>
+          {:else}
+            <TrashIcon size={16} class="mr-2" />
+          {/if}
+          Delete Topology
+        </Button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Closes #552 (Phase 4 of #547 — the entity lifecycle). Completes the registry.

## What

- **Retire** (`retireStaleEntities`, run after adopt-or-mint at `materializeContribution`): an entity flips to `status='retired'` after `RETIRE_THRESHOLD_SYNCS` (default 3) consecutive syncs where a source **that returned data** didn't observe it. A **failed/offline fetch never runs the retire pass** (early return on `status==='failed'`), so an outage can't retire anything; misses are counted per-source only against entities that source previously observed, so source A never retires source-B-only entities. Retired entities keep their id; adopt/merge un-retire on re-observation → a returning device re-adopts the same id.
- **Orphan repair**: `POST /:id/mapping/orphans/:entityId/reassign {toEntityId}` (validates target present + kind match, alias-follows) and `DELETE /:id/mapping/orphans/:entityId`. The mapping page renders an additive "Orphaned mappings (N)" section (only when orphans exist) with per-row Reassign (select a current element) + Discard.
- **Full reset**: `POST /:id/registry/reset` wipes registry + identity keys + aliases + retire counters + metrics_mapping for the topology (distinct from Rebuild, which keeps the entity layer); next resolve re-mints. Settings danger-zone button with a confirm.
- Merge-review UI deferred (merges stay automatic).

migration `027_entity_retire_counter.sql`.

## Live verification (NetBox demo)

| check | result |
|---|---|
| normal sync + retire pass coexist (rebuild) | mapping/entities intact |
| orphans endpoint + bogus-target reassign | refused 400 "orphan not found" / validation holds |
| **registry reset → rebuild** | 50/50 nodes **re-minted to fresh ULIDs** (all differ from prior), mapping wiped as designed |

Tests: server-api 117/117 (+8 lifecycle: retire-after-N, failed-fetch-no-retire, retired→active-same-id, last_seen advances on no-change, orphan reassign/refuse/discard, reset+re-mint), web check clean, typecheck/biome clean.

Cherry-picked onto Phase C (#564) with the one shared-file conflict (both add methods after `mappingOrphans`) resolved by keeping both. Implemented by a Sonnet subagent; reviewed + live-verified by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj