### PR TITLE
fix(web): strip renderer markup from plain-text node labels

### DIFF
--- a/apps/server/web/src/lib/utils/node-label.ts
+++ b/apps/server/web/src/lib/utils/node-label.ts
@@ -16,7 +16,16 @@ interface NodeLike {
 export function nodeLabel(node: NodeLike | undefined | null): string {
   if (!node) return ''
   const raw = Array.isArray(node.label) ? node.label.join(' ') : node.label
-  return raw && raw.length > 0 ? raw : node.id
+  if (!raw || raw.length === 0) return node.id
+  // Labels may carry renderer markup ("<b>edge-rt-01</b>" renders bold on the
+  // canvas). Every caller of this helper is a PLAIN-TEXT context (lists,
+  // dropdowns, name matching), so strip the tags here — the one place — rather
+  // than leaking "<b>…</b>" into the UI.
+  const text = raw
+    .replace(/<[^>]*>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return text.length > 0 ? text : node.id
 }
 
 /** Look up a node by id and return its label. Returns the id if not found. */


### PR DESCRIPTION
Mapping lists/dropdowns showed raw `<b>edge-rt-01</b>` — labels carry canvas markup, and every `nodeLabel()` caller is a plain-text context. Stripped at the single helper chokepoint. svelte-check/biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj