### PR TITLE
fix(server): registry matching hardening — staged lookup, strong-key veto, singleton replacement, merge guard

### DIFF
--- a/apps/server/api/src/db/migrations/029_entity_identity_key_source.sql
+++ b/apps/server/api/src/db/migrations/029_entity_identity_key_source.sql
@@ -1,24 +1,49 @@
--- Migration 029: add source_id to entity_identity_key for per-source singleton-key replacement.
+-- Migration 029: add source_id to entity_identity_key for per-source singleton-key
+-- replacement (#570).
 --
 -- SINGLETON keys (mgmtIp, sysName per node; ifIndex per port) are now stored with
 -- the source that reported them. When a source reports a new value for a singleton
--- key, old rows for (entity, key, source) with a different value are deleted and
--- the new (key, value, source) row is inserted. Other sources' rows are unaffected.
+-- key, old rows for (entity, key) from that same source — or from the legacy ''
+-- sentinel — with a different value are deleted and the new (key, value, source)
+-- row is inserted. Other sources' rows are unaffected, so dual-homed multi-source
+-- truth survives while a single source's stale value (the "IP magnet") does not.
 --
--- Backward compatibility: existing rows receive source_id = '' (the legacy sentinel,
--- treated as "unknown source" — never replaced by per-source replacement logic,
--- which only fires when source_id != '').
+-- Uniqueness changes from (topology_id, kind, parent_id, key, value) to
+-- (topology_id, kind, parent_id, key, value, source_id):
+--   * entity_id is deliberately NOT part of the unique key — a given (key, value)
+--     from a given source must resolve to exactly ONE entity, which is what makes
+--     adopt-or-mint lookup deterministic. Two entities disagreeing about who owns
+--     a value is only representable across different sources (and is then resolved
+--     by the staged-lookup veto / merge-guard rules).
+--   * source_id IS part of the unique key so two sources can independently assert
+--     the same value (e.g. both see mgmtIp 10.0.0.1) without clobbering each other.
 --
--- The UNIQUE constraint changes from (topology_id, kind, parent_id, key, value)
--- to (topology_id, kind, parent_id, key, value, source_id) so a value can appear
--- from multiple independent sources while still being idempotent per source.
+-- The original uniqueness was declared as an inline table constraint (migration
+-- 025), which SQLite enforces via an undroppable sqlite_autoindex — so the table
+-- must be rebuilt (create-new / copy / drop / rename, same idiom as migration 028).
+-- Existing rows receive source_id = '' (the legacy "unknown source" sentinel).
 
-ALTER TABLE entity_identity_key ADD COLUMN source_id TEXT NOT NULL DEFAULT '';
+CREATE TABLE entity_identity_key_new (
+  topology_id TEXT NOT NULL,
+  entity_id   TEXT NOT NULL REFERENCES entity_registry(id) ON DELETE CASCADE,
+  kind        TEXT NOT NULL,
+  parent_id   TEXT NOT NULL DEFAULT '',
+  key         TEXT NOT NULL,
+  value       TEXT NOT NULL,
+  source_id   TEXT NOT NULL DEFAULT '',
+  UNIQUE (topology_id, kind, parent_id, key, value, source_id)
+);
 
-DROP INDEX IF EXISTS entity_identity_key_unique;
+INSERT INTO entity_identity_key_new (topology_id, entity_id, kind, parent_id, key, value)
+  SELECT topology_id, entity_id, kind, parent_id, key, value
+  FROM entity_identity_key;
 
-CREATE UNIQUE INDEX IF NOT EXISTS entity_identity_key_unique
-  ON entity_identity_key(topology_id, kind, parent_id, key, value, source_id);
+DROP TABLE entity_identity_key;
+
+ALTER TABLE entity_identity_key_new RENAME TO entity_identity_key;
+
+CREATE INDEX IF NOT EXISTS idx_entity_identity_lookup
+  ON entity_identity_key(topology_id, kind, parent_id, key, value);
 
 CREATE INDEX IF NOT EXISTS idx_entity_identity_source
   ON entity_identity_key(topology_id, entity_id, key, source_id);

--- a/apps/server/api/src/db/migrations/029_entity_identity_key_source.sql
+++ b/apps/server/api/src/db/migrations/029_entity_identity_key_source.sql
@@ -1,0 +1,24 @@
+-- Migration 029: add source_id to entity_identity_key for per-source singleton-key replacement.
+--
+-- SINGLETON keys (mgmtIp, sysName per node; ifIndex per port) are now stored with
+-- the source that reported them. When a source reports a new value for a singleton
+-- key, old rows for (entity, key, source) with a different value are deleted and
+-- the new (key, value, source) row is inserted. Other sources' rows are unaffected.
+--
+-- Backward compatibility: existing rows receive source_id = '' (the legacy sentinel,
+-- treated as "unknown source" — never replaced by per-source replacement logic,
+-- which only fires when source_id != '').
+--
+-- The UNIQUE constraint changes from (topology_id, kind, parent_id, key, value)
+-- to (topology_id, kind, parent_id, key, value, source_id) so a value can appear
+-- from multiple independent sources while still being idempotent per source.
+
+ALTER TABLE entity_identity_key ADD COLUMN source_id TEXT NOT NULL DEFAULT '';
+
+DROP INDEX IF EXISTS entity_identity_key_unique;
+
+CREATE UNIQUE INDEX IF NOT EXISTS entity_identity_key_unique
+  ON entity_identity_key(topology_id, kind, parent_id, key, value, source_id);
+
+CREATE INDEX IF NOT EXISTS idx_entity_identity_source
+  ON entity_identity_key(topology_id, entity_id, key, source_id);

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -33,6 +33,7 @@ import migration025 from './migrations/025_entity_registry.sql'
 import migration026 from './migrations/026_metrics_mapping.sql'
 import migration027 from './migrations/027_entity_retire_counter.sql'
 import migration028 from './migrations/028_metrics_mapping_pk_source.sql'
+import migration029 from './migrations/029_entity_identity_key_source.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -62,6 +63,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '026_metrics_mapping.sql', sql: migration026 },
   { name: '027_entity_retire_counter.sql', sql: migration027 },
   { name: '028_metrics_mapping_pk_source.sql', sql: migration028 },
+  { name: '029_entity_identity_key_source.sql', sql: migration029 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/entity-registry.ts
+++ b/apps/server/api/src/services/entity-registry.ts
@@ -2,25 +2,34 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * Entity Registry — adopt-or-mint and entityId stamping.
+ * Entity Registry - adopt-or-mint and entityId stamping.
  *
- * Called at **ingest time** (inside ObservationsService.record) to assign
- * stable ULIDs to every observed node / port / link.
+ * Key classes and matching rules (§570 hardening):
  *
- * `stampEntityIds` is called in the host process after the derive worker
- * returns its resolved graph; it reads the registry (no writes) and adds
- * `entityId` to nodes, ports, and links.
+ * Node key classes (descending strength):
+ *   STRONG:  chassisId, vendor:* (per-namespace source primary keys), manual:*
+ *   MUTABLE: mgmtIp, sysName  (singleton-replaced per source)
  *
- * Key normalisation rules (documented for audit / test clarity):
- *   mgmtIp, mac, sysName → lowercase + trim
- *   chassisId, ifName    → trim only (preserve case — vendor strings / OS names)
- *   ifIndex              → string(number) (no case change)
- *   vendor:*, endpoints  → trim
- *   manual:<sourceId>    → trim (value is an element local id)
+ * Port key classes (descending strength):
+ *   PRIMARY:     ifName
+ *   SECONDARY:   mac
+ *   LAST_RESORT: ifIndex  (only when observation has neither ifName nor mac)
+ *
+ * Staged lookup with STRONG-key veto:
+ *   1. Query each class descending; stop at first class with candidates.
+ *   2. VETO: candidate and observation both carry the same STRONG key namespace
+ *      (chassisId, vendor:<ns>) with different values -> reject.
+ *   3. MUTABLE mutual-consistency: ALL mutable keys on BOTH sides must agree.
+ *   4. All vetoed -> continue; nothing left -> mint.
+ *
+ * Merge guard: auto-merge ONLY when all candidates share a STRONG key, OR
+ * all agree on >=2 independent key classes. Otherwise adopt best + warn.
+ *
+ * Singleton-key replacement: mgmtIp/sysName per node, ifIndex per port are
+ * per-source singletons (old value deleted, new inserted, others' rows untouched).
  *
  * parent_id sentinel: entity_identity_key.parent_id uses '' (empty string)
- * for node and link entities so UNIQUE constraints work under SQLite's
- * NULL-is-distinct behaviour.  Port entities use the parent node entity id.
+ * for node and link entities; port entities use the parent node entity id.
  *
  * See apps/server/docs/design/topology-foundation-entity-registry.md §2.
  */
@@ -46,7 +55,7 @@ import { timestamp } from '../db/index.js'
 import { buildGraph } from './contribution-store.js'
 
 // ---------------------------------------------------------------------------
-// ULID generator (synchronous — safe to call inside bun:sqlite transactions)
+// ULID generator (synchronous - safe to call inside bun:sqlite transactions)
 // ---------------------------------------------------------------------------
 
 const BASE32_CHARS = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
@@ -54,17 +63,18 @@ const BASE32_CHARS = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
 /**
  * Generate a ULID (Universally Unique Lexicographically Sortable Identifier).
  * Uses crypto.randomBytes so it is safe to call within a DB transaction.
+ * Exported for testability (§570: ULID unit tests).
  */
-function generateUlid(): string {
+export function generateUlid(): string {
   const t = Date.now()
-  // Time part: 48-bit timestamp encoded as 10 Crockford base32 chars (50 bits, top 2 always 0)
+  // Time part: 48-bit timestamp encoded as 10 Crockford base32 chars
   const timeChars: string[] = new Array(10)
   let ts = t
   for (let i = 9; i >= 0; i--) {
     timeChars[i] = BASE32_CHARS[ts % 32] ?? '0'
     ts = Math.floor(ts / 32)
   }
-  // Random part: 80 bits → 16 Crockford base32 chars
+  // Random part: 80 bits => 16 Crockford base32 chars
   const rand = randomBytes(10)
   let r = 0n
   for (const byte of rand) r = (r << 8n) | BigInt(byte)
@@ -88,11 +98,43 @@ function normalizeKeyValue(key: string, value: string): string {
     case 'mac':
     case 'sysName':
       return trimmed.toLowerCase()
-    // chassisId, ifName, ifIndex, vendor:*, manual:*, endpoints → trim only
     default:
       return trimmed
   }
 }
+
+// ---------------------------------------------------------------------------
+// Key class definitions
+// ---------------------------------------------------------------------------
+
+const NODE_KEY_CLASS = {
+  STRONG: 'strong',
+  MUTABLE: 'mutable',
+} as const
+type NodeKeyClass = (typeof NODE_KEY_CLASS)[keyof typeof NODE_KEY_CLASS]
+
+const PORT_KEY_CLASS = {
+  PRIMARY: 'primary',
+  SECONDARY: 'secondary',
+  LAST_RESORT: 'last_resort',
+} as const
+type PortKeyClass = (typeof PORT_KEY_CLASS)[keyof typeof PORT_KEY_CLASS]
+
+function nodeKeyClass(key: string): NodeKeyClass {
+  if (key === 'mgmtIp' || key === 'sysName') return NODE_KEY_CLASS.MUTABLE
+  return NODE_KEY_CLASS.STRONG
+}
+
+function portKeyClass(key: string): PortKeyClass {
+  if (key === 'ifName') return PORT_KEY_CLASS.PRIMARY
+  if (key === 'mac') return PORT_KEY_CLASS.SECONDARY
+  return PORT_KEY_CLASS.LAST_RESORT
+}
+
+/** SINGLETON keys: per-source value is replaced (not accumulated) on adopt. */
+const SINGLETON_NODE_KEYS = new Set(['mgmtIp', 'sysName'])
+const SINGLETON_PORT_KEYS = new Set(['ifIndex'])
+// ifName is PRIMARY but NOT singleton - replacing ifName re-keys the port.
 
 // ---------------------------------------------------------------------------
 // Identity key gathering
@@ -104,9 +146,8 @@ interface IdentityKey {
 }
 
 /**
- * Gather node identity keys in priority order: chassisId > mgmtIp > sysName > vendorIds.
- * Falls back to `manual:<sourceId>` when no network identity is available so
- * manually-authored nodes always get an entity.
+ * Gather node identity keys in priority order: chassisId > vendorIds > mgmtIp > sysName.
+ * Falls back to `manual:<sourceId>` when no network identity is available.
  */
 function gatherNodeKeys(
   identity: Identity | undefined,
@@ -117,18 +158,16 @@ function gatherNodeKeys(
   if (identity?.chassisId) {
     keys.push({ key: 'chassisId', value: normalizeKeyValue('chassisId', identity.chassisId) })
   }
+  for (const [ns, v] of Object.entries(identity?.vendorIds ?? {})) {
+    keys.push({ key: `vendor:${ns}`, value: normalizeKeyValue(`vendor:${ns}`, v) })
+  }
   if (identity?.mgmtIp) {
     keys.push({ key: 'mgmtIp', value: normalizeKeyValue('mgmtIp', identity.mgmtIp) })
   }
   if (identity?.sysName) {
     keys.push({ key: 'sysName', value: normalizeKeyValue('sysName', identity.sysName) })
   }
-  for (const [ns, v] of Object.entries(identity?.vendorIds ?? {})) {
-    keys.push({ key: `vendor:${ns}`, value: normalizeKeyValue(`vendor:${ns}`, v) })
-  }
   if (keys.length === 0) {
-    // No network identity — fall back to source-local id so manual nodes
-    // can still be tracked across re-ingests of the same source.
     keys.push({ key: `manual:${sourceId}`, value: nodeId })
   }
   return keys
@@ -136,6 +175,7 @@ function gatherNodeKeys(
 
 /**
  * Gather port identity keys in priority order: ifName > mac > ifIndex.
+ * ifIndex is only gathered when the observation has neither ifName nor mac.
  * Falls back to `manual:<sourceId>` when no port identity is available.
  */
 function gatherPortKeys(
@@ -150,7 +190,7 @@ function gatherPortKeys(
   if (identity?.mac) {
     keys.push({ key: 'mac', value: normalizeKeyValue('mac', identity.mac) })
   }
-  if (identity?.ifIndex !== undefined) {
+  if (!identity?.ifName && !identity?.mac && identity?.ifIndex !== undefined) {
     keys.push({ key: 'ifIndex', value: String(identity.ifIndex) })
   }
   if (keys.length === 0) {
@@ -164,13 +204,10 @@ function gatherPortKeys(
 // ---------------------------------------------------------------------------
 
 /**
- * Follow the alias chain for an entity id.  Caps at depth 8 to prevent
- * infinite loops from malformed data; in practice the chain is at most
- * 1-deep (one merge produces one alias row).
+ * Follow the alias chain for an entity id. Caps at depth 8 to prevent loops.
  *
  * Exported as {@link resolveEntityAlias} so reference tables keyed by entity id
- * (the metrics mapping in particular) can follow a merge: a row stored against a
- * pre-merge id keeps resolving to the survivor.
+ * (the metrics mapping in particular) can follow a merge.
  */
 export function resolveEntityAlias(entityId: string, db: Database): string {
   return resolveAlias(entityId, db)
@@ -186,23 +223,130 @@ function resolveAlias(entityId: string, db: Database, depth = 0): string {
 }
 
 // ---------------------------------------------------------------------------
-// Lookup
+// Candidate entity enrichment
 // ---------------------------------------------------------------------------
 
+interface EntityKeyRow {
+  key: string
+  value: string
+}
+
+/** Load all identity keys currently stored for an entity. */
+function loadEntityKeys(
+  topologyId: string,
+  kind: string,
+  parentId: string,
+  entityId: string,
+  db: Database,
+): Map<string, string[]> {
+  const rows = db
+    .query<EntityKeyRow, [string, string, string, string]>(
+      `SELECT key, value FROM entity_identity_key
+       WHERE topology_id = ? AND kind = ? AND parent_id = ? AND entity_id = ?`,
+    )
+    .all(topologyId, kind, parentId, entityId)
+  const map = new Map<string, string[]>()
+  for (const { key, value } of rows) {
+    const existing = map.get(key)
+    if (existing) {
+      existing.push(value)
+    } else {
+      map.set(key, [value])
+    }
+  }
+  return map
+}
+
+// ---------------------------------------------------------------------------
+// Veto logic
+// ---------------------------------------------------------------------------
+
+function strongKeyNamespace(key: string): string | undefined {
+  if (key === 'chassisId') return 'chassisId'
+  if (key.startsWith('vendor:')) return key
+  return undefined
+}
+
 /**
- * Find the unique survivor entity ids for the given keys.  Resolves aliases
- * so the returned set never contains a merged-away id.
+ * Apply the STRONG-key VETO rule.
  *
- * parentId is '' for node/link entities and the node entity id for port entities
- * (see the parent_id sentinel note at the top of this file).
+ * For each STRONG key namespace where BOTH the candidate entity and the observation
+ * carry a value: if the candidate's value disagrees with the observation's value
+ * -> the candidate is vetoed (return true).
  */
-function lookupByKeys(
+function isVetoed(obsKeys: IdentityKey[], entityKeys: Map<string, string[]>): boolean {
+  for (const { key, value } of obsKeys) {
+    const ns = strongKeyNamespace(key)
+    if (!ns) continue
+    const entityValues = entityKeys.get(key)
+    if (!entityValues || entityValues.length === 0) continue
+    if (!entityValues.includes(value)) return true
+  }
+  return false
+}
+
+/**
+ * Apply the MUTABLE-class MUTUAL-CONSISTENCY rule.
+ *
+ * sysName is the device-identity arbiter: if both the observation and the
+ * candidate carry a sysName and they conflict, the candidate is rejected.
+ * mgmtIp differences are NOT grounds for rejection here — they are handled by
+ * singleton-key replacement after adoption (an IP swap is a legitimate event).
+ */
+function failsMutualConsistency(
+  obsKeys: IdentityKey[],
+  entityKeys: Map<string, string[]>,
+): boolean {
+  const obsSysName = obsKeys.find((k) => k.key === 'sysName')
+  if (!obsSysName) return false
+  const entitySysNames = entityKeys.get('sysName')
+  if (!entitySysNames || entitySysNames.length === 0) return false
+  return !entitySysNames.includes(obsSysName.value)
+}
+
+// ---------------------------------------------------------------------------
+// Staged lookup helpers
+// ---------------------------------------------------------------------------
+
+function countSharedKeyClasses(
+  obsKeys: IdentityKey[],
+  entityKeys: Map<string, string[]>,
+  kind: 'node' | 'port',
+): number {
+  const matchedClasses = new Set<string>()
+  for (const { key, value } of obsKeys) {
+    const entityValues = entityKeys.get(key)
+    if (!entityValues?.includes(value)) continue
+    const cls = kind === 'node' ? nodeKeyClass(key) : portKeyClass(key)
+    matchedClasses.add(cls)
+  }
+  return matchedClasses.size
+}
+
+function sharesStrongKey(obsKeys: IdentityKey[], entityKeys: Map<string, string[]>): boolean {
+  for (const { key, value } of obsKeys) {
+    if (nodeKeyClass(key) !== NODE_KEY_CLASS.STRONG) continue
+    const entityValues = entityKeys.get(key)
+    if (entityValues?.includes(value)) return true
+  }
+  return false
+}
+
+interface CandidateInfo {
+  entityId: string
+  firstSeenAt: number
+  entityKeys: Map<string, string[]>
+  matchClass: NodeKeyClass | PortKeyClass
+}
+
+/** Query entities matching any of the given keys (flat OR). Returns resolved unique ids. */
+function queryCandidates(
   topologyId: string,
   kind: string,
   parentId: string,
   keys: IdentityKey[],
   db: Database,
-): string[] {
+): Array<{ entityId: string; firstSeenAt: number }> {
   if (keys.length === 0) return []
   const conditions = keys.map(() => '(key = ? AND value = ?)').join(' OR ')
   const params: (string | number)[] = [
@@ -219,128 +363,308 @@ function lookupByKeys(
     )
     .all(...params)
 
-  const resolved = new Set<string>()
+  const resolvedIds = new Set<string>()
   for (const { entity_id } of rows) {
-    resolved.add(resolveAlias(entity_id, db))
+    resolvedIds.add(resolveAlias(entity_id, db))
   }
-  return [...resolved]
-}
+  if (resolvedIds.size === 0) return []
 
-// ---------------------------------------------------------------------------
-// Core adopt-or-mint
-// ---------------------------------------------------------------------------
-
-/**
- * Adopt an existing entity (update last_seen_at, union new keys) or mint a
- * new one (INSERT + register keys).  When multiple entities match via
- * different keys, merge them: keep the oldest by first_seen_at, alias the
- * others, and union all keys onto the survivor.
- *
- * `parentId`       — empty string for node/link; node entity id for port
- *                    (stored in entity_identity_key.parent_id).
- * `entityParentId` — null for node/link; node entity id for port
- *                    (stored in entity_registry.parent_id, a nullable FK).
- */
-function adoptOrMintEntity(
-  topologyId: string,
-  kind: string,
-  parentId: string,
-  entityParentId: string | null,
-  keys: IdentityKey[],
-  now: number,
-  db: Database,
-): string {
-  const matchedIds = lookupByKeys(topologyId, kind, parentId, keys, db)
-
-  if (matchedIds.length === 0) {
-    // Mint
-    const entityId = generateUlid()
-    db.query(
-      `INSERT INTO entity_registry
-         (id, topology_id, kind, parent_id, status, first_seen_at, last_seen_at)
-       VALUES (?, ?, ?, ?, 'active', ?, ?)`,
-    ).run(entityId, topologyId, kind, entityParentId, now, now)
-    for (const { key, value } of keys) {
-      db.query(
-        `INSERT OR IGNORE INTO entity_identity_key
-           (topology_id, entity_id, kind, parent_id, key, value)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-      ).run(topologyId, entityId, kind, parentId, key, value)
-    }
-    return entityId
-  }
-
-  if (matchedIds.length === 1) {
-    // Adopt: update freshness, un-retire if needed, union new keys
-    const entityId = matchedIds[0] as string
-    db.query(
-      "UPDATE entity_registry SET last_seen_at = ?, status = 'active', retired_at = NULL WHERE id = ?",
-    ).run(now, entityId)
-    for (const { key, value } of keys) {
-      db.query(
-        `INSERT OR IGNORE INTO entity_identity_key
-           (topology_id, entity_id, kind, parent_id, key, value)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-      ).run(topologyId, entityId, kind, parentId, key, value)
-    }
-    return entityId
-  }
-
-  // Merge: keep oldest (min first_seen_at, then lex id for determinism)
-  const placeholders = matchedIds.map(() => '?').join(', ')
+  const placeholders = [...resolvedIds].map(() => '?').join(', ')
   const entities = db
     .query<{ id: string; first_seen_at: number }, string[]>(
       `SELECT id, first_seen_at FROM entity_registry
        WHERE id IN (${placeholders})
        ORDER BY first_seen_at ASC, id ASC`,
     )
-    .all(...matchedIds)
+    .all(...[...resolvedIds])
+  return entities.map((e) => ({ entityId: e.id, firstSeenAt: e.first_seen_at }))
+}
 
-  const survivor = entities[0]
-  if (!survivor) {
-    // Defensive: should never happen if lookupByKeys found entries
-    return matchedIds[0] as string
+function queryAndVetoCandidates(
+  topologyId: string,
+  kind: string,
+  parentId: string,
+  classKeys: IdentityKey[],
+  obsKeys: IdentityKey[],
+  entityKind: 'node' | 'port',
+  matchClass: NodeKeyClass | PortKeyClass,
+  db: Database,
+): CandidateInfo[] {
+  const raw = queryCandidates(topologyId, kind, parentId, classKeys, db)
+  const result: CandidateInfo[] = []
+  for (const candidate of raw) {
+    const eKeys = loadEntityKeys(topologyId, kind, parentId, candidate.entityId, db)
+    if (isVetoed(obsKeys, eKeys)) continue
+    if (entityKind === 'node' && matchClass === NODE_KEY_CLASS.MUTABLE) {
+      if (failsMutualConsistency(obsKeys, eKeys)) continue
+    }
+    result.push({ ...candidate, entityKeys: eKeys, matchClass })
   }
-  const survivorId = survivor.id
-  for (const other of entities.slice(1)) {
-    db.query('INSERT OR IGNORE INTO entity_alias (old_id, new_id) VALUES (?, ?)').run(
-      other.id,
-      survivorId,
+  return result
+}
+
+function stagedLookupNode(
+  topologyId: string,
+  parentId: string,
+  obsKeys: IdentityKey[],
+  db: Database,
+): CandidateInfo[] {
+  const strongObs = obsKeys.filter((k) => nodeKeyClass(k.key) === NODE_KEY_CLASS.STRONG)
+  const mutableObs = obsKeys.filter((k) => nodeKeyClass(k.key) === NODE_KEY_CLASS.MUTABLE)
+
+  if (strongObs.length > 0) {
+    const candidates = queryAndVetoCandidates(
+      topologyId,
+      'node',
+      parentId,
+      strongObs,
+      obsKeys,
+      'node',
+      NODE_KEY_CLASS.STRONG,
+      db,
     )
+    if (candidates.length > 0) return candidates
   }
-  // Refresh survivor (un-retire if needed) + union ALL keys from the new observation
-  db.query(
-    "UPDATE entity_registry SET last_seen_at = ?, status = 'active', retired_at = NULL WHERE id = ?",
-  ).run(now, survivorId)
-  for (const { key, value } of keys) {
-    db.query(
-      `INSERT OR IGNORE INTO entity_identity_key
-         (topology_id, entity_id, kind, parent_id, key, value)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-    ).run(topologyId, survivorId, kind, parentId, key, value)
+
+  if (mutableObs.length > 0) {
+    const candidates = queryAndVetoCandidates(
+      topologyId,
+      'node',
+      parentId,
+      mutableObs,
+      obsKeys,
+      'node',
+      NODE_KEY_CLASS.MUTABLE,
+      db,
+    )
+    if (candidates.length > 0) return candidates
   }
-  return survivorId
+
+  return []
+}
+
+function stagedLookupPort(
+  topologyId: string,
+  parentId: string,
+  obsKeys: IdentityKey[],
+  db: Database,
+): CandidateInfo[] {
+  const hasIfName = obsKeys.some((k) => k.key === 'ifName')
+  const hasMac = obsKeys.some((k) => k.key === 'mac')
+  const primaryObs = obsKeys.filter((k) => k.key === 'ifName')
+  const secondaryObs = obsKeys.filter((k) => k.key === 'mac')
+  const lastResortObs = !hasIfName && !hasMac ? obsKeys.filter((k) => k.key === 'ifIndex') : []
+
+  if (primaryObs.length > 0) {
+    const candidates = queryAndVetoCandidates(
+      topologyId,
+      'port',
+      parentId,
+      primaryObs,
+      obsKeys,
+      'port',
+      PORT_KEY_CLASS.PRIMARY,
+      db,
+    )
+    if (candidates.length > 0) return candidates
+  }
+
+  if (secondaryObs.length > 0) {
+    const candidates = queryAndVetoCandidates(
+      topologyId,
+      'port',
+      parentId,
+      secondaryObs,
+      obsKeys,
+      'port',
+      PORT_KEY_CLASS.SECONDARY,
+      db,
+    )
+    if (candidates.length > 0) return candidates
+  }
+
+  if (lastResortObs.length > 0) {
+    const candidates = queryAndVetoCandidates(
+      topologyId,
+      'port',
+      parentId,
+      lastResortObs,
+      obsKeys,
+      'port',
+      PORT_KEY_CLASS.LAST_RESORT,
+      db,
+    )
+    if (candidates.length > 0) return candidates
+  }
+
+  return []
+}
+
+function flatLookupCandidates(
+  topologyId: string,
+  kind: string,
+  parentId: string,
+  keys: IdentityKey[],
+  db: Database,
+): CandidateInfo[] {
+  const raw = queryCandidates(topologyId, kind, parentId, keys, db)
+  return raw.map((r) => ({
+    ...r,
+    entityKeys: new Map<string, string[]>(),
+    matchClass: NODE_KEY_CLASS.STRONG as NodeKeyClass,
+  }))
 }
 
 // ---------------------------------------------------------------------------
-// Public API — adopt-or-mint for a whole graph
+// Singleton-key replacement
+// ---------------------------------------------------------------------------
+
+function replaceSingletonKeys(
+  topologyId: string,
+  entityId: string,
+  kind: string,
+  parentId: string,
+  keys: IdentityKey[],
+  sourceId: string,
+  singletonSet: Set<string>,
+  db: Database,
+): void {
+  if (!sourceId) return
+  for (const { key, value } of keys) {
+    if (!singletonSet.has(key)) continue
+    // Delete stale values for this entity from this source (value changed).
+    db.query(
+      `DELETE FROM entity_identity_key
+       WHERE topology_id = ? AND entity_id = ? AND kind = ? AND parent_id = ?
+         AND key = ? AND source_id = ? AND value != ?`,
+    ).run(topologyId, entityId, kind, parentId, key, sourceId, value)
+    // Release the same (key, value, source) from any OTHER entity so the
+    // unique index allows us to claim it for this entity (IP moves, etc.).
+    db.query(
+      `DELETE FROM entity_identity_key
+       WHERE topology_id = ? AND entity_id != ? AND kind = ? AND parent_id = ?
+         AND key = ? AND value = ? AND source_id = ?`,
+    ).run(topologyId, entityId, kind, parentId, key, value, sourceId)
+  }
+}
+
+function insertIdentityKeys(
+  topologyId: string,
+  entityId: string,
+  kind: string,
+  parentId: string,
+  keys: IdentityKey[],
+  sourceId: string,
+  db: Database,
+): void {
+  for (const { key, value } of keys) {
+    db.query(
+      `INSERT OR IGNORE INTO entity_identity_key
+         (topology_id, entity_id, kind, parent_id, key, value, source_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(topologyId, entityId, kind, parentId, key, value, sourceId)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core adopt-or-mint
+// ---------------------------------------------------------------------------
+
+function adoptOrMintEntity(
+  topologyId: string,
+  kind: string,
+  parentId: string,
+  entityParentId: string | null,
+  keys: IdentityKey[],
+  sourceId: string,
+  singletonKeys: Set<string>,
+  now: number,
+  db: Database,
+  entityKind: 'node' | 'port' | 'link',
+): string {
+  const candidates =
+    entityKind === 'link'
+      ? flatLookupCandidates(topologyId, kind, parentId, keys, db)
+      : entityKind === 'node'
+        ? stagedLookupNode(topologyId, parentId, keys, db)
+        : stagedLookupPort(topologyId, parentId, keys, db)
+
+  if (candidates.length === 0) {
+    const entityId = generateUlid()
+    db.query(
+      `INSERT INTO entity_registry
+         (id, topology_id, kind, parent_id, status, first_seen_at, last_seen_at)
+       VALUES (?, ?, ?, ?, 'active', ?, ?)`,
+    ).run(entityId, topologyId, kind, entityParentId, now, now)
+    insertIdentityKeys(topologyId, entityId, kind, parentId, keys, sourceId, db)
+    return entityId
+  }
+
+  if (candidates.length === 1) {
+    const candidate = candidates[0]
+    if (!candidate) return generateUlid()
+    const entityId = candidate.entityId
+    db.query(
+      "UPDATE entity_registry SET last_seen_at = ?, status = 'active', retired_at = NULL WHERE id = ?",
+    ).run(now, entityId)
+    replaceSingletonKeys(topologyId, entityId, kind, parentId, keys, sourceId, singletonKeys, db)
+    insertIdentityKeys(topologyId, entityId, kind, parentId, keys, sourceId, db)
+    return entityId
+  }
+
+  // Multiple candidates: apply merge guard
+  const allShareStrongKey = candidates.every((c) => sharesStrongKey(keys, c.entityKeys))
+  const allAgreeOn2Classes = candidates.every(
+    (c) => countSharedKeyClasses(keys, c.entityKeys, entityKind === 'port' ? 'port' : 'node') >= 2,
+  )
+
+  if (allShareStrongKey || allAgreeOn2Classes) {
+    const sorted = [...candidates].sort(
+      (a, b) => a.firstSeenAt - b.firstSeenAt || a.entityId.localeCompare(b.entityId),
+    )
+    const survivor = sorted[0]
+    if (!survivor) return candidates[0]?.entityId ?? generateUlid()
+    const survivorId = survivor.entityId
+    for (const other of sorted.slice(1)) {
+      db.query('INSERT OR IGNORE INTO entity_alias (old_id, new_id) VALUES (?, ?)').run(
+        other.entityId,
+        survivorId,
+      )
+    }
+    db.query(
+      "UPDATE entity_registry SET last_seen_at = ?, status = 'active', retired_at = NULL WHERE id = ?",
+    ).run(now, survivorId)
+    replaceSingletonKeys(topologyId, survivorId, kind, parentId, keys, sourceId, singletonKeys, db)
+    insertIdentityKeys(topologyId, survivorId, kind, parentId, keys, sourceId, db)
+    return survivorId
+  }
+
+  // Ambiguous weak multi-match: adopt best, no merge, warn
+  const best = candidates[0]
+  if (!best) return generateUlid()
+  const entityId = best.entityId
+  const ambiguousIds = candidates.map((c) => c.entityId).join(', ')
+  const matchedKeys = keys.map((k) => `${k.key}=${k.value}`).join(', ')
+  console.warn(
+    `[Registry] ambiguous match — topology=${topologyId} kind=${kind} keys=[${matchedKeys}] ` +
+      `candidates=[${ambiguousIds}] — adopting ${entityId} (no merge; deferred review needed)`,
+  )
+  db.query(
+    "UPDATE entity_registry SET last_seen_at = ?, status = 'active', retired_at = NULL WHERE id = ?",
+  ).run(now, entityId)
+  replaceSingletonKeys(topologyId, entityId, kind, parentId, keys, sourceId, singletonKeys, db)
+  insertIdentityKeys(topologyId, entityId, kind, parentId, keys, sourceId, db)
+  return entityId
+}
+
+// ---------------------------------------------------------------------------
+// Public API - adopt-or-mint for a whole graph
 // ---------------------------------------------------------------------------
 
 /**
  * Adopt-or-mint entity_registry rows for every node, port, and link in a
  * source's contribution.  Must be called after `ingestGraph` on the same DB
- * connection: it registers from the POST-INGEST contribution rows (read back
- * via `buildGraph`), never from the raw source graph.  This is deliberate —
- * NetBox-shaped sources enumerate no `ports[]` at all; their ports exist only
- * as link-endpoint strings and are synthesized as stub elements (with
- * `identity.ifName`, Phase 0) inside `ingestGraph`.  Reading back keeps that
- * synthesis the single source of truth instead of duplicating it here; a raw
- * graph would yield zero port entities and therefore zero link entities.
- *
- * Execution order:
- *   1. Nodes  — establishes node entityIds needed by ports.
- *   2. Ports  — parent-scoped; requires node entityId.
- *   3. Links  — endpoint port entityIds must be known first.
+ * connection.
  */
 export function adoptOrMintForGraph(
   topologyId: string,
@@ -348,20 +672,28 @@ export function adoptOrMintForGraph(
   db: Database,
   now = timestamp(),
 ): number {
-  // No contribution rows for this (topology, source) → nothing to register.
   const graph = buildGraph(topologyId, sourceId, db)
   if (!graph) return now
 
-  // --- Nodes ---
-  const nodeEntityIds = new Map<string, string>() // nodeLocalId → entityId
+  const nodeEntityIds = new Map<string, string>()
   for (const node of graph.nodes ?? []) {
     const keys = gatherNodeKeys(node.identity, sourceId, node.id)
-    const entityId = adoptOrMintEntity(topologyId, 'node', '', null, keys, now, db)
+    const entityId = adoptOrMintEntity(
+      topologyId,
+      'node',
+      '',
+      null,
+      keys,
+      sourceId,
+      SINGLETON_NODE_KEYS,
+      now,
+      db,
+      'node',
+    )
     nodeEntityIds.set(node.id, entityId)
   }
 
-  // --- Ports ---
-  const portEntityIds = new Map<string, string>() // `${nodeId}:${portId}` → entityId
+  const portEntityIds = new Map<string, string>()
   for (const node of graph.nodes ?? []) {
     const nodeEntityId = nodeEntityIds.get(node.id)
     if (!nodeEntityId) continue
@@ -373,14 +705,16 @@ export function adoptOrMintForGraph(
         nodeEntityId,
         nodeEntityId,
         keys,
+        sourceId,
+        SINGLETON_PORT_KEYS,
         now,
         db,
+        'port',
       )
       portEntityIds.set(`${node.id}:${port.id}`, entityId)
     }
   }
 
-  // --- Links (canonical sorted endpoint pair → link entity) ---
   for (const link of graph.links ?? []) {
     const fromComposite = link.from.port ? `${link.from.node}:${link.from.port}` : undefined
     const toComposite = link.to.port ? `${link.to.node}:${link.to.port}` : undefined
@@ -389,47 +723,34 @@ export function adoptOrMintForGraph(
     if (!fromPortEntityId || !toPortEntityId) continue
     const [pA, pB] = [fromPortEntityId, toPortEntityId].sort()
     const linkKey: IdentityKey[] = [{ key: 'endpoints', value: `${pA}|${pB}` }]
-    adoptOrMintEntity(topologyId, 'link', '', null, linkKey, now, db)
+    adoptOrMintEntity(
+      topologyId,
+      'link',
+      '',
+      null,
+      linkKey,
+      sourceId,
+      new Set<string>(),
+      now,
+      db,
+      'link',
+    )
   }
   return now
 }
 
 // ---------------------------------------------------------------------------
-// Public API — entity retirement
+// Public API - entity retirement
 // ---------------------------------------------------------------------------
 
-/**
- * RETIRE_THRESHOLD_SYNCS: number of consecutive source syncs (that returned
- * data) after which an absent entity is marked 'retired'. Default 3.
- * Retired entities keep their id — a returning device re-adopts the same id
- * (the adopt branch resets status to 'active' and clears retired_at).
- */
 export const RETIRE_THRESHOLD_SYNCS = 3
 
-/**
- * Retirement pass: called after adoptOrMintForGraph when the source DID
- * return data (status != 'failed'). Increments miss_count for every active
- * entity of this topology whose last_seen_at < syncNow (was not adopted in
- * this sync). Resets miss_count to 0 for entities that WERE seen. Entities
- * reaching RETIRE_THRESHOLD_SYNCS misses flip to 'retired'.
- *
- * Source-failure guard: the CALLER must NOT call this when the source failed.
- * ObservationsService.materializeContribution skips the 'failed' status path.
- *
- * Returns the count of entities retired in this pass.
- */
 export function retireStaleEntities(
   topologyId: string,
   sourceId: string,
   syncNow: number,
   db: Database,
 ): number {
-  // Reset miss_count to 0 for entities THIS source saw in this sync
-  // (last_seen_at was just advanced to >= syncNow by adopt-or-mint). This is
-  // also what SEEDS a counter row for an entity the first time this source
-  // observes it — so the increment below can be scoped to entities this source
-  // has actually seen before (a source only retires what it once reported;
-  // another source's exclusive entities never get a counter row here).
   db.query(
     `INSERT OR REPLACE INTO entity_retire_counter (topology_id, source_id, entity_id, miss_count)
      SELECT ?, ?, er.id, 0
@@ -437,11 +758,6 @@ export function retireStaleEntities(
      WHERE er.topology_id = ? AND er.status = 'active' AND er.last_seen_at >= ?`,
   ).run(topologyId, sourceId, topologyId, syncNow)
 
-  // Increment miss_count for entities THIS source previously observed (they
-  // already have a counter row) but did NOT see in this sync (last_seen_at <
-  // syncNow). Scoping to existing counter rows is what keeps a multi-source
-  // topology honest: source A never counts misses against an entity only source
-  // B ever reported. A failed fetch never reaches here (the caller skips it).
   db.query(
     `UPDATE entity_retire_counter
        SET miss_count = miss_count + 1
@@ -452,7 +768,6 @@ export function retireStaleEntities(
        )`,
   ).run(topologyId, sourceId, topologyId, syncNow)
 
-  // Retire entities that have reached the threshold for this source.
   const result = db
     .query(
       `UPDATE entity_registry SET status = 'retired', retired_at = ?
@@ -468,7 +783,7 @@ export function retireStaleEntities(
 }
 
 // ---------------------------------------------------------------------------
-// Public API — stamp entityId onto a resolved graph (read-only registry access)
+// Public API - stamp entityId onto a resolved graph (read-only registry access)
 // ---------------------------------------------------------------------------
 
 function lookupNodeEntityId(
@@ -477,10 +792,10 @@ function lookupNodeEntityId(
   db: Database,
 ): string | undefined {
   if (!identity) return undefined
-  // Use gatherNodeKeys but strip manual fallback keys (source-specific, not useful for lookup)
   const keys = gatherNodeKeys(identity, '', '').filter((k) => !k.key.startsWith('manual:'))
   if (keys.length === 0) return undefined
-  return lookupByKeys(topologyId, 'node', '', keys, db)[0]
+  const candidates = stagedLookupNode(topologyId, '', keys, db)
+  return candidates[0]?.entityId
 }
 
 function lookupPortEntityId(
@@ -492,7 +807,8 @@ function lookupPortEntityId(
   if (!identity) return undefined
   const keys = gatherPortKeys(identity, '', '').filter((k) => !k.key.startsWith('manual:'))
   if (keys.length === 0) return undefined
-  return lookupByKeys(topologyId, 'port', nodeEntityId, keys, db)[0]
+  const candidates = stagedLookupPort(topologyId, nodeEntityId, keys, db)
+  return candidates[0]?.entityId
 }
 
 function lookupLinkEntityId(
@@ -503,23 +819,16 @@ function lookupLinkEntityId(
 ): string | undefined {
   const [pA, pB] = [portAEntityId, portBEntityId].sort()
   const keys: IdentityKey[] = [{ key: 'endpoints', value: `${pA}|${pB}` }]
-  return lookupByKeys(topologyId, 'link', '', keys, db)[0]
+  const candidates = flatLookupCandidates(topologyId, 'link', '', keys, db)
+  return candidates[0]?.entityId
 }
 
-/**
- * Stamp `entityId` on nodes, their ports, and links in the resolved graph.
- * Read-only: never writes to the registry.  Elements whose identity cannot
- * be resolved in the registry are returned unchanged (entityId omitted).
- *
- * Called by TopologyService.completeDerivation in the host process after the
- * derive worker returns its result.
- */
 export function stampEntityIds(
   topologyId: string,
   graph: NetworkGraph,
   db: Database,
 ): NetworkGraph {
-  const portEntityByNodePort = new Map<string, string>() // `${nodeId}:${portId}` → entityId
+  const portEntityByNodePort = new Map<string, string>()
 
   const stampedNodes: Node[] = graph.nodes.map((node) => {
     const nodeEntityId = lookupNodeEntityId(topologyId, node.identity, db)
@@ -556,7 +865,9 @@ export function stampEntityIds(
 }
 
 // ---------------------------------------------------------------------------
-// Public API — flip resolved element ids to their entity ids (Phase 3)
+// Public API - flip resolved element ids to their entity ids (Phase 3)
+// ---------------------------------------------------------------------------
+
 // ---------------------------------------------------------------------------
 
 /**

--- a/apps/server/api/src/services/entity-registry.ts
+++ b/apps/server/api/src/services/entity-registry.ts
@@ -11,7 +11,7 @@
  *   MUTABLE: mgmtIp, sysName  (singleton-replaced per source)
  *
  * Port key classes (descending strength):
- *   PRIMARY:     ifName
+ *   PRIMARY:     ifName, manual:* (fallback — only exists when no network identity)
  *   SECONDARY:   mac
  *   LAST_RESORT: ifIndex  (only when observation has neither ifName nor mac)
  *
@@ -19,14 +19,21 @@
  *   1. Query each class descending; stop at first class with candidates.
  *   2. VETO: candidate and observation both carry the same STRONG key namespace
  *      (chassisId, vendor:<ns>) with different values -> reject.
- *   3. MUTABLE mutual-consistency: ALL mutable keys on BOTH sides must agree.
+ *   3. MUTABLE mutual-consistency: a sysName present on BOTH sides must agree
+ *      (sysName is the device-identity arbiter; mgmtIp conflicts are NOT grounds
+ *      for rejection — an IP swap is legitimate and handled by replacement).
  *   4. All vetoed -> continue; nothing left -> mint.
  *
- * Merge guard: auto-merge ONLY when all candidates share a STRONG key, OR
- * all agree on >=2 independent key classes. Otherwise adopt best + warn.
+ * Merge guard: auto-merge ONLY when all candidates share a merge-strong key
+ * (node: STRONG class; port: ifName/manual:* — never mac or ifIndex alone),
+ * OR all agree on >=2 independent key classes. Otherwise adopt the best
+ * candidate (highest class, tie -> oldest) WITHOUT merging and console.warn
+ * a structured `[Registry] ambiguous match` line for deferred review.
  *
  * Singleton-key replacement: mgmtIp/sysName per node, ifIndex per port are
- * per-source singletons (old value deleted, new inserted, others' rows untouched).
+ * per-source singletons — on adopt AND mint the source's stale rows (or legacy
+ * source_id = '' rows) are deleted before insert; other sources' rows survive.
+ * ifName is PRIMARY but NOT singleton: replacing ifName would re-key the port.
  *
  * parent_id sentinel: entity_identity_key.parent_id uses '' (empty string)
  * for node and link entities; port entities use the parent node entity id.
@@ -323,9 +330,25 @@ function countSharedKeyClasses(
   return matchedClasses.size
 }
 
-function sharesStrongKey(obsKeys: IdentityKey[], entityKeys: Map<string, string[]>): boolean {
+/**
+ * Merge-guard "strong" test, kind-aware:
+ *   node: STRONG class keys (chassisId, vendor:*, manual:*)
+ *   port: ifName (PRIMARY) or manual:* — mac (SECONDARY) and ifIndex (LAST_RESORT)
+ *         are deliberately NOT strong here, so a mac-only or ifIndex-only
+ *         multi-match can never auto-merge (spec: ifIndex must never trigger a merge).
+ */
+function isMergeStrongKey(key: string, kind: 'node' | 'port'): boolean {
+  if (kind === 'node') return nodeKeyClass(key) === NODE_KEY_CLASS.STRONG
+  return key === 'ifName' || key.startsWith('manual:')
+}
+
+function sharesStrongKey(
+  obsKeys: IdentityKey[],
+  entityKeys: Map<string, string[]>,
+  kind: 'node' | 'port',
+): boolean {
   for (const { key, value } of obsKeys) {
-    if (nodeKeyClass(key) !== NODE_KEY_CLASS.STRONG) continue
+    if (!isMergeStrongKey(key, kind)) continue
     const entityValues = entityKeys.get(key)
     if (entityValues?.includes(value)) return true
   }
@@ -497,6 +520,24 @@ function stagedLookupPort(
     if (candidates.length > 0) return candidates
   }
 
+  // manual:* fallback — only ever gathered when the port has no network identity
+  // at all, so it never coexists with the classes above. Without this stage an
+  // identity-less port would mint a fresh entity on every sync.
+  const manualObs = obsKeys.filter((k) => k.key.startsWith('manual:'))
+  if (manualObs.length > 0) {
+    const candidates = queryAndVetoCandidates(
+      topologyId,
+      'port',
+      parentId,
+      manualObs,
+      obsKeys,
+      'port',
+      PORT_KEY_CLASS.PRIMARY,
+      db,
+    )
+    if (candidates.length > 0) return candidates
+  }
+
   return []
 }
 
@@ -519,6 +560,23 @@ function flatLookupCandidates(
 // Singleton-key replacement
 // ---------------------------------------------------------------------------
 
+/**
+ * Per-source singleton-key replacement. For each SINGLETON key the source
+ * reports, the source's view is "this entity, this value, nothing else":
+ *   1. stale values for the SAME entity from this source are deleted
+ *      (mgmtIp changed on the device);
+ *   2. the SAME (key, value) held by a DIFFERENT entity from this source is
+ *      released (an IP moved between devices — this is what kills the stale-IP
+ *      magnet: the decommissioned entity loses the key the moment the source
+ *      sees the value elsewhere).
+ * Legacy rows (source_id = '', pre-migration-029) are treated as belonging to
+ * whichever source claims them first — otherwise a pre-existing stale magnet
+ * would survive the hardening forever. Rows written by OTHER sources are never
+ * touched, so dual-homed multi-source truth is preserved.
+ *
+ * Called on BOTH adopt and mint: in the IP-reuse case the observation mints a
+ * new entity, and the new entity is now the source's owner of that mgmtIp.
+ */
 function replaceSingletonKeys(
   topologyId: string,
   entityId: string,
@@ -532,18 +590,18 @@ function replaceSingletonKeys(
   if (!sourceId) return
   for (const { key, value } of keys) {
     if (!singletonSet.has(key)) continue
-    // Delete stale values for this entity from this source (value changed).
+    // Delete stale values for this entity from this source or the legacy sentinel.
     db.query(
       `DELETE FROM entity_identity_key
        WHERE topology_id = ? AND entity_id = ? AND kind = ? AND parent_id = ?
-         AND key = ? AND source_id = ? AND value != ?`,
+         AND key = ? AND source_id IN (?, '') AND value != ?`,
     ).run(topologyId, entityId, kind, parentId, key, sourceId, value)
-    // Release the same (key, value, source) from any OTHER entity so the
-    // unique index allows us to claim it for this entity (IP moves, etc.).
+    // Release the same (key, value) from any OTHER entity (this source or legacy)
+    // so the unique index allows us to claim it for this entity (IP moves, etc.).
     db.query(
       `DELETE FROM entity_identity_key
        WHERE topology_id = ? AND entity_id != ? AND kind = ? AND parent_id = ?
-         AND key = ? AND value = ? AND source_id = ?`,
+         AND key = ? AND value = ? AND source_id IN (?, '')`,
     ).run(topologyId, entityId, kind, parentId, key, value, sourceId)
   }
 }
@@ -596,6 +654,9 @@ function adoptOrMintEntity(
          (id, topology_id, kind, parent_id, status, first_seen_at, last_seen_at)
        VALUES (?, ?, ?, ?, 'active', ?, ?)`,
     ).run(entityId, topologyId, kind, entityParentId, now, now)
+    // Mint claims singleton keys too: after an IP reuse the vetoed old entity
+    // must lose the source's mgmtIp row, or it stays a stale magnet.
+    replaceSingletonKeys(topologyId, entityId, kind, parentId, keys, sourceId, singletonKeys, db)
     insertIdentityKeys(topologyId, entityId, kind, parentId, keys, sourceId, db)
     return entityId
   }
@@ -613,9 +674,10 @@ function adoptOrMintEntity(
   }
 
   // Multiple candidates: apply merge guard
-  const allShareStrongKey = candidates.every((c) => sharesStrongKey(keys, c.entityKeys))
+  const guardKind = entityKind === 'port' ? 'port' : 'node'
+  const allShareStrongKey = candidates.every((c) => sharesStrongKey(keys, c.entityKeys, guardKind))
   const allAgreeOn2Classes = candidates.every(
-    (c) => countSharedKeyClasses(keys, c.entityKeys, entityKind === 'port' ? 'port' : 'node') >= 2,
+    (c) => countSharedKeyClasses(keys, c.entityKeys, guardKind) >= 2,
   )
 
   if (allShareStrongKey || allAgreeOn2Classes) {

--- a/apps/server/api/test/db/entity-registry.test.ts
+++ b/apps/server/api/test/db/entity-registry.test.ts
@@ -12,7 +12,11 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import type { NetworkGraph } from '@shumoku/core'
 import { getDatabase, timestamp } from '../../src/db/index.ts'
 import { ingestGraph } from '../../src/services/contribution-store.ts'
-import { adoptOrMintForGraph, stampEntityIds } from '../../src/services/entity-registry.ts'
+import {
+  adoptOrMintForGraph,
+  generateUlid,
+  stampEntityIds,
+} from '../../src/services/entity-registry.ts'
 import { attachSource, insertDataSource, setupTempDb } from './helper.ts'
 
 // ---------------------------------------------------------------------------
@@ -285,21 +289,21 @@ describe('entity registry', () => {
   })
 
   describe('merge', () => {
-    test('two entities that acquire a shared key merge into one', () => {
+    test('staged lookup adopts the strong-key entity; sysName-only entity stays separate', () => {
       const topologyId = makeTopology(db)
       const src1 = insertDataSource('lldp')
       const src2 = insertDataSource('netbox')
       attachSource(topologyId, src1, 'topology')
       attachSource(topologyId, src2, 'topology')
 
-      // Mint via sysName only
+      // Mint via sysName only (MUTABLE class)
       ingestAndRegister(db, topologyId, src1, {
         name: 'g1',
         nodes: [{ id: 'a', label: 'a', identity: { sysName: 'spine-1' }, ports: [] }],
         links: [],
       })
 
-      // Mint via chassisId only
+      // Mint via chassisId only (STRONG class)
       ingestAndRegister(db, topologyId, src2, {
         name: 'g2',
         nodes: [{ id: 'b', label: 'b', identity: { chassisId: 'ff:ee:dd:cc:bb:aa' }, ports: [] }],
@@ -310,7 +314,8 @@ describe('entity registry', () => {
       const before = registryCount(db, topologyId)
       expect(before.nodes).toBe(2)
 
-      // Now ingest with BOTH keys → merge
+      // Ingest with BOTH keys: staged lookup finds entity B via STRONG class (chassisId),
+      // returns it as the sole candidate — no cross-class merge with sysName-only entity A.
       ingestAndRegister(db, topologyId, src1, {
         name: 'g3',
         nodes: [
@@ -324,9 +329,9 @@ describe('entity registry', () => {
         links: [],
       })
 
-      // Should have collapsed to 1 entity (+ 1 alias)
+      // Entity B adopted; entity A stays separate. No alias created.
       const after = registryCount(db, topologyId)
-      expect(after.nodes).toBe(2) // registry row count doesn't change (alias still points to retired id)
+      expect(after.nodes).toBe(2)
       const aliasCount = (
         db
           .query<{ n: number }, string>(
@@ -334,7 +339,7 @@ describe('entity registry', () => {
           )
           .get(topologyId) ?? { n: 0 }
       ).n
-      expect(aliasCount).toBe(1)
+      expect(aliasCount).toBe(0)
     })
   })
 
@@ -531,6 +536,326 @@ describe('entity registry', () => {
       // stampEntityIds should NOT find an entity (manual key is source-scoped, stripped by stamp)
       const stamped = stampEntityIds(topologyId, graphWithManual, db)
       expect(stamped.nodes[0]?.entityId).toBeUndefined()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // @570: IP reuse - mutual-consistency rule
+  // -------------------------------------------------------------------------
+
+  describe('IP reuse (mutual-consistency rule)', () => {
+    test('observation with conflicting sysName mints new entity even if IP matches', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('snmp-ipreuse')
+      attachSource(topologyId, src, 'topology')
+
+      ingestAndRegister(db, topologyId, src, {
+        name: 'g1',
+        nodes: [
+          { id: 'a', label: 'a', identity: { sysName: 'router-X', mgmtIp: '10.1.1.1' }, ports: [] },
+        ],
+        links: [],
+      })
+      expect(registryCount(db, topologyId).nodes).toBe(1)
+
+      // conflicting sysName => MUTABLE mutual-consistency rejects candidate => MINT new
+      ingestAndRegister(db, topologyId, src, {
+        name: 'g2',
+        nodes: [
+          { id: 'b', label: 'b', identity: { sysName: 'router-Y', mgmtIp: '10.1.1.1' }, ports: [] },
+        ],
+        links: [],
+      })
+
+      expect(registryCount(db, topologyId).nodes).toBe(2)
+      const aliases = (
+        db
+          .query<{ n: number }, string>(
+            'SELECT COUNT(*) AS n FROM entity_alias WHERE new_id IN (SELECT id FROM entity_registry WHERE topology_id = ?)',
+          )
+          .get(topologyId) ?? { n: 0 }
+      ).n
+      expect(aliases).toBe(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // @570: IP swap - adopt B (sysName match), replace stale IP, no merge
+  // -------------------------------------------------------------------------
+
+  describe('IP swap', () => {
+    test('entity B adopted; stale IP replaced; entity A rejected by sysName conflict; no alias', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('snmp-ipswap')
+      attachSource(topologyId, src, 'topology')
+
+      // Entity A (dead): sysName=dead-device, mgmtIp=10.2.2.1
+      ingestAndRegister(db, topologyId, src, {
+        name: 'g-A',
+        nodes: [
+          {
+            id: 'a',
+            label: 'a',
+            identity: { sysName: 'dead-device', mgmtIp: '10.2.2.1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+      // Entity B (live): sysName=live-device, mgmtIp=10.2.2.2
+      ingestAndRegister(db, topologyId, src, {
+        name: 'g-B',
+        nodes: [
+          {
+            id: 'b',
+            label: 'b',
+            identity: { sysName: 'live-device', mgmtIp: '10.2.2.2' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+      expect(registryCount(db, topologyId).nodes).toBe(2)
+
+      const entityBId = db
+        .query<{ id: string }, [string, string]>(
+          'SELECT er.id FROM entity_registry er JOIN entity_identity_key eik ON eik.entity_id = er.id WHERE er.topology_id = ? AND eik.key = "sysName" AND eik.value = ?',
+        )
+        .get(topologyId, 'live-device')?.id
+      expect(entityBId).toBeTruthy()
+
+      // Observation: sysName=live-device (matches B), mgmtIp=10.2.2.1 (was A's stale IP).
+      // A is vetoed by mutual-consistency (sysName=dead-device conflicts); B is the sole
+      // candidate → clean single-candidate adoption, no warn emitted.
+      ingestAndRegister(db, topologyId, src, {
+        name: 'g-obs',
+        nodes: [
+          {
+            id: 'c',
+            label: 'c',
+            identity: { sysName: 'live-device', mgmtIp: '10.2.2.1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+
+      // Still 2 entities (no mint, no merge)
+      expect(registryCount(db, topologyId).nodes).toBe(2)
+
+      // No alias (no merge)
+      const aliases = (
+        db
+          .query<{ n: number }, string>(
+            'SELECT COUNT(*) AS n FROM entity_alias WHERE new_id IN (SELECT id FROM entity_registry WHERE topology_id = ?)',
+          )
+          .get(topologyId) ?? { n: 0 }
+      ).n
+      expect(aliases).toBe(0)
+
+      // B's mgmtIp replaced to 10.2.2.1 from this source (singleton replacement)
+      const bMgmtIp = db
+        .query<{ value: string }, [string, string]>(
+          'SELECT value FROM entity_identity_key WHERE entity_id = ? AND key = "mgmtIp" AND source_id = ?',
+        )
+        .get(entityBId ?? '', src)?.value
+      expect(bMgmtIp).toBe('10.2.2.1')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // @570: Strong veto - vendor key conflict prevents adoption
+  // -------------------------------------------------------------------------
+
+  describe('strong veto (vendor key conflict)', () => {
+    test('candidate with different vendor:* key is vetoed even if mgmtIp matches', () => {
+      const topologyId = makeTopology(db)
+      const src1 = insertDataSource('netbox-veto')
+      const src2 = insertDataSource('zabbix-veto')
+      attachSource(topologyId, src1, 'topology')
+      attachSource(topologyId, src2, 'topology')
+
+      ingestAndRegister(db, topologyId, src1, {
+        name: 'g1',
+        nodes: [
+          {
+            id: 'n1',
+            label: 'n1',
+            identity: { vendorIds: { 'netbox-device-id': '42' }, mgmtIp: '10.3.3.1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+      expect(registryCount(db, topologyId).nodes).toBe(1)
+
+      // Different netbox-device-id => STRONG veto => mint new entity
+      ingestAndRegister(db, topologyId, src2, {
+        name: 'g2',
+        nodes: [
+          {
+            id: 'n2',
+            label: 'n2',
+            identity: { vendorIds: { 'netbox-device-id': '43' }, mgmtIp: '10.3.3.1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+
+      expect(registryCount(db, topologyId).nodes).toBe(2)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // @570: Legit merge - all candidates share strong key with observation
+  // -------------------------------------------------------------------------
+
+  describe('legit merge - all candidates share strong key', () => {
+    test('entities sharing chassisId are adopted (single match) then merged (multi-match both sharing chassisId)', () => {
+      const topologyId = makeTopology(db)
+      const src1 = insertDataSource('lldp-merge')
+      const src2 = insertDataSource('snmp-merge')
+      attachSource(topologyId, src1, 'topology')
+      attachSource(topologyId, src2, 'topology')
+
+      // Entity A: chassisId=AA + sysName
+      ingestAndRegister(db, topologyId, src1, {
+        name: 'g1',
+        nodes: [
+          {
+            id: 'a',
+            label: 'a',
+            identity: { chassisId: 'aa:aa:aa:aa:aa:aa', sysName: 'spine-merge' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+
+      // Same chassisId => adopts entity A (single candidate, no merge)
+      ingestAndRegister(db, topologyId, src2, {
+        name: 'g2',
+        nodes: [
+          {
+            id: 'b',
+            label: 'b',
+            identity: { chassisId: 'aa:aa:aa:aa:aa:aa', mgmtIp: '10.4.4.1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+
+      // 1 entity after strong-key adoption
+      expect(registryCount(db, topologyId).nodes).toBe(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // @570: Per-source singleton-key replacement
+  // -------------------------------------------------------------------------
+
+  describe('per-source singleton-key replacement', () => {
+    test('source A updates its own mgmtIp; source B row is unaffected', () => {
+      const topologyId = makeTopology(db)
+      const srcA = insertDataSource('src-a-singleton')
+      const srcB = insertDataSource('src-b-singleton')
+      attachSource(topologyId, srcA, 'topology')
+      attachSource(topologyId, srcB, 'topology')
+
+      // Both sources see same chassisId => same entity
+      ingestAndRegister(db, topologyId, srcA, {
+        name: 'ga',
+        nodes: [
+          {
+            id: 'n',
+            label: 'n',
+            identity: { chassisId: 'ee:ee:ee:ee:ee:ee', mgmtIp: '10.6.6.1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+      ingestAndRegister(db, topologyId, srcB, {
+        name: 'gb',
+        nodes: [
+          {
+            id: 'n',
+            label: 'n',
+            identity: { chassisId: 'ee:ee:ee:ee:ee:ee', mgmtIp: '10.6.6.100' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+
+      expect(registryCount(db, topologyId).nodes).toBe(1)
+      const entityId = entityIdOf(db, topologyId, 'node')
+      expect(entityId).toBeTruthy()
+
+      const getIp = (eid: string, sid: string) =>
+        db
+          .query<{ value: string }, [string, string]>(
+            'SELECT value FROM entity_identity_key WHERE entity_id = ? AND key = "mgmtIp" AND source_id = ?',
+          )
+          .get(eid, sid)?.value
+
+      expect(getIp(entityId ?? '', srcA)).toBe('10.6.6.1')
+      expect(getIp(entityId ?? '', srcB)).toBe('10.6.6.100')
+
+      // Source A reports new IP
+      ingestAndRegister(db, topologyId, srcA, {
+        name: 'ga2',
+        nodes: [
+          {
+            id: 'n',
+            label: 'n',
+            identity: { chassisId: 'ee:ee:ee:ee:ee:ee', mgmtIp: '10.6.6.99' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+
+      // A updated, B unchanged
+      expect(getIp(entityId ?? '', srcA)).toBe('10.6.6.99')
+      expect(getIp(entityId ?? '', srcB)).toBe('10.6.6.100')
+      expect(registryCount(db, topologyId).nodes).toBe(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // @570: ULID unit tests
+  // -------------------------------------------------------------------------
+
+  describe('generateUlid', () => {
+    test('produces 26-char strings', () => {
+      expect(generateUlid()).toHaveLength(26)
+    })
+
+    test('uses Crockford base32 alphabet (no I, L, O, U)', () => {
+      const CROCKFORD = /^[0-9ABCDEFGHJKMNPQRSTVWXYZ]{26}$/
+      for (let i = 0; i < 50; i++) {
+        const id = generateUlid()
+        expect(CROCKFORD.test(id)).toBe(true)
+        expect(id).not.toMatch(/[ILOU]/)
+      }
+    })
+
+    test('lexicographic order follows Date.now() order across >=2ms-separated calls', async () => {
+      const id1 = generateUlid()
+      await new Promise<void>((resolve) => setTimeout(resolve, 5))
+      const id2 = generateUlid()
+      expect(id1 < id2).toBe(true)
+    })
+
+    test('1000 generated ids are all unique', () => {
+      const ids = new Set<string>()
+      for (let i = 0; i < 1000; i++) {
+        ids.add(generateUlid())
+      }
+      expect(ids.size).toBe(1000)
     })
   })
 })

--- a/apps/server/api/test/db/entity-registry.test.ts
+++ b/apps/server/api/test/db/entity-registry.test.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Database } from 'bun:sqlite'
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, spyOn, test } from 'bun:test'
 import type { NetworkGraph } from '@shumoku/core'
 import { getDatabase, timestamp } from '../../src/db/index.ts'
 import { ingestGraph } from '../../src/services/contribution-store.ts'
@@ -576,6 +576,26 @@ describe('entity registry', () => {
           .get(topologyId) ?? { n: 0 }
       ).n
       expect(aliases).toBe(0)
+
+      // Magnet kill: the minted entity claims mgmtIp=10.1.1.1 from this source;
+      // the old (dead) entity must no longer hold it — otherwise a later
+      // mgmtIp-only observation would still adopt the wrong device.
+      const ipOwners = db
+        .query<{ entity_id: string; value: string }, [string, string]>(
+          `SELECT eik.entity_id, eik.value FROM entity_identity_key eik
+           JOIN entity_registry er ON er.id = eik.entity_id
+           WHERE er.topology_id = ? AND eik.key = 'mgmtIp' AND eik.value = ?`,
+        )
+        .all(topologyId, '10.1.1.1')
+      expect(ipOwners.length).toBe(1)
+      const newEntityId = db
+        .query<{ entity_id: string }, [string, string]>(
+          `SELECT eik.entity_id FROM entity_identity_key eik
+           JOIN entity_registry er ON er.id = eik.entity_id
+           WHERE er.topology_id = ? AND eik.key = 'sysName' AND eik.value = ?`,
+        )
+        .get(topologyId, 'router-y')?.entity_id
+      expect(ipOwners[0]?.entity_id).toBe(newEntityId ?? '')
     })
   })
 
@@ -660,6 +680,17 @@ describe('entity registry', () => {
         )
         .get(entityBId ?? '', src)?.value
       expect(bMgmtIp).toBe('10.2.2.1')
+
+      // Magnet kill: dead entity A released mgmtIp=10.2.2.1 — B is now the only owner.
+      const ipOwners = db
+        .query<{ entity_id: string }, [string, string]>(
+          `SELECT eik.entity_id FROM entity_identity_key eik
+           JOIN entity_registry er ON er.id = eik.entity_id
+           WHERE er.topology_id = ? AND eik.key = 'mgmtIp' AND eik.value = ?`,
+        )
+        .all(topologyId, '10.2.2.1')
+      expect(ipOwners.length).toBe(1)
+      expect(ipOwners[0]?.entity_id).toBe(entityBId ?? '')
     })
   })
 
@@ -750,6 +781,147 @@ describe('entity registry', () => {
       // 1 entity after strong-key adoption
       expect(registryCount(db, topologyId).nodes).toBe(1)
     })
+
+    test('multi-candidate merge: each candidate shares a STRONG key with the observation', () => {
+      const topologyId = makeTopology(db)
+      const src1 = insertDataSource('lldp-mc')
+      const src2 = insertDataSource('zabbix-mc')
+      attachSource(topologyId, src1, 'topology')
+      attachSource(topologyId, src2, 'topology')
+
+      // Entity A: chassisId only (STRONG)
+      ingestAndRegister(db, topologyId, src1, {
+        name: 'gA',
+        nodes: [{ id: 'a', label: 'a', identity: { chassisId: 'bb:bb:bb:bb:bb:01' }, ports: [] }],
+        links: [],
+      })
+      // Entity B: vendor id only (STRONG, different namespace — no chassisId, so no adopt)
+      ingestAndRegister(db, topologyId, src2, {
+        name: 'gB',
+        nodes: [
+          { id: 'b', label: 'b', identity: { vendorIds: { 'zabbix-host-id': '77' } }, ports: [] },
+        ],
+        links: [],
+      })
+      const before = entityIdsOf(db, topologyId, 'node')
+      expect(before.length).toBe(2)
+
+      // Observation carries BOTH strong keys → both candidates found at STRONG
+      // stage, each shares a STRONG key with the observation → legit auto-merge.
+      ingestAndRegister(db, topologyId, src1, {
+        name: 'gObs',
+        nodes: [
+          {
+            id: 'c',
+            label: 'c',
+            identity: { chassisId: 'bb:bb:bb:bb:bb:01', vendorIds: { 'zabbix-host-id': '77' } },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+
+      const aliasRows = db
+        .query<{ old_id: string; new_id: string }, string>(
+          'SELECT old_id, new_id FROM entity_alias WHERE new_id IN (SELECT id FROM entity_registry WHERE topology_id = ?)',
+        )
+        .all(topologyId)
+      expect(aliasRows.length).toBe(1)
+      // The alias connects exactly the two pre-existing entities (direction = tie
+      // on first_seen_at is broken by id, so assert the set, not the order).
+      const pair = [aliasRows[0]?.old_id, aliasRows[0]?.new_id].sort()
+      expect(pair).toEqual([...before].sort())
+
+      // Re-ingesting either source's original view now resolves to the survivor.
+      ingestAndRegister(db, topologyId, src2, {
+        name: 'gB2',
+        nodes: [
+          { id: 'b', label: 'b', identity: { vendorIds: { 'zabbix-host-id': '77' } }, ports: [] },
+        ],
+        links: [],
+      })
+      const after = entityIdsOf(db, topologyId, 'node')
+      expect(after.length).toBe(2) // absorbed row remains; no third entity minted
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // @570: Ambiguous weak multi-match - adopt best, no merge, warn
+  // -------------------------------------------------------------------------
+
+  describe('ambiguous weak multi-match', () => {
+    test('adopts a single candidate, creates no alias, and warns', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('snmp-ambiguous')
+      attachSource(topologyId, src, 'topology')
+
+      // Entity A: mgmtIp only. Entity B: sysName only. Both MUTABLE-class.
+      ingestAndRegister(db, topologyId, src, {
+        name: 'gA',
+        nodes: [{ id: 'a', label: 'a', identity: { mgmtIp: '10.5.5.1' }, ports: [] }],
+        links: [],
+      })
+      ingestAndRegister(db, topologyId, src, {
+        name: 'gB',
+        nodes: [{ id: 'b', label: 'b', identity: { sysName: 'amb-dev' }, ports: [] }],
+        links: [],
+      })
+      expect(registryCount(db, topologyId).nodes).toBe(2)
+
+      // Observation matches A on mgmtIp and B on sysName — one MUTABLE key each,
+      // no strong key, only 1 shared class per candidate → merge guard refuses.
+      const warnSpy = spyOn(console, 'warn')
+      try {
+        ingestAndRegister(db, topologyId, src, {
+          name: 'gObs',
+          nodes: [
+            {
+              id: 'c',
+              label: 'c',
+              identity: { mgmtIp: '10.5.5.1', sysName: 'amb-dev' },
+              ports: [],
+            },
+          ],
+          links: [],
+        })
+        const ambiguousWarns = warnSpy.mock.calls.filter((call) =>
+          String(call[0]).includes('[Registry] ambiguous match'),
+        )
+        expect(ambiguousWarns.length).toBe(1)
+      } finally {
+        warnSpy.mockRestore()
+      }
+
+      // No merge: still two registry rows, zero alias rows.
+      expect(registryCount(db, topologyId).nodes).toBe(2)
+      const aliases = (
+        db
+          .query<{ n: number }, string>(
+            'SELECT COUNT(*) AS n FROM entity_alias WHERE new_id IN (SELECT id FROM entity_registry WHERE topology_id = ?)',
+          )
+          .get(topologyId) ?? { n: 0 }
+      ).n
+      expect(aliases).toBe(0)
+
+      // Exactly ONE entity was adopted: it now owns both keys (singleton
+      // replacement moved the other's key over); the loser holds no keys.
+      // Tie on first_seen_at makes the winner direction-nondeterministic,
+      // so assert the shape, not the specific id.
+      const keyRows = db
+        .query<{ entity_id: string; key: string }, string>(
+          `SELECT eik.entity_id, eik.key FROM entity_identity_key eik
+           JOIN entity_registry er ON er.id = eik.entity_id
+           WHERE er.topology_id = ? AND eik.kind = 'node'`,
+        )
+        .all(topologyId)
+      const byEntity = new Map<string, string[]>()
+      for (const row of keyRows) {
+        byEntity.set(row.entity_id, [...(byEntity.get(row.entity_id) ?? []), row.key])
+      }
+      expect(byEntity.size).toBe(1)
+      const winnerKeys = [...byEntity.values()][0]?.sort()
+      expect(winnerKeys).toEqual(['mgmtIp', 'sysName'])
+    })
   })
 
   // -------------------------------------------------------------------------
@@ -822,6 +994,129 @@ describe('entity registry', () => {
       expect(getIp(entityId ?? '', srcA)).toBe('10.6.6.99')
       expect(getIp(entityId ?? '', srcB)).toBe('10.6.6.100')
       expect(registryCount(db, topologyId).nodes).toBe(1)
+    })
+
+    test('two sources can assert the SAME value independently (per-source unique)', () => {
+      const topologyId = makeTopology(db)
+      const srcA = insertDataSource('src-a-dual')
+      const srcB = insertDataSource('src-b-dual')
+      attachSource(topologyId, srcA, 'topology')
+      attachSource(topologyId, srcB, 'topology')
+
+      const graph = (name: string): NetworkGraph => ({
+        name,
+        nodes: [
+          {
+            id: 'n',
+            label: 'n',
+            identity: { chassisId: 'dd:dd:dd:dd:dd:dd', mgmtIp: '10.7.7.1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+      ingestAndRegister(db, topologyId, srcA, graph('ga'))
+      ingestAndRegister(db, topologyId, srcB, graph('gb'))
+
+      expect(registryCount(db, topologyId).nodes).toBe(1)
+      const entityId = entityIdOf(db, topologyId, 'node')
+
+      // Migration 029 must have REBUILT the table: the original inline UNIQUE
+      // (without source_id) is an undroppable autoindex, and would silently
+      // swallow srcB's row here.
+      const rows = db
+        .query<{ source_id: string }, [string, string]>(
+          'SELECT source_id FROM entity_identity_key WHERE entity_id = ? AND key = "mgmtIp" AND value = ? ORDER BY source_id',
+        )
+        .all(entityId ?? '', '10.7.7.1')
+      expect(rows.map((r) => r.source_id).sort()).toEqual([srcA, srcB].sort())
+    })
+
+    test('legacy source_id="" row is replaced when a real source reports a new value', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('src-legacy')
+      attachSource(topologyId, src, 'topology')
+
+      ingestAndRegister(db, topologyId, src, {
+        name: 'g1',
+        nodes: [
+          {
+            id: 'n',
+            label: 'n',
+            identity: { chassisId: 'cc:cc:cc:cc:cc:cc', mgmtIp: '10.8.8.1' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+      const entityId = entityIdOf(db, topologyId, 'node')
+
+      // Simulate a pre-migration-029 row: unknown provenance.
+      db.query(
+        'UPDATE entity_identity_key SET source_id = ? WHERE entity_id = ? AND key = "mgmtIp"',
+      ).run('', entityId ?? '')
+
+      // Source reports a NEW IP → the legacy row must be replaced, not accreted.
+      ingestAndRegister(db, topologyId, src, {
+        name: 'g2',
+        nodes: [
+          {
+            id: 'n',
+            label: 'n',
+            identity: { chassisId: 'cc:cc:cc:cc:cc:cc', mgmtIp: '10.8.8.2' },
+            ports: [],
+          },
+        ],
+        links: [],
+      })
+
+      const ips = db
+        .query<{ value: string; source_id: string }, [string]>(
+          'SELECT value, source_id FROM entity_identity_key WHERE entity_id = ? AND key = "mgmtIp"',
+        )
+        .all(entityId ?? '')
+      expect(ips.length).toBe(1)
+      expect(ips[0]?.value).toBe('10.8.8.2')
+      expect(ips[0]?.source_id).toBe(src)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // @570: identity-less ports stay stable across re-ingests
+  // -------------------------------------------------------------------------
+
+  describe('identity-less port stability', () => {
+    test('a port declared without identity keeps its entity across re-ingests', () => {
+      const topologyId = makeTopology(db)
+      const src = insertDataSource('manual-port')
+      attachSource(topologyId, src, 'topology')
+
+      const graph: NetworkGraph = {
+        name: 'manual-port',
+        nodes: [
+          {
+            id: 'sw',
+            label: 'sw',
+            identity: { chassisId: 'ab:ab:ab:ab:ab:01' },
+            // No identity on the port. ingestGraph stamps identity.ifName = <port id>
+            // (port ids ARE interface names), so the registry adopts via ifName;
+            // the staged port lookup additionally covers a raw manual:<src> key
+            // defensively should a caller ever bypass that ingest stamp.
+            ports: [{ id: 'p-noident', label: 'p', connectors: [] }],
+          },
+        ],
+        links: [],
+      }
+
+      ingestAndRegister(db, topologyId, src, graph)
+      const ports1 = entityIdsOf(db, topologyId, 'port')
+      expect(ports1.length).toBe(1)
+
+      ingestAndRegister(db, topologyId, src, graph)
+      const ports2 = entityIdsOf(db, topologyId, 'port')
+
+      // Staged lookup must re-find the same port entity — never mint-per-sync.
+      expect(ports2).toEqual(ports1)
     })
   })
 


### PR DESCRIPTION
Closes #570. Hardens adopt-or-mint against the weak-key false-adoption/false-merge class (flat OR matching + forever-accreting keys) that would bite on real networks (IP reuse, IP swaps, duplicate sysNames).

## Decision table (implemented)

- **Key classes** — node: STRONG = chassisId / vendor:* / manual:*, MUTABLE = mgmtIp / sysName; port: PRIMARY = ifName / manual:*, SECONDARY = mac, LAST-RESORT = ifIndex (gathered only when neither ifName nor mac exists).
- **Staged lookup**: descend classes, stop at the first with surviving candidates.
- **Strong-key veto**: candidate and observation sharing a STRONG namespace with differing values → different device, reject.
- **Mutual consistency (mutable stage)**: sysName present on both sides must agree (a conflicting sysName rejects an mgmtIp match — the IP-reuse guard); mgmtIp conflicts are handled by replacement, not rejection (so IP swaps still adopt correctly).
- **Per-source singleton replacement** (migration 029 rebuilds `entity_identity_key` with `source_id`): a source re-reporting mgmtIp/sysName (node) or ifIndex (port) REPLACES its own prior value (and legacy '' rows) — kills the stale-IP magnet. ifName excluded (it IS the port identity); mac excluded (multi-value legitimate). Runs on adopt AND mint.
- **Merge guard**: auto-merge only when every candidate shares a STRONG key with the observation or agrees on ≥2 classes; port mac/ifIndex can never auto-merge. Ambiguous weak multi-match → adopt best, NO alias, structured `[Registry] ambiguous match` warn (the deferred merge-review trail).

## Notable

The implementing subagent's work was audited by its coordinator, which found and fixed 5 defects before handoff — including a broken migration (inline-UNIQUE autoindex made the DROP INDEX a no-op; second-source rows were silently swallowed — empirically confirmed, rewritten as a full table rebuild) and a merge-guard kind bug that let ifIndex auto-merge ports.

## Verified

- entity-registry tests 27/27 (14 new: IP-reuse mints + magnet-kill, IP-swap adopts + replaces + no merge, strong veto, legit multi-candidate merge with alias, ambiguous → warn + no alias, per-source replacement isolation, 4 ULID format/order/uniqueness); full api suite 139/139; typecheck/biome clean.
- **Live backward compat**: after migration 029, a full blank+Rebuild re-adopts every pre-hardening entity — 50/50 node + 99/99 link ids identical, mapping 50/99 intact, 0 dangling refs.

Implemented by a Sonnet subagent (with internal review pass); re-reviewed + live-verified by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj