### PR TITLE
fix(server,core): integration-review gaps — scheduler lifecycle, queue dedupe, validator parity

### DIFF
--- a/.changeset/identity-contract-store-parity.md
+++ b/.changeset/identity-contract-store-parity.md
@@ -1,0 +1,5 @@
+---
+'@shumoku/core': patch
+---
+
+validateTopologyIdentityContract now mirrors the server's ingest fallback exactly: a port with an empty identity object is fallback-eligible (ifName = port id), not a violation.

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -419,17 +419,26 @@ export class Server {
       this.pollScheduler?.notifyWatchChanged(topologyId)
     })
 
-    this.pollScheduler.start()
-
-    // Wire the topology service's mapping-write hook to the poll scheduler
-    // so a mapping save immediately triggers a fresh poll (Item 3, #569).
-    // topology.ts must not import server.ts — callback injection keeps it clean.
+    // Wire the topology service's hooks BEFORE starting the scheduler so no
+    // write can fall into a hook-less window. topology.ts must not import
+    // server.ts — callback injection keeps it clean.
     if (this.topologyService) {
       const sched = this.pollScheduler
+      // Mapping save → immediate poll (Item 3, #569).
       this.topologyService.setMappingWriteHook((topologyId) => {
         sched.pokeTopology(topologyId)
       })
+      // Topology create/delete → register/unregister with the scheduler. The
+      // scheduler seeds its state map once at start(); without this, a
+      // topology created after startup would never be polled again once its
+      // last live subscriber disconnects.
+      this.topologyService.setTopologyLifecycleHook((topologyId, event) => {
+        if (event === 'created') sched.addTopology(topologyId)
+        else sched.removeTopology(topologyId)
+      })
     }
+
+    this.pollScheduler.start()
 
     // Signal-stream housekeeping (signal-streams.md retentions): once at
     // startup, then every 6h. Cheap deletes; never let it crash the server.

--- a/apps/server/api/src/services/poll-scheduler.ts
+++ b/apps/server/api/src/services/poll-scheduler.ts
@@ -37,6 +37,13 @@ export interface TopologyScheduleState {
   lastPollAt: number
   inFlight: boolean
   timer: ReturnType<typeof setTimeout> | null
+  /**
+   * True while a run for this topology is waiting in the concurrency-cap
+   * queue. Guards against rapid pokes enqueueing duplicate closures — without
+   * it a burst of mapping saves under a saturated cap grows the queue
+   * unboundedly (one stale closure per poke).
+   */
+  queued: boolean
 }
 
 /**
@@ -184,6 +191,7 @@ export class PollScheduler {
       lastPollAt: 0,
       inFlight: false,
       timer: null,
+      queued: false,
     }
     this.states.set(topologyId, state)
     return state
@@ -221,8 +229,16 @@ export class PollScheduler {
     }
 
     if (this.activeCount >= this.config.concurrencyLimit) {
-      // Global concurrency cap — queue this poll until a slot opens
-      this.queue.push(() => this.runPoll(topologyId))
+      // Global concurrency cap — queue this poll until a slot opens. At most
+      // ONE queued run per topology: a rapid poke burst must not stack
+      // duplicate closures (each would re-run and reschedule).
+      if (state.queued) return
+      state.queued = true
+      this.queue.push(() => {
+        const s = this.states.get(topologyId)
+        if (s) s.queued = false
+        this.runPoll(topologyId)
+      })
       return
     }
 

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -494,6 +494,28 @@ export class TopologyService {
   }
 
   /**
+   * Optional hook fired when a topology is created or deleted. Injected by
+   * server.ts to register/unregister the topology with the poll scheduler —
+   * without this, a topology created AFTER startup never enters the polling
+   * loop (the scheduler seeds its state map once at start()). Same injection
+   * pattern as the mapping-write hook: topology.ts must not import server.ts.
+   */
+  private onTopologyLifecycle: ((topologyId: string, event: 'created' | 'deleted') => void) | null =
+    null
+
+  setTopologyLifecycleHook(fn: (topologyId: string, event: 'created' | 'deleted') => void): void {
+    this.onTopologyLifecycle = fn
+  }
+
+  private fireTopologyLifecycle(topologyId: string, event: 'created' | 'deleted'): void {
+    try {
+      this.onTopologyLifecycle?.(topologyId, event)
+    } catch (err) {
+      console.error('[TopologyService] lifecycle hook failed:', err)
+    }
+  }
+
+  /**
    * Find the Manual data source id attached to a topology, if any.
    * Returns the *data source* id (PK of `data_sources`), not the
    * junction row id. (A topology may have several Manual sources; this
@@ -652,6 +674,7 @@ export class TopologyService {
 
     const created = this.get(id)
     if (!created) throw new Error('Topology disappeared immediately after creation')
+    this.fireTopologyLifecycle(id, 'created')
     return created
   }
 
@@ -1165,6 +1188,7 @@ export class TopologyService {
     const result = this.db.query('DELETE FROM topologies WHERE id = ?').run(id)
     this.cache.delete(id)
     this.renderCache.delete(id)
+    if (result.changes > 0) this.fireTopologyLifecycle(id, 'deleted')
     return result.changes > 0
   }
 
@@ -1879,6 +1903,13 @@ export class TopologyService {
    * Validates that the target entity exists in the current resolved graph and
    * that the orphan and target kinds match. Returns `ok: false` with a reason
    * when either check fails, so the caller surfaces WHY a repair was refused.
+   *
+   * Semantics note: "orphaned" means absent from the CURRENT graph, which can
+   * be transient (an observation gap). If the original entity is later
+   * re-observed, it comes back UNMAPPED — the moved rows stay with the target
+   * (the operator's explicit choice is never silently reverted). Reassignment
+   * is therefore only the *final* answer for permanently removed elements; a
+   * returning device needs a fresh mapping (auto-map re-covers it).
    *
    * Fix 1 (#547): with the new PK (topology_id, entity_id, source_id) an orphaned
    * entity can have multiple rows (one per source). Reassign moves ALL of that

--- a/libs/@shumoku/core/src/plugin-kit/plugin-kit.test.ts
+++ b/libs/@shumoku/core/src/plugin-kit/plugin-kit.test.ts
@@ -316,3 +316,32 @@ describe('validateAgainstSchema', () => {
     expect(bad.errors[0]?.path).toBe('targets[1]')
   })
 })
+
+describe('validateTopologyIdentityContract — store-fallback parity', () => {
+  // Mirrors the server's portIdentityWithIfNameFallback exactly: a port with
+  // an ABSENT identity and one with an EMPTY identity object are equivalent
+  // (both get ifName = port.id stamped on ingest), so neither may be flagged.
+  it('treats an empty identity object like an absent one (fallback-eligible)', async () => {
+    const { validateTopologyIdentityContract } = await import('./topology-identity-contract.js')
+    const graph = {
+      name: 't',
+      nodes: [
+        {
+          id: 'sw1',
+          label: 'sw1',
+          identity: { sysName: 'sw1' },
+          ports: [
+            { id: 'ge-0/0/1' }, // absent identity → fallback
+            { id: 'ge-0/0/2', identity: {} }, // EMPTY identity → same fallback
+            { id: 'ge-0/0/3', identity: { ifIndex: 7 } }, // port key w/o ifName → weak, flagged
+          ],
+        },
+      ],
+      links: [],
+    }
+    // biome-ignore lint/suspicious/noExplicitAny: minimal structural fixture
+    const result = validateTopologyIdentityContract(graph as any)
+    expect(result.nodesMissingIdentity).toEqual([])
+    expect(result.portsMissingIfName).toEqual(['ge-0/0/3'])
+  })
+})

--- a/libs/@shumoku/core/src/plugin-kit/topology-identity-contract.ts
+++ b/libs/@shumoku/core/src/plugin-kit/topology-identity-contract.ts
@@ -14,10 +14,11 @@
  *
  *   - Every node in a topology graph must carry at least one network identity
  *     key (mgmtIp, chassisId, sysName, or a non-empty vendorIds entry).
- *   - Every port that either (a) carries an `identity` field, or (b) is
- *     referenced as a link endpoint, must have `identity.ifName` OR use a port
- *     id that itself IS the interface name (the contribution-store fallback
- *     accepts a port id used as ifName, so we mirror that leniency here).
+ *   - A port with NO port-identity key (ifName/ifIndex/mac — absent and empty
+ *     identity objects are equivalent) is fine: ingest stamps
+ *     `ifName = port.id` (port ids ARE interface names by convention).
+ *   - A port that DOES carry a port key but lacks ifName is flagged: the store
+ *     keeps it as-is and it anchors weakly (ifIndex renumbers across reboots).
  */
 
 import type { NetworkGraph } from '../models/types.js'
@@ -26,16 +27,14 @@ export interface TopologyIdentityContractResult {
   /** Node ids (node.id) that have no network identity key at all. */
   nodesMissingIdentity: string[]
   /**
-   * Port ids that are referenced by a link endpoint or carry an identity field
-   * but lack identity.ifName AND cannot be treated as an interface name via the
-   * id-as-ifName fallback.
+   * Port ids that carry a PORT-identity key (ifIndex or mac) but no ifName.
    *
-   * The fallback: contribution-store's `portIdentityWithIfNameFallback` fills
-   * `ifName = portId` when a port has no identity key. We mirror that: a port
-   * counts as "ok" when it either has `identity.ifName` explicitly, or when its
-   * id has no identity at all (the store will default it). A port with a
-   * non-ifName identity key (ifIndex, mac) but no ifName is flagged so callers
-   * can verify the store will still anchor it.
+   * The server's fallback (`portIdentityWithIfNameFallback`, contribution-store)
+   * fills `ifName = portId` ONLY when a port has none of ifName/ifIndex/mac —
+   * an absent OR empty identity object both qualify. A port with ifIndex/mac
+   * but no ifName is left as-is by the store and anchors weakly (ifIndex is a
+   * last-resort key that renumbers across reboots), so the contract flags it:
+   * plugins should provide the interface name whenever they enumerate ports.
    */
   portsMissingIfName: string[]
 }
@@ -54,41 +53,23 @@ export function validateTopologyIdentityContract(
   const nodesMissingIdentity: string[] = []
   const portsMissingIfName: string[] = []
 
-  // --- 1. Collect all port ids referenced by link endpoints. -----------------
-  const linkedPortIds = new Set<string>()
-  for (const link of graph.links ?? []) {
-    if (link.from.port) linkedPortIds.add(link.from.port)
-    if (link.to.port) linkedPortIds.add(link.to.port)
-  }
-
-  // --- 2. Validate each node and its ports. ----------------------------------
   for (const node of graph.nodes ?? []) {
     // A node must have at least one identity key.
     if (!hasAnyIdentityKey(node.identity)) {
       nodesMissingIdentity.push(node.id)
     }
 
-    // Check ports that are either link-endpoint-referenced or carry an explicit
-    // identity.  A port with NO identity field at all is fine: the contribution
-    // store will default `ifName = portId` via portIdentityWithIfNameFallback.
+    // Mirror the server's ingest EXACTLY (portIdentityWithIfNameFallback):
+    // fallback-eligible means the port has NO port-identity key at all —
+    // `identity` absent and `identity: {}` are equivalent, both get
+    // `ifName = portId` stamped on ingest, so neither is a violation.
+    // Only a port that DOES carry a port key (ifIndex / mac) without ifName is
+    // flagged: the store keeps it as-is and it anchors weakly.
     for (const port of node.ports ?? []) {
-      const isLinked = linkedPortIds.has(port.id)
-      const hasIdentity = port.identity !== undefined
-
-      if (!isLinked && !hasIdentity) {
-        // Not linked, no identity field — no concern; store will default on ingest.
-        continue
-      }
-
-      // Linked or has explicit identity → must have ifName (or no identity at all,
-      // relying on the store's id-as-ifName fallback).
-      if (!hasIdentity) {
-        // No identity field; store will fill ifName from id. Count as ok.
-        continue
-      }
-
-      // Has an identity field but no ifName — flag it.
-      if (!port.identity?.ifName) {
+      const id = port.identity
+      const hasPortKey = !!(id && (id.ifName || id.ifIndex !== undefined || id.mac))
+      if (!hasPortKey) continue // store defaults ifName = port.id on ingest
+      if (!id?.ifName) {
         portsMissingIfName.push(port.id)
       }
     }


### PR DESCRIPTION
Closes the verified findings from the adversarial INTEGRATION review run over the merged waves (#553…#573) — probing the seams between features rather than re-reviewing each in isolation.

## Verified & fixed (3)

1. **Post-startup topologies never polled** (highest severity): `PollScheduler.addTopology`/`removeTopology` existed but had zero callers — a topology created after `start()` had no schedule state; SSE-subscription created one transiently, but once the last subscriber disconnected the topology went permanently dark. `TopologyService` now fires an injected lifecycle hook on create/delete (same injection pattern as the mapping-write hook), wired by server.ts. Hooks are wired **before** `scheduler.start()` (also closes the tiny hook-less startup window the review flagged).
2. **Concurrency-cap queue leak**: rapid pokes while the cap was saturated stacked duplicate queued closures. At most one queued run per topology now (`queued` flag).
3. **Contract validator ↔ ingest-fallback parity**: a port with an EMPTY `identity: {}` was flagged by the validator but silently fixed by ingest (`portIdentityWithIfNameFallback` treats no-port-keys as fallback-eligible regardless of object presence) — a plugin passing the server could fail the guard. Validator now mirrors the store exactly; misleading JSDoc corrected; dead linked-port collection removed. (core patch changeset)

## Refuted (1) — documented instead

"Orphan reassignment silently reverted by the next sync": false — moved mapping rows stay with the target. The real (subtle) semantics — a transiently-absent entity that returns comes back UNMAPPED because the operator moved its mapping — is now documented on `reassignOrphan`.

## Review also confirmed CLEAN (the seams that mattered)

Cross-source adoption under the hardened staged matching (the key regression risk of #573), migration-029 cascades through reset, backfill source_id supply, retire syncNow sentinel, mapping-write transaction ordering vs the poke, partial-scan retire guard on both paths.

Tests: api 139/139, core 374/374 (+1 parity regression test), zabbix 16/16, netbox 5/5, biome/typecheck clean.

Integration review by a Sonnet subagent; findings verified against code (1 refuted) and fixed directly by the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj