### PR TITLE
fix(server): guard the entity-id flip against duplicate claims — vanishing nodes

### DIFF
--- a/apps/server/api/src/services/entity-registry.ts
+++ b/apps/server/api/src/services/entity-registry.ts
@@ -977,12 +977,48 @@ interface FlipMaps {
 /** Build the flip maps from an already entityId-stamped graph. */
 function buildFlipMaps(graph: NetworkGraph): FlipMaps {
   const nodeIdMap = new Map<string, string>()
+  // Uniqueness guard: the registry can (correctly) unify two RESOLVED nodes as
+  // one entity when resolve's fold didn't bridge them (e.g. a zabbix host node
+  // and its LLDP-peer stub, chained through a NetBox observation). Flipping
+  // BOTH to the same id collapses every id-keyed collection downstream — the
+  // renderer draws one box and the other node silently vanishes (its ports,
+  // keyed separately, keep rendering — the observed "node missing, ports
+  // remain" defect). Until resolve folds registry-unified nodes into one
+  // (registry-driven fold), only the FIRST node in graph order takes the
+  // entity id; later claimants keep their original element id, stay visible,
+  // and the disagreement is logged as the fold work-list.
+  const claimed = new Map<string, string>()
   for (const n of graph.nodes) {
-    if (n.entityId && n.entityId !== n.id) nodeIdMap.set(n.id, n.entityId)
+    if (!n.entityId || n.entityId === n.id) {
+      if (n.entityId) claimed.set(n.entityId, n.id)
+      continue
+    }
+    const holder = claimed.get(n.entityId)
+    if (holder !== undefined) {
+      console.warn(
+        `[Registry] entity ${n.entityId} claimed by multiple resolved nodes ` +
+          `(${holder}, ${n.id}) — resolve fold lags the registry; keeping ${n.id} un-flipped`,
+      )
+      continue
+    }
+    claimed.set(n.entityId, n.id)
+    nodeIdMap.set(n.id, n.entityId)
   }
   const linkEntityByEndpoints = new Map<string, string>()
+  // Same uniqueness guard for links: two resolved links (e.g. the same cable
+  // observed by two sources with endpoints that didn't fold) can carry one
+  // link entity. First claimant flips; later ones keep their element id.
+  const claimedLinks = new Set<string>()
   for (const l of graph.links) {
-    if (l.entityId) linkEntityByEndpoints.set(endpointSignature(l.from, l.to), l.entityId)
+    if (!l.entityId) continue
+    if (claimedLinks.has(l.entityId)) {
+      console.warn(
+        `[Registry] link entity ${l.entityId} claimed by multiple resolved links — keeping later claimant un-flipped`,
+      )
+      continue
+    }
+    claimedLinks.add(l.entityId)
+    linkEntityByEndpoints.set(endpointSignature(l.from, l.to), l.entityId)
   }
   return { nodeIdMap, linkEntityByEndpoints }
 }
@@ -1009,11 +1045,15 @@ function flipEmbeddedLink(link: Link, newId: string | undefined, maps: FlipMaps)
  * without an entity id keep their existing id.  Pure — never mutates input.
  */
 function flipGraph(graph: NetworkGraph, maps: FlipMaps): NetworkGraph {
-  const nodes = graph.nodes.map((n) =>
-    n.entityId && n.entityId !== n.id ? { ...n, id: n.entityId } : n,
-  )
+  // Flip STRICTLY through the maps — buildFlipMaps enforces the uniqueness
+  // guard (one node/link per entity id), so consulting `entityId` directly
+  // here would reintroduce the duplicate-id collapse the guard exists for.
+  const nodes = graph.nodes.map((n) => {
+    const newId = maps.nodeIdMap.get(n.id)
+    return newId !== undefined ? { ...n, id: newId } : n
+  })
   const links = graph.links.map((l) => {
-    const newId = l.entityId
+    const newId = maps.linkEntityByEndpoints.get(endpointSignature(l.from, l.to))
     return flipEmbeddedLink(l, newId, maps)
   })
   return { ...graph, nodes, links }

--- a/apps/server/api/test/db/entity-id-flip.test.ts
+++ b/apps/server/api/test/db/entity-id-flip.test.ts
@@ -121,6 +121,55 @@ describe('flip mechanics (pure)', () => {
     expect(flipped.resolved).toBe(resolved)
   })
 
+  test('duplicate entity claims: only the first node flips; ids stay unique', () => {
+    // The registry can (correctly) unify two RESOLVED nodes as one entity when
+    // resolve's fold didn't bridge them (zabbix host node + its LLDP-peer stub,
+    // chained through a NetBox observation). Flipping BOTH to the same id
+    // collapsed the renderer's keyed collections — one box vanished while its
+    // ports kept rendering (the prod defect). The guard: first claimant in
+    // graph order takes the entity id, later claimants keep their element id.
+    const base = sampleGraph('flip-dup')
+    const stamped: NetworkGraph = {
+      ...base,
+      nodes: [
+        { ...base.nodes[0], entityId: 'DDDDDDDDDDDDDDDDDDDDDDDDDD' },
+        { ...base.nodes[1], entityId: 'DDDDDDDDDDDDDDDDDDDDDDDDDD' }, // same entity!
+      ] as NetworkGraph['nodes'],
+      links: base.links,
+    }
+    const g = flipGraphToEntityIds(stamped)
+    const ids = g.nodes.map((n) => n.id)
+    // first claimant flipped, second keeps its original element id
+    expect(ids[0]).toBe('DDDDDDDDDDDDDDDDDDDDDDDDDD')
+    expect(ids[1]).toBe('b')
+    // the invariant that matters: no duplicate ids in the flipped graph
+    expect(new Set(ids).size).toBe(ids.length)
+    // links referencing the un-flipped node still resolve to its (kept) id
+    expect(g.links[0]?.to.node).toBe('b')
+    expect(g.links[0]?.from.node).toBe('DDDDDDDDDDDDDDDDDDDDDDDDDD')
+  })
+
+  test('duplicate link-entity claims: later links keep their element id', () => {
+    const base = sampleGraph('flip-dup-link')
+    const stamped: NetworkGraph = {
+      ...base,
+      links: [
+        { ...base.links[0], entityId: 'KKKKKKKKKKKKKKKKKKKKKKKKKK' },
+        {
+          id: 'second',
+          from: { node: 'a', port: 'px' },
+          to: { node: 'b', port: 'py' },
+          entityId: 'KKKKKKKKKKKKKKKKKKKKKKKKKK', // same entity!
+        },
+      ] as NetworkGraph['links'],
+    }
+    const g = flipGraphToEntityIds(stamped)
+    const ids = g.links.map((l) => l.id)
+    expect(ids[0]).toBe('KKKKKKKKKKKKKKKKKKKKKKKKKK')
+    expect(ids[1]).toBe('second')
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
   test('flipGraphToEntityIds flips a graph-only structure', () => {
     const base = sampleGraph('flip-graph-only')
     const stamped: NetworkGraph = {


### PR DESCRIPTION
**Prod defect** (reported on the demo): nodes vanishing while their ports keep rendering, in 27 of 76 places.

## Root cause (verified on prod data)

The registry **correctly** unified pairs of resolved nodes as one entity — a zabbix host node (`acc-main-1f-01 - Access Switch`: mgmtIp + hostid) and its LLDP-peer stub (`acc-main-1f-01`: chassisId + LLDP sysName), chained through the NetBox observation (shares mgmtIp with one, sysName with the other) during the flat-OR matching era; the alias is permanent and matching hardening doesn't undo history. Resolve's fold, which is not transitive across that bridge, still emits TWO nodes — and the Phase-3 flip assigned both the same id. Every id-keyed collection downstream collapsed: one box rendered, the other vanished, its separately-keyed ports stayed visible.

## Fix (hotfix tier)

`buildFlipMaps` admits ONE claimant per entity id (first in graph order); later claimants keep their element id, stay visible, and log a structured `[Registry] entity … claimed by multiple resolved nodes` warning — the work-list for the real fix. `flipGraph` now flips strictly through the maps (it consulted `entityId` directly, bypassing any guard). Same guard for link entities (one cable seen by two sources).

## What this does and doesn't fix

- ✅ No more vanishing nodes — invariant: flipped graphs never contain duplicate ids (regression-tested).
- ⏳ The duplicated *representations* (two boxes / twin cables from two topology sources) still render as duplicates, some thin/lane-less — the correct end state (one device = one box) needs **registry-driven fold in resolve** (registry equivalences passed as derive input; RESOLVER bump). Follow-up filed.

Tests: 141/141 api (+2 flip-guard regressions), typecheck/biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj