### PR TITLE
fix(zabbix): use real sysname for identity and resolve LLDP neighbors against all name fields

### DIFF
--- a/.changeset/zabbix-real-sysname.md
+++ b/.changeset/zabbix-real-sysname.md
@@ -1,0 +1,5 @@
+---
+"shumoku-plugin-zabbix": patch
+---
+
+Fix LLDP neighbor resolution by using real sysname from host inventory and matching against all name fields.

--- a/libs/plugins/zabbix/src/plugin.ts
+++ b/libs/plugins/zabbix/src/plugin.ts
@@ -807,7 +807,16 @@ export class ZabbixPlugin
       ...(groupIds && groupIds.length > 0 ? { groupids: groupIds } : {}),
       output: ['hostid', 'host', 'name', 'status'],
       selectInterfaces: ['ip', 'dns', 'main', 'type', 'useip'],
-      selectInventory: ['type', 'vendor', 'model', 'hardware', 'os', 'serialno_a', 'location'],
+      selectInventory: [
+        'type',
+        'vendor',
+        'model',
+        'hardware',
+        'os',
+        'serialno_a',
+        'location',
+        'name',
+      ],
       selectHostGroups: ['groupid', 'name'],
       selectTags: 'extend',
     })

--- a/libs/plugins/zabbix/src/topology.test.ts
+++ b/libs/plugins/zabbix/src/topology.test.ts
@@ -212,4 +212,79 @@ describe('convertZabbixToGraph', () => {
     const { nodesMissingIdentity } = validateTopologyIdentityContract(g)
     expect(nodesMissingIdentity).toEqual([])
   })
+
+  it('uses inventory.name as sysName when present; label stays as display name', () => {
+    const hosts = [
+      mkHost({
+        hostid: '1',
+        host: '10.0.0.1',
+        name: 'acc-main-1f-01 - Access Switch',
+        inventory: { name: 'acc-main-1f-01' },
+      }),
+    ]
+    const g = convertZabbixToGraph(hosts, NO_NBR, NO_DESCR, OPTS)
+    const n = g.nodes[0]
+    expect(n?.label).toBe('acc-main-1f-01 - Access Switch')
+    expect(n?.identity?.sysName).toBe('acc-main-1f-01')
+  })
+
+  it('falls back to host.name for sysName when inventory.name is absent', () => {
+    const hosts = [
+      mkHost({
+        hostid: '1',
+        host: '10.0.0.1',
+        name: 'ptxA.noc',
+        inventory: { vendor: 'Juniper' }, // no inventory.name
+      }),
+    ]
+    const g = convertZabbixToGraph(hosts, NO_NBR, NO_DESCR, OPTS)
+    const n = g.nodes[0]
+    expect(n?.identity?.sysName).toBe('ptxA.noc')
+  })
+
+  it('resolves LLDP neighbor by real sysname (inventory.name); no stub created', () => {
+    const hosts = [
+      mkHost({
+        hostid: '1',
+        host: '10.0.0.1',
+        name: 'acc-main-1f-01 - Access Switch',
+        inventory: { name: 'acc-main-1f-01' },
+      }),
+      mkHost({
+        hostid: '2',
+        host: '10.0.0.2',
+        name: 'core-sw - Core Switch',
+        inventory: { name: 'core-sw' },
+      }),
+    ]
+    // core-sw's LLDP TLV reports 'acc-main-1f-01' (the real sysname, not the display name)
+    const nbr = new Map<string, ZabbixLldpNeighbor[]>([
+      ['2', [{ localIf: 'gi1', remSysname: 'acc-main-1f-01', remPortId: 'gi2' }]],
+    ])
+    const g = convertZabbixToGraph(hosts, nbr, NO_DESCR, OPTS)
+    // Only the two host nodes should exist — no stub for 'acc-main-1f-01'
+    expect(g.nodes).toHaveLength(2)
+    expect(g.links).toHaveLength(1)
+    const nodeIds = new Set(g.nodes.map((n) => n.id))
+    expect(nodeIds.has('inst1:host:1')).toBe(true)
+    expect(nodeIds.has('inst1:host:2')).toBe(true)
+    // Link endpoints must point to the two host nodes
+    const link = g.links[0]
+    expect([link?.from.node, link?.to.node].sort()).toEqual(['inst1:host:1', 'inst1:host:2'])
+  })
+
+  it('resolves LLDP neighbor by host.name as fallback when no inventory.name', () => {
+    const hosts = [
+      mkHost({ hostid: '1', name: 'ptxA.noc' }),
+      mkHost({ hostid: '2', name: 'ptxB.noc' }),
+    ]
+    const nbr = new Map<string, ZabbixLldpNeighbor[]>([
+      ['2', [{ localIf: 'et-0/0/1', remSysname: 'ptxA.noc', remPortId: 'et-0/0/1' }]],
+    ])
+    const g = convertZabbixToGraph(hosts, nbr, NO_DESCR, OPTS)
+    expect(g.nodes).toHaveLength(2)
+    expect(g.links).toHaveLength(1)
+    const link = g.links[0]
+    expect([link?.from.node, link?.to.node].sort()).toEqual(['inst1:host:1', 'inst1:host:2'])
+  })
 })

--- a/libs/plugins/zabbix/src/topology.ts
+++ b/libs/plugins/zabbix/src/topology.ts
@@ -72,17 +72,26 @@ export function convertZabbixToGraph(
   // --- 1. Host nodes (parent assigned during grouping). -------------------
   const staged: StagedNode[] = []
   const nodeByHostId = new Map<string, Node>()
-  const nodeBySysName = new Map<string, Node>() // host.name → node, for neighbor resolution
+  // Composite sysname lookup: each host's realSysname / host.host / host.name
+  // are all registered so that LLDP TLVs (which carry the real sysname, not
+  // the Zabbix display name) resolve to the existing host node instead of
+  // generating a duplicate stub.
+  const nodeBySysName = new Map<string, Node>()
   for (const host of hosts) {
+    // `inventory.name` carries the real system name (e.g. "acc-main-1f-01"),
+    // while `host.name` is the Zabbix display name (e.g. "acc-main-1f-01 - Access Switch").
+    // LLDP TLVs always report the real sysname, so we use it for identity.
+    const realSysname = host.inventory?.['name']?.trim() || undefined
     const node: Node = {
       id: `${sourceId}:host:${host.hostid}`,
       label: host.name || host.host || host.hostid,
       spec: deriveSpec(host, sysDescrByHostId.get(host.hostid)),
       identity: buildIdentity({
         mgmtIp: pickMgmtIp(host),
-        // sysName = host.name (the real hostname). NOT host.host, which is the
-        // management IP here — using it breaks neighbor resolution + clustering.
-        sysName: host.name || undefined,
+        // sysName = realSysname when available (from inventory.name), else
+        // host.name. NOT host.host, which is the management IP here — using
+        // it breaks neighbor resolution + clustering.
+        sysName: realSysname ?? host.name ?? undefined,
         vendorIds: { 'zabbix-hostid': host.hostid },
       }),
       provenance: { source: sourceId, observedAt },
@@ -99,6 +108,10 @@ export function convertZabbixToGraph(
     }
     staged.push({ node, host })
     nodeByHostId.set(host.hostid, node)
+    // Register all name variants so LLDP neighbor resolution hits the host
+    // node regardless of which name the remote TLV carries.
+    if (realSysname) nodeBySysName.set(realSysname, node)
+    if (host.host) nodeBySysName.set(host.host, node)
     if (host.name) nodeBySysName.set(host.name, node)
   }
 


### PR DESCRIPTION
## Summary
- `identity.sysName` now carries the device's **real sysname** (`host.inventory.name`, auto-collected from `system.name` under SNMP monitoring) instead of the Zabbix display name; falls back to `host.name` when inventory is absent (previous behavior preserved). `label` stays the display name.
- LLDP neighbor resolution matches the remote sysname TLV against **realSysname / `host.host` / `host.name`** — when it hits an existing host, the link connects to that host node and **no duplicate stub is created**.
- Zero extra API round-trips: `'name'` added to the existing `selectInventory` array.

Part of #581 (W1, upstream correction so the entity registry can unify from the first sync on fresh installs). Prod incident: `host.name` = `"acc-main-1f-01 - Access Switch"` never matched the LLDP-announced `"acc-main-1f-01"`, so every switch grew a duplicate stub node.

## Tests
- 20/20 pass (16 existing + 4 new: inventory→sysName, fallback behavior, no-stub via real sysname, host.name backward compat), identity-contract guard included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj
