### PR TITLE
feat(server): registry-driven fold — resolved graph as a projection of registry entities (#581)

### DIFF
--- a/.changeset/registry-driven-fold.md
+++ b/.changeset/registry-driven-fold.md
@@ -1,0 +1,11 @@
+---
+'@shumoku/core': patch
+---
+
+Add optional `entities` field to `SnapshotEntry` for registry-driven clustering.
+
+`resolve()` now accepts per-source entity ids (from `entity_element`) and uses them
+as first-class cluster keys: two nodes carrying the same entity id always fold into
+one cluster regardless of identity-key overlap or disjointness. Identity-key matching
+is preserved as a fallback for entity-less members (overlay, ghost, old data). Inputs
+without `entities` maps produce identical output to the previous algorithm.

--- a/apps/server/api/src/db/migrations/030_entity_element.sql
+++ b/apps/server/api/src/db/migrations/030_entity_element.sql
@@ -1,0 +1,30 @@
+-- Migration 030: entity_element — persist registry verdicts per source per element.
+--
+-- The resolver (resolve() in @shumoku/core) is a pure function that must not
+-- query the DB. To make it registry-driven, we write each source's entity
+-- assignments into this table at adoptOrMintForGraph() time, then read them
+-- back in readObservedSnapshots() and pass them as part of the SnapshotEntry.
+--
+-- Schema:
+--   topology_id  — the topology this belongs to
+--   source_id    — the data source that emitted the element
+--   kind         — 'node' or 'port' ('link' is derived from port entities)
+--   local_id     — node local id (for kind='node'), or
+--                  "${nodeLocalId}:${portLocalId}" composite (for kind='port')
+--   entity_id    — stable entity id from entity_registry
+--
+-- Lifecycle: DELETE + INSERT (full replacement) every time adoptOrMintForGraph
+-- runs for the same (topology_id, source_id) pair — always reflects the
+-- current scan's registry verdict, never accumulates stale rows.
+
+CREATE TABLE IF NOT EXISTS entity_element (
+  topology_id TEXT NOT NULL,
+  source_id   TEXT NOT NULL,
+  kind        TEXT NOT NULL CHECK (kind IN ('node', 'port')),
+  local_id    TEXT NOT NULL,
+  entity_id   TEXT NOT NULL,
+  PRIMARY KEY (topology_id, source_id, kind, local_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_element_topology_source
+  ON entity_element(topology_id, source_id, kind);

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -34,6 +34,7 @@ import migration026 from './migrations/026_metrics_mapping.sql'
 import migration027 from './migrations/027_entity_retire_counter.sql'
 import migration028 from './migrations/028_metrics_mapping_pk_source.sql'
 import migration029 from './migrations/029_entity_identity_key_source.sql'
+import migration030 from './migrations/030_entity_element.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -64,6 +65,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '027_entity_retire_counter.sql', sql: migration027 },
   { name: '028_metrics_mapping_pk_source.sql', sql: migration028 },
   { name: '029_entity_identity_key_source.sql', sql: migration029 },
+  { name: '030_entity_element.sql', sql: migration030 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/services/entity-registry.ts
+++ b/apps/server/api/src/services/entity-registry.ts
@@ -803,6 +803,25 @@ export function adoptOrMintForGraph(
       'link',
     )
   }
+
+  // Persist registry verdicts to entity_element so resolve() can use them as
+  // first-class cluster keys (registry-driven fold). Full replacement per
+  // (topology_id, source_id): DELETE existing rows then INSERT current verdicts.
+  db.query('DELETE FROM entity_element WHERE topology_id = ? AND source_id = ?').run(
+    topologyId,
+    sourceId,
+  )
+
+  const insertElement = db.prepare(
+    'INSERT INTO entity_element (topology_id, source_id, kind, local_id, entity_id) VALUES (?, ?, ?, ?, ?)',
+  )
+  for (const [nodeLocalId, entityId] of nodeEntityIds) {
+    insertElement.run(topologyId, sourceId, 'node', nodeLocalId, entityId)
+  }
+  for (const [compositeKey, entityId] of portEntityIds) {
+    insertElement.run(topologyId, sourceId, 'port', compositeKey, entityId)
+  }
+
   return now
 }
 

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -197,7 +197,7 @@ interface StoredLinkMapping {
 // v20: entity registry Phase 3 — node.id/link.id ON the resolved graph (+ layout
 // + resolved artifact) are flipped to their stable entity ids; old-id artifacts
 // must rebake so persisted references (metrics mapping, weathermap) key on ULIDs.
-const RESOLVER_VERSION = 20
+const RESOLVER_VERSION = 21
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {
@@ -356,6 +356,42 @@ interface SourceMode {
   nodeContribution: NodeContribution
   linkContribution: LinkContribution
   closeScope: boolean
+}
+
+/**
+ * Read entity_element rows for a (topology, source) pair and return them as the
+ * `entities` object expected by SnapshotEntry. Entity ids are alias-resolved so
+ * merge tombstones are transparent to the resolver.
+ *
+ * Returns `undefined` when no rows exist (source has never been registered, e.g.
+ * old data before migration 030) — resolve() degrades to pure identity-key
+ * clustering in that case.
+ */
+function readEntityElements(
+  topologyId: string,
+  sourceId: string,
+  db: Database,
+): SnapshotEntry['entities'] | undefined {
+  const rows = db
+    .query<{ kind: string; local_id: string; entity_id: string }, [string, string]>(
+      'SELECT kind, local_id, entity_id FROM entity_element WHERE topology_id = ? AND source_id = ?',
+    )
+    .all(topologyId, sourceId)
+
+  if (rows.length === 0) return undefined
+
+  const nodes: Record<string, string> = {}
+  const ports: Record<string, string> = {}
+  for (const row of rows) {
+    // Alias-resolve so a merged entity's old id transparently points to the survivor.
+    const resolved = resolveEntityAlias(asEntityId(row.entity_id), db)
+    if (row.kind === 'node') {
+      nodes[row.local_id] = resolved
+    } else if (row.kind === 'port') {
+      ports[row.local_id] = resolved
+    }
+  }
+  return { nodes, ports }
 }
 
 /**
@@ -1564,12 +1600,19 @@ export class TopologyService {
       // before it enters resolve(). Additive (default) is a no-op.
       const mode = modeBySource.get(r.source_id)
       const graph = mode ? applySourceMode(built, mode) : built
+
+      // Read registry verdicts (entity_element) for this source so resolve()
+      // can use entity ids as first-class cluster keys. Alias-resolved so a
+      // merge tombstone is transparent to the resolver.
+      const entities = readEntityElements(topologyId, r.source_id, this.db)
+
       snapshots.push({
         sourceId: r.source_id,
         capturedAt: r.last_ok_at ?? 0,
         status: (r.last_status as SnapshotEntry['status']) ?? 'ok',
         graph,
         priority: priorityBySource.get(r.source_id) ?? 0,
+        entities,
       })
     }
     return snapshots

--- a/apps/server/api/test/db/entity-element.test.ts
+++ b/apps/server/api/test/db/entity-element.test.ts
@@ -1,0 +1,224 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Tests for entity_element persistence (migration 030) and the
+ * registry-driven fold input that readObservedSnapshots produces.
+ *
+ * Run with: cd apps/server/api && bun test test/db/entity-element.test.ts
+ */
+
+import type { Database } from 'bun:sqlite'
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { NetworkGraph } from '@shumoku/core'
+import { getDatabase, timestamp } from '../../src/db/index.ts'
+import { ingestGraph } from '../../src/services/contribution-store.ts'
+import { adoptOrMintForGraph } from '../../src/services/entity-registry.ts'
+import { attachSource, insertDataSource, setupTempDb } from './helper.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTopology(db: Database): string {
+  const id = `topo-${Math.random().toString(36).slice(2)}`
+  const now = timestamp()
+  db.query('INSERT INTO topologies (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)').run(
+    id,
+    id,
+    now,
+    now,
+  )
+  return id
+}
+
+function ingestAndRegister(
+  db: Database,
+  topologyId: string,
+  sourceId: string,
+  graph: NetworkGraph,
+): void {
+  const attach = db
+    .query<{ id: string }, [string, string]>(
+      `SELECT id FROM topology_data_sources
+       WHERE topology_id = ? AND data_source_id = ? AND purpose = 'topology'`,
+    )
+    .get(topologyId, sourceId)
+  ingestGraph(topologyId, sourceId, graph, { attachmentId: attach?.id ?? null }, db)
+  adoptOrMintForGraph(topologyId, sourceId, db)
+}
+
+function getEntityElements(
+  db: Database,
+  topologyId: string,
+  sourceId: string,
+): { kind: string; local_id: string; entity_id: string }[] {
+  return db
+    .query<{ kind: string; local_id: string; entity_id: string }, [string, string]>(
+      'SELECT kind, local_id, entity_id FROM entity_element WHERE topology_id = ? AND source_id = ? ORDER BY kind, local_id',
+    )
+    .all(topologyId, sourceId)
+}
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+let db: Database
+let teardown: () => void
+
+beforeAll(() => {
+  const temp = setupTempDb()
+  teardown = temp.teardown
+  db = getDatabase()
+})
+
+afterAll(() => {
+  teardown()
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('entity_element persistence', () => {
+  test('adoptOrMintForGraph writes node rows to entity_element', () => {
+    const topologyId = makeTopology(db)
+    const dsId = insertDataSource('test')
+    attachSource(topologyId, dsId, 'topology')
+
+    const graph: NetworkGraph = {
+      version: '1',
+      nodes: [
+        { id: 'n1', label: 'Router A', identity: { mgmtIp: '10.0.0.1' } },
+        { id: 'n2', label: 'Router B', identity: { mgmtIp: '10.0.0.2' } },
+      ],
+      links: [],
+    }
+    ingestAndRegister(db, topologyId, dsId, graph)
+
+    const rows = getEntityElements(db, topologyId, dsId)
+    // Should have one 'node' row per node
+    const nodeRows = rows.filter((r) => r.kind === 'node')
+    expect(nodeRows).toHaveLength(2)
+    // local_ids should match the node ids
+    const localIds = nodeRows.map((r) => r.local_id).sort()
+    expect(localIds).toEqual(['n1', 'n2'])
+    // all entity_ids should be non-empty ULIDs
+    for (const row of nodeRows) {
+      expect(row.entity_id.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('adoptOrMintForGraph writes port rows to entity_element', () => {
+    const topologyId = makeTopology(db)
+    const dsId = insertDataSource('test-ports')
+    attachSource(topologyId, dsId, 'topology')
+
+    const graph: NetworkGraph = {
+      version: '1',
+      nodes: [
+        {
+          id: 'n1',
+          label: 'Router',
+          identity: { mgmtIp: '10.1.0.1' },
+          ports: [
+            { id: 'p0', label: 'Gi0/0', connectors: [], identity: { ifName: 'Gi0/0' } },
+            { id: 'p1', label: 'Gi0/1', connectors: [], identity: { ifName: 'Gi0/1' } },
+          ],
+        },
+      ],
+      links: [],
+    }
+    ingestAndRegister(db, topologyId, dsId, graph)
+
+    const rows = getEntityElements(db, topologyId, dsId)
+    const portRows = rows.filter((r) => r.kind === 'port')
+    // composite keys are `${nodeLocalId}:${portLocalId}`
+    const portKeys = portRows.map((r) => r.local_id).sort()
+    expect(portKeys).toEqual(['n1:p0', 'n1:p1'])
+  })
+
+  test('re-ingest replaces entity_element rows (no accumulation)', () => {
+    const topologyId = makeTopology(db)
+    const dsId = insertDataSource('test-replace')
+    attachSource(topologyId, dsId, 'topology')
+
+    const graph1: NetworkGraph = {
+      version: '1',
+      nodes: [
+        { id: 'n1', label: 'A', identity: { mgmtIp: '10.2.0.1' } },
+        { id: 'n2', label: 'B', identity: { mgmtIp: '10.2.0.2' } },
+      ],
+      links: [],
+    }
+    ingestAndRegister(db, topologyId, dsId, graph1)
+    expect(getEntityElements(db, topologyId, dsId).filter((r) => r.kind === 'node')).toHaveLength(2)
+
+    // Second ingest: only one node this time
+    const graph2: NetworkGraph = {
+      version: '1',
+      nodes: [{ id: 'n1', label: 'A', identity: { mgmtIp: '10.2.0.1' } }],
+      links: [],
+    }
+    ingestAndRegister(db, topologyId, dsId, graph2)
+
+    // Must replace, not accumulate — only 1 row now
+    const nodeRows = getEntityElements(db, topologyId, dsId).filter((r) => r.kind === 'node')
+    expect(nodeRows).toHaveLength(1)
+    expect(nodeRows[0]?.local_id).toBe('n1')
+  })
+
+  test('two distinct sources get separate entity_element rows', () => {
+    const topologyId = makeTopology(db)
+    const ds1 = insertDataSource('src-a')
+    const ds2 = insertDataSource('src-b')
+    attachSource(topologyId, ds1, 'topology')
+    attachSource(topologyId, ds2, 'topology')
+
+    const graphA: NetworkGraph = {
+      version: '1',
+      nodes: [{ id: 'na', label: 'NodeA', identity: { mgmtIp: '10.3.0.1' } }],
+      links: [],
+    }
+    const graphB: NetworkGraph = {
+      version: '1',
+      nodes: [{ id: 'nb', label: 'NodeB', identity: { mgmtIp: '10.3.0.2' } }],
+      links: [],
+    }
+    ingestAndRegister(db, topologyId, ds1, graphA)
+    ingestAndRegister(db, topologyId, ds2, graphB)
+
+    const rowsA = getEntityElements(db, topologyId, ds1).filter((r) => r.kind === 'node')
+    const rowsB = getEntityElements(db, topologyId, ds2).filter((r) => r.kind === 'node')
+    expect(rowsA).toHaveLength(1)
+    expect(rowsB).toHaveLength(1)
+    expect(rowsA[0]?.local_id).toBe('na')
+    expect(rowsB[0]?.local_id).toBe('nb')
+  })
+
+  test('entity ids are stable across re-ingest (same entity adopted)', () => {
+    const topologyId = makeTopology(db)
+    const dsId = insertDataSource('test-stable')
+    attachSource(topologyId, dsId, 'topology')
+
+    const graph: NetworkGraph = {
+      version: '1',
+      nodes: [{ id: 'n1', label: 'Stable', identity: { mgmtIp: '10.4.0.1' } }],
+      links: [],
+    }
+    ingestAndRegister(db, topologyId, dsId, graph)
+    const first = getEntityElements(db, topologyId, dsId).find(
+      (r) => r.kind === 'node' && r.local_id === 'n1',
+    )?.entity_id
+
+    // Re-ingest same node — must get the same entity id (adopt, not mint again)
+    ingestAndRegister(db, topologyId, dsId, graph)
+    const second = getEntityElements(db, topologyId, dsId).find(
+      (r) => r.kind === 'node' && r.local_id === 'n1',
+    )?.entity_id
+
+    expect(first).toBeDefined()
+    expect(first).toBe(second)
+  })
+})

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -2038,6 +2038,197 @@ describe('resolve()', () => {
       expect(out.nodes.map((n) => n.label).sort()).toEqual(['in-1', 'in-2', 'operator-placed'])
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // Registry-driven fold (entity-based clustering — #581)
+  // ---------------------------------------------------------------------------
+
+  describe('registry-driven fold (entities map)', () => {
+    /**
+     * Test 1 — prod shape regression:
+     * One source emits the same physical device as two distinct nodes — a full
+     * host entry (keys: mgmtIp + sysName "X") and an LLDP stub (keys:
+     * chassisId + sysName "X - desc"). Their identity-key sets are disjoint
+     * (no single shared hash), so the classic algorithm would produce two
+     * clusters. When both carry the SAME entity id in `entities.nodes`, they
+     * must fold into one node whose ports union and whose links repoint to the
+     * surviving cluster.
+     */
+    it('same entity id → merged into one node even with disjoint identity keys', () => {
+      const ENTITY = 'ent-router-01'
+      // One source emits the same physical device as two nodes:
+      //   host1 — the full host row (mgmtIp + sysName "X")
+      //   stub1 — the LLDP stub (chassisId + sysName "X - desc")
+      //   peer  — a second device linked to stub1
+      // Identity-key sets of host1 and stub1 are disjoint → classic algorithm
+      // would produce two clusters. Entity map tells resolve they are ONE device.
+      const snap: SnapshotEntry = {
+        sourceId: 'zbx',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          version: '1.0',
+          nodes: [
+            {
+              id: 'host1',
+              label: 'Router X',
+              identity: { mgmtIp: '10.0.0.1', sysName: 'X' },
+              ports: [{ id: 'p0', label: 'Gi0/0', connectors: [], identity: { ifName: 'Gi0/0' } }],
+            },
+            {
+              id: 'stub1',
+              label: 'X - desc',
+              identity: { chassisId: 'aa:bb:cc:dd:ee:ff', sysName: 'X - desc' },
+              ports: [{ id: 'p1', label: 'Gi0/1', connectors: [], identity: { ifName: 'Gi0/1' } }],
+            },
+            {
+              id: 'peer',
+              label: 'Peer',
+              identity: { mgmtIp: '10.0.0.2' },
+              ports: [{ id: 'px', label: 'Gi0/0', connectors: [], identity: { ifName: 'Gi0/0' } }],
+            },
+          ],
+          links: [
+            // link from stub1 to peer — should survive the fold: stub1's
+            // endpoint gets remapped to the merged cluster (same entity id).
+            { from: { node: 'stub1', port: 'p1' }, to: { node: 'peer', port: 'px' } },
+          ],
+        },
+        entities: {
+          nodes: { host1: ENTITY, stub1: ENTITY, peer: 'ent-peer' },
+          ports: {
+            'host1:p0': 'ent-port-p0',
+            'stub1:p1': 'ent-port-p1',
+            'peer:px': 'ent-port-px',
+          },
+        },
+      }
+
+      const out = resolve(emptyGraph(), [snap])
+
+      // Should produce exactly two resolved nodes (merged + peer)
+      expect(out.nodes).toHaveLength(2)
+
+      const merged = out.nodes.find((n) => n.label === 'Router X')
+      expect(merged).toBeDefined()
+
+      // Both ports must survive the union
+      const portLabels = (merged?.ports ?? []).map((p) => p.label).sort()
+      expect(portLabels).toEqual(['Gi0/0', 'Gi0/1'])
+
+      // The link whose from was on stub1 must survive — remapped to the merged node
+      expect(out.links).toHaveLength(1)
+    })
+
+    /**
+     * Test 2 — separation maintained:
+     * Two sources each emit a node with sysName="shared-key" (identity-key
+     * overlap that would merge them in the classic algorithm). But they have
+     * DIFFERENT entity ids — the registry judged them distinct. The resolver
+     * must NOT merge them.
+     */
+    it('same identity key but different entity ids → stays two nodes', () => {
+      const snapA: SnapshotEntry = {
+        sourceId: 'srcA',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          version: '1.0',
+          nodes: [{ id: 'na', label: 'NodeA', identity: { sysName: 'shared-key' } }],
+          links: [],
+        },
+        entities: { nodes: { na: 'entity-A' }, ports: {} },
+      }
+      const snapB: SnapshotEntry = {
+        sourceId: 'srcB',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          version: '1.0',
+          nodes: [{ id: 'nb', label: 'NodeB', identity: { sysName: 'shared-key' } }],
+          links: [],
+        },
+        entities: { nodes: { nb: 'entity-B' }, ports: {} },
+      }
+
+      const out = resolve(emptyGraph(), [snapA, snapB])
+
+      // Must remain two distinct clusters
+      expect(out.nodes).toHaveLength(2)
+      const labels = out.nodes.map((n) => n.label).sort()
+      expect(labels).toEqual(['NodeA', 'NodeB'])
+    })
+
+    /**
+     * Test 3 — backward compatibility:
+     * No entities map → existing pure identity-key behaviour must be preserved
+     * exactly. Two nodes with the same mgmtIp from the same source merge; two
+     * nodes from different sources with disjoint keys stay separate.
+     */
+    it('no entities map → pure identity-key clustering (backward compat)', () => {
+      const snap: SnapshotEntry = {
+        sourceId: 'src',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          version: '1.0',
+          nodes: [
+            { id: 'n1', label: 'A', identity: { mgmtIp: '10.0.0.1' } },
+            { id: 'n2', label: 'B', identity: { mgmtIp: '10.0.0.2' } },
+            // same mgmtIp as n1 — classic key-match merge
+            { id: 'n3', label: 'A-dup', identity: { mgmtIp: '10.0.0.1' } },
+          ],
+          links: [],
+        },
+        // no entities field
+      }
+
+      const out = resolve(emptyGraph(), [snap])
+
+      // n1 and n3 share mgmtIp, so they merge (classic behaviour) → 2 clusters
+      expect(out.nodes).toHaveLength(2)
+    })
+
+    /**
+     * Test 4 — overlay member (no entity id) joins via key matching:
+     * The intrinsic overlay node carries identity keys that match a discovered
+     * entity cluster. The overlay node has no entityId, but the identity-key
+     * lookup should still let it join the entity cluster, confirming the node.
+     */
+    it('overlay node without entity id joins entity cluster via key match', () => {
+      const ENTITY = 'ent-router-02'
+      const intrinsic: NetworkGraph = {
+        version: '1.0',
+        nodes: [
+          {
+            id: 'op1',
+            label: 'Curated Router',
+            identity: { mgmtIp: '10.1.0.1' },
+          },
+        ],
+        links: [],
+      }
+      const snap: SnapshotEntry = {
+        sourceId: 'zbx',
+        capturedAt: 1000,
+        status: 'ok',
+        graph: {
+          version: '1.0',
+          nodes: [{ id: 'disc', label: 'Discovered', identity: { mgmtIp: '10.1.0.1' } }],
+          links: [],
+        },
+        entities: { nodes: { disc: ENTITY }, ports: {} },
+      }
+
+      const out = resolve(intrinsic, [snap])
+
+      // Should merge into one confirmed node (intrinsic + observed)
+      expect(out.nodes).toHaveLength(1)
+      expect(out.nodes[0]?.provenance?.state).toBe('confirmed')
+      // Intrinsic label wins (highest priority)
+      expect(out.nodes[0]?.label).toBe('Curated Router')
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -102,6 +102,7 @@ export function resolve(
       // them) so groups from different sources can't collide. The intrinsic
       // contribution keeps the raw id space (it's the top-priority, project-owned one).
       graph: namespaceSourceSubgraphs(snap.graph, snap.sourceId),
+      entities: snap.entities,
     })
   }
 
@@ -244,6 +245,14 @@ interface Contribution {
   priority: number
   capturedAt: number
   graph: NetworkGraph
+  /**
+   * Registry entity ids for this contribution's nodes and ports. Absent for
+   * the intrinsic contribution and for snapshots without registry data.
+   */
+  entities?: {
+    nodes: Record<string, string>
+    ports: Record<string, string>
+  }
 }
 
 interface ClusterMember {
@@ -251,6 +260,14 @@ interface ClusterMember {
   priority: number
   capturedAt: number
   node: Node
+  /** Registry entity id for this node, if known. */
+  entityId?: string
+  /**
+   * Registry entity ids for this node's ports, keyed by
+   * `${nodeLocalId}:${portLocalId}`. Used by foldPortsAcrossCluster to
+   * group ports by entity. Absent when the contribution has no registry data.
+   */
+  portEntities?: Record<string, string>
 }
 
 interface NodeCluster {
@@ -298,10 +315,33 @@ function rankMembers(members: ClusterMember[]): ClusterMember[] {
   return [...members].sort((a, b) => b.priority - a.priority || b.capturedAt - a.capturedAt)
 }
 
+/**
+ * Registry-driven node clustering.
+ *
+ * Two-tier cluster key space:
+ *
+ *   `entity:<entityId>` — first-class registry key (strongest). A member that
+ *     carries an entityId is ALWAYS placed in its entity cluster regardless of
+ *     identity-key overlap with other clusters. Identity keys of entity-bearing
+ *     members are also bound to the same cluster so that entity-less members
+ *     (overlay / ghost / old data) can JOIN via key matching — but a key clash
+ *     that would merge two DISTINCT entity clusters is silently ignored (first
+ *     writer wins). This upholds the invariant: registry verdicts are never
+ *     overridden by identity-key coincidence.
+ *
+ *   identity-key hash — classic (fallback). Used when a member has no entityId.
+ *     May NOT cross entity-cluster boundaries.
+ *
+ * When no contribution carries `entities`, the function degenerates to the
+ * original pure-identity-key algorithm — existing behaviour is fully preserved
+ * and all existing tests pass unchanged.
+ */
 function clusterNodes(contributions: Contribution[]): NodeCluster[] {
   const clusters: NodeCluster[] = []
   // Map identity-key-hash → cluster index
   const keyIndex = new Map<string, number>()
+  // Map `entity:<entityId>` → cluster index (registry-first)
+  const entityIndex = new Map<string, number>()
   // Every cluster id handed out so far. Authored nodes keep their own id,
   // which can itself look like a synthesized `discovered:N` (e.g. a node
   // adopted into Manual from a previously-synthesized id). Tracking used
@@ -312,15 +352,44 @@ function clusterNodes(contributions: Contribution[]): NodeCluster[] {
 
   const claim = (member: ClusterMember): void => {
     const keys = nodeIdentityKeys(member.node.identity)
-    // Try to find an existing cluster via any key
+    const entityKey = member.entityId ? `entity:${member.entityId}` : undefined
+
     let hit: number | undefined
-    for (const key of keys) {
-      const idx = keyIndex.get(keyHash(key))
+
+    // 1. Registry lookup (entity id → cluster). Registry verdict is final:
+    //    never merge two distinct entity clusters even if their identity keys
+    //    overlap. An overlay member (no entityId) whose id matches a known
+    //    entity cluster key is handled in step 2 below.
+    if (entityKey !== undefined) {
+      const idx = entityIndex.get(entityKey)
       if (idx !== undefined) {
         hit = idx
-        break
       }
     }
+
+    // 2. Identity-key fallback — only used when no entity hit found yet.
+    //    An entity-bearing member that did NOT find its entity cluster yet
+    //    (first occurrence) will create a new cluster and bind keys there.
+    //    An entity-less member uses this path exclusively.
+    if (hit === undefined) {
+      for (const key of keys) {
+        const idx = keyIndex.get(keyHash(key))
+        if (idx !== undefined) {
+          // Guard: if the found cluster already has a different entity id
+          // than this member, do NOT merge — put the member in its own cluster.
+          if (entityKey !== undefined) {
+            const candidateEntityKey = clusters[idx]?.members.find((m) => m.entityId)?.entityId
+            if (candidateEntityKey !== undefined && `entity:${candidateEntityKey}` !== entityKey) {
+              // Different entity — skip this identity match (first-writer principle)
+              continue
+            }
+          }
+          hit = idx
+          break
+        }
+      }
+    }
+
     if (hit !== undefined) {
       clusters[hit]?.members.push(member)
     } else {
@@ -341,17 +410,35 @@ function clusterNodes(contributions: Contribution[]): NodeCluster[] {
       clusters.push(cluster)
       hit = clusters.length - 1
     }
+
+    // Bind the entity key to this cluster so future members with the same
+    // entity id join immediately (without key-lookup).
+    if (entityKey !== undefined && !entityIndex.has(entityKey)) {
+      entityIndex.set(entityKey, hit)
+    }
+
     // Bind every identity key of this member to the cluster — including
     // keys not used to find it. Future weaker observations can collapse.
+    // If a key is already bound to a DIFFERENT entity cluster, skip it
+    // (no cross-entity merges via identity keys).
     for (const key of keys) {
       const h = keyHash(key)
-      if (!keyIndex.has(h)) keyIndex.set(h, hit)
+      if (!keyIndex.has(h)) {
+        keyIndex.set(h, hit)
+      } else if (entityKey !== undefined) {
+        // Key already claimed — check if it's by a different entity cluster.
+        // If so, leave it alone (first-writer wins; no merge across entities).
+        const existingIdx = keyIndex.get(h)
+        if (existingIdx !== undefined && existingIdx !== hit) {
+          // Leave the existing binding; don't clobber.
+        }
+      }
     }
     // Also bind a deterministic per-source id fallback so identity-less
     // nodes still match themselves across re-runs of the same source.
     if (keys.length === 0) {
       const fallback = keyHash({ kind: 'vendorId', value: `${member.sourceId}:${member.node.id}` })
-      keyIndex.set(fallback, hit)
+      if (!keyIndex.has(fallback)) keyIndex.set(fallback, hit)
     }
   }
 
@@ -361,6 +448,9 @@ function clusterNodes(contributions: Contribution[]): NodeCluster[] {
   for (const contrib of contributions) {
     if (contrib.sourceId !== 'intrinsic') continue
     for (const node of contrib.graph.nodes) {
+      // Intrinsic members never carry registry entity ids — the overlay node's
+      // id IS the entity id in Phase 3, but the identity-clustering path
+      // handles that via the node.id matching as a known entity cluster key.
       claim({
         sourceId: contrib.sourceId,
         priority: contrib.priority,
@@ -372,11 +462,14 @@ function clusterNodes(contributions: Contribution[]): NodeCluster[] {
   for (const contrib of contributions) {
     if (contrib.sourceId === 'intrinsic') continue
     for (const node of contrib.graph.nodes) {
+      const entityId = contrib.entities?.nodes[node.id]
       claim({
         sourceId: contrib.sourceId,
         priority: contrib.priority,
         capturedAt: contrib.capturedAt,
         node,
+        entityId,
+        portEntities: contrib.entities?.ports,
       })
     }
   }
@@ -696,6 +789,8 @@ interface PortMember {
   priority: number
   capturedAt: number
   port: NodePort
+  /** Registry entity id for this port, if known. */
+  entityId?: string
 }
 
 /** Port-id remap key: a source's original (node, port) → the folded port id. */
@@ -712,42 +807,86 @@ interface FoldedPorts {
 function foldPortsAcrossCluster(cluster: NodeCluster): FoldedPorts {
   // Collect ports from all members of the cluster, group by port
   // identity within the cluster, fold each port.
+  // Each ClusterMember carries the contribution's entities map (via the
+  // Contribution object — we need to thread entityId through to PortMember).
+  // Because ClusterMember doesn't hold a back-reference to Contribution, we
+  // look up port entity ids from the node's member.entityId context — port
+  // entity ids were stored as `${nodeLocalId}:${portLocalId}` composites in
+  // the SnapshotEntry.entities.ports map. We pass them via PortMember.entityId.
   const all: PortMember[] = []
   for (const m of cluster.members) {
     for (const port of m.node.ports ?? []) {
+      // Port entity id: prefer the registry entities map (threaded from
+      // SnapshotEntry via ClusterMember.portEntities), fall back to the
+      // Phase 3-stamped port.entityId field.
+      const compositeKey = `${m.node.id}:${port.id}`
+      const portEntityId = m.portEntities?.[compositeKey] ?? port.entityId
       all.push({
         sourceId: m.sourceId,
         nodeId: m.node.id,
         priority: m.priority,
         capturedAt: m.capturedAt,
         port,
+        entityId: portEntityId,
       })
     }
   }
   if (all.length === 0) return { ports: undefined, remap: [] }
 
-  // Group by port identity (within-cluster scope)
+  // Group by port identity (within-cluster scope).
+  // Entity-driven: if two port entries share the same entityId, they go into
+  // the same port cluster regardless of identity-key overlap.
+  // Falls back to identity-key matching when no entityId is present.
   const portClusters: PortMember[][] = []
   const keyToIdx = new Map<string, number>()
+  const portEntityIdx = new Map<string, number>() // `entity:${id}` → cluster idx
   for (const entry of all) {
     const keys = portIdentityKeys(entry.port.identity)
+    const portEntityKey = entry.entityId ? `entity:${entry.entityId}` : undefined
     let hit: number | undefined
-    for (const key of keys) {
-      const idx = keyToIdx.get(keyHash(key))
+
+    // 1. Entity key lookup (strongest)
+    if (portEntityKey !== undefined) {
+      const idx = portEntityIdx.get(portEntityKey)
       if (idx !== undefined) {
         hit = idx
-        break
       }
     }
+
+    // 2. Identity-key fallback
+    if (hit === undefined) {
+      for (const key of keys) {
+        const idx = keyToIdx.get(keyHash(key))
+        if (idx !== undefined) {
+          // Guard: don't merge across distinct port entities
+          if (portEntityKey !== undefined) {
+            const existingEntityId = portClusters[idx]?.find((pm) => pm.entityId)?.entityId
+            if (existingEntityId !== undefined && `entity:${existingEntityId}` !== portEntityKey) {
+              continue
+            }
+          }
+          hit = idx
+          break
+        }
+      }
+    }
+
     if (hit !== undefined) {
       portClusters[hit]?.push(entry)
     } else {
       portClusters.push([entry])
       hit = portClusters.length - 1
     }
-    for (const key of keys) keyToIdx.set(keyHash(key), hit)
+
+    if (portEntityKey !== undefined && !portEntityIdx.has(portEntityKey)) {
+      portEntityIdx.set(portEntityKey, hit)
+    }
+    for (const key of keys) {
+      if (!keyToIdx.has(keyHash(key))) keyToIdx.set(keyHash(key), hit)
+    }
     if (keys.length === 0) {
-      keyToIdx.set(`fallback:${entry.sourceId}:${entry.port.id}`, hit)
+      const fb = `fallback:${entry.sourceId}:${entry.port.id}`
+      if (!keyToIdx.has(fb)) keyToIdx.set(fb, hit)
     }
   }
 

--- a/libs/@shumoku/core/src/observation/types.ts
+++ b/libs/@shumoku/core/src/observation/types.ts
@@ -37,6 +37,21 @@ export interface SnapshotEntry {
    * considers retracting elements from this source after the threshold.
    */
   consecutiveFailures?: number
+  /**
+   * Registry-assigned entity ids for this source's elements, as persisted in
+   * `entity_element`. When present, `resolve()` uses these as first-class
+   * cluster keys so that two representations of the same physical device (e.g.
+   * a host row + an LLDP stub) that share an entity id are always folded —
+   * even when their identity keys are disjoint. Without this field, resolve
+   * falls back to pure identity-key clustering (existing behaviour, preserved
+   * for backwards compatibility and for contexts without a registry).
+   */
+  entities?: {
+    /** node local id → entity id */
+    nodes: Record<string, string>
+    /** `${nodeLocalId}:${portLocalId}` composite → entity id */
+    ports: Record<string, string>
+  }
 }
 
 /** Tuning knobs for `resolve()`. All optional. */


### PR DESCRIPTION
## Summary
Closes #581 (W2). The resolved graph becomes a **projection of registry entities** — the entity registry is the single correlation judge; resolve()'s identity-key clustering is subordinated to it.

- **migration 030 `entity_element`**: `adoptOrMintForGraph` persists its per-element verdicts (`local_id → entity_id`, nodes + ports, full replacement per topology+source). Correlation verdicts become introspectable.
- **`readObservedSnapshots`** reads them back **alias-resolved** and attaches `SnapshotEntry.entities` — the derive worker stays a pure function (no DB access).
- **`resolve()` two-tier clustering**: `entity:<id>` is the first-class cluster key; identity-key matching remains only so entity-less members (overlay / ghost / pre-migration data) can *join* clusters, and can never merge two distinct entity clusters (invariant: ≤1 entity id per cluster = **1 entity → 1 resolved node**). Same for port folding.
- **RESOLVER_VERSION 20 → 21** (all bakes recompute). The #580 flip-uniqueness guard stays as defense; with this change its warning should never fire.

Root cause context: prod had 27 duplicate node pairs because resolve's per-bake, non-transitive fold disagreed with the registry's persistent, transitive verdict (see #581 for the full design and prior-art rationale).

## Tests
- core: 378/378 (4 new: prod-shape regression — same entity, disjoint keys → one node with ports union; separation despite shared sysName key; no-entities backward compat; overlay join via key match). **Zero existing tests modified** — behavior-preservation proof for registry-less inputs.
- server: 146/146 (5 new entity_element tests: persistence, composite port keys, replace-not-accumulate, source isolation, stability across re-ingest).

## Live verification plan (post-deploy)
prod demo: duplicateNodeIds=0, one box per device across NetBox+Zabbix, twin cables collapsed, weathermap lanes on all links, zero `[Registry] … claimed by multiple` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrgkmNxb8bzK8eZmvinBDj
