### PR TITLE
fix(renderer): eliminate topology pan/zoom lag on large diagrams

### DIFF
--- a/.changeset/heavy-camera-lag-fixes.md
+++ b/.changeset/heavy-camera-lag-fixes.md
@@ -1,0 +1,5 @@
+---
+'@shumoku/renderer': patch
+---
+
+Fix pan/zoom lag on large diagrams: cache the root CTM per wheel gesture (was forcing a synchronous reflow on every wheel event), coalesce viewport transform writes to one per animation frame, drop per-node feDropShadow filters and port/link labels while a camera gesture is active (`.camera-gesture` class on the svg, now also applied during drag pans), and stop re-applying the last wheel event when wheel-gestures delivers its gesture-end notification (zoomed one extra step ~400ms after scrolling stopped).

--- a/apps/server/web/src/lib/components/topology/NodeStatusOverlay.svelte
+++ b/apps/server/web/src/lib/components/topology/NodeStatusOverlay.svelte
@@ -143,6 +143,13 @@
       from { opacity: 1; }
       to   { opacity: 0.55; }
     }
+    /* Camera gesture LOD (see attachCamera): freeze the pulse and drop
+       the glow filter while panning/zooming so down-status nodes don't
+       force full-SVG repaints mid-gesture. */
+    svg.camera-gesture g.node.status-down .node-bg rect {
+      animation-play-state: paused;
+      filter: none;
+    }
     @media (prefers-reduced-motion: reduce) {
       g.node.status-down .node-bg rect { animation: none; }
     }

--- a/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
+++ b/apps/server/web/src/lib/components/topology/WeathermapLinkOverlay.svelte
@@ -161,6 +161,19 @@
     opacity: 0.7;
   }
 
+  /* Camera gesture LOD: the dashoffset animations force a full SVG
+         repaint every frame (~5fps idle on a 460-node diagram), which
+         starves pan/zoom of frame budget — and even a *paused* dashed
+         stroke roughly quadruples repaint cost (drag measured 11fps paused
+         vs 50fps hidden on the same diagram). attachCamera toggles
+         .camera-gesture on the svg while a wheel/drag gesture is active —
+         hide the lanes for its duration; the base link keeps its
+         utilization tint via `.wm-active > path.link`, so only the moving
+         dots vanish mid-gesture. */
+  :global(svg.camera-gesture) .wm-overlay {
+    display: none;
+  }
+
   :global(.wm-active > path.link) {
     stroke: var(--wm-base-color, currentColor);
     opacity: 0.55;
@@ -170,8 +183,8 @@
   }
 
   /* Down: no lane overlay; the base link itself is the indicator —
-                           solid red dashed line, full opacity, so it can never be confused
-                           with the animated red lanes of a 90-100% utilized link. */
+                               solid red dashed line, full opacity, so it can never be confused
+                               with the animated red lanes of a 90-100% utilized link. */
   :global(.wm-active.wm-down > path.link) {
     opacity: 1;
     stroke-dasharray: 8 4;

--- a/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgCanvas.svelte
@@ -223,6 +223,25 @@
     /* Edit-only UI (hidden in view mode) */
     .edge-zone { pointer-events: none; }
 
+    /* Zoom/pan LOD: while a camera wheel gesture is active (camera.ts
+       toggles .camera-gesture on the svg), drop the two most expensive
+       ornament groups so repaints keep up with the wheel:
+       - per-node feDropShadow filters: each one re-rasterizes the node
+         through an offscreen buffer on every scale change (2fps → 24fps
+         on a 460-node diagram when dropped). CSS 'filter' outranks the
+         presentation attribute, so 'none' wins while the class is on.
+       - port/link labels: thousands of tiny text glyphs repainted per
+         frame (24fps → ~31fps when dropped). Node labels stay — hiding
+         the device names mid-zoom reads as the diagram falling apart.
+       NOTE: this style element lives inside the svg (SVG namespace), so
+       markup is parsed inside it — never write literal angle brackets
+       in these comments or the stylesheet silently truncates there. */
+    svg.camera-gesture .node[filter] { filter: none; }
+    svg.camera-gesture .port-label,
+    svg.camera-gesture .port-label-bg,
+    svg.camera-gesture .port-label-text,
+    svg.camera-gesture .link-label { display: none; }
+
     /* Marquee selection rectangle (drag-on-background). Hairline solid
        stroke with a faint translucent fill — non-scaling so it stays
        legible at any camera zoom. */

--- a/libs/@shumoku/renderer/src/lib/camera.ts
+++ b/libs/@shumoku/renderer/src/lib/camera.ts
@@ -137,15 +137,28 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
   // `svg.getScreenCTM().inverse()`). Otherwise the cursor drifts from
   // the zoom focus by a factor of the viewBox scale.
 
+  // getScreenCTM() forces a synchronous layout when called after the
+  // viewport transform was written in the same frame — per wheel event
+  // that adds up to seconds of reflow on large diagrams. The root CTM
+  // only depends on the svg's viewBox and CSS box (NOT the viewport
+  // <g>'s transform), so it's stable for the duration of a gesture:
+  // compute it lazily once per gesture and reuse.
+  let cachedCtm: DOMMatrix | null = null
+
   const cursorToUserCoords = (clientX: number, clientY: number): [number, number] | null => {
-    const ctm = svg.getScreenCTM()?.inverse()
-    if (!ctm) return null
+    if (!cachedCtm) {
+      cachedCtm = svg.getScreenCTM()?.inverse() ?? null
+      if (!cachedCtm) return null
+    }
     const pt = svg.createSVGPoint()
     pt.x = clientX
     pt.y = clientY
-    const p = pt.matrixTransform(ctm)
+    const p = pt.matrixTransform(cachedCtm)
     return [p.x, p.y]
   }
+
+  let rafId: number | null = null
+  let pendingTransform: string | null = null
 
   const svgSel = select(svg)
   const zoomBehavior: ZoomBehavior<SVGSVGElement, unknown> = zoom<SVGSVGElement, unknown>()
@@ -173,7 +186,17 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
       return false
     })
     .on('zoom', (e: D3ZoomEvent<SVGSVGElement, unknown>) => {
-      viewportEl.setAttribute('transform', e.transform.toString())
+      // Coalesce transform writes to one per frame. d3-zoom's internal
+      // state (read via `zoomTransform(svg)`) updates synchronously
+      // regardless — only the DOM write (which triggers a full SVG
+      // repaint) is deferred, so wheel events arriving faster than the
+      // display refresh don't queue up redundant repaints.
+      pendingTransform = e.transform.toString()
+      if (rafId !== null) return
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        if (pendingTransform !== null) viewportEl.setAttribute('transform', pendingTransform)
+      })
     })
 
   svgSel.call(zoomBehavior)
@@ -182,6 +205,31 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
   // Sticky per-gesture device verdict — set at `isStart`, read on
   // every subsequent event in the same gesture.
   let gestureDevice: 'mouse' | 'trackpad' = 'mouse'
+
+  // While a wheel gesture is active the svg carries this class so the
+  // renderer's CSS can drop expensive ornaments (per-node feDropShadow
+  // filters re-rasterize every node on every scale change — the
+  // dominant zoom cost on large diagrams; see SvgCanvas.svelte).
+  const GESTURE_CLASS = 'camera-gesture'
+
+  const endGesture = () => {
+    svg.classList.remove(GESTURE_CLASS)
+    cachedCtm = null
+  }
+
+  // Pan drags (d3-zoom's mousedown/pointerdown path) carry the gesture
+  // class too, so drags get the same LOD relief as wheel zooms.
+  // Programmatic transforms (scaleBy/translateBy/transform) dispatch
+  // start+end synchronously per call with `sourceEvent === null` —
+  // skip those, otherwise every wheel-driven scaleBy would tear the
+  // class down mid-gesture (the wheel path manages the class itself
+  // with wheel-gestures' more reliable gesture boundaries).
+  zoomBehavior.on('start.camera-lod', (e: D3ZoomEvent<SVGSVGElement, unknown>) => {
+    if (e.sourceEvent) svg.classList.add(GESTURE_CLASS)
+  })
+  zoomBehavior.on('end.camera-lod', (e: D3ZoomEvent<SVGSVGElement, unknown>) => {
+    if (e.sourceEvent) endGesture()
+  })
 
   const wg = WheelGestures({ preventWheelAction: true })
   const unobserve = wg.observe(svg)
@@ -192,6 +240,16 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
     // is reliable thanks to wheel-gestures' momentum tracking.
     if (state.isStart) {
       gestureDevice = detectDevice(rawEvent, rawEvent.deltaX, rawEvent.deltaY)
+      svg.classList.add(GESTURE_CLASS)
+      cachedCtm = null
+    }
+    // The gesture-end notification re-delivers the LAST wheel event
+    // with `isEnding: true` after wheel-gestures' end timeout — it is
+    // not new input. Applying it zoomed one extra step ~400ms after
+    // the user stopped scrolling ("delayed second zoom" bug).
+    if (state.isEnding) {
+      endGesture()
+      return
     }
 
     const point = cursorToUserCoords(rawEvent.clientX, rawEvent.clientY)
@@ -288,6 +346,11 @@ export function attachCamera(svg: SVGSVGElement, options: CameraOptions = {}): C
     },
 
     detach() {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+      endGesture()
       offWheel()
       unobserve()
       svgSel.on('.zoom', null)


### PR DESCRIPTION
## 問題

大きなトポロジー(実測: 460ノード/761リンク、SVG要素 15,455個)でズーム/パンが著しく重い。実測でホイールズーム中 **約2fps**、さらに1スクロールの約400ms後に余分なズームが一段掛かる「遅延二段ズーム」も発生していた。

## 計測で特定した原因と修正

すべて Chrome DevTools のトレース+実ブラウザでのfps実測に基づく。

| 原因 | 修正 | 効果 |
|---|---|---|
| 全ノードの `feDropShadow` がスケール変更毎に再ラスタライズ | ジェスチャ中は `.camera-gesture` クラスでフィルタを落とす | 2fps → 24fps |
| ポート/リンクラベル(~1,900 text)の毎フレーム再ペイント | ジェスチャ中は非表示(ノード名は残す) | 24fps → ~31fps |
| wheelイベント毎の `getScreenCTM()` が強制リフロー(12sトレース中 1,650ms) | ルートCTMをジェスチャ単位でキャッシュ | リフロー 26ms に |
| transform書き込みがイベント毎 | rAFで1フレーム1回にコアレス(d3内部状態は同期のまま) | 高速入力時の無駄な再ペイント排除 |
| wheel-gestures のジェスチャ終了通知(最後のイベントを再配送)をズーム入力として再適用 | `isEnding` は後始末のみで return | 遅延二段ズーム解消 |
| ウェザーマップの dashoffset アニメーションが**アイドルでも全面再ペイント(~5fps)**。pause しても破線描画だけで4倍のコスト | ジェスチャ中はレーンを `display:none`(ベースリンクの利用率色は残る) | ドラッグ 11fps → 50fps |
| ドラッグパンにLODが効いていない | d3 の `start`/`end`(`sourceEvent` 有りのみ)でもクラス付与 | ドラッグにも全LOD適用 |

## 結果(460ノード/761リンク)

- ホイールズーム: **2fps → ~31fps**、入力詰まり解消(2.7s分の入力処理 12.0s → ~3.0s)
- ドラッグパン(ウェザーマップ有効相当): **8fps → ~50fps**
- 1スクロール=transform書き込み1回のみ(遅延二段ズーム消滅)を MutationObserver で確認

## 残課題(別issue予定)

- 高速連続操作時は ~25-31fps が上限。原因は1.5万要素SVGのフレーム毎ペイント/合成コストで、構造的(合成レイヤー化しても Layerize ~14ms/frame)。60fps化はジェスチャ中ビットマップ代理(Figma式)かレンダーレベルLODが必要。
- ウェザーマップのアイドル時常時再ペイント(メトリクス付きで ~5fps 相当のCPU消費)は仕様のまま。

## 補足

- SVG内に注入する `<style>`(SvgCanvas)のCSSコメントに山括弧を書くとSVG名前空間では要素としてパースされスタイルシートが切断される罠を踏んだため、警告コメントを追加。
- changeset: `@shumoku/renderer` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCL6ozdX6i56q989TrD3KZ