### PR TITLE
fix(server-web): keep dialog header/footer pinned and scroll only the body

### DIFF
--- a/apps/server/web/src/lib/components/DiscoveryNodeDetail.svelte
+++ b/apps/server/web/src/lib/components/DiscoveryNodeDetail.svelte
@@ -375,364 +375,367 @@
         </Dialog.Description>
       </Dialog.Header>
 
-      <div class="space-y-4 text-sm">
-        <!-- Observed (read-only): identity + what the sources reported. -->
-        <section>
-          <h3 class="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
-            Observed
-          </h3>
-          <dl class="space-y-1 rounded-lg border border-border bg-card shadow-sm p-3">
-            <div class="flex justify-between gap-3">
-              <dt class="text-muted-foreground">mgmtIp</dt>
-              <dd class="font-mono">{node.mgmtIp ?? '—'}</dd>
-            </div>
-            <div class="flex justify-between gap-3">
-              <dt class="text-muted-foreground">sysName</dt>
-              <dd>{node.sysName ?? '—'}</dd>
-            </div>
-            <div class="flex justify-between gap-3">
-              <dt class="text-muted-foreground">chassisId</dt>
-              <dd class="font-mono text-xs truncate ml-2 max-w-[260px]" title={node.chassisId}>
-                {node.chassisId ?? '—'}
-              </dd>
-            </div>
-            <div class="flex justify-between gap-3">
-              <dt class="text-muted-foreground">Read via</dt>
-              <dd>
-                {#if node.readVia}
-                  {protocolLabel(node.readVia)}
-                {:else if node.syncState === 'notice'}
-                  <span class="italic text-muted-foreground">not registered yet</span>
-                {:else}
-                  —
-                {/if}
-              </dd>
-            </div>
-            <div class="flex justify-between gap-3">
-              <dt class="text-muted-foreground">Tracked by</dt>
-              <dd>{node.sourceName ?? node.sourceId ?? '—'}</dd>
-            </div>
-            <div class="flex justify-between gap-3">
-              <dt class="text-muted-foreground">Last seen</dt>
-              <dd>{node.observedAt ? formatAgo(node.observedAt) : '—'}</dd>
-            </div>
-            <div class="flex justify-between gap-3">
-              <dt class="text-muted-foreground">catalogId</dt>
-              <dd class="font-mono text-xs">{node.catalogId ?? '— (no match)'}</dd>
-            </div>
-          </dl>
-        </section>
+      <Dialog.Body>
+        <div class="space-y-4 text-sm">
+          <!-- Observed (read-only): identity + what the sources reported. -->
+          <section>
+            <h3 class="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+              Observed
+            </h3>
+            <dl class="space-y-1 rounded-lg border border-border bg-card shadow-sm p-3">
+              <div class="flex justify-between gap-3">
+                <dt class="text-muted-foreground">mgmtIp</dt>
+                <dd class="font-mono">{node.mgmtIp ?? '—'}</dd>
+              </div>
+              <div class="flex justify-between gap-3">
+                <dt class="text-muted-foreground">sysName</dt>
+                <dd>{node.sysName ?? '—'}</dd>
+              </div>
+              <div class="flex justify-between gap-3">
+                <dt class="text-muted-foreground">chassisId</dt>
+                <dd class="font-mono text-xs truncate ml-2 max-w-[260px]" title={node.chassisId}>
+                  {node.chassisId ?? '—'}
+                </dd>
+              </div>
+              <div class="flex justify-between gap-3">
+                <dt class="text-muted-foreground">Read via</dt>
+                <dd>
+                  {#if node.readVia}
+                    {protocolLabel(node.readVia)}
+                  {:else if node.syncState === 'notice'}
+                    <span class="italic text-muted-foreground">not registered yet</span>
+                  {:else}
+                    —
+                  {/if}
+                </dd>
+              </div>
+              <div class="flex justify-between gap-3">
+                <dt class="text-muted-foreground">Tracked by</dt>
+                <dd>{node.sourceName ?? node.sourceId ?? '—'}</dd>
+              </div>
+              <div class="flex justify-between gap-3">
+                <dt class="text-muted-foreground">Last seen</dt>
+                <dd>{node.observedAt ? formatAgo(node.observedAt) : '—'}</dd>
+              </div>
+              <div class="flex justify-between gap-3">
+                <dt class="text-muted-foreground">catalogId</dt>
+                <dd class="font-mono text-xs">{node.catalogId ?? '— (no match)'}</dd>
+              </div>
+            </dl>
+          </section>
 
-        <!-- Settings: name / discovery policy / access for this one node.
+          <!-- Settings: name / discovery policy / access for this one node.
              Each is a single effective value the operator can edit, override,
              or delete — not a separate "authored layer". -->
-        <section>
-          <div class="flex items-center justify-between mb-2">
-            <h3 class="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-              Settings
-            </h3>
-            {#if patchingPolicy}
-              <span class="text-[10px] text-muted-foreground">saving…</span>
-            {/if}
-          </div>
+          <section>
+            <div class="flex items-center justify-between mb-2">
+              <h3 class="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Settings
+              </h3>
+              {#if patchingPolicy}
+                <span class="text-[10px] text-muted-foreground">saving…</span>
+              {/if}
+            </div>
 
-          <div class="space-y-2">
-            <!-- Name — an authored override of the display name. Gated behind
+            <div class="space-y-2">
+              <!-- Name — an authored override of the display name. Gated behind
                  an explicit Edit action (not a permanently-open text box). The
                  observed identity (sysName / mgmtIp) stays in the section
                  above; this just renames the node. Reset reverts to the
                  discovered name — crucial for nodes whose name is just an IP. -->
-            <div class="rounded-lg border border-border bg-card shadow-sm p-3">
-              {#if editingName}
-                <div class="mb-2 text-sm font-semibold text-foreground">Name</div>
-                <Input
-                  placeholder={node.sysName ?? node.mgmtIp ?? 'name'}
-                  bind:value={nameDraft}
-                  disabled={patchingPolicy}
-                  onkeydown={(e) => {
+              <div class="rounded-lg border border-border bg-card shadow-sm p-3">
+                {#if editingName}
+                  <div class="mb-2 text-sm font-semibold text-foreground">Name</div>
+                  <Input
+                    placeholder={node.sysName ?? node.mgmtIp ?? 'name'}
+                    bind:value={nameDraft}
+                    disabled={patchingPolicy}
+                    onkeydown={(e) => {
                     if (e.key === 'Enter') saveName()
                     else if (e.key === 'Escape') cancelEditName()
                   }}
-                />
-                <div class="flex items-center gap-2 mt-2">
-                  <Button size="sm" onclick={saveName} disabled={patchingPolicy}>Save</Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    disabled={patchingPolicy}
-                    onclick={cancelEditName}
-                  >
-                    Cancel
-                  </Button>
-                  {#if node.sysName}
-                    <span class="text-[10px] text-muted-foreground ml-auto">
-                      empty → discovered (<span class="font-mono">{node.sysName}</span>)
-                    </span>
-                  {/if}
-                </div>
-              {:else}
-                <div class="flex items-center justify-between gap-2">
-                  <div class="min-w-0">
-                    <div class="text-[11px] uppercase tracking-wide text-muted-foreground">
-                      Name
-                    </div>
-                    <p class="text-sm font-medium truncate">{node.label}</p>
+                  />
+                  <div class="flex items-center gap-2 mt-2">
+                    <Button size="sm" onclick={saveName} disabled={patchingPolicy}>Save</Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={patchingPolicy}
+                      onclick={cancelEditName}
+                    >
+                      Cancel
+                    </Button>
+                    {#if node.sysName}
+                      <span class="text-[10px] text-muted-foreground ml-auto">
+                        empty → discovered (<span class="font-mono">{node.sysName}</span>)
+                      </span>
+                    {/if}
                   </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    class="h-8 shrink-0"
-                    disabled={patchingPolicy || !onSetLabel}
-                    onclick={startEditName}
-                  >
-                    Edit
-                  </Button>
-                </div>
-              {/if}
-            </div>
+                {:else}
+                  <div class="flex items-center justify-between gap-2">
+                    <div class="min-w-0">
+                      <div class="text-[11px] uppercase tracking-wide text-muted-foreground">
+                        Name
+                      </div>
+                      <p class="text-sm font-medium truncate">{node.label}</p>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      class="h-8 shrink-0"
+                      disabled={patchingPolicy || !onSetLabel}
+                      onclick={startEditName}
+                    >
+                      Edit
+                    </Button>
+                  </div>
+                {/if}
+              </div>
 
-            <!-- Discovery policy — always shown: every node has an effective
+              <!-- Discovery policy — always shown: every node has an effective
                  mode (auto/observe/disabled). A segmented control sets a
                  per-node override; the selection reflects the *effective* mode
                  so it's never empty. When inheriting, the control reads as
                  "following …"; overriding shows a Reset-to-inherit action. -->
-            <div class="rounded-lg border border-border bg-card shadow-sm p-3">
-              <div class="text-sm font-semibold text-foreground mb-1">Discovery policy</div>
-              <p class="text-[11px] text-muted-foreground mb-2.5">
-                {#if hasPolicy}
-                  Overridden on this node.
-                {:else if effectivePolicy}
-                  Following {originLabel(effectivePolicy.source.mode)} ·
-                  <span class="font-mono">{effectivePolicy.mode}</span>
-                  · every {formatInterval(effectivePolicy.intervalMs)}
-                {:else}
-                  Not set.
-                {/if}
-              </p>
+              <div class="rounded-lg border border-border bg-card shadow-sm p-3">
+                <div class="text-sm font-semibold text-foreground mb-1">Discovery policy</div>
+                <p class="text-[11px] text-muted-foreground mb-2.5">
+                  {#if hasPolicy}
+                    Overridden on this node.
+                  {:else if effectivePolicy}
+                    Following {originLabel(effectivePolicy.source.mode)} ·
+                    <span class="font-mono">{effectivePolicy.mode}</span>
+                    · every {formatInterval(effectivePolicy.intervalMs)}
+                  {:else}
+                    Not set.
+                  {/if}
+                </p>
 
-              <!-- Segmented control: one selection out of the three modes. -->
-              <div class="inline-flex w-full rounded-md border border-border p-0.5 bg-background">
-                {#each MODE_OPTIONS as m (m)}
-                  {@const selected = (hasPolicy ? policyMode : effectivePolicy?.mode) === m}
-                  <button
-                    type="button"
-                    class="flex-1 rounded-[5px] px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50
+                <!-- Segmented control: one selection out of the three modes. -->
+                <div class="inline-flex w-full rounded-md border border-border p-0.5 bg-background">
+                  {#each MODE_OPTIONS as m (m)}
+                    {@const selected = (hasPolicy ? policyMode : effectivePolicy?.mode) === m}
+                    <button
+                      type="button"
+                      class="flex-1 rounded-[5px] px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50
                       {selected
                       ? MODE_SELECTED_CLASS[m]
                       : 'text-muted-foreground hover:text-foreground'}
                       {selected && !hasPolicy ? 'opacity-80' : ''}"
-                    disabled={patchingPolicy}
-                    aria-pressed={selected}
-                    onclick={() => setMode(m)}
-                  >
-                    {m}
-                  </button>
-                {/each}
-              </div>
-
-              {#if hasPolicy}
-                <div class="mt-2 flex justify-end">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    class="h-7 px-2 text-muted-foreground"
-                    disabled={patchingPolicy}
-                    title="Clear the per-node override and inherit"
-                    onclick={clearPolicyOverride}
-                  >
-                    Reset to inherited
-                  </Button>
-                </div>
-              {/if}
-            </div>
-
-            <!-- Access — how the node is read. Header carries a + button that
-                 opens a dropdown of the protocols not yet attached (SNMP / SSH
-                 / NETCONF / HTTP); choosing one appends a row with its fields.
-                 The ones the engine can't read with yet are flagged. -->
-            <div class="rounded-lg border border-border bg-card shadow-sm overflow-hidden">
-              <div class="flex items-center justify-between gap-2 px-3 pt-3 pb-2">
-                <div class="min-w-0">
-                  <div class="text-sm font-semibold text-foreground">Access</div>
-                  <div class="text-[11px] text-muted-foreground">how this node is read</div>
-                </div>
-                {#if addableProtocols.length > 0}
-                  <DropdownMenu.Root>
-                    <DropdownMenu.Trigger
                       disabled={patchingPolicy}
-                      class="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground hover:border-primary hover:text-primary disabled:opacity-50 transition-colors shrink-0"
-                      title="Add access method"
-                      aria-label="Add access method"
+                      aria-pressed={selected}
+                      onclick={() => setMode(m)}
                     >
-                      <PlusIcon size={16} weight="bold" />
-                    </DropdownMenu.Trigger>
-                    <DropdownMenu.Content
-                      sideOffset={6}
-                      align="end"
-                      class="z-50 min-w-[15rem] rounded-md border border-border bg-popover p-1 shadow-lg"
+                      {m}
+                    </button>
+                  {/each}
+                </div>
+
+                {#if hasPolicy}
+                  <div class="mt-2 flex justify-end">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      class="h-7 px-2 text-muted-foreground"
+                      disabled={patchingPolicy}
+                      title="Clear the per-node override and inherit"
+                      onclick={clearPolicyOverride}
                     >
-                      {#each addableProtocols as p (p.protocol)}
-                        <DropdownMenu.Item
-                          disabled={patchingPolicy}
-                          onSelect={() => addAccess(p.protocol)}
-                          class="flex items-center justify-between gap-3 rounded-sm px-2.5 py-2 text-left cursor-pointer outline-none data-[highlighted]:bg-accent data-[disabled]:opacity-50"
-                        >
-                          <span class="flex flex-col">
-                            <span class="text-sm font-medium">{p.label}</span>
-                            <span class="text-[11px] text-muted-foreground">{p.hint}</span>
-                          </span>
-                          {#if !p.reads}
-                            <span class="text-[10px] text-muted-foreground whitespace-nowrap">
-                              not read yet
-                            </span>
-                          {/if}
-                        </DropdownMenu.Item>
-                      {/each}
-                    </DropdownMenu.Content>
-                  </DropdownMenu.Root>
+                      Reset to inherited
+                    </Button>
+                  </div>
                 {/if}
               </div>
 
-              <!-- Attached protocols: one row each. Tap a row to expand its
+              <!-- Access — how the node is read. Header carries a + button that
+                 opens a dropdown of the protocols not yet attached (SNMP / SSH
+                 / NETCONF / HTTP); choosing one appends a row with its fields.
+                 The ones the engine can't read with yet are flagged. -->
+              <div class="rounded-lg border border-border bg-card shadow-sm overflow-hidden">
+                <div class="flex items-center justify-between gap-2 px-3 pt-3 pb-2">
+                  <div class="min-w-0">
+                    <div class="text-sm font-semibold text-foreground">Access</div>
+                    <div class="text-[11px] text-muted-foreground">how this node is read</div>
+                  </div>
+                  {#if addableProtocols.length > 0}
+                    <DropdownMenu.Root>
+                      <DropdownMenu.Trigger
+                        disabled={patchingPolicy}
+                        class="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground hover:border-primary hover:text-primary disabled:opacity-50 transition-colors shrink-0"
+                        title="Add access method"
+                        aria-label="Add access method"
+                      >
+                        <PlusIcon size={16} weight="bold" />
+                      </DropdownMenu.Trigger>
+                      <DropdownMenu.Content
+                        sideOffset={6}
+                        align="end"
+                        class="z-50 min-w-[15rem] rounded-md border border-border bg-popover p-1 shadow-lg"
+                      >
+                        {#each addableProtocols as p (p.protocol)}
+                          <DropdownMenu.Item
+                            disabled={patchingPolicy}
+                            onSelect={() => addAccess(p.protocol)}
+                            class="flex items-center justify-between gap-3 rounded-sm px-2.5 py-2 text-left cursor-pointer outline-none data-[highlighted]:bg-accent data-[disabled]:opacity-50"
+                          >
+                            <span class="flex flex-col">
+                              <span class="text-sm font-medium">{p.label}</span>
+                              <span class="text-[11px] text-muted-foreground">{p.hint}</span>
+                            </span>
+                            {#if !p.reads}
+                              <span class="text-[10px] text-muted-foreground whitespace-nowrap">
+                                not read yet
+                              </span>
+                            {/if}
+                          </DropdownMenu.Item>
+                        {/each}
+                      </DropdownMenu.Content>
+                    </DropdownMenu.Root>
+                  {/if}
+                </div>
+
+                <!-- Attached protocols: one row each. Tap a row to expand its
                    fields (accordion — at most one open). Collapsed rows show a
                    value summary + chevron, iOS-Settings-style. -->
-              {#if unifiedAccess.length > 0}
-                <!-- ONE row per protocol. No observed/authored layers: the
+                {#if unifiedAccess.length > 0}
+                  <!-- ONE row per protocol. No observed/authored layers: the
                      field is always editable (typing sets a top-priority
                      override); the caption just says where the current value
                      comes from. Clearing the field / Revert drops the override
                      back to the source value. -->
-                <div class="border-t border-border divide-y divide-border">
-                  {#each unifiedAccess as row (row.protocol)}
-                    {@const effective = row.authored ?? row.observed}
-                    {@const overridden = !!row.authored}
-                    {@const expanded = openAccess === row.protocol}
-                    <div>
-                      <button
-                        type="button"
-                        class="w-full flex items-center justify-between gap-2 px-3 py-2.5 text-left hover:bg-accent/50 transition-colors"
-                        aria-expanded={expanded}
-                        onclick={() => toggleAccess(row.protocol)}
-                      >
-                        <span class="flex items-center gap-2 min-w-0">
-                          <CaretRightIcon
-                            size={14}
-                            class="text-muted-foreground shrink-0 transition-transform {expanded
+                  <div class="border-t border-border divide-y divide-border">
+                    {#each unifiedAccess as row (row.protocol)}
+                      {@const effective = row.authored ?? row.observed}
+                      {@const overridden = !!row.authored}
+                      {@const expanded = openAccess === row.protocol}
+                      <div>
+                        <button
+                          type="button"
+                          class="w-full flex items-center justify-between gap-2 px-3 py-2.5 text-left hover:bg-accent/50 transition-colors"
+                          aria-expanded={expanded}
+                          onclick={() => toggleAccess(row.protocol)}
+                        >
+                          <span class="flex items-center gap-2 min-w-0">
+                            <CaretRightIcon
+                              size={14}
+                              class="text-muted-foreground shrink-0 transition-transform {expanded
                               ? 'rotate-90'
                               : ''}"
-                          />
-                          <span class="text-sm font-medium">{protocolLabel(row.protocol)}</span>
-                          {#if !protocolReads(row.protocol)}
+                            />
+                            <span class="text-sm font-medium">{protocolLabel(row.protocol)}</span>
+                            {#if !protocolReads(row.protocol)}
+                              <span
+                                class="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground whitespace-nowrap"
+                                title="Stored, but the discovery engine doesn't read via this protocol yet"
+                              >
+                                not read yet
+                              </span>
+                            {/if}
+                          </span>
+                          {#if !expanded && effective}
                             <span
-                              class="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-muted text-muted-foreground whitespace-nowrap"
-                              title="Stored, but the discovery engine doesn't read via this protocol yet"
+                              class="text-xs text-muted-foreground truncate max-w-[150px] font-mono"
                             >
-                              not read yet
+                              {accessSummary(effective)}
                             </span>
                           {/if}
-                        </span>
-                        {#if !expanded && effective}
-                          <span
-                            class="text-xs text-muted-foreground truncate max-w-[150px] font-mono"
-                          >
-                            {accessSummary(effective)}
-                          </span>
-                        {/if}
-                      </button>
+                        </button>
 
-                      {#if expanded && effective}
-                        <div class="px-3 pb-3 pl-9 space-y-2">
-                          <p class="text-[11px] text-muted-foreground">
-                            {#if overridden}
-                              Your value
-                              {#if row.observed}
-                                · source read
-                                <span class="font-mono">{accessSummary(row.observed)}</span>
-                                · clear to revert
-                              {/if}
-                            {:else}
-                              From {node.sourceName ?? 'the source'} — edit to set your own
-                            {/if}
-                          </p>
-                          {#if row.protocol === 'snmp'}
-                            <div class="space-y-1">
-                              <Label class="text-[11px] text-muted-foreground">Community</Label>
-                              <Input
-                                class="h-8 text-xs font-mono"
-                                placeholder="community (e.g. public)"
-                                value={snmpCommunityOf(effective)}
-                                disabled={patchingPolicy}
-                                onchange={(e) => setSnmpCommunity(e.currentTarget.value)}
-                              />
-                            </div>
-                          {:else if row.protocol === 'ssh'}
-                            <div class="space-y-1">
-                              <Label class="text-[11px] text-muted-foreground">Username</Label>
-                              <Input
-                                class="h-8 text-xs"
-                                placeholder="username"
-                                value={sshUsernameOf(effective)}
-                                disabled={patchingPolicy}
-                                onchange={(e) => setSshUsername(e.currentTarget.value)}
-                              />
-                            </div>
-                          {:else}
+                        {#if expanded && effective}
+                          <div class="px-3 pb-3 pl-9 space-y-2">
                             <p class="text-[11px] text-muted-foreground">
-                              No editable fields for this protocol yet.
+                              {#if overridden}
+                                Your value
+                                {#if row.observed}
+                                  · source read
+                                  <span class="font-mono">{accessSummary(row.observed)}</span>
+                                  · clear to revert
+                                {/if}
+                              {:else}
+                                From {node.sourceName ?? 'the source'} — edit to set your own
+                              {/if}
                             </p>
-                          {/if}
-                          <!-- ✕ deletes the access (any row, incl. source-supplied).
+                            {#if row.protocol === 'snmp'}
+                              <div class="space-y-1">
+                                <Label class="text-[11px] text-muted-foreground">Community</Label>
+                                <Input
+                                  class="h-8 text-xs font-mono"
+                                  placeholder="community (e.g. public)"
+                                  value={snmpCommunityOf(effective)}
+                                  disabled={patchingPolicy}
+                                  onchange={(e) => setSnmpCommunity(e.currentTarget.value)}
+                                />
+                              </div>
+                            {:else if row.protocol === 'ssh'}
+                              <div class="space-y-1">
+                                <Label class="text-[11px] text-muted-foreground">Username</Label>
+                                <Input
+                                  class="h-8 text-xs"
+                                  placeholder="username"
+                                  value={sshUsernameOf(effective)}
+                                  disabled={patchingPolicy}
+                                  onchange={(e) => setSshUsername(e.currentTarget.value)}
+                                />
+                              </div>
+                            {:else}
+                              <p class="text-[11px] text-muted-foreground">
+                                No editable fields for this protocol yet.
+                              </p>
+                            {/if}
+                            <!-- ✕ deletes the access (any row, incl. source-supplied).
                                A source-supplied one is suppressed so it stays gone
                                across re-scans; Reset (whole node) restores it. -->
-                          <div class="flex items-center justify-end">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              class="h-7 gap-1 px-2 text-muted-foreground hover:text-destructive"
-                              disabled={patchingPolicy}
-                              title="Delete this access. Reset restores it from the source."
-                              onclick={() => deleteAccess(row.protocol, !!row.observed)}
-                            >
-                              <TrashIcon size={14} />
-                              Delete
-                            </Button>
+                            <div class="flex items-center justify-end">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                class="h-7 gap-1 px-2 text-muted-foreground hover:text-destructive"
+                                disabled={patchingPolicy}
+                                title="Delete this access. Reset restores it from the source."
+                                onclick={() => deleteAccess(row.protocol, !!row.observed)}
+                              >
+                                <TrashIcon size={14} />
+                                Delete
+                              </Button>
+                            </div>
                           </div>
-                        </div>
-                      {/if}
-                    </div>
-                  {/each}
-                </div>
-              {:else}
-                <!-- Empty / inheritance state when nothing is attached here. -->
-                <div class="border-t border-border px-3 py-2.5 text-[11px] text-muted-foreground">
-                  {#if effectivePolicy?.community}
-                    No override — SNMP community inherited from
-                    {originLabel(effectivePolicy.source.community)}
-                    (<span class="font-mono">{effectivePolicy.community}</span>). Use + to override.
-                  {:else if node.readVia}
-                    No override — reading with the {node.sourceName ?? 'source'} default community.
-                    Use + to override.
-                  {:else if node.syncState === 'notice'}
-                    <span class="text-amber-700 dark:text-amber-300">
-                      Reachable but not readable — use + to add SNMP and set a community.
-                    </span>
-                  {:else}
-                    No access method attached. Use + to add one.
-                  {/if}
-                </div>
-              {/if}
+                        {/if}
+                      </div>
+                    {/each}
+                  </div>
+                {:else}
+                  <!-- Empty / inheritance state when nothing is attached here. -->
+                  <div class="border-t border-border px-3 py-2.5 text-[11px] text-muted-foreground">
+                    {#if effectivePolicy?.community}
+                      No override — SNMP community inherited from
+                      {originLabel(effectivePolicy.source.community)}
+                      (<span class="font-mono">{effectivePolicy.community}</span>). Use + to
+                      override.
+                    {:else if node.readVia}
+                      No override — reading with the {node.sourceName ?? 'source'} default
+                      community. Use + to override.
+                    {:else if node.syncState === 'notice'}
+                      <span class="text-amber-700 dark:text-amber-300">
+                        Reachable but not readable — use + to add SNMP and set a community.
+                      </span>
+                    {:else}
+                      No access method attached. Use + to add one.
+                    {/if}
+                  </div>
+                {/if}
+              </div>
             </div>
-          </div>
 
-          {#if policyErrorMessage}
-            <div
-              class="mt-2 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300"
-            >
-              {policyErrorMessage}
-            </div>
-          {/if}
-        </section>
-      </div>
+            {#if policyErrorMessage}
+              <div
+                class="mt-2 rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300"
+              >
+                {policyErrorMessage}
+              </div>
+            {/if}
+          </section>
+        </div>
+      </Dialog.Body>
 
       <Dialog.Footer class="flex items-center justify-between gap-2">
         <div class="flex items-center gap-1.5">

--- a/apps/server/web/src/lib/components/NodeMappingModal.svelte
+++ b/apps/server/web/src/lib/components/NodeMappingModal.svelte
@@ -346,342 +346,348 @@
     {#if nodeData}
       {#if mode === 'status'}
         <!-- STATUS VIEW -->
-        <div class="space-y-4">
-          <!-- Node Info & Status -->
-          <div class="bg-muted/50 rounded-lg p-4 space-y-3">
-            <!-- Mapping row -->
-            <div class="flex items-center justify-between">
-              <span class="text-xs uppercase tracking-wide text-muted-foreground">Mapping</span>
-              {#if currentNodeMapping?.hostId}
-                <span class="text-xs text-foreground">
-                  {currentNodeMapping.hostName || currentNodeMapping.hostId}
-                </span>
-              {:else}
-                <span class="inline-flex items-center gap-1 text-xs text-warning">
-                  <LinkBreakIcon size={12} />
-                  Not mapped
-                </span>
-              {/if}
-            </div>
-
-            <!-- Device status row -->
-            <div class="flex items-center justify-between">
-              <span class="text-xs uppercase tracking-wide text-muted-foreground">Device</span>
-              <div class="flex items-center gap-2">
-                <span
-                  class="w-2.5 h-2.5 rounded-full {getStatusBgColor(nodeMetrics?.status)}"
-                ></span>
-                <span class="text-sm font-medium {getStatusColor(nodeMetrics?.status)}">
-                  {getDeviceLabel(nodeMetrics?.status)}
-                </span>
-              </div>
-            </div>
-
-            <!-- Monitoring health row (orthogonal to device) -->
-            {#if currentNodeMapping?.hostId}
+        <Dialog.Body>
+          <div class="space-y-4">
+            <!-- Node Info & Status -->
+            <div class="bg-muted/50 rounded-lg p-4 space-y-3">
+              <!-- Mapping row -->
               <div class="flex items-center justify-between">
-                <span class="text-xs uppercase tracking-wide text-muted-foreground">
-                  Monitoring
-                </span>
-                <div class="flex flex-col items-end gap-0.5">
-                  <div class="flex items-center gap-2">
-                    <span
-                      class="w-2.5 h-2.5 rounded-full {getMonitoringBgColor(
-                        nodeMetrics?.monitoring,
-                      )}"
-                    ></span>
-                    <span
-                      class="text-sm font-medium {getMonitoringTextColor(nodeMetrics?.monitoring)}"
-                    >
-                      {getMonitoringLabel(nodeMetrics?.monitoring)}
-                    </span>
-                  </div>
-                  {#if nodeMetrics?.monitoringError}
-                    <span
-                      class="text-xs text-muted-foreground max-w-[16rem] truncate"
-                      title={nodeMetrics.monitoringError}
-                    >
-                      {nodeMetrics.monitoringError}
-                    </span>
-                  {/if}
+                <span class="text-xs uppercase tracking-wide text-muted-foreground">Mapping</span>
+                {#if currentNodeMapping?.hostId}
+                  <span class="text-xs text-foreground">
+                    {currentNodeMapping.hostName || currentNodeMapping.hostId}
+                  </span>
+                {:else}
+                  <span class="inline-flex items-center gap-1 text-xs text-warning">
+                    <LinkBreakIcon size={12} />
+                    Not mapped
+                  </span>
+                {/if}
+              </div>
+
+              <!-- Device status row -->
+              <div class="flex items-center justify-between">
+                <span class="text-xs uppercase tracking-wide text-muted-foreground">Device</span>
+                <div class="flex items-center gap-2">
+                  <span
+                    class="w-2.5 h-2.5 rounded-full {getStatusBgColor(nodeMetrics?.status)}"
+                  ></span>
+                  <span class="text-sm font-medium {getStatusColor(nodeMetrics?.status)}">
+                    {getDeviceLabel(nodeMetrics?.status)}
+                  </span>
                 </div>
               </div>
-            {/if}
 
-            <!-- Device Info -->
-            <div class="flex flex-wrap gap-2 text-xs text-muted-foreground">
-              {#if nodeData.node.spec?.type}
-                <span class="bg-background px-2 py-1 rounded">{nodeData.node.spec.type}</span>
+              <!-- Monitoring health row (orthogonal to device) -->
+              {#if currentNodeMapping?.hostId}
+                <div class="flex items-center justify-between">
+                  <span class="text-xs uppercase tracking-wide text-muted-foreground">
+                    Monitoring
+                  </span>
+                  <div class="flex flex-col items-end gap-0.5">
+                    <div class="flex items-center gap-2">
+                      <span
+                        class="w-2.5 h-2.5 rounded-full {getMonitoringBgColor(
+                        nodeMetrics?.monitoring,
+                      )}"
+                      ></span>
+                      <span
+                        class="text-sm font-medium {getMonitoringTextColor(nodeMetrics?.monitoring)}"
+                      >
+                        {getMonitoringLabel(nodeMetrics?.monitoring)}
+                      </span>
+                    </div>
+                    {#if nodeMetrics?.monitoringError}
+                      <span
+                        class="text-xs text-muted-foreground max-w-[16rem] truncate"
+                        title={nodeMetrics.monitoringError}
+                      >
+                        {nodeMetrics.monitoringError}
+                      </span>
+                    {/if}
+                  </div>
+                </div>
               {/if}
-              {#if nodeData.node.spec?.vendor}
-                <span class="bg-background px-2 py-1 rounded">{nodeData.node.spec.vendor}</span>
-              {/if}
-              {#if nodeData.node.spec?.model}
-                <span class="bg-background px-2 py-1 rounded">{nodeData.node.spec.model}</span>
-              {/if}
-              {#if !nodeData.node.spec?.type && !nodeData.node.spec?.vendor && !nodeData.node.spec?.model}
-                <span class="text-muted-foreground italic">No device info</span>
+
+              <!-- Device Info -->
+              <div class="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                {#if nodeData.node.spec?.type}
+                  <span class="bg-background px-2 py-1 rounded">{nodeData.node.spec.type}</span>
+                {/if}
+                {#if nodeData.node.spec?.vendor}
+                  <span class="bg-background px-2 py-1 rounded">{nodeData.node.spec.vendor}</span>
+                {/if}
+                {#if nodeData.node.spec?.model}
+                  <span class="bg-background px-2 py-1 rounded">{nodeData.node.spec.model}</span>
+                {/if}
+                {#if !nodeData.node.spec?.type && !nodeData.node.spec?.vendor && !nodeData.node.spec?.model}
+                  <span class="text-muted-foreground italic">No device info</span>
+                {/if}
+              </div>
+
+              <!-- NetBox Link -->
+              {#if netboxDeviceUrl}
+                <a
+                  href={netboxDeviceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+                >
+                  <CubeIcon size={12} />
+                  View in NetBox
+                  <ArrowSquareOutIcon size={10} />
+                </a>
               {/if}
             </div>
 
-            <!-- NetBox Link -->
-            {#if netboxDeviceUrl}
-              <a
-                href={netboxDeviceUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
-              >
-                <CubeIcon size={12} />
-                View in NetBox
-                <ArrowSquareOutIcon size={10} />
-              </a>
-            {/if}
-          </div>
-
-          <!-- Discovery (observation-model identity + provenance) -->
-          {#if nodeData.node.identity || nodeData.node.provenance}
-            <div class="bg-muted/30 rounded-lg p-4 space-y-2">
-              <div class="flex items-center justify-between">
-                <span class="text-xs uppercase tracking-wide text-muted-foreground">Discovery</span>
-                {#if nodeData.node.provenance?.state}
-                  {@const state = nodeData.node.provenance.state}
-                  <span
-                    class="text-xs font-medium {state === 'confirmed'
+            <!-- Discovery (observation-model identity + provenance) -->
+            {#if nodeData.node.identity || nodeData.node.provenance}
+              <div class="bg-muted/30 rounded-lg p-4 space-y-2">
+                <div class="flex items-center justify-between">
+                  <span class="text-xs uppercase tracking-wide text-muted-foreground"
+                    >Discovery</span
+                  >
+                  {#if nodeData.node.provenance?.state}
+                    {@const state = nodeData.node.provenance.state}
+                    <span
+                      class="text-xs font-medium {state === 'confirmed'
                       ? 'text-green-600 dark:text-green-400'
                       : state === 'conflicting'
                         ? 'text-amber-600 dark:text-amber-400'
                         : state === 'discovered-only'
                           ? 'text-blue-500 dark:text-blue-400'
                           : 'text-muted-foreground'}"
-                  >
-                    {state}
-                  </span>
-                {/if}
-              </div>
-
-              {#if nodeData.node.provenance}
-                <div class="grid grid-cols-[80px_1fr] gap-x-2 gap-y-1 text-xs">
-                  <span class="text-muted-foreground">source</span>
-                  <span class="font-mono">{nodeData.node.provenance.source}</span>
-                  {#if nodeData.node.provenance.observedAt}
-                    <span class="text-muted-foreground">observed</span>
-                    <span> {new Date(nodeData.node.provenance.observedAt).toLocaleString()} </span>
-                  {/if}
-                </div>
-              {/if}
-
-              {#if nodeData.node.identity}
-                {@const id = nodeData.node.identity}
-                <div
-                  class="grid grid-cols-[80px_1fr] gap-x-2 gap-y-1 text-xs pt-2 border-t border-border"
-                >
-                  {#if id.mgmtIp}
-                    <span class="text-muted-foreground">mgmtIp</span>
-                    <span class="font-mono">{id.mgmtIp}</span>
-                  {/if}
-                  {#if id.chassisId}
-                    <span class="text-muted-foreground">chassisId</span>
-                    <span class="font-mono">{id.chassisId}</span>
-                  {/if}
-                  {#if id.sysName}
-                    <span class="text-muted-foreground">sysName</span>
-                    <span>{id.sysName}</span>
-                  {/if}
-                  {#if id.vendorIds}
-                    <span class="text-muted-foreground">vendorIds</span>
-                    <span class="font-mono break-all">
-                      {Object.entries(id.vendorIds)
-                        .map(([k, v]) => `${k}=${v}`)
-                        .join(' / ')}
+                    >
+                      {state}
                     </span>
                   {/if}
                 </div>
-              {/if}
-            </div>
-          {/if}
 
-          <!-- Connected Links with Traffic -->
-          {#if nodeData.connectedLinks.length > 0}
-            <div class="space-y-2">
-              <div class="flex items-center gap-2 text-sm font-medium">
-                <LinkIcon size={14} />
-                <span>Traffic ({nodeData.connectedLinks.length} links)</span>
-              </div>
-              <div class="border rounded-lg divide-y max-h-48 overflow-y-auto">
-                {#each nodeData.connectedLinks as link}
-                  {@const isFrom = link.from.id === nodeData.node.id}
-                  {@const otherNode = isFrom ? link.to : link.from}
-                  {@const metrics = linkMetricsMap[link.id]}
-                  <div class="p-3 space-y-1">
-                    <div class="flex items-center justify-between">
-                      <span class="text-sm font-medium flex items-center gap-1.5">
-                        <span
-                          class="w-2 h-2 rounded-full {getStatusBgColor(metrics?.status)}"
-                        ></span>
-                        {isFrom ? '→' : '←'}
-                        {otherNode.label}
+                {#if nodeData.node.provenance}
+                  <div class="grid grid-cols-[80px_1fr] gap-x-2 gap-y-1 text-xs">
+                    <span class="text-muted-foreground">source</span>
+                    <span class="font-mono">{nodeData.node.provenance.source}</span>
+                    {#if nodeData.node.provenance.observedAt}
+                      <span class="text-muted-foreground">observed</span>
+                      <span>
+                        {new Date(nodeData.node.provenance.observedAt).toLocaleString()}
                       </span>
-                      {#if link.standard}
-                        <span class="text-xs text-muted-foreground">{link.standard}</span>
-                      {/if}
-                    </div>
-                    {#if metrics?.inBps !== undefined || metrics?.outBps !== undefined}
-                      <!-- Show actual traffic values -->
-                      <div class="flex gap-4 text-xs">
-                        <span class="text-muted-foreground">In:</span>
-                        <span class="font-medium">{formatTraffic(metrics.inBps ?? 0)}</span>
-                        <span class="text-muted-foreground">Out:</span>
-                        <span class="font-medium">{formatTraffic(metrics.outBps ?? 0)}</span>
+                    {/if}
+                  </div>
+                {/if}
+
+                {#if nodeData.node.identity}
+                  {@const id = nodeData.node.identity}
+                  <div
+                    class="grid grid-cols-[80px_1fr] gap-x-2 gap-y-1 text-xs pt-2 border-t border-border"
+                  >
+                    {#if id.mgmtIp}
+                      <span class="text-muted-foreground">mgmtIp</span>
+                      <span class="font-mono">{id.mgmtIp}</span>
+                    {/if}
+                    {#if id.chassisId}
+                      <span class="text-muted-foreground">chassisId</span>
+                      <span class="font-mono">{id.chassisId}</span>
+                    {/if}
+                    {#if id.sysName}
+                      <span class="text-muted-foreground">sysName</span>
+                      <span>{id.sysName}</span>
+                    {/if}
+                    {#if id.vendorIds}
+                      <span class="text-muted-foreground">vendorIds</span>
+                      <span class="font-mono break-all">
+                        {Object.entries(id.vendorIds)
+                        .map(([k, v]) => `${k}=${v}`)
+                        .join(' / ')}
+                      </span>
+                    {/if}
+                  </div>
+                {/if}
+              </div>
+            {/if}
+
+            <!-- Connected Links with Traffic -->
+            {#if nodeData.connectedLinks.length > 0}
+              <div class="space-y-2">
+                <div class="flex items-center gap-2 text-sm font-medium">
+                  <LinkIcon size={14} />
+                  <span>Traffic ({nodeData.connectedLinks.length} links)</span>
+                </div>
+                <div class="border rounded-lg divide-y max-h-48 overflow-y-auto">
+                  {#each nodeData.connectedLinks as link}
+                    {@const isFrom = link.from.id === nodeData.node.id}
+                    {@const otherNode = isFrom ? link.to : link.from}
+                    {@const metrics = linkMetricsMap[link.id]}
+                    <div class="p-3 space-y-1">
+                      <div class="flex items-center justify-between">
+                        <span class="text-sm font-medium flex items-center gap-1.5">
+                          <span
+                            class="w-2 h-2 rounded-full {getStatusBgColor(metrics?.status)}"
+                          ></span>
+                          {isFrom ? '→' : '←'}
+                          {otherNode.label}
+                        </span>
+                        {#if link.standard}
+                          <span class="text-xs text-muted-foreground">{link.standard}</span>
+                        {/if}
                       </div>
-                      <!-- Utilization bar if available -->
-                      {#if metrics.utilization !== undefined && metrics.utilization > 0}
-                        <div class="flex items-center gap-2 text-xs">
-                          <div class="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
-                            <div
-                              class="h-full rounded-full transition-all {metrics.utilization > 80
+                      {#if metrics?.inBps !== undefined || metrics?.outBps !== undefined}
+                        <!-- Show actual traffic values -->
+                        <div class="flex gap-4 text-xs">
+                          <span class="text-muted-foreground">In:</span>
+                          <span class="font-medium">{formatTraffic(metrics.inBps ?? 0)}</span>
+                          <span class="text-muted-foreground">Out:</span>
+                          <span class="font-medium">{formatTraffic(metrics.outBps ?? 0)}</span>
+                        </div>
+                        <!-- Utilization bar if available -->
+                        {#if metrics.utilization !== undefined && metrics.utilization > 0}
+                          <div class="flex items-center gap-2 text-xs">
+                            <div class="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
+                              <div
+                                class="h-full rounded-full transition-all {metrics.utilization > 80
                                 ? 'bg-destructive'
                                 : metrics.utilization > 50
                                   ? 'bg-warning'
                                   : 'bg-success'}"
-                              style="width: {Math.min(metrics.utilization, 100)}%"
-                            ></div>
+                                style="width: {Math.min(metrics.utilization, 100)}%"
+                              ></div>
+                            </div>
+                            <span class="text-muted-foreground w-12 text-right">
+                              {formatUtilization(metrics.utilization)}
+                            </span>
                           </div>
-                          <span class="text-muted-foreground w-12 text-right">
-                            {formatUtilization(metrics.utilization)}
-                          </span>
+                        {/if}
+                      {:else}
+                        <div class="text-xs text-muted-foreground italic">No traffic data</div>
+                      {/if}
+                    </div>
+                  {/each}
+                </div>
+              </div>
+            {:else}
+              <div class="text-sm text-muted-foreground text-center py-4">No connected links</div>
+            {/if}
+
+            <!-- Discovered Metrics Section (expandable) -->
+            {#if hasMetricsSource && currentNodeMapping?.hostId}
+              <div class="space-y-2">
+                <button
+                  class="flex items-center gap-2 text-sm font-medium w-full hover:text-primary transition-colors"
+                  onclick={handleMetricsToggle}
+                >
+                  {#if metricsExpanded}
+                    <CaretDownIcon size={14} />
+                  {:else}
+                    <CaretRightIcon size={14} />
+                  {/if}
+                  <ChartLineIcon size={14} />
+                  <span>All Metrics</span>
+                  {#if discoveredMetrics.length > 0}
+                    <span class="text-xs text-muted-foreground">({discoveredMetrics.length})</span>
+                  {/if}
+                </button>
+
+                {#if metricsExpanded}
+                  <div class="border rounded-lg">
+                    {#if loadingMetrics}
+                      <div class="flex items-center justify-center py-8">
+                        <div
+                          class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"
+                        ></div>
+                        <span class="ml-2 text-sm text-muted-foreground">Loading metrics...</span>
+                      </div>
+                    {:else if metricsError}
+                      <div class="p-3 text-sm">
+                        <p class="text-destructive">{metricsError}</p>
+                        <button
+                          class="text-xs text-primary hover:underline mt-1"
+                          onclick={loadDiscoveredMetrics}
+                        >
+                          Retry
+                        </button>
+                      </div>
+                    {:else if discoveredMetrics.length === 0}
+                      <div class="p-3 text-sm text-muted-foreground text-center">
+                        No metrics found
+                      </div>
+                    {:else}
+                      <!-- Search -->
+                      <div class="p-2 border-b">
+                        <div class="relative">
+                          <MagnifyingGlassIcon
+                            size={14}
+                            class="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+                          />
+                          <input
+                            type="text"
+                            placeholder="Search metrics..."
+                            class="w-full pl-7 pr-2 py-1 text-xs bg-background border rounded focus:outline-none focus:ring-1 focus:ring-ring"
+                            bind:value={metricsSearchQuery}
+                          >
+                        </div>
+                      </div>
+
+                      <!-- Metrics List -->
+                      <div class="max-h-64 overflow-y-auto divide-y">
+                        {#each filteredMetrics as metric}
+                          <div class="p-2 hover:bg-muted/30 text-xs space-y-1">
+                            <div class="flex items-start justify-between gap-2">
+                              <div class="font-mono font-medium text-foreground break-all">
+                                {metric.name}
+                              </div>
+                              <div class="font-mono text-right flex-shrink-0 tabular-nums">
+                                {formatMetricValue(metric.value)}
+                              </div>
+                            </div>
+                            {#if metric.help}
+                              <div class="text-muted-foreground">{metric.help}</div>
+                            {/if}
+                            {#if Object.keys(metric.labels).length > 0}
+                              <div class="flex flex-wrap gap-1">
+                                {#each Object.entries(metric.labels) as [ key, value ]}
+                                  <span class="bg-muted px-1.5 py-0.5 rounded text-[10px]">
+                                    {key}=<span class="text-muted-foreground">{value}</span>
+                                  </span>
+                                {/each}
+                              </div>
+                            {/if}
+                          </div>
+                        {/each}
+                      </div>
+
+                      {#if metricsSearchQuery && filteredMetrics.length === 0}
+                        <div class="p-3 text-sm text-muted-foreground text-center">
+                          No metrics match your search
                         </div>
                       {/if}
-                    {:else}
-                      <div class="text-xs text-muted-foreground italic">No traffic data</div>
                     {/if}
                   </div>
-                {/each}
+                {/if}
               </div>
-            </div>
-          {:else}
-            <div class="text-sm text-muted-foreground text-center py-4">No connected links</div>
-          {/if}
+            {/if}
 
-          <!-- Discovered Metrics Section (expandable) -->
-          {#if hasMetricsSource && currentNodeMapping?.hostId}
-            <div class="space-y-2">
-              <button
-                class="flex items-center gap-2 text-sm font-medium w-full hover:text-primary transition-colors"
-                onclick={handleMetricsToggle}
+            <!-- No metrics source warning -->
+            {#if !hasMetricsSource}
+              <div
+                class="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg text-sm"
               >
-                {#if metricsExpanded}
-                  <CaretDownIcon size={14} />
-                {:else}
-                  <CaretRightIcon size={14} />
-                {/if}
-                <ChartLineIcon size={14} />
-                <span>All Metrics</span>
-                {#if discoveredMetrics.length > 0}
-                  <span class="text-xs text-muted-foreground">({discoveredMetrics.length})</span>
-                {/if}
-              </button>
-
-              {#if metricsExpanded}
-                <div class="border rounded-lg">
-                  {#if loadingMetrics}
-                    <div class="flex items-center justify-center py-8">
-                      <div
-                        class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"
-                      ></div>
-                      <span class="ml-2 text-sm text-muted-foreground">Loading metrics...</span>
-                    </div>
-                  {:else if metricsError}
-                    <div class="p-3 text-sm">
-                      <p class="text-destructive">{metricsError}</p>
-                      <button
-                        class="text-xs text-primary hover:underline mt-1"
-                        onclick={loadDiscoveredMetrics}
-                      >
-                        Retry
-                      </button>
-                    </div>
-                  {:else if discoveredMetrics.length === 0}
-                    <div class="p-3 text-sm text-muted-foreground text-center">
-                      No metrics found
-                    </div>
-                  {:else}
-                    <!-- Search -->
-                    <div class="p-2 border-b">
-                      <div class="relative">
-                        <MagnifyingGlassIcon
-                          size={14}
-                          class="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
-                        />
-                        <input
-                          type="text"
-                          placeholder="Search metrics..."
-                          class="w-full pl-7 pr-2 py-1 text-xs bg-background border rounded focus:outline-none focus:ring-1 focus:ring-ring"
-                          bind:value={metricsSearchQuery}
-                        >
-                      </div>
-                    </div>
-
-                    <!-- Metrics List -->
-                    <div class="max-h-64 overflow-y-auto divide-y">
-                      {#each filteredMetrics as metric}
-                        <div class="p-2 hover:bg-muted/30 text-xs space-y-1">
-                          <div class="flex items-start justify-between gap-2">
-                            <div class="font-mono font-medium text-foreground break-all">
-                              {metric.name}
-                            </div>
-                            <div class="font-mono text-right flex-shrink-0 tabular-nums">
-                              {formatMetricValue(metric.value)}
-                            </div>
-                          </div>
-                          {#if metric.help}
-                            <div class="text-muted-foreground">{metric.help}</div>
-                          {/if}
-                          {#if Object.keys(metric.labels).length > 0}
-                            <div class="flex flex-wrap gap-1">
-                              {#each Object.entries(metric.labels) as [ key, value ]}
-                                <span class="bg-muted px-1.5 py-0.5 rounded text-[10px]">
-                                  {key}=<span class="text-muted-foreground">{value}</span>
-                                </span>
-                              {/each}
-                            </div>
-                          {/if}
-                        </div>
-                      {/each}
-                    </div>
-
-                    {#if metricsSearchQuery && filteredMetrics.length === 0}
-                      <div class="p-3 text-sm text-muted-foreground text-center">
-                        No metrics match your search
-                      </div>
-                    {/if}
-                  {/if}
+                <WarningIcon size={16} class="text-warning mt-0.5 flex-shrink-0" />
+                <div class="space-y-1">
+                  <p class="font-medium text-warning">No metrics source configured</p>
+                  <p class="text-xs text-muted-foreground">
+                    Configure a data source to see live metrics.
+                  </p>
+                  <a
+                    href="/topologies/{topologyId}/sources"
+                    class="text-xs text-primary hover:underline"
+                  >
+                    Configure Data Sources
+                  </a>
                 </div>
-              {/if}
-            </div>
-          {/if}
-
-          <!-- No metrics source warning -->
-          {#if !hasMetricsSource}
-            <div
-              class="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg text-sm"
-            >
-              <WarningIcon size={16} class="text-warning mt-0.5 flex-shrink-0" />
-              <div class="space-y-1">
-                <p class="font-medium text-warning">No metrics source configured</p>
-                <p class="text-xs text-muted-foreground">
-                  Configure a data source to see live metrics.
-                </p>
-                <a
-                  href="/topologies/{topologyId}/sources"
-                  class="text-xs text-primary hover:underline"
-                >
-                  Configure Data Sources
-                </a>
               </div>
-            </div>
-          {/if}
-        </div>
+            {/if}
+          </div>
+        </Dialog.Body>
 
         <Dialog.Footer>
           <Button variant="outline" onclick={handleClose}>Close</Button>
@@ -692,122 +698,126 @@
         </Dialog.Footer>
       {:else}
         <!-- MAPPING VIEW -->
-        <div class="space-y-4">
-          <!-- Current mapping status -->
-          <div class="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
-            <span class="text-sm">Current mapping:</span>
-            {#if currentNodeMapping?.hostId}
-              <span class="text-sm font-medium flex items-center gap-1">
-                <CheckCircleIcon size={14} class="text-success" />
-                {currentNodeMapping.hostName || currentNodeMapping.hostId}
-              </span>
-            {:else}
-              <span class="text-sm text-muted-foreground flex items-center gap-1">
-                <LinkBreakIcon size={14} />
-                Not mapped
-              </span>
-            {/if}
-          </div>
-
-          <!-- Host Selection -->
-          <div class="space-y-2">
-            <span class="text-sm font-medium">Select Host</span>
-
-            {#if !hasMetricsSource}
-              <div
-                class="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg text-sm"
-              >
-                <WarningIcon size={16} class="text-warning mt-0.5 flex-shrink-0" />
-                <div class="space-y-1">
-                  <p class="font-medium text-warning">No metrics source configured</p>
-                  <a
-                    href="/topologies/{topologyId}/sources"
-                    class="text-xs text-primary hover:underline"
-                  >
-                    Configure Data Sources
-                  </a>
-                </div>
-              </div>
-            {:else if loadingHosts}
-              <div class="flex items-center justify-center py-8">
-                <div
-                  class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"
-                ></div>
-                <span class="ml-2 text-sm text-muted-foreground">Loading hosts...</span>
-              </div>
-            {:else}
-              <!-- Search -->
-              <div class="relative">
-                <MagnifyingGlassIcon
-                  size={16}
-                  class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-                />
-                <input
-                  type="text"
-                  placeholder="Search hosts..."
-                  class="w-full pl-9 pr-3 py-2 text-sm bg-background border rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
-                  bind:value={searchQuery}
-                >
-              </div>
-
-              <!-- Host List (grouped by source when 2+ sources are attached) -->
-              <div class="max-h-48 overflow-y-auto border rounded-md">
-                {#if filteredHosts.length === 0}
-                  <div class="p-3 text-sm text-muted-foreground text-center">
-                    {searchQuery ? 'No hosts match your search' : 'No hosts available'}
-                  </div>
-                {:else}
-                  <div class="divide-y">
-                    {#each groupedFilteredHosts as group}
-                      {#if groupedFilteredHosts.length > 1}
-                        <div
-                          class="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground bg-muted/30 sticky top-0"
-                        >
-                          {group.sourceName}
-                        </div>
-                      {/if}
-                      {#each group.items as host}
-                        <label
-                          class="flex items-center gap-3 p-2 hover:bg-muted/50 cursor-pointer transition-colors"
-                        >
-                          <input
-                            type="radio"
-                            name="host"
-                            value={host.id}
-                            bind:group={selectedHostId}
-                            class="w-4 h-4"
-                          >
-                          <div class="flex-1 min-w-0">
-                            <div class="text-sm font-medium truncate">
-                              {host.displayName || host.name}
-                            </div>
-                            {#if host.ip}
-                              <div class="text-xs text-muted-foreground">{host.ip}</div>
-                            {/if}
-                          </div>
-                          {#if host.status === 'up'}
-                            <span class="w-2 h-2 bg-success rounded-full flex-shrink-0"></span>
-                          {:else if host.status === 'down'}
-                            <span class="w-2 h-2 bg-destructive rounded-full flex-shrink-0"></span>
-                          {/if}
-                        </label>
-                      {/each}
-                    {/each}
-                  </div>
-                {/if}
-              </div>
-
-              {#if selectedHostId}
-                <button
-                  class="text-xs text-muted-foreground hover:text-foreground"
-                  onclick={handleClear}
-                >
-                  Clear selection
-                </button>
+        <Dialog.Body>
+          <div class="space-y-4">
+            <!-- Current mapping status -->
+            <div class="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+              <span class="text-sm">Current mapping:</span>
+              {#if currentNodeMapping?.hostId}
+                <span class="text-sm font-medium flex items-center gap-1">
+                  <CheckCircleIcon size={14} class="text-success" />
+                  {currentNodeMapping.hostName || currentNodeMapping.hostId}
+                </span>
+              {:else}
+                <span class="text-sm text-muted-foreground flex items-center gap-1">
+                  <LinkBreakIcon size={14} />
+                  Not mapped
+                </span>
               {/if}
-            {/if}
+            </div>
+
+            <!-- Host Selection -->
+            <div class="space-y-2">
+              <span class="text-sm font-medium">Select Host</span>
+
+              {#if !hasMetricsSource}
+                <div
+                  class="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg text-sm"
+                >
+                  <WarningIcon size={16} class="text-warning mt-0.5 flex-shrink-0" />
+                  <div class="space-y-1">
+                    <p class="font-medium text-warning">No metrics source configured</p>
+                    <a
+                      href="/topologies/{topologyId}/sources"
+                      class="text-xs text-primary hover:underline"
+                    >
+                      Configure Data Sources
+                    </a>
+                  </div>
+                </div>
+              {:else if loadingHosts}
+                <div class="flex items-center justify-center py-8">
+                  <div
+                    class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"
+                  ></div>
+                  <span class="ml-2 text-sm text-muted-foreground">Loading hosts...</span>
+                </div>
+              {:else}
+                <!-- Search -->
+                <div class="relative">
+                  <MagnifyingGlassIcon
+                    size={16}
+                    class="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+                  />
+                  <input
+                    type="text"
+                    placeholder="Search hosts..."
+                    class="w-full pl-9 pr-3 py-2 text-sm bg-background border rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
+                    bind:value={searchQuery}
+                  >
+                </div>
+
+                <!-- Host List (grouped by source when 2+ sources are attached) -->
+                <div class="max-h-48 overflow-y-auto border rounded-md">
+                  {#if filteredHosts.length === 0}
+                    <div class="p-3 text-sm text-muted-foreground text-center">
+                      {searchQuery ? 'No hosts match your search' : 'No hosts available'}
+                    </div>
+                  {:else}
+                    <div class="divide-y">
+                      {#each groupedFilteredHosts as group}
+                        {#if groupedFilteredHosts.length > 1}
+                          <div
+                            class="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground bg-muted/30 sticky top-0"
+                          >
+                            {group.sourceName}
+                          </div>
+                        {/if}
+                        {#each group.items as host}
+                          <label
+                            class="flex items-center gap-3 p-2 hover:bg-muted/50 cursor-pointer transition-colors"
+                          >
+                            <input
+                              type="radio"
+                              name="host"
+                              value={host.id}
+                              bind:group={selectedHostId}
+                              class="w-4 h-4"
+                            >
+                            <div class="flex-1 min-w-0">
+                              <div class="text-sm font-medium truncate">
+                                {host.displayName || host.name}
+                              </div>
+                              {#if host.ip}
+                                <div class="text-xs text-muted-foreground">{host.ip}</div>
+                              {/if}
+                            </div>
+                            {#if host.status === 'up'}
+                              <span class="w-2 h-2 bg-success rounded-full flex-shrink-0"></span>
+                            {:else if host.status === 'down'}
+                              <span
+                                class="w-2 h-2 bg-destructive rounded-full flex-shrink-0"
+                              ></span>
+                            {/if}
+                          </label>
+                        {/each}
+                      {/each}
+                    </div>
+                  {/if}
+                </div>
+
+                {#if selectedHostId}
+                  <button
+                    class="text-xs text-muted-foreground hover:text-foreground"
+                    onclick={handleClear}
+                  >
+                    Clear selection
+                  </button>
+                {/if}
+              {/if}
+            </div>
           </div>
-        </div>
+        </Dialog.Body>
 
         <Dialog.Footer>
           <Button variant="outline" onclick={() => (mode = 'status')}>Cancel</Button>

--- a/apps/server/web/src/lib/components/ui/dialog/dialog-body.svelte
+++ b/apps/server/web/src/lib/components/ui/dialog/dialog-body.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  // Wrap any variable-height content between Dialog.Header/Dialog.Footer in this
+  // so header/footer stay pinned and only the body scrolls. Content placed
+  // directly in Dialog.Content (skipping this) still works, but the whole
+  // dialog scrolls together as a fallback — see dialog-content.svelte.
+  import type { WithElementRef } from 'bits-ui'
+  import type { HTMLAttributes } from 'svelte/elements'
+  import { cn } from '$lib/utils.js'
+
+  let {
+    ref = $bindable(null),
+    class: className,
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props()
+</script>
+
+<div
+  bind:this={ref}
+  data-slot="dialog-body"
+  class={cn('-mx-1 min-h-0 flex-1 overflow-y-auto px-1', className)}
+  {...restProps}
+>
+  {@render children?.()}
+</div>

--- a/apps/server/web/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/apps/server/web/src/lib/components/ui/dialog/dialog-content.svelte
@@ -26,7 +26,7 @@
     bind:ref
     data-slot="dialog-content"
     class={cn(
-			"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+			"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 flex max-h-[85vh] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] flex-col gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 			className
 		)}
     {...restProps}

--- a/apps/server/web/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/apps/server/web/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -14,7 +14,7 @@
 <div
   bind:this={ref}
   data-slot="dialog-footer"
-  class={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+  class={cn("flex shrink-0 flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
   {...restProps}
 >
   {@render children?.()}

--- a/apps/server/web/src/lib/components/ui/dialog/dialog-header.svelte
+++ b/apps/server/web/src/lib/components/ui/dialog/dialog-header.svelte
@@ -14,7 +14,7 @@
 <div
   bind:this={ref}
   data-slot="dialog-header"
-  class={cn("flex flex-col gap-2 text-center sm:text-start", className)}
+  class={cn("flex shrink-0 flex-col gap-2 text-center sm:text-start", className)}
   {...restProps}
 >
   {@render children?.()}

--- a/apps/server/web/src/lib/components/ui/dialog/index.ts
+++ b/apps/server/web/src/lib/components/ui/dialog/index.ts
@@ -1,4 +1,5 @@
 import Root from './dialog.svelte'
+import Body from './dialog-body.svelte'
 import Close from './dialog-close.svelte'
 import Content from './dialog-content.svelte'
 import Description from './dialog-description.svelte'
@@ -10,6 +11,8 @@ import Title from './dialog-title.svelte'
 import Trigger from './dialog-trigger.svelte'
 
 export {
+  Body,
+  Body as DialogBody,
   Close,
   Close as DialogClose,
   Content,

--- a/apps/server/web/src/routes/(app)/datasources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/+page.svelte
@@ -380,91 +380,95 @@
 
     {#if !selectedPlugin}
       <!-- Plugin Selection Grid -->
-      <div class="py-4">
-        {#if pluginTypes.length === 0}
-          <div class="text-center py-8 text-theme-text-muted">
-            <div
-              class="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-2"
-            ></div>
-            Loading plugins...
-          </div>
-        {:else}
-          <div class="grid grid-cols-2 gap-3">
-            {#each pluginTypes as plugin}
-              <button
-                type="button"
-                class="p-4 rounded-lg border border-theme-border hover:border-primary hover:bg-primary/5 transition-colors text-left group"
-                onclick={() => selectPlugin(plugin)}
-              >
-                <div class="flex items-start gap-3">
-                  <div
-                    class="p-2 rounded-lg bg-theme-bg group-hover:bg-primary/10 transition-colors"
-                  >
-                    {#if plugin.capabilities.includes('topology')}
-                      <TreeStructureIcon
-                        size={24}
-                        class="text-theme-text-muted group-hover:text-primary"
-                      />
-                    {:else if plugin.capabilities.includes('metrics')}
-                      <ChartLineIcon
-                        size={24}
-                        class="text-theme-text-muted group-hover:text-primary"
-                      />
-                    {:else}
-                      <DatabaseIcon
-                        size={24}
-                        class="text-theme-text-muted group-hover:text-primary"
-                      />
-                    {/if}
-                  </div>
-                  <div class="flex-1 min-w-0">
-                    <p class="font-medium text-theme-text-emphasis">{plugin.displayName}</p>
-                    <div class="flex flex-wrap gap-1 mt-1">
-                      {#each plugin.capabilities as cap}
-                        <span
-                          class="text-xs px-1.5 py-0.5 rounded bg-theme-bg text-theme-text-muted"
-                        >
-                          {cap}
-                        </span>
-                      {/each}
+      <Dialog.Body>
+        <div class="py-4">
+          {#if pluginTypes.length === 0}
+            <div class="text-center py-8 text-theme-text-muted">
+              <div
+                class="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-2"
+              ></div>
+              Loading plugins...
+            </div>
+          {:else}
+            <div class="grid grid-cols-2 gap-3">
+              {#each pluginTypes as plugin}
+                <button
+                  type="button"
+                  class="p-4 rounded-lg border border-theme-border hover:border-primary hover:bg-primary/5 transition-colors text-left group"
+                  onclick={() => selectPlugin(plugin)}
+                >
+                  <div class="flex items-start gap-3">
+                    <div
+                      class="p-2 rounded-lg bg-theme-bg group-hover:bg-primary/10 transition-colors"
+                    >
+                      {#if plugin.capabilities.includes('topology')}
+                        <TreeStructureIcon
+                          size={24}
+                          class="text-theme-text-muted group-hover:text-primary"
+                        />
+                      {:else if plugin.capabilities.includes('metrics')}
+                        <ChartLineIcon
+                          size={24}
+                          class="text-theme-text-muted group-hover:text-primary"
+                        />
+                      {:else}
+                        <DatabaseIcon
+                          size={24}
+                          class="text-theme-text-muted group-hover:text-primary"
+                        />
+                      {/if}
+                    </div>
+                    <div class="flex-1 min-w-0">
+                      <p class="font-medium text-theme-text-emphasis">{plugin.displayName}</p>
+                      <div class="flex flex-wrap gap-1 mt-1">
+                        {#each plugin.capabilities as cap}
+                          <span
+                            class="text-xs px-1.5 py-0.5 rounded bg-theme-bg text-theme-text-muted"
+                          >
+                            {cap}
+                          </span>
+                        {/each}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </button>
-            {/each}
-          </div>
-        {/if}
-      </div>
+                </button>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </Dialog.Body>
 
       <Dialog.Footer>
         <Button variant="outline" onclick={() => showCreateModal = false}>Cancel</Button>
       </Dialog.Footer>
     {:else}
       <!-- Plugin Configuration Form -->
-      <form class="space-y-4 py-2" onsubmit={(e) => { e.preventDefault(); handleCreate(); }}>
-        {#if formError}
-          <div
-            class="p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-destructive text-sm"
-          >
-            {formError}
+      <Dialog.Body>
+        <form class="space-y-4 py-2" onsubmit={(e) => { e.preventDefault(); handleCreate(); }}>
+          {#if formError}
+            <div
+              class="p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-destructive text-sm"
+            >
+              {formError}
+            </div>
+          {/if}
+
+          <div>
+            <label for="name" class="label">Name</label>
+            <input
+              type="text"
+              id="name"
+              class="input"
+              placeholder="My {selectedPlugin.displayName} Server"
+              bind:value={formName}
+            >
           </div>
-        {/if}
 
-        <div>
-          <label for="name" class="label">Name</label>
-          <input
-            type="text"
-            id="name"
-            class="input"
-            placeholder="My {selectedPlugin.displayName} Server"
-            bind:value={formName}
-          >
-        </div>
-
-        {#if selectedPlugin.configSchema}
-          <SchemaForm schema={selectedPlugin.configSchema} bind:value={config} />
-        {/if}
-      </form>
+          {#if selectedPlugin.configSchema}
+            <SchemaForm schema={selectedPlugin.configSchema} bind:value={config} />
+          {/if}
+        </form>
+      </Dialog.Body>
 
       <Dialog.Footer>
         <Button variant="outline" onclick={() => selectedPlugin = null}>Back</Button>

--- a/apps/server/web/src/routes/(app)/plugins/+page.svelte
+++ b/apps/server/web/src/routes/(app)/plugins/+page.svelte
@@ -355,7 +355,7 @@
       </Dialog.Description>
     </Dialog.Header>
 
-    <div class="py-4 space-y-4">
+    <Dialog.Body class="py-4 space-y-4">
       {#if addError}
         <div
           class="p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-destructive text-sm"
@@ -472,7 +472,7 @@
           </div>
         </div>
       {/if}
-    </div>
+    </Dialog.Body>
 
     <Dialog.Footer>
       <Button variant="outline" onclick={() => showAddModal = false}>Cancel</Button>
@@ -501,7 +501,7 @@
       </Dialog.Description>
     </Dialog.Header>
 
-    <div class="py-4">
+    <Dialog.Body class="py-4">
       <label class="flex items-center gap-2 cursor-pointer">
         <input
           type="checkbox"
@@ -510,7 +510,7 @@
         >
         <span class="text-sm text-theme-text">Also delete plugin files from disk</span>
       </label>
-    </div>
+    </Dialog.Body>
 
     <Dialog.Footer>
       <Button variant="outline" onclick={() => deletePlugin = null}>Cancel</Button>

--- a/apps/server/web/src/routes/(app)/topologies/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/+page.svelte
@@ -123,32 +123,34 @@
       </Dialog.Description>
     </Dialog.Header>
 
-    <form
-      class="space-y-4"
-      onsubmit={(e) => {
-        e.preventDefault()
-        handleCreate()
-      }}
-    >
-      {#if formError}
-        <div
-          class="p-3 bg-destructive/10 border border-destructive/20 rounded-md text-destructive text-sm"
-        >
-          {formError}
-        </div>
-      {/if}
+    <Dialog.Body>
+      <form
+        class="space-y-4"
+        onsubmit={(e) => {
+          e.preventDefault()
+          handleCreate()
+        }}
+      >
+        {#if formError}
+          <div
+            class="p-3 bg-destructive/10 border border-destructive/20 rounded-md text-destructive text-sm"
+          >
+            {formError}
+          </div>
+        {/if}
 
-      <div class="space-y-2">
-        <Label for="name">Name</Label>
-        <Input
-          id="name"
-          placeholder="My Network"
-          bind:value={formName}
-          autofocus
-          disabled={formSubmitting}
-        />
-      </div>
-    </form>
+        <div class="space-y-2">
+          <Label for="name">Name</Label>
+          <Input
+            id="name"
+            placeholder="My Network"
+            bind:value={formName}
+            autofocus
+            disabled={formSubmitting}
+          />
+        </div>
+      </form>
+    </Dialog.Body>
 
     <Dialog.Footer>
       <Button variant="outline" onclick={() => (showCreateModal = false)}>Cancel</Button>

--- a/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
@@ -1030,58 +1030,60 @@
     </Dialog.Header>
 
     {#if syncJob}
-      <div class="space-y-4">
-        <div class="h-2 rounded-full bg-theme-bg-subtle overflow-hidden">
-          <div
-            class="h-full rounded-full transition-all duration-500 {syncJob.state === 'failed'
-              ? 'bg-danger'
-              : syncJob.state === 'cancelled'
-                ? 'bg-theme-text-muted'
-                : 'bg-primary'}"
-            style="width: {syncJob.state === 'running' ? syncProgress : 100}%"
-          ></div>
-        </div>
+      <Dialog.Body>
+        <div class="space-y-4">
+          <div class="h-2 rounded-full bg-theme-bg-subtle overflow-hidden">
+            <div
+              class="h-full rounded-full transition-all duration-500 {syncJob.state === 'failed'
+                ? 'bg-danger'
+                : syncJob.state === 'cancelled'
+                  ? 'bg-theme-text-muted'
+                  : 'bg-primary'}"
+              style="width: {syncJob.state === 'running' ? syncProgress : 100}%"
+            ></div>
+          </div>
 
-        <ul class="space-y-2">
-          {#each syncJob.steps as step (step.key)}
-            <li class="flex items-start gap-2 text-sm">
-              {#if step.status === 'running'}
-                <span
-                  class="mt-0.5 w-4 h-4 shrink-0 border-2 border-primary border-t-transparent rounded-full animate-spin"
-                ></span>
-              {:else if step.status === 'done'}
-                <CheckCircleIcon size={16} class="mt-0.5 shrink-0 text-success" />
-              {:else if step.status === 'failed'}
-                <span class="mt-0.5 w-4 h-4 shrink-0 text-danger leading-4 text-center">✕</span>
-              {:else if step.status === 'skipped'}
-                <span class="mt-0.5 w-4 h-4 shrink-0 text-theme-text-muted leading-4 text-center"
-                  >–</span
-                >
-              {:else}
-                <span
-                  class="mt-0.5 w-4 h-4 shrink-0 border-2 border-theme-border rounded-full"
-                ></span>
-              {/if}
-              <div class="min-w-0">
-                <span class="text-theme-text-emphasis">
-                  {step.label}
-                  {#if step.key === 'derive' && step.status === 'running' && step.stage}
-                    <span class="text-theme-text-muted"> — {step.stage}</span>
-                  {/if}
-                </span>
-                {#if step.status === 'done' && step.nodeCount !== undefined}
-                  <span class="text-theme-text-muted">
-                    · {step.nodeCount} nodes / {step.linkCount} links</span
+          <ul class="space-y-2">
+            {#each syncJob.steps as step (step.key)}
+              <li class="flex items-start gap-2 text-sm">
+                {#if step.status === 'running'}
+                  <span
+                    class="mt-0.5 w-4 h-4 shrink-0 border-2 border-primary border-t-transparent rounded-full animate-spin"
+                  ></span>
+                {:else if step.status === 'done'}
+                  <CheckCircleIcon size={16} class="mt-0.5 shrink-0 text-success" />
+                {:else if step.status === 'failed'}
+                  <span class="mt-0.5 w-4 h-4 shrink-0 text-danger leading-4 text-center">✕</span>
+                {:else if step.status === 'skipped'}
+                  <span class="mt-0.5 w-4 h-4 shrink-0 text-theme-text-muted leading-4 text-center"
+                    >–</span
                   >
+                {:else}
+                  <span
+                    class="mt-0.5 w-4 h-4 shrink-0 border-2 border-theme-border rounded-full"
+                  ></span>
                 {/if}
-                {#if step.message}
-                  <p class="text-xs text-theme-text-muted break-words">{step.message}</p>
-                {/if}
-              </div>
-            </li>
-          {/each}
-        </ul>
-      </div>
+                <div class="min-w-0">
+                  <span class="text-theme-text-emphasis">
+                    {step.label}
+                    {#if step.key === 'derive' && step.status === 'running' && step.stage}
+                      <span class="text-theme-text-muted"> — {step.stage}</span>
+                    {/if}
+                  </span>
+                  {#if step.status === 'done' && step.nodeCount !== undefined}
+                    <span class="text-theme-text-muted">
+                      · {step.nodeCount} nodes / {step.linkCount} links</span
+                    >
+                  {/if}
+                  {#if step.message}
+                    <p class="text-xs text-theme-text-muted break-words">{step.message}</p>
+                  {/if}
+                </div>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      </Dialog.Body>
     {/if}
 
     <Dialog.Footer>


### PR DESCRIPTION
## Summary
- `Dialog.Content` had no height cap, so tall modals (e.g. the Prometheus data source config form) could render with their top edge off-screen and unreachable.
- Cap `Dialog.Content` at `max-h-[85vh]`, make `Dialog.Header`/`Dialog.Footer` `shrink-0`, and add a new `Dialog.Body` region (`flex-1 overflow-y-auto`) so only the variable-height middle content scrolls while header/footer/close button stay pinned.
- Content left outside `Dialog.Body` still falls back to scrolling the whole dialog (via `overflow-y-auto` on `Dialog.Content` itself) rather than being silently clipped, in case a future modal forgets to use it.
- Fixed a focus-ring clipping side effect (`.input:focus`'s `box-shadow` was cut by the new scroll container) by giving `Dialog.Body` a small `-mx-1 px-1` inset.
- Applied `Dialog.Body` to the modals with variable-length content: data source config, topology create, plugin add/delete, source sync progress, node mapping, and discovery node detail.

## Test plan
- [x] `svelte-check` (`bun run check` in `apps/server/web`) — 0 errors
- [x] `biome check` on the changed files
- [ ] Manually re-verify in the browser that the Prometheus config modal (and the other modals touched) render correctly and scroll only in the body region