### PR TITLE
fix(plugin-prometheus): fail testConnection when the query API isn't reachable

### DIFF
--- a/.changeset/prometheus-test-connection-query-check.md
+++ b/.changeset/prometheus-test-connection-query-check.md
@@ -1,0 +1,11 @@
+---
+'shumoku-plugin-prometheus': patch
+---
+
+`testConnection()` now fails (instead of silently reporting success) when the
+health check passes but `/api/v1/status/buildinfo` doesn't respond. Hosts and
+metrics both depend on the query API, so a target that passes the health
+check with no query engine at all (e.g. this URL points at a scrape/forward
+agent like vmagent instead of the queryable Prometheus/VictoriaMetrics
+server) was previously reported as a successful connection with zero
+hosts/metrics and no indication why.

--- a/libs/plugins/prometheus/src/plugin.ts
+++ b/libs/plugins/prometheus/src/plugin.ts
@@ -133,7 +133,11 @@ export class PrometheusPlugin
         }
       }
 
-      // Try to get build info for version
+      // The query API is what hosts/metrics actually depend on — a target can
+      // pass the health check while having no query engine at all (e.g. this
+      // URL points at a scrape/forward agent like vmagent instead of the
+      // queryable Prometheus/VictoriaMetrics server), so treat this as
+      // required rather than falling back to a soft "connected".
       try {
         const buildInfo = await this.query<PrometheusBuildInfo>('/api/v1/status/buildinfo')
         return addHttpWarning(this.config.url, {
@@ -141,12 +145,12 @@ export class PrometheusPlugin
           message: `Connected to Prometheus ${buildInfo.version}`,
           version: buildInfo.version,
         })
-      } catch {
-        // Build info might not be available, but health check passed
-        return addHttpWarning(this.config.url, {
-          success: true,
-          message: 'Connected to Prometheus',
-        })
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err)
+        return {
+          success: false,
+          message: `Health check passed, but the query API isn't responding (${detail}). This URL may point at a scrape/forward agent (e.g. vmagent) rather than a queryable Prometheus/VictoriaMetrics endpoint.`,
+        }
       }
     } catch (err) {
       return {


### PR DESCRIPTION
## Summary
- `testConnection()` checked `/-/healthy` then tried `/api/v1/status/buildinfo` for the version, but on failure it silently fell back to a "Connected to Prometheus" success — so a data source whose URL points at a target with no query engine at all (e.g. vmagent, which only scrapes/forwards and doesn't implement `/api/v1/query` etc.) showed a green "connected" status while `getHosts()`/`pollMetrics()` silently returned zero results.
- Found this while debugging a real data source named "vmagent" pointed at vmagent's own port (8429, self-monitoring only) instead of the actual queryable VictoriaMetrics endpoint — the query API check now surfaces that mismatch immediately as a failed connection test instead of a confusing "connected, but nothing shows up".

## Test plan
- [x] `bun run typecheck` / `biome check` (via pre-commit hook, all green)
- [x] Manually verified against a real vmagent endpoint: before the fix, Test Connection showed "Connected to Prometheus"; after, it shows "Failed — Health check passed, but the query API isn't responding (...)"
- [x] Verified against the real VictoriaMetrics query endpoint on the same host: still reports success with version (`Connected to Prometheus 2.24.0`)