### PR TITLE
ci(docker): sign images, attach SBOM/provenance, build multi-arch

### DIFF
--- a/.changeset/docker-sign-sbom-multiarch.md
+++ b/.changeset/docker-sign-sbom-multiarch.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(ci): multi-arch (amd64+arm64) server image with Cosign signing, SBOM, and SLSA provenance (no published-package release).

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,9 +17,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # keyless Cosign signing via Sigstore/OIDC
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -81,10 +85,14 @@ jobs:
             type=raw,value=edge,enable=${{ steps.build.outputs.release == 'true' }}
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/server/Dockerfile
+          # Cross-build arm64 only for real releases (QEMU emulation is slow);
+          # PR builds stay amd64-only just to validate the Dockerfile.
+          platforms: ${{ steps.build.outputs.release == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ steps.build.outputs.release == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -95,6 +103,25 @@ jobs:
             SHUMOKU_CHANNEL=${{ steps.build.outputs.channel }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Attach an SBOM and SLSA provenance to released images (pushed as
+          # OCI attestations). Only on release, since they require the image
+          # to actually be pushed.
+          sbom: ${{ steps.build.outputs.release == 'true' }}
+          provenance: ${{ steps.build.outputs.release == 'true' && 'mode=max' || 'false' }}
+
+      - name: Install Cosign
+        if: steps.build.outputs.release == 'true'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign the published image (keyless)
+        if: steps.build.outputs.release == 'true'
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        shell: bash
+        run: |
+          # Keyless signing via GitHub OIDC — no long-lived keys. Signs the
+          # immutable digest so every tag pointing at it is covered.
+          cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
 
   release:
     if: startsWith(github.ref, 'refs/tags/server-v')

--- a/apps/server/docs/installation.en.mdx
+++ b/apps/server/docs/installation.en.mdx
@@ -102,6 +102,34 @@ docker compose up -d --build
 
 The `--build` flag rebuilds the image with the latest source.
 
+## Verifying the image (signature & SBOM)
+
+Published images carry a **keyless Cosign signature** (via GitHub Actions OIDC)
+and an attached **SBOM and SLSA provenance** as OCI attestations (for releases
+built after this feature landed). Verify an image came from the official CI
+before pulling it:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/konoe-akitoshi/shumoku/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/konoe-akitoshi/shumoku:latest
+```
+
+Inspect the SBOM / provenance:
+
+```bash
+# SBOM (packages included in the image)
+cosign download sbom ghcr.io/konoe-akitoshi/shumoku:latest
+
+# provenance (how/where it was built)
+docker buildx imagetools inspect ghcr.io/konoe-akitoshi/shumoku:latest \
+  --format '{{ json .Provenance }}'
+```
+
+Images are published multi-arch (**linux/amd64** and **linux/arm64**), so the
+same tags run on ARM VPSes and Apple Silicon.
+
 ## Systemd (Linux)
 
 ### Prerequisites

--- a/apps/server/docs/installation.ja.mdx
+++ b/apps/server/docs/installation.ja.mdx
@@ -95,6 +95,33 @@ docker compose up -d --build
 
 `--build` フラグにより最新のソースでイメージが再ビルドされます。
 
+## イメージの検証（署名・SBOM）
+
+公開イメージには GitHub Actions の OIDC を用いた **Cosign キーレス署名**が付き、
+**SBOM と SLSA provenance** が OCI アテステーションとして添付されています（本機能導入
+以降に公開されたリリースが対象）。取得前に、正規の CI が作ったイメージか検証できます:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/konoe-akitoshi/shumoku/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/konoe-akitoshi/shumoku:latest
+```
+
+SBOM / provenance の確認:
+
+```bash
+# SBOM（含まれるパッケージ一覧）
+cosign download sbom ghcr.io/konoe-akitoshi/shumoku:latest
+
+# provenance（どのビルドで作られたか）
+docker buildx imagetools inspect ghcr.io/konoe-akitoshi/shumoku:latest \
+  --format '{{ json .Provenance }}'
+```
+
+イメージは **linux/amd64** と **linux/arm64** のマルチアーキで公開されるため、ARM の
+VPS や Apple Silicon でも同じタグがそのまま動きます。
+
 ## Systemd（Linux）
 
 ### 前提条件


### PR DESCRIPTION
## 概要

サーバの公開イメージパイプラインを **サプライチェーン基準に対応** させ、**arm64 マルチアーキ** を追加します。前回調査で「配布側の現代的責務」として残っていた欠けを埋めるものです。

## 変更点（`.github/workflows/docker.yml`）

- **マルチアーキ**: QEMU をセットアップし、リリース時に `linux/amd64,linux/arm64` をビルド。PR ビルドは高速化のため amd64 のみ（Dockerfile 検証目的）。
- **SBOM + SLSA provenance**: リリースイメージに OCI アテステーションとして添付（`sbom: true` / `provenance: mode=max`）。
- **署名**: GitHub OIDC による **Cosign キーレス署名**（`id-token: write`）。可変タグではなく不変ダイジェストに署名。
- すべて release 条件でゲートしているため、PR ビルドの挙動は不変。

## ドキュメント

利用者向けに `installation`（ja 正本 + en）へ「イメージの検証」節を追加：`cosign verify` コマンド、SBOM/provenance の確認方法、マルチアーキ公開の明記。既存 `latest`（0.1.4）は本機能導入前のため未署名で、以降のリリースが対象である旨も明記。

## 検証

- `actionlint` で通過（式構文含め指摘なし）。
- 署名/SBOM/provenance/arm64 の実運用はリリースタグ push 時に初めて走るため、本PRでは静的検証（actionlint）まで。次回 `server-v*` リリースで実生成物を確認できます。
- ベースイメージ `oven/bun:1.3.4-slim` は amd64/arm64 両対応をマニフェストで確認済み。

## リリース影響

`@shumoku/server` は private パッケージのため公開リリースなし。空の changeset を添付。

🤖 Generated with [Claude Code](https://claude.com/claude-code)