### PR TITLE
feat(plugins): populate Host.identity in getHosts for identity-aware auto-mapping

### DIFF
--- a/.changeset/plugin-hosts-identity.md
+++ b/.changeset/plugin-hosts-identity.md
@@ -1,7 +1,6 @@
 ---
 'shumoku-plugin-prometheus': patch
 'shumoku-plugin-netbox': patch
-'shumoku-plugin-aruba-instant-on': patch
 ---
 
 Populate `Host.identity` in `getHosts()` so node auto-mapping can bind a

--- a/.changeset/plugin-hosts-identity.md
+++ b/.changeset/plugin-hosts-identity.md
@@ -1,0 +1,22 @@
+---
+'shumoku-plugin-prometheus': patch
+'shumoku-plugin-netbox': patch
+'shumoku-plugin-aruba-instant-on': patch
+---
+
+Populate `Host.identity` in `getHosts()` so node auto-mapping can bind a
+topology node to a monitored host by a stable key (mgmtIp > chassisId >
+sysName > vendorId) instead of only fuzzy name matching. Previously only the
+zabbix plugin filled host identity (the original PoC was Zabbix-only), so
+mapping e.g. a NetBox topology onto Prometheus/SNMP hosts matched nothing —
+the hosts were named by IP/hostname while the nodes were named by device
+name, and with no shared identity key auto-map produced zero matches.
+
+- **prometheus**: derive identity from the `instance` label — an IPv4 target
+  (bare or `IP:port`, e.g. an SNMP target) becomes `mgmtIp`; a hostname
+  becomes `sysName`.
+- **netbox**: mirror the topology-node identity (`mgmtIp` from `primary_ip`,
+  `sysName` from device name) on the host side too.
+- **aruba-instant-on**: `mgmtIp` from `ipAddress`, `mac` from `macAddress`,
+  and `{ 'aruba-serial': … }` in `vendorIds`; the operator-editable `name`
+  stays a `displayName`, never `sysName`.

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -160,6 +160,7 @@ interface Host {
   displayName?: string  // operator-assigned label, if different
   status?: 'up' | 'down' | 'unknown'
   ip?: string
+  identity?: Identity   // neutral device keys for deterministic auto-mapping
 }
 ```
 
@@ -167,6 +168,35 @@ Pick `id` from the **most stable** upstream identifier. For Aruba
 we use serial number; for Zabbix the `hostid`; for Prometheus the
 `instance` label. Renames in the upstream system shouldn't change
 `id`.
+
+**Populate `identity`.** Node auto-mapping (the mapping UI's "Auto-map")
+matches a topology node to a host by shared identity key first — in
+priority order `mgmtIp > chassisId > sysName > vendorId` — and only falls
+back to fuzzy name matching when no key is shared. A host with no
+`identity` can therefore *only* be name-matched, which fails whenever the
+monitoring system names a host by IP or hostname while the topology names
+it by device name (the common NetBox × Prometheus/SNMP case). Fill it the
+same way topology nodes do, via `buildIdentity(parts)` at the plugin
+boundary — translate your upstream's addressing into core's neutral keys
+and never leak plugin vocabulary in:
+
+- **`mgmtIp`** — the management/primary IP (Zabbix management interface,
+  NetBox `primary_ip`, a Prometheus SNMP target's `instance` IP, Aruba
+  `ipAddress`). The strongest key; usually enough on its own.
+- **`sysName`** — the device's *self-reported* name (see the semantic
+  rules under [Identity contract](#identity-contract-for-topology-plugins)).
+  A Prometheus exporter `instance` hostname works; an operator-editable
+  display name (Aruba `name`) does **not** — that is a `displayName`, not a
+  `sysName`.
+- **`mac` / `chassisId`** — device MAC / LLDP chassis id when the upstream
+  reports one (Aruba `macAddress`).
+- **`vendorIds`** — source-local strong ids (`{ 'aruba-serial': … }`,
+  `{ 'netbox-device-id': … }`); strong *within* your source, never matched
+  across sources.
+
+`buildIdentity` drops empty parts and returns `undefined` when nothing
+identifying was supplied, so spread it conditionally:
+`...(identity ? { identity } : {})`.
 
 ### `HostItem`
 

--- a/libs/plugins/aruba-instant-on/src/plugin.ts
+++ b/libs/plugins/aruba-instant-on/src/plugin.ts
@@ -31,7 +31,7 @@ import type {
   NativeApiCapable,
   NodeMetrics,
 } from '@shumoku/core'
-import { flattenObject } from '@shumoku/core'
+import { buildIdentity, flattenObject } from '@shumoku/core'
 import { ArubaInstantOnApi } from './api.js'
 import type {
   ArubaInstantOnConfig,
@@ -101,12 +101,22 @@ export class ArubaInstantOnPlugin
         // numbers) then fall back to the portal's id (MAC) or macAddress.
         const id = d.serialNumber || d.id || d.macAddress
         if (!id) continue
+        // Translate Aruba's identifiers into core's neutral identity at the
+        // boundary so node auto-mapping can bind by key. `name` is operator-
+        // assigned (a display string), so it stays out of sysName; the device
+        // MAC and serial are the stable machine keys.
+        const identity = buildIdentity({
+          mgmtIp: d.ipAddress,
+          mac: d.macAddress,
+          vendorIds: { 'aruba-serial': d.serialNumber },
+        })
         out.push({
           id,
           name: d.name || d.defaultName || id,
           displayName: d.name || d.defaultName,
           status: classifyDeviceStatus(d.status) === 'up' ? 'up' : 'down',
-          ip: d.ipAddress,
+          ...(d.ipAddress ? { ip: d.ipAddress } : {}),
+          ...(identity ? { identity } : {}),
         })
       }
     }

--- a/libs/plugins/netbox/src/plugin.ts
+++ b/libs/plugins/netbox/src/plugin.ts
@@ -7,6 +7,7 @@
 import type { NetworkGraph } from '@shumoku/core'
 import {
   addHttpWarning,
+  buildIdentity,
   type ConfigOption,
   type ConfigOptionsCapable,
   type ConnectionResult,
@@ -153,13 +154,22 @@ export class NetBoxPlugin
 
     const deviceResp = await this.client.fetchDevices()
 
-    return deviceResp.results.map((device) => ({
-      id: String(device.id),
-      name: device.name ?? `device-${device.id}`,
-      displayName: device.name ?? `device-${device.id}`,
-      status: this.mapDeviceStatus(device.status?.value),
-      ip: device.primary_ip4?.address?.split('/')[0] || device.primary_ip6?.address?.split('/')[0],
-    }))
+    return deviceResp.results.map((device) => {
+      const name = device.name ?? `device-${device.id}`
+      const ip =
+        device.primary_ip4?.address?.split('/')[0] || device.primary_ip6?.address?.split('/')[0]
+      // Mirror the topology-node identity built in converter.ts so a host and
+      // its own topology node share keys and auto-mapping can bind by identity.
+      const identity = buildIdentity({ mgmtIp: ip, sysName: device.name ?? undefined })
+      return {
+        id: String(device.id),
+        name,
+        displayName: name,
+        status: this.mapDeviceStatus(device.status?.value),
+        ...(ip ? { ip } : {}),
+        ...(identity ? { identity } : {}),
+      }
+    })
   }
 
   async getHostItems(hostId: string): Promise<HostItem[]> {

--- a/libs/plugins/prometheus/src/plugin.ts
+++ b/libs/plugins/prometheus/src/plugin.ts
@@ -11,6 +11,7 @@ import {
   type AlertQueryOptions,
   type AlertsCapable,
   addHttpWarning,
+  buildIdentity,
   type ConnectionResult,
   type DataSourceCapability,
   type DataSourcePlugin,
@@ -18,6 +19,7 @@ import {
   type Host,
   type HostItem,
   type HostsCapable,
+  type Identity,
   type MetricsCapable,
   type MetricsData,
   type MetricsMapping,
@@ -41,6 +43,24 @@ export function labelSelector(pairs: Record<string, string | undefined>): string
     .filter(([, v]) => v !== undefined && v !== '')
     .map(([key, v]) => `${key}="${escapeLabelValue(v as string)}"`)
   return `{${parts.join(',')}}`
+}
+
+/**
+ * Derive an `Identity` from a Prometheus `instance` label value, translating
+ * Prometheus' addressing into core's neutral keys at the plugin boundary:
+ * an IPv4 target (bare or `IP:port`, e.g. an SNMP target `192.168.10.13`)
+ * becomes `mgmtIp`; anything else (a hostname like `j58-vm-dns-01`, optionally
+ * `host:port`) becomes a `sysName` fallback. Lets node auto-mapping bind
+ * deterministically to a topology node carrying the same mgmtIp/sysName
+ * instead of fuzzy-matching an IP/hostname against a device name.
+ */
+export function instanceIdentity(value: string): { ip?: string; identity?: Identity } {
+  // Strip a trailing :<port> so `IP:9116` / `host:9100` resolve to the address.
+  const host = value.replace(/:\d+$/, '')
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) {
+    return { ip: host, identity: buildIdentity({ mgmtIp: host }) }
+  }
+  return { identity: buildIdentity({ sysName: host }) }
 }
 
 /**
@@ -276,13 +296,21 @@ export class PrometheusPlugin
 
       const response = await this.apiRequest<string[]>(url)
 
-      // Convert label values to Host objects
-      const hosts: Host[] = response.map((value) => ({
-        id: value,
-        name: value,
-        displayName: this.formatHostDisplayName(value),
-        status: 'unknown' as const,
-      }))
+      // Convert label values to Host objects. Populate `identity` at the
+      // plugin boundary so node auto-mapping can bind by a stable key
+      // (mgmtIp for SNMP IP targets, sysName for exporter hostnames)
+      // instead of fuzzy name matching — the instance label IS the address.
+      const hosts: Host[] = response.map((value) => {
+        const { ip, identity } = instanceIdentity(value)
+        return {
+          id: value,
+          name: value,
+          displayName: this.formatHostDisplayName(value),
+          status: 'unknown' as const,
+          ...(ip ? { ip } : {}),
+          ...(identity ? { identity } : {}),
+        }
+      })
 
       // Optionally check status for each host (can be slow for many hosts)
       // For now, return with unknown status - UI can check on demand

--- a/libs/plugins/prometheus/src/promql.test.ts
+++ b/libs/plugins/prometheus/src/promql.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { escapeLabelValue, labelSelector } from './plugin.js'
+import { escapeLabelValue, instanceIdentity, labelSelector } from './plugin.js'
 
 describe('escapeLabelValue', () => {
   it('escapes backslash, double-quote, and newline', () => {
@@ -35,5 +35,33 @@ describe('labelSelector', () => {
     expect(sel.startsWith('{instance="')).toBe(true)
     expect(sel.endsWith('"}')).toBe(true)
     expect(sel).toContain('\\"')
+  })
+})
+
+describe('instanceIdentity', () => {
+  it('maps a bare IPv4 SNMP target to mgmtIp (and ip)', () => {
+    expect(instanceIdentity('192.168.10.13')).toEqual({
+      ip: '192.168.10.13',
+      identity: { mgmtIp: '192.168.10.13' },
+    })
+  })
+
+  it('strips a :port and still resolves an IPv4 target to mgmtIp', () => {
+    expect(instanceIdentity('192.168.10.15:9221')).toEqual({
+      ip: '192.168.10.15',
+      identity: { mgmtIp: '192.168.10.15' },
+    })
+  })
+
+  it('maps an exporter hostname to sysName (no ip)', () => {
+    expect(instanceIdentity('j58-vm-dns-01')).toEqual({
+      identity: { sysName: 'j58-vm-dns-01' },
+    })
+  })
+
+  it('strips a :port from a hostname target and uses sysName', () => {
+    expect(instanceIdentity('snmp-exporter:9116')).toEqual({
+      identity: { sysName: 'snmp-exporter' },
+    })
   })
 })


### PR DESCRIPTION
## Summary
Node auto-mapping (the mapping UI's "Auto-map") binds a topology node to a monitored host by **shared identity key first** — priority `mgmtIp > chassisId > sysName > vendorId` — and only falls back to fuzzy name matching when no key is shared (`matchNodeToHost` in `apps/server/web/src/lib/auto-mapping.ts`, common to all plugins).

That identity-aware matching shipped as a **Zabbix-only PoC** (`0b7f4b39`), whose commit message noted: *"PoC scope: Zabbix only. NetBox/Prometheus/Aruba can fill `Host.identity` the same way in follow-ups."* Those follow-ups were never done, so `Host.identity` stayed empty for every plugin except zabbix. Consequence: mapping a NetBox topology onto Prometheus/SNMP hosts matched **nothing** — the hosts are named by IP/hostname while the nodes are named by device name, and with no shared identity key the fuzzy name score is 0.

This fills the deferred follow-up.

## Changes
- **prometheus**: derive identity from the `instance` label — an IPv4 target (bare or `IP:port`, e.g. an SNMP target) → `mgmtIp`; a hostname → `sysName`. Extracted as a pure, unit-tested `instanceIdentity()`.
- **netbox**: mirror the topology-node identity already built in `converter.ts` (`mgmtIp` from `primary_ip`, `sysName` from device name) on the host side too.
- **aruba-instant-on**: `mgmtIp` from `ipAddress`, `mac` from `macAddress`, `{ 'aruba-serial': … }` in `vendorIds`; the operator-editable `name` stays `displayName`, never `sysName`.
- **docs(plugin-authoring)**: document `Host.identity` and how to fill it via `buildIdentity`.

(zabbix already fills identity; grafana/network-scan have no `getHosts`.)

## Test plan
- [x] Unit tests: new `instanceIdentity` cases (bare IP, `IP:port`, hostname, `host:port`); prometheus 8 pass, netbox 5 pass.
- [x] `typecheck` clean for all three plugins (verified in isolation).
- [x] **Live**: against a real VictoriaMetrics, `PrometheusPlugin.getHosts()` with `preset=snmp` now returns all 36 SNMP hosts carrying `identity.mgmtIp` (e.g. `192.168.10.13 → { mgmtIp: "192.168.10.13" }`), where before they had none.