### PR TITLE
feat(plugins): Arista CV-CUE data source (Wi-Fi APs + uplink switches)

### DIFF
--- a/.changeset/arista-cv-cue-plugin.md
+++ b/.changeset/arista-cv-cue-plugin.md
@@ -1,0 +1,4 @@
+---
+---
+
+feat(plugins): add Arista CV-CUE (CloudVision Cognitive Unified Edge) Wi-Fi data source plugin — hosts (APs + uplink switches), node metrics, and event-based alerts over the CV-CUE Open API session auth (bundled, private package; no published npm release).

--- a/.changeset/layout-structural-apex.md
+++ b/.changeset/layout-structural-apex.md
@@ -1,0 +1,19 @@
+---
+'@shumoku/core': patch
+---
+
+**layout**: choose the diagram apex from structure first, role hints second.
+Device-type tiers say what a box *is*, not where it *sits* — when the only
+role-tagged router in an inventory is a degree-1 management stub while the real
+WAN edge is a `generic` switch terminating the fattest trunk, trusting the role
+rooted the whole map at the stub and drew the network upside down.
+
+- A boundary-role device (≤ Router tier) seeds the rank root only when the
+  structure corroborates it: degree ≥ 2, or it sits on a fat trunk, or the
+  graph carries no bandwidth data at all (no evidence against it).
+- With no trustworthy boundary role, the root falls back to the physics: the
+  most peripheral endpoint (lowest degree) of the fattest trunks.
+- Leaf classes (AP/CPE and deeper) never seed the root — a network whose
+  lowest resolvable tier is its access points has no hierarchy information,
+  and rooting at the leaves is exactly the inversion bug. Falls through to
+  highest-degree instead.

--- a/.changeset/resolve-port-label-invariant.md
+++ b/.changeset/resolve-port-label-invariant.md
@@ -1,12 +1,14 @@
 ---
 "@shumoku/core": patch
+"@shumoku/renderer": patch
 ---
 
-fix(resolve): guarantee a folded port always has a string `label`
+fix(layout): a port with no label no longer crashes layout/render
 
 A link that referenced a bare interface name on a node that never enumerated
-the port produced a resolved `NodePort` with `label: undefined`, crashing layout
-and SVG rendering (`port.label.trim()`). `foldPortCluster` now falls back to the
-port's interface name (or empty string) so the `NodePort.label: string` contract
-always holds. Surfaced by the Arista CV-CUE topology (AP↔switch links) merged
-onto a NetBox topology.
+the port yielded a `ResolvedPort`/`NodePort` with `label: undefined`, crashing
+the layout and SVG renderer (`port.label.trim()` in the flat-tree engine,
+composite router, port-geometry, and SvgPort). The flat-tree `PortInfo` now
+defaults a missing label to `''`, the resolver's `foldPortCluster` falls back
+to the interface name, and the `.trim()` sites are null-safe. Surfaced by
+merging the Arista CV-CUE topology (AP↔switch links) onto a NetBox topology.

--- a/.changeset/resolve-port-label-invariant.md
+++ b/.changeset/resolve-port-label-invariant.md
@@ -1,0 +1,12 @@
+---
+"@shumoku/core": patch
+---
+
+fix(resolve): guarantee a folded port always has a string `label`
+
+A link that referenced a bare interface name on a node that never enumerated
+the port produced a resolved `NodePort` with `label: undefined`, crashing layout
+and SVG rendering (`port.label.trim()`). `foldPortCluster` now falls back to the
+port's interface name (or empty string) so the `NodePort.label: string` contract
+always holds. Surfaced by the Arista CV-CUE topology (AP↔switch links) merged
+onto a NetBox topology.

--- a/.changeset/router-shared-port-seating.md
+++ b/.changeset/router-shared-port-seating.md
@@ -1,0 +1,12 @@
+---
+"@shumoku/core": patch
+---
+
+fix(layout): seat multi-link ports once, toward the mean of their peers
+
+The composite router's port-seating loop assumes 1 port = 1 link, so a port
+wired into several links (LLDP reporting many devices behind one switch port,
+breakouts) was re-seated once per edge with last-writer-wins — its face
+flip-flopped with edge order and the losing edges dropped out of the
+octilinear router into long Bezier curves. Shared ports are now seated once,
+toward the mean of their peers' centers, and pinned.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Plugins implement `DataSourcePlugin` from `@shumoku/core` and depend only on cor
 - **prometheus**: Metrics, hosts, alerts from Prometheus/Alertmanager
 - **zabbix**: Topology (hosts + LLDP neighbor links), metrics, hosts, auto-mapping, alerts from Zabbix
 - **aruba-instant-on**: Hosts, metrics, alerts from the (unofficial) Aruba Instant On portal API
-- **arista-cv-cue**: Hosts (APs + uplink switches), metrics, alerts from the Arista CV-CUE (CloudVision CUE) Wi-Fi Open API (session auth)
+- **arista-cv-cue**: Topology (AP↔switch from LLDP uplinks), hosts (APs + uplink switches), metrics, alerts from the Arista CV-CUE (CloudVision CUE) Wi-Fi Open API (session auth)
 
 **Plugin contract invariants** (see `docs/plugin-authoring.md` for the full reference):
 - Core types are the display contract. Plugins translate their upstream vocabulary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ Plugins implement `DataSourcePlugin` from `@shumoku/core` and depend only on cor
 - **prometheus**: Metrics, hosts, alerts from Prometheus/Alertmanager
 - **zabbix**: Topology (hosts + LLDP neighbor links), metrics, hosts, auto-mapping, alerts from Zabbix
 - **aruba-instant-on**: Hosts, metrics, alerts from the (unofficial) Aruba Instant On portal API
+- **arista-cv-cue**: Hosts (APs + uplink switches), metrics, alerts from the Arista CV-CUE (CloudVision CUE) Wi-Fi Open API (session auth)
 
 **Plugin contract invariants** (see `docs/plugin-authoring.md` for the full reference):
 - Core types are the display contract. Plugins translate their upstream vocabulary

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -129,7 +129,7 @@ Configured entirely from the web UI — forms render generically from each plugi
 | **NetBox** | topology, hosts |
 | **Grafana** | alerts (webhook or Alertmanager) |
 | **Aruba Instant On** | hosts, metrics, alerts |
-| **Arista CV-CUE** | hosts (APs + switches), metrics, alerts |
+| **Arista CV-CUE** | topology (AP↔switch), hosts (APs + switches), metrics, alerts |
 | **Network discovery** | SNMP + LLDP seed-crawl (autoscan) |
 
 ## Web UI

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -11,7 +11,7 @@ A **Bun + [Hono](https://hono.dev)** API with an SQLite store and a **SvelteKit*
 
 ## Features
 
-- **Multi-source** — Zabbix, Prometheus, NetBox, Grafana, Aruba Instant On, and SNMP/LLDP network discovery
+- **Multi-source** — Zabbix, Prometheus, NetBox, Grafana, Aruba Instant On, Arista CV-CUE, and SNMP/LLDP network discovery
 - **Real-time metrics** — WebSocket live updates for link utilization and node status
 - **Weathermap** — links color-coded by traffic load
 - **Dashboards** — gridstack widget layouts combining topologies and metrics
@@ -129,6 +129,7 @@ Configured entirely from the web UI — forms render generically from each plugi
 | **NetBox** | topology, hosts |
 | **Grafana** | alerts (webhook or Alertmanager) |
 | **Aruba Instant On** | hosts, metrics, alerts |
+| **Arista CV-CUE** | hosts (APs + switches), metrics, alerts |
 | **Network discovery** | SNMP + LLDP seed-crawl (autoscan) |
 
 ## Web UI

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -20,6 +20,7 @@
     "@shumoku/core": "workspace:*",
     "@shumoku/renderer-svg": "workspace:*",
     "@shumoku/renderer-html": "workspace:*",
+    "shumoku-plugin-arista-cv-cue": "workspace:*",
     "shumoku-plugin-aruba-instant-on": "workspace:*",
     "shumoku-plugin-grafana": "workspace:*",
     "shumoku-plugin-netbox": "workspace:*",

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -781,7 +781,10 @@ export function createTopologiesApi(): Hono {
   })
 
   // Server-side link auto-map: resolves interface via port identity, writes mapping rows.
-  // Wave B-3 (#569): optional `sourceId` in body addresses a specific metrics source.
+  // Default (no sourceId): consults EVERY attached metrics source and unions their
+  // interfaces per host — the poller's self-select contract, so the operator never
+  // has to fan out per source by hand. Optional `sourceId` in body targets one
+  // specific metrics source (Wave B-3, #569).
   app.post('/:id/mapping/auto-map-links', async (c) => {
     const id = c.req.param('id')
     try {

--- a/apps/server/api/src/plugins/index.ts
+++ b/apps/server/api/src/plugins/index.ts
@@ -4,6 +4,7 @@
  * Data source plugin system for Shumoku.
  */
 
+export { AristaCvCuePlugin } from 'shumoku-plugin-arista-cv-cue'
 export { ArubaInstantOnPlugin } from 'shumoku-plugin-aruba-instant-on'
 export { GrafanaPlugin } from 'shumoku-plugin-grafana'
 // Re-export plugin classes from bundled plugins
@@ -31,6 +32,7 @@ export {
 export * from './registry.js'
 export * from './types.js'
 
+import { register as registerAristaCvCue } from 'shumoku-plugin-arista-cv-cue'
 import { register as registerArubaInstantOn } from 'shumoku-plugin-aruba-instant-on'
 import { register as registerGrafana } from 'shumoku-plugin-grafana'
 import { register as registerNetBox } from 'shumoku-plugin-netbox'
@@ -48,6 +50,7 @@ export function registerBundledPlugins(): void {
   registerPrometheus(pluginRegistry)
   registerGrafana(pluginRegistry)
   registerArubaInstantOn(pluginRegistry)
+  registerAristaCvCue(pluginRegistry)
   registerNetworkScan(pluginRegistry)
 
   console.log('[Plugins] Bundled plugins registered')

--- a/apps/server/api/src/services/link-automap.test.ts
+++ b/apps/server/api/src/services/link-automap.test.ts
@@ -10,6 +10,7 @@ import {
   matchInterface,
   type PlannableLink,
   planLinkAutoMap,
+  unionInterfacesAcrossSources,
 } from './link-automap.js'
 
 describe('extractInterfaceNames', () => {
@@ -275,5 +276,85 @@ describe('planLinkAutoMap — multi-source interface feeds (Wave B-3, #569)', ()
     const plan = planLinkAutoMap([link('l0', ['sw1', 'GE0/1'], ['sw2', 'GE0/2'])], {}, deps)
     expect(plan.matched).toBe(0)
     expect(plan.resolved.l0).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// unionInterfacesAcrossSources — the all-sources self-select union that makes
+// link auto-map "auto" on a multi-source topology.
+// ---------------------------------------------------------------------------
+
+describe('unionInterfacesAcrossSources', () => {
+  const mapSerial = async <T, R>(items: T[], _limit: number, fn: (item: T) => Promise<R>) =>
+    Promise.all(items.map(fn))
+
+  it('unions interfaces from whichever source recognizes each host', async () => {
+    // Source "prom" knows the switch; source "cvcue" knows the AP.
+    const getHostItems = async (sourceId: string, hostId: string) => {
+      if (sourceId === 'prom' && hostId === 'sw-1')
+        return [{ name: 'Ethernet13 in', interfaceName: 'Ethernet13' }]
+      if (sourceId === 'cvcue' && hostId === 'ap-28')
+        return [{ name: 'eth0 received', interfaceName: 'eth0' }]
+      return []
+    }
+    const out = await unionInterfacesAcrossSources(
+      ['sw-1', 'ap-28'],
+      ['prom', 'cvcue'],
+      getHostItems,
+      mapSerial,
+    )
+    expect(out.get('sw-1')).toEqual(['Ethernet13'])
+    expect(out.get('ap-28')).toEqual(['eth0'])
+  })
+
+  it('a throwing source self-deselects instead of failing the run', async () => {
+    const getHostItems = async (sourceId: string, _hostId: string) => {
+      if (sourceId === 'broken') throw new Error('upstream down')
+      return [{ name: 'GE0/1', interfaceName: 'GE0/1' }]
+    }
+    const out = await unionInterfacesAcrossSources(
+      ['h1'],
+      ['broken', 'ok'],
+      getHostItems,
+      mapSerial,
+    )
+    expect(out.get('h1')).toEqual(['GE0/1'])
+  })
+
+  it('drops a repeatedly-failing source after maxConsecutiveFailures (circuit breaker)', async () => {
+    let deadCalls = 0
+    const getHostItems = async (sourceId: string, _hostId: string) => {
+      if (sourceId === 'dead') {
+        deadCalls++
+        throw new Error('unreachable')
+      }
+      return [{ name: 'x', interfaceName: 'GE0/1' }]
+    }
+    // Strictly serial map: the breaker counts CONSECUTIVE failures, so the
+    // deterministic assertion needs hosts processed one at a time (production
+    // runs a small concurrent window, which just means a few extra calls
+    // before the breaker engages).
+    const mapStrictSerial = async <T, R>(items: T[], _l: number, fn: (i: T) => Promise<R>) => {
+      const out: R[] = []
+      for (const item of items) out.push(await fn(item))
+      return out
+    }
+    const out = await unionInterfacesAcrossSources(
+      ['h1', 'h2', 'h3', 'h4'],
+      ['dead', 'ok'],
+      getHostItems,
+      mapStrictSerial,
+      { maxConsecutiveFailures: 2 },
+    )
+    // The dead source is consulted for the first two hosts, then skipped.
+    expect(deadCalls).toBe(2)
+    // The healthy source still answers for every host.
+    expect(out.get('h4')).toEqual(['GE0/1'])
+  })
+
+  it('dedupes the same interface reported by two sources', async () => {
+    const getHostItems = async () => [{ name: 'x', interfaceName: 'GE0/1' }]
+    const out = await unionInterfacesAcrossSources(['h1'], ['a', 'b'], getHostItems, mapSerial)
+    expect(out.get('h1')).toEqual(['GE0/1'])
   })
 })

--- a/apps/server/api/src/services/link-automap.ts
+++ b/apps/server/api/src/services/link-automap.ts
@@ -263,3 +263,71 @@ export function planLinkAutoMap(
 
   return { resolved, matched, skipped }
 }
+
+/**
+ * Union a host's interface names across several metrics sources — the
+ * self-select contract the poller already relies on: every attached source is
+ * asked, and a source that doesn't know the host (or errors) contributes
+ * nothing. This is what makes link auto-map "auto" on a multi-source
+ * topology: the operator doesn't pick which source owns which host; whichever
+ * source recognizes the hostId answers with its interfaces.
+ *
+ * Robustness: sources are queried in PARALLEL per host, each call is bounded
+ * by a timeout, and a source that fails twice in a row is dropped for the
+ * remaining hosts (circuit breaker) — one unreachable upstream must not turn
+ * an auto-map into minutes of serial network timeouts.
+ */
+export async function unionInterfacesAcrossSources(
+  hostIds: readonly string[],
+  sourceIds: readonly string[],
+  getHostItems: (
+    sourceId: string,
+    hostId: string,
+  ) => Promise<readonly { name: string; interfaceName?: string }[]>,
+  mapConcurrent: <T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>) => Promise<R[]>,
+  opts: { timeoutMs?: number; maxConsecutiveFailures?: number } = {},
+): Promise<Map<string, string[]>> {
+  const timeoutMs = opts.timeoutMs ?? 8000
+  const maxFailures = opts.maxConsecutiveFailures ?? 2
+  const consecutiveFailures = new Map<string, number>()
+
+  const withTimeout = <T>(promise: Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('getHostItems timeout')), timeoutMs)
+      promise.then(
+        (v) => {
+          clearTimeout(timer)
+          resolve(v)
+        },
+        (e) => {
+          clearTimeout(timer)
+          reject(e)
+        },
+      )
+    })
+
+  const fetched = await mapConcurrent([...hostIds], 5, async (hostId) => {
+    const names = new Set<string>()
+    const live = sourceIds.filter((sid) => (consecutiveFailures.get(sid) ?? 0) < maxFailures)
+    const results = await Promise.allSettled(
+      live.map(async (sourceId) => ({
+        sourceId,
+        items: await withTimeout(getHostItems(sourceId, hostId)),
+      })),
+    )
+    for (const r of results) {
+      if (r.status === 'fulfilled') {
+        consecutiveFailures.set(r.value.sourceId, 0)
+        for (const name of extractInterfaceNames(r.value.items)) names.add(name)
+      }
+    }
+    for (const [i, r] of results.entries()) {
+      if (r.status === 'rejected') {
+        const sid = live[i]
+        if (sid) consecutiveFailures.set(sid, (consecutiveFailures.get(sid) ?? 0) + 1)
+      }
+    }
+    return [hostId, [...names]] as [string, string[]]
+  })
+  return new Map(fetched)
+}

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -75,7 +75,7 @@ import {
   resolveEntityAlias,
   stampEntityIds,
 } from './entity-registry.js'
-import { extractInterfaceNames, planLinkAutoMap } from './link-automap.js'
+import { planLinkAutoMap, unionInterfacesAcrossSources } from './link-automap.js'
 import { TopologySourcesService } from './topology-sources.js'
 
 /**
@@ -2091,18 +2091,24 @@ export class TopologyService {
     if (!parsed) throw new Error('topology not resolved; cannot auto-map links')
     const total = parsed.graph.links.length
 
-    // Resolve which metrics source to use (Wave B-3, #569).
-    let sourceId: string | undefined
+    // Resolve which metrics sources to consult. With an explicit sourceId the
+    // caller is targeting one source (Wave B-3, #569). WITHOUT one, auto-map
+    // consults EVERY attached metrics source — same self-select contract as
+    // the poller: a node's hostId means something to exactly the source that
+    // minted it, and that source answers with its interfaces while the others
+    // return nothing. Per-source "Writing to" fan-out by the operator is not
+    // "auto".
+    const attached = this.topologySources.listByPurpose(id, 'metrics')
+    let sourceIds: string[]
     if (opts.sourceId) {
-      const attached = this.topologySources.listByPurpose(id, 'metrics')
       const found = attached.find((s) => s.dataSourceId === opts.sourceId)
       if (!found) return { matched: 0, total, skipped: 0, error: 'invalidSource' }
-      sourceId = opts.sourceId
+      sourceIds = [opts.sourceId]
     } else {
-      sourceId = this.metricsSourceIdFor(id)
+      sourceIds = attached.map((s) => s.dataSourceId)
     }
 
-    if (!sourceId) return { matched: 0, total, skipped: 0 }
+    if (sourceIds.length === 0) return { matched: 0, total, skipped: 0 }
 
     const currentMapping = parsed.mapping ?? { nodes: {}, links: {} }
     const nodeById = new Map(parsed.graph.nodes.map((n) => [n.id, n]))
@@ -2136,16 +2142,15 @@ export class TopologyService {
 
     // Bounded parallelism (shared plugin-kit helper) — the old serial for-await
     // here was the metrics poller's per-host N+1 (#557) living on in this path.
-    const ifacesByHost = new Map<string, string[]>()
-    const fetched = await mapWithConcurrency([...neededHosts], 5, async (hostId) => {
-      const items = await dataSourceService.getHostItems(sourceId, hostId)
-      // The INTERFACE NAME is what port identities match — never the full,
-      // per-direction item `name` (see extractInterfaceNames).
-      return [hostId, extractInterfaceNames(items)] as const
-    })
-    for (const [hostId, ifaces] of fetched) {
-      ifacesByHost.set(hostId, ifaces)
-    }
+    // Interfaces come from the UNION across the consulted sources (the
+    // INTERFACE NAME is what port identities match — never the full,
+    // per-direction item `name`; see extractInterfaceNames).
+    const ifacesByHost = await unionInterfacesAcrossSources(
+      [...neededHosts],
+      sourceIds,
+      (sid, hostId) => dataSourceService.getHostItems(sid, hostId),
+      mapWithConcurrency,
+    )
 
     // Port identity candidates for an endpoint: id (== ifName for inventory
     // sources), identity.ifName, label, and aliases — in preference order.
@@ -2171,14 +2176,16 @@ export class TopologyService {
 
     // Fold the resolved links onto the current mapping and persist via
     // updateMapping so rows are entity-keyed (Phase 2) and durable (Phase 3).
-    // Pass the resolved sourceId so the write targets the same source whose
-    // interfaces were fetched (Wave B-3, #569).
+    // Write under the targeted source, or the first-priority source in
+    // all-sources mode (the same default convention as per-node PATCH). At
+    // poll time the merged mapping is broadcast to every source anyway — the
+    // row's source column is bookkeeping, not routing.
     if (plan.matched > 0) {
       const newMapping: MetricsMapping = {
         nodes: { ...(currentMapping.nodes ?? {}) },
         links: { ...(currentMapping.links ?? {}), ...plan.resolved },
       }
-      await this.updateMapping(id, newMapping, { sourceId })
+      await this.updateMapping(id, newMapping, { sourceId: sourceIds[0] })
     }
 
     return { matched: plan.matched, total, skipped: plan.skipped }

--- a/apps/server/docs/datasources.en.mdx
+++ b/apps/server/docs/datasources.en.mdx
@@ -85,6 +85,18 @@ Pull access points, switches, per-device metrics, and site alerts from the Aruba
 | Password | Portal password |
 | Site ID | Optional — restrict to one site; blank polls every site the account can see |
 
+## Arista CV-CUE
+
+Pull managed access points, uplink switches, per-device status, and events (alerts) from the Arista CV-CUE (CloudVision Cognitive Unified Edge) Wi-Fi Open API. Authenticates with an API key (Key ID / Key Value) over a session.
+
+| Field | Description |
+|-------|-------------|
+| API base URL | The CV-CUE Open API base, ending in `/wifi/api` (per tenant/region), e.g. `https://awm17001-c4.srv.wifi.arista.com/wifi/api` |
+| API key ID | Key ID issued under CV-CUE → Manage API Keys (e.g. `KEY-XXXXXXXX-NN`) |
+| API key value | The secret paired with the Key ID |
+| Customer ID (CID) | Optional — only when the key spans more than one customer |
+| Location ID | Optional — scope queries to a location subtree (`0` is the root) |
+
 ## Network Scan
 
 Actively discover topology with no upstream inventory: seed-crawls the network over SNMP and LLDP, identifying devices, walking ports, and harvesting neighbor links.
@@ -100,7 +112,7 @@ Actively discover topology with no upstream inventory: seed-crawls the network o
 Additional data sources can be added via the plugin system. Navigate to **Plugins** in the sidebar to manage installed plugins.
 
 Plugins can be added from:
-- Built-in plugins (Manual, Zabbix, Prometheus, Grafana, NetBox, Aruba Instant On, Network Scan)
+- Built-in plugins (Manual, Zabbix, Prometheus, Grafana, NetBox, Aruba Instant On, Arista CV-CUE, Network Scan)
 - GitHub URL
 - Local file path
 - ZIP file upload

--- a/apps/server/docs/datasources.en.mdx
+++ b/apps/server/docs/datasources.en.mdx
@@ -87,7 +87,7 @@ Pull access points, switches, per-device metrics, and site alerts from the Aruba
 
 ## Arista CV-CUE
 
-Pull managed access points, uplink switches, per-device status, and events (alerts) from the Arista CV-CUE (CloudVision Cognitive Unified Edge) Wi-Fi Open API. Authenticates with an API key (Key ID / Key Value) over a session.
+Pull managed access points, uplink switches, per-device status, and events (alerts) from the Arista CV-CUE (CloudVision Cognitive Unified Edge) Wi-Fi Open API. It also **auto-generates the AP↔switch topology** from LLDP uplink info, which composition merges (by identity) with a wired topology from NetBox etc. Authenticates with an API key (Key ID / Key Value) over a session.
 
 | Field | Description |
 |-------|-------------|

--- a/apps/server/docs/datasources.ja.mdx
+++ b/apps/server/docs/datasources.ja.mdx
@@ -92,6 +92,18 @@ Aruba Instant On クラウドポータルからアクセスポイント・スイ
 | Password | ポータルのパスワード |
 | Site ID | 任意 — 1 サイトに限定。空欄の場合はアカウントが参照できる全サイトをポーリング |
 
+## Arista CV-CUE
+
+Arista CV-CUE（CloudVision Cognitive Unified Edge）の Wi-Fi Open API から、管理下のアクセスポイント・アップリンクスイッチ・デバイス別ステータス・イベント（アラート）を取得します。API キー（Key ID / Key Value）でセッション認証します。
+
+| フィールド | 説明 |
+|-----------|------|
+| API base URL | CV-CUE Open API のベース（末尾 `/wifi/api`）。テナント/リージョンごと（例: `https://awm17001-c4.srv.wifi.arista.com/wifi/api`） |
+| API key ID | CV-CUE の「Manage API Keys」で発行した Key ID（例: `KEY-XXXXXXXX-NN`） |
+| API key value | Key ID に対応するシークレット |
+| Customer ID (CID) | 任意 — キーが複数カスタマーにアクセスできる場合のみ |
+| Location ID | 任意 — クエリを特定のロケーション配下に限定（`0` がルート） |
+
 ## Network Scan
 
 上流のインベントリなしでトポロジーを能動的に発見します。SNMP と LLDP でネットワークをシードクロールし、デバイスの特定・ポートの列挙・ネイバーリンクの収集を行います。
@@ -107,7 +119,7 @@ Aruba Instant On クラウドポータルからアクセスポイント・スイ
 プラグインシステムで追加のデータソースを導入できます。サイドバーの **Plugins** からインストール済みプラグインを管理できます。
 
 プラグインの追加方法:
-- ビルトインプラグイン（Manual、Zabbix、Prometheus、Grafana、NetBox、Aruba Instant On、Network Scan）
+- ビルトインプラグイン（Manual、Zabbix、Prometheus、Grafana、NetBox、Aruba Instant On、Arista CV-CUE、Network Scan）
 - GitHub URL
 - ローカルファイルパス
 - ZIP ファイルアップロード

--- a/apps/server/docs/datasources.ja.mdx
+++ b/apps/server/docs/datasources.ja.mdx
@@ -94,7 +94,7 @@ Aruba Instant On クラウドポータルからアクセスポイント・スイ
 
 ## Arista CV-CUE
 
-Arista CV-CUE（CloudVision Cognitive Unified Edge）の Wi-Fi Open API から、管理下のアクセスポイント・アップリンクスイッチ・デバイス別ステータス・イベント（アラート）を取得します。API キー（Key ID / Key Value）でセッション認証します。
+Arista CV-CUE（CloudVision Cognitive Unified Edge）の Wi-Fi Open API から、管理下のアクセスポイント・アップリンクスイッチ・デバイス別ステータス・イベント（アラート）を取得します。LLDP のアップリンク情報から **AP↔スイッチのトポロジも自動生成**し、NetBox 等の有線トポロジと identity でマージできます。API キー（Key ID / Key Value）でセッション認証します。
 
 | フィールド | 説明 |
 |-----------|------|

--- a/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
+++ b/apps/server/web/src/lib/components/InteractiveSvgDiagram.svelte
@@ -89,17 +89,19 @@
     WeathermapLinkOverlay,
   } from '$lib/components/topology'
   import {
+    linkMapping,
     liveUpdatesEnabled,
     metricsData,
     metricsStore,
     metricsWarnings,
+    nodeMapping,
     showNodeStatus,
     showTrafficFlow,
   } from '$lib/stores'
   import { resolvedTheme } from '$lib/stores/theme'
   import { formatTraffic } from '$lib/utils/format'
   import { nodeLabel, nodeLabelById } from '$lib/utils/node-label'
-  import { getUtilizationColor } from '$lib/weathermap'
+  import { getUtilizationColor, IDLE_LINK_METRICS, isLinkInstrumented } from '$lib/weathermap'
 
   // --- Props (Svelte 5 runes) ---
   interface Props {
@@ -326,6 +328,24 @@
     })
   }
 
+  // --- Metrics-layer membership (mapping) vs live values (metrics) ---
+  // An overlay is shown when the element BELONGS to the metrics layer (is mapped);
+  // live values only decide its appearance. Membership and values are two inputs,
+  // composed here so the overlays stay pure renderers. A mapped node the live feed
+  // omits gets a neutral 'unknown' marker (present, but no value yet). Where the
+  // mapping store isn't hydrated (widgets, shared views) `$nodeMapping` is empty,
+  // so this collapses to exactly the previous values-only behaviour.
+  const nodeStatusView = $derived.by(() => {
+    const live = $metricsData?.nodes
+    const mapped = $nodeMapping
+    if (!mapped || Object.keys(mapped).length === 0) return live
+    const out: Record<string, { status: string; monitoring?: string }> = { ...(live ?? {}) }
+    for (const [nodeId, m] of Object.entries(mapped)) {
+      if (m?.hostId && !out[nodeId]) out[nodeId] = { status: 'unknown' }
+    }
+    return out
+  })
+
   // --- Tooltip content: live metrics-aware for links ---
 
   function buildTooltip(hovered: HoveredElement, g: NetworkGraph): string {
@@ -445,14 +465,15 @@
       {#snippet linkOverlay(edge, context)}
         <WeathermapLinkOverlay
           {context}
-          metrics={$metricsData?.links?.[edge.id]}
+          metrics={$metricsData?.links?.[edge.id] ??
+            (isLinkInstrumented($linkMapping?.[edge.id]) ? IDLE_LINK_METRICS : undefined)}
           enabled={$liveUpdatesEnabled && $showTrafficFlow}
         />
       {/snippet}
       {#snippet children({ svgElement, graph: activeGraph })}
         <NodeStatusOverlay
           {svgElement}
-          status={$metricsData?.nodes}
+          status={nodeStatusView}
           enabled={$liveUpdatesEnabled && $showNodeStatus}
         />
         <HighlightOverlay {svgElement} />

--- a/apps/server/web/src/lib/components/NodeMappingModal.svelte
+++ b/apps/server/web/src/lib/components/NodeMappingModal.svelte
@@ -117,7 +117,15 @@
       : undefined,
   )
 
-  // Get current metrics for this node
+  // Get current metrics for this node.
+  // NOTE: this reads the RAW live metrics only (not the diagram's composed
+  // membership+value view). So a node that IS mapped but hasn't received its
+  // first poll shows Device "Unknown" / Monitoring "—" until a value lands —
+  // the same membership-vs-values conflation the weathermap overlay was
+  // refactored to separate (see InteractiveSvgDiagram's nodeStatusView). If we
+  // want the modal to distinguish "mapped, awaiting first value" from a genuine
+  // 'unknown' verdict, compose $nodeMapping here the same way and show a
+  // distinct "waiting for data" state instead of "Unknown".
   let nodeMetrics = $derived(nodeData ? $metricsData?.nodes?.[nodeData.node.id] : null)
 
   // Get metrics for connected links - explicitly access $metricsData outside reduce for reactivity

--- a/apps/server/web/src/lib/stores/index.ts
+++ b/apps/server/web/src/lib/stores/index.ts
@@ -28,7 +28,6 @@ export {
   mappingStore,
   metricsSources,
   nodeMapping,
-  selectedWriteSourceId,
 } from './mapping'
 export {
   type EdgeMetrics,

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -61,7 +61,6 @@ interface MappingState {
    * a compact source selector; this field tracks the operator's choice.
    * `undefined` means "first source" (the server default; backward compatible).
    */
-  selectedSourceId: string | undefined
   // Interfaces per host (hostId -> interfaces)
   hostInterfaces: Record<string, HostItem[]>
   hostInterfacesLoading: Record<string, boolean>
@@ -77,7 +76,6 @@ const initialState: MappingState = {
   mapping: { nodes: {}, links: {} },
   hosts: [],
   metricsSources: [],
-  selectedSourceId: undefined,
   hostInterfaces: {},
   hostInterfacesLoading: {},
   hostNeighbors: {},
@@ -289,12 +287,10 @@ function createMappingStore() {
 
       // Persist to backend
       try {
-        const opts = current.selectedSourceId ? { sourceId: current.selectedSourceId } : undefined
         const result = await api.topologies.updateLinkMapping(
           current.topologyId,
           linkId,
           linkMapping,
-          opts,
         )
         topologies.upsert(result.topology)
       } catch (e) {
@@ -379,9 +375,6 @@ function createMappingStore() {
      * revert to the first-source default. The page calls this when the operator
      * changes the source selector.
      */
-    setSelectedSource: (sourceId: string | undefined) => {
-      update((s) => ({ ...s, selectedSourceId: sourceId }))
-    },
 
     /**
      * Auto-map nodes to hosts via composite identity + name matching
@@ -444,8 +437,8 @@ function createMappingStore() {
       update((s) => ({ ...s, mapping: { ...s.mapping, nodes: {} } }))
 
       try {
-        const opts = current.selectedSourceId ? { sourceId: current.selectedSourceId } : undefined
-        await api.topologies.clearNodeMappings(current.topologyId, opts)
+        // No sourceId: clear EVERY source's rows — "Clear" means clear.
+        await api.topologies.clearNodeMappings(current.topologyId)
       } catch (e) {
         update((s) => ({
           ...s,
@@ -465,8 +458,8 @@ function createMappingStore() {
       update((s) => ({ ...s, mapping: { ...s.mapping, links: {} } }))
 
       try {
-        const opts = current.selectedSourceId ? { sourceId: current.selectedSourceId } : undefined
-        await api.topologies.clearLinkMappings(current.topologyId, opts)
+        // No sourceId: clear EVERY source's rows — "Clear" means clear.
+        await api.topologies.clearLinkMappings(current.topologyId)
       } catch (e) {
         update((s) => ({
           ...s,
@@ -499,7 +492,6 @@ export const mappingError = derived(mappingStore, ($s) => $s.error)
 export const nodeMapping = derived(mappingStore, ($s) => $s.mapping.nodes)
 export const linkMapping = derived(mappingStore, ($s) => $s.mapping.links)
 /** Wave B-3 (#569): the source id currently selected for writes (undefined = first source). */
-export const selectedWriteSourceId = derived(mappingStore, ($s) => $s.selectedSourceId)
 export const mappingHosts = derived(mappingStore, ($s) => $s.hosts)
 export const metricsSources = derived(mappingStore, ($s) => $s.metricsSources)
 export const hostInterfaces = derived(mappingStore, ($s) => $s.hostInterfaces)

--- a/apps/server/web/src/lib/weathermap/index.ts
+++ b/apps/server/web/src/lib/weathermap/index.ts
@@ -19,6 +19,30 @@ export interface LinkFlowMetrics {
   outBps?: number
 }
 
+// --- Metrics-layer membership (mapping) vs live values ---
+
+/**
+ * Marker for a link that IS mapped to a metrics source (belongs to the metrics
+ * layer) but has no live value yet — or its source reports nothing. Renders as a
+ * static gray lane with no motion (utilization 0 → gray, bps 0 → paused), so a
+ * mapped-but-idle link reads as "instrumented, waiting" and is visually distinct
+ * from an unmapped link (which draws no overlay at all). Membership comes from
+ * mapping; this constant is the appearance when there's no value to show.
+ */
+export const IDLE_LINK_METRICS: LinkFlowMetrics = { status: 'idle', utilization: 0 }
+
+/**
+ * Whether a link's metrics mapping is instrumented — i.e. actually pollable, so
+ * it genuinely belongs to the metrics layer. Matches what `pollMetrics` requires:
+ * the monitored node (→ host/instance) and an interface. This is the MEMBERSHIP
+ * signal, independent of whether a value has arrived.
+ */
+export function isLinkInstrumented(
+  mapping: { monitoredNodeId?: string; interface?: string } | undefined,
+): boolean {
+  return !!(mapping?.monitoredNodeId && mapping?.interface)
+}
+
 // --- Utilization → color ---
 
 const UTILIZATION_COLORS: readonly (readonly [number, string])[] = [

--- a/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/mapping/+page.svelte
@@ -23,7 +23,6 @@
     mappingHosts,
     mappingStore,
     nodeMapping,
-    selectedWriteSourceId,
   } from '$lib/stores'
   import type { MetricsData } from '$lib/stores/metrics'
   import type { EdgeEndpoint, Identity, MetricsMapping } from '$lib/types'
@@ -307,15 +306,14 @@
 
   // Link auto-map: delegates to the server endpoint which fetches host interfaces
   // and matches port identity keys (id / ifName / label) server-side.
-  // Wave B-3 (#569): passes the selected sourceId so the server uses that source's
-  // interfaces and writes rows under it.
+  // No sourceId: the server consults every attached metrics source and unions
+  // their interfaces (self-select) — "Writing to" only scopes MANUAL edits.
   async function handleLinkAutoMap() {
     if (autoMapBusy) return
     autoMapBusy = 'links'
     try {
       const result = await api.topologies.autoMapLinks(ctx.topologyId, {
         overwrite: false,
-        sourceId: $selectedWriteSourceId,
       })
       // Reload the mapping from the server so the UI reflects the persisted state.
       await mappingStore.load(ctx.topologyId, true)
@@ -443,29 +441,6 @@
       </a>
     </div>
   {:else}
-    <!-- Wave B-3 (#569): source selector — only rendered when >1 metrics sources are
-         attached. With ≤1 source there is no choice to make; hide to avoid clutter. -->
-    {#if $mappingStore.metricsSources.length > 1}
-      <div class="flex items-center gap-2 text-sm">
-        <span class="text-theme-text-muted">Writing to:</span>
-        <select
-          class="input"
-          style="width: 14rem;"
-          value={$selectedWriteSourceId ?? $mappingStore.metricsSources[0]?.id ?? ''}
-          onchange={(e) => {
-            const val = e.currentTarget.value
-            mappingStore.setSelectedSource(
-              val === ($mappingStore.metricsSources[0]?.id ?? '') ? undefined : val,
-            )
-          }}
-        >
-          {#each $mappingStore.metricsSources as src (src.id)}
-            <option value={src.id}>{src.name}</option>
-          {/each}
-        </select>
-      </div>
-    {/if}
-
     <div class="text-sm text-theme-text-muted">
       {mappedCount}/{totalNodes}
       nodes • {mappedLinksCount}/{totalLinks}

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
         "hono": "^4.7.11",
         "js-yaml": "^4.1.0",
         "nanoid": "^5.0.9",
+        "shumoku-plugin-arista-cv-cue": "workspace:*",
         "shumoku-plugin-aruba-instant-on": "workspace:*",
         "shumoku-plugin-grafana": "workspace:*",
         "shumoku-plugin-netbox": "workspace:*",
@@ -244,6 +245,13 @@
       "version": "0.2.25",
       "dependencies": {
         "@shumoku/core": "^0.2.23",
+      },
+    },
+    "libs/plugins/arista-cv-cue": {
+      "name": "shumoku-plugin-arista-cv-cue",
+      "version": "0.1.0",
+      "dependencies": {
+        "@shumoku/core": "workspace:*",
       },
     },
     "libs/plugins/aruba-instant-on": {
@@ -1680,6 +1688,8 @@
     "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "shumoku": ["shumoku@workspace:libs/shumoku"],
+
+    "shumoku-plugin-arista-cv-cue": ["shumoku-plugin-arista-cv-cue@workspace:libs/plugins/arista-cv-cue"],
 
     "shumoku-plugin-aruba-instant-on": ["shumoku-plugin-aruba-instant-on@workspace:libs/plugins/aruba-instant-on"],
 

--- a/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.ts
+++ b/libs/@shumoku/core/src/layout/auto-placement/flat-tree/auto-layout.ts
@@ -249,7 +249,10 @@ export function autoLayoutFlatTree(
     }
     const node = nodesById.get(a.nodeId)
     const port = node?.ports?.find((p) => p.id === a.portId)
-    const info: PortInfo = { id: a.portId, label: port?.label }
+    // A link may reference a port id the resolved node doesn't enumerate (a bare
+    // interface name whose port was folded under a different id). PortInfo.label
+    // is a string that downstream geometry `.trim()`s, so default to ''.
+    const info: PortInfo = { id: a.portId, label: port?.label ?? '' }
     bucket[a.side].push(info)
   }
 

--- a/libs/@shumoku/core/src/layout/composite/composite.test.ts
+++ b/libs/@shumoku/core/src/layout/composite/composite.test.ts
@@ -554,3 +554,97 @@ describe('chamferCorners', () => {
     expect(straight).toHaveLength(2)
   })
 })
+
+describe('alignPortsToPeers — shared ports', () => {
+  // Several links wired into ONE port object (LLDP reporting many devices
+  // behind a single switch port, breakouts). The per-edge seating loop
+  // assumes 1 port = 1 link; without the aggregate pass the shared port's
+  // face was last-writer-wins over edge order.
+  const build = (edgeOrder: 'forward' | 'reverse') => {
+    const nodes = new Map<string, Node>([
+      [
+        'hub',
+        { id: 'hub', label: 'hub', position: { x: 0, y: 0 }, size: { width: 80, height: 60 } },
+      ],
+      [
+        'below-a',
+        {
+          id: 'below-a',
+          label: 'a',
+          position: { x: -80, y: 200 },
+          size: { width: 80, height: 60 },
+        },
+      ],
+      [
+        'below-b',
+        { id: 'below-b', label: 'b', position: { x: 80, y: 200 }, size: { width: 80, height: 60 } },
+      ],
+      [
+        'above-c',
+        { id: 'above-c', label: 'c', position: { x: 0, y: -200 }, size: { width: 80, height: 60 } },
+      ],
+    ])
+    // ONE shared hub port for all three links.
+    const hubPort: ResolvedPort = {
+      id: 'hub:Ethernet1',
+      nodeId: 'hub',
+      label: 'Ethernet1',
+      absolutePosition: { x: 0, y: 30 },
+      side: 'bottom',
+      size: { width: 8, height: 8 },
+    }
+    const edge = (id: string, peer: string): ResolvedEdge => {
+      const toPort: ResolvedPort = {
+        id: `${peer}:up`,
+        nodeId: peer,
+        label: 'up',
+        absolutePosition: { x: nodes.get(peer)?.position?.x ?? 0, y: 170 },
+        side: 'top',
+        size: { width: 8, height: 8 },
+      }
+      return {
+        id,
+        fromPortId: hubPort.id,
+        toPortId: toPort.id,
+        fromPort: hubPort,
+        toPort,
+        fromNodeId: 'hub',
+        toNodeId: peer,
+        fromEndpoint: { node: 'hub', port: 'Ethernet1' },
+        toEndpoint: { node: peer, port: 'up' },
+        points: [hubPort.absolutePosition, toPort.absolutePosition],
+        width: 2,
+        link: { from: { node: 'hub', port: 'Ethernet1' }, to: { node: peer, port: 'up' } },
+      }
+    }
+    const list =
+      edgeOrder === 'forward'
+        ? [edge('e1', 'below-a'), edge('e2', 'below-b'), edge('e3', 'above-c')]
+        : [edge('e3', 'above-c'), edge('e2', 'below-b'), edge('e1', 'below-a')]
+    const edges = new Map<string, ResolvedEdge>(list.map((e) => [e.id, e]))
+    return { nodes, edges, hubPort }
+  }
+
+  it('seats a multi-link port once, toward the mean of its peers', () => {
+    const { nodes, edges, hubPort } = build('forward')
+    alignPortsToPeers(edges, nodes)
+    // Two peers below, one above → mean peer is below → bottom face.
+    expect(hubPort.side).toBe('bottom')
+  })
+
+  it('is independent of edge iteration order (no last-writer-wins)', () => {
+    const a = build('forward')
+    alignPortsToPeers(a.edges, a.nodes)
+    const b = build('reverse')
+    alignPortsToPeers(b.edges, b.nodes)
+    expect(a.hubPort.side).toBe(b.hubPort.side)
+  })
+
+  it('single-link ports keep the existing per-edge seating', () => {
+    const { nodes, edges } = build('forward')
+    alignPortsToPeers(edges, nodes)
+    // The above-child's own (unshared) port faces the hub below it.
+    const e3 = edges.get('e3')
+    expect(e3?.toPort.side).toBe('bottom')
+  })
+})

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -86,11 +86,14 @@ export function alignPortsToPeers(
   let flipped = 0
   const minWidths = new Map<string, number>()
   const minHeights = new Map<string, number>()
+  /** Ports seated once by the shared-port aggregate pass; per-edge seating skips them. */
+  const pinned = new Set<ResolvedEdge['fromPort']>()
   const seat = (
     port: ResolvedEdge['fromPort'],
     nodeId: string,
     side: 'top' | 'bottom' | 'left' | 'right',
   ): void => {
+    if (pinned.has(port)) return
     // Uniform label policy for the composite schematic: top/bottom port
     // labels ALWAYS run along the wire (vertical), side ports stay
     // horizontal. Mixed orientations on one face read as clutter, and
@@ -119,6 +122,53 @@ export function alignPortsToPeers(
     flipped++
   }
   const sortedForSeat = [...edges.values()].sort((a, b) => (a.id < b.id ? -1 : 1))
+
+  // -- shared-port aggregate seating ---------------------------------------
+  // The per-edge loop below assumes 1 port = 1 link (each flip only affects
+  // its own edge). A port wired into SEVERAL links (LLDP data reporting many
+  // devices behind one switch port, breakouts) would get re-seated once per
+  // edge with last-writer-wins — the face flip-flops with edge order, and
+  // edges whose peer lost the race drop out of the octilinear router into
+  // Bezier fallback. Seat such ports ONCE, toward the mean of their peers'
+  // centers, and pin them so the loop can't thrash them.
+  {
+    const refs = new Map<
+      ResolvedEdge['fromPort'],
+      { nodeId: string; peerXs: number[]; peerYs: number[] }
+    >()
+    for (const edge of sortedForSeat) {
+      if (edge.coupling) continue
+      const fromCenter = nodes.get(edge.fromNodeId)?.position
+      const toCenter = nodes.get(edge.toNodeId)?.position
+      if (!fromCenter || !toCenter) continue
+      const ends: [ResolvedEdge['fromPort'], string, Position][] = [
+        [edge.fromPort, edge.fromNodeId, toCenter],
+        [edge.toPort, edge.toNodeId, fromCenter],
+      ]
+      for (const [port, nodeId, peer] of ends) {
+        const entry = refs.get(port) ?? { nodeId, peerXs: [], peerYs: [] }
+        entry.peerXs.push(peer.x)
+        entry.peerYs.push(peer.y)
+        refs.set(port, entry)
+      }
+    }
+    for (const [port, info] of refs) {
+      if (info.peerYs.length < 2) continue
+      const own = nodes.get(info.nodeId)?.position
+      if (!own) continue
+      const meanY = info.peerYs.reduce((s, y) => s + y, 0) / info.peerYs.length
+      const meanX = info.peerXs.reduce((s, x) => s + x, 0) / info.peerXs.length
+      const dy = meanY - own.y
+      if (Math.abs(dy) > 40) {
+        seat(port, info.nodeId, dy > 0 ? 'bottom' : 'top')
+      } else {
+        const outward = options.outwardSide?.get(info.nodeId)
+        seat(port, info.nodeId, outward ?? (meanX >= own.x ? 'right' : 'left'))
+      }
+      pinned.add(port)
+    }
+  }
+
   for (const edge of sortedForSeat) {
     if (edge.coupling) continue
     const fromCenter = nodes.get(edge.fromNodeId)?.position

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -251,7 +251,7 @@ function collectLabelPorts(edges: readonly ResolvedEdge[]): LabelPort[] {
   for (const edge of edges) {
     if (edge.coupling) continue
     for (const port of [edge.fromPort, edge.toPort]) {
-      if (port.label.trim() === '') continue
+      if ((port.label ?? '').trim() === '') continue
       ports.set(port.id, { port, nodeId: port.nodeId })
     }
   }

--- a/libs/@shumoku/core/src/layout/port-geometry.ts
+++ b/libs/@shumoku/core/src/layout/port-geometry.ts
@@ -85,7 +85,7 @@ export function portBox(port: ResolvedPort): Bounds {
  *   - horizontal: classic placement per side (above / below / beside).
  */
 export function portLabelBox(port: ResolvedPort): Bounds | undefined {
-  const label = port.label.trim()
+  const label = (port.label ?? '').trim()
   if (label.length === 0) return undefined
   const w = portLabelLength(label)
   const px = port.absolutePosition.x

--- a/libs/@shumoku/core/src/layout/problem.test.ts
+++ b/libs/@shumoku/core/src/layout/problem.test.ts
@@ -129,6 +129,74 @@ describe('buildLayoutProblem', () => {
     expect(ranks.get('fw')).toBeLessThan(ranks.get('core') ?? Number.POSITIVE_INFINITY)
   })
 
+  it('demotes a stub-tagged router when the fat trunks point elsewhere', () => {
+    // Role metadata can point at the wrong box: the only `router` in this
+    // inventory is a degree-1 management box off an access switch, while the
+    // real WAN edge is a `generic` switch terminating the 400G trunk. The
+    // wiring must win — rooting at the stub inverts the whole map.
+    const source: NetworkGraph = {
+      name: 'stub-router',
+      nodes: [
+        { id: 'wan-edge', label: 'wan-edge', spec: { kind: 'hardware', type: DeviceType.Generic } },
+        { id: 'agg', label: 'agg', spec: { kind: 'hardware', type: DeviceType.Generic } },
+        { id: 'core', label: 'core', spec: { kind: 'hardware', type: DeviceType.Generic } },
+        { id: 'eps', label: 'eps', spec: { kind: 'hardware', type: DeviceType.Generic } },
+        { id: 'stub-rtr', label: 'stub-rtr', spec: { kind: 'hardware', type: DeviceType.Router } },
+        { id: 'ap1', label: 'ap1', spec: { kind: 'hardware', type: DeviceType.AccessPoint } },
+      ],
+      links: [
+        {
+          from: { node: 'wan-edge', port: 'a' },
+          to: { node: 'agg', port: 'a' },
+          rateBps: 400e9,
+        },
+        { from: { node: 'agg', port: 'b' }, to: { node: 'core', port: 'a' } },
+        { from: { node: 'core', port: 'b' }, to: { node: 'eps', port: 'a' } },
+        { from: { node: 'eps', port: 'b' }, to: { node: 'stub-rtr', port: 'a' } },
+        { from: { node: 'eps', port: 'c' }, to: { node: 'ap1', port: 'a' } },
+      ],
+    }
+
+    const problem = buildLayoutProblem(source)
+    const ranks = computeRoleDrivenRanks(source)
+
+    expect(problem.diagnostics.apexNodeId).toBe('wan-edge')
+    // The stub router sits BELOW the switch it hangs off, not at the top.
+    expect(ranks.get('stub-rtr')).toBeGreaterThan(ranks.get('eps') ?? Number.POSITIVE_INFINITY)
+    expect(ranks.get('wan-edge')).toBe(0)
+    expect(ranks.get('core')).toBeGreaterThan(ranks.get('agg') ?? Number.POSITIVE_INFINITY)
+  })
+
+  it('never seeds the rank root at a leaf class (AP) when no hierarchy info exists', () => {
+    // All-generic switches + APs: no boundary role, no bandwidth. The lowest
+    // resolvable tier is the APs' — rooting there is the inversion bug. The
+    // root must fall through to structure (highest degree) instead.
+    const source: NetworkGraph = {
+      name: 'aps-only',
+      nodes: [
+        { id: 'sw1', label: 'sw1', spec: { kind: 'hardware', type: DeviceType.Generic } },
+        { id: 'sw2', label: 'sw2', spec: { kind: 'hardware', type: DeviceType.Generic } },
+        { id: 'ap1', label: 'ap1', spec: { kind: 'hardware', type: DeviceType.AccessPoint } },
+        { id: 'ap2', label: 'ap2', spec: { kind: 'hardware', type: DeviceType.AccessPoint } },
+        { id: 'ap3', label: 'ap3', spec: { kind: 'hardware', type: DeviceType.AccessPoint } },
+      ],
+      links: [
+        { from: { node: 'sw1', port: 'a' }, to: { node: 'sw2', port: 'a' } },
+        { from: { node: 'sw1', port: 'b' }, to: { node: 'ap1', port: 'a' } },
+        { from: { node: 'sw1', port: 'c' }, to: { node: 'ap2', port: 'a' } },
+        { from: { node: 'sw2', port: 'b' }, to: { node: 'ap3', port: 'a' } },
+      ],
+    }
+
+    const problem = buildLayoutProblem(source)
+    const ranks = computeRoleDrivenRanks(source)
+
+    expect(problem.diagnostics.apexNodeId).toBe('sw1')
+    for (const ap of ['ap1', 'ap2', 'ap3']) {
+      expect(ranks.get(ap)).toBeGreaterThan(0)
+    }
+  })
+
   it('anchors the apex to the rank root, not raw cable direction', () => {
     // Inventory cables are undirected: from→to is arbitrary. Here every cable
     // is written leaf-first, so a direction-based heuristic would crown a

--- a/libs/@shumoku/core/src/layout/problem.ts
+++ b/libs/@shumoku/core/src/layout/problem.ts
@@ -404,16 +404,28 @@ export function computeRoleDrivenRanks(
   const tierOf = (id: string): number | undefined =>
     resolveTierFromSpec(nodeById.get(id)?.spec)?.tier
 
-  // Default apex: lowest device tier among non-sink, degree-bearing nodes.
-  let bestTier = Number.POSITIVE_INFINITY
-  for (const node of graph.nodes) {
-    if (degreeOf(node.id) === 0 || sinks.has(node.id)) continue
-    const tier = tierOf(node.id)
-    if (tier !== undefined) bestTier = Math.min(bestTier, tier)
+  // Max incident bandwidth per node — the structural fat-trunk signal. Used to
+  // corroborate role hints and to find the WAN edge when roles are absent or
+  // point at the wrong box: a device-type tier says what a box IS, the wiring
+  // says where it SITS, and when the two disagree the wiring wins.
+  const bwOf = new Map<string, number>()
+  let maxBw = 0
+  for (const link of graph.links) {
+    if (
+      !nodeById.has(link.from.node) ||
+      !nodeById.has(link.to.node) ||
+      link.from.node === link.to.node
+    ) {
+      continue
+    }
+    const bw = linkSpeedBps(link) ?? 0
+    maxBw = Math.max(maxBw, bw)
+    bwOf.set(link.from.node, Math.max(bwOf.get(link.from.node) ?? 0, bw))
+    bwOf.set(link.to.node, Math.max(bwOf.get(link.to.node) ?? 0, bw))
   }
-  let roots = graph.nodes
-    .filter((node) => tierOf(node.id) === bestTier && degreeOf(node.id) > 0 && !sinks.has(node.id))
-    .map((node) => node.id)
+  const FAT_TRUNK_RATIO = 0.5
+  const onFatTrunk = (id: string): boolean =>
+    maxBw > 0 && (bwOf.get(id) ?? 0) >= maxBw * FAT_TRUNK_RATIO
 
   // Among boundary devices (≤ Router), root at the most PERIPHERAL one
   // (max BFS eccentricity = the WAN edge). The device-type table alone ranks
@@ -445,12 +457,53 @@ export function computeRoleDrivenRanks(
         (tierOf(node.id) ?? Number.POSITIVE_INFINITY) <= BOUNDARY_TIER,
     )
     .map((node) => node.id)
-  if (boundary.length > 0) {
-    const ecc = new Map(boundary.map((id) => [id, eccOf(id)]))
+  // A boundary role only counts when the structure doesn't contradict it: a
+  // degree-1 box on thin links, in a network that HAS fat trunks elsewhere, is
+  // a management stub that happens to be tagged router — rooting there inverts
+  // the whole map. (No bandwidth data at all = no evidence against it.)
+  const corroborated = boundary.filter((id) => degreeOf(id) >= 2 || maxBw === 0 || onFatTrunk(id))
+  let roots: string[] = []
+  if (corroborated.length > 0) {
+    const ecc = new Map(corroborated.map((id) => [id, eccOf(id)]))
     let maxEcc = -1
     for (const value of ecc.values()) maxEcc = Math.max(maxEcc, value)
-    const eccRoots = boundary.filter((id) => ecc.get(id) === maxEcc)
-    if (eccRoots.length > 0) roots = eccRoots
+    roots = corroborated.filter((id) => ecc.get(id) === maxEcc)
+  }
+  if (roots.length === 0 && maxBw > 0) {
+    // No trustworthy boundary role — fall back to the physics: the WAN edge is
+    // the most peripheral endpoint of the fattest trunks (lowest degree first;
+    // the outer end of a fat pair has fewer legs than the aggregation side).
+    const trunkEnds = graph.nodes
+      .filter((node) => degreeOf(node.id) > 0 && !sinks.has(node.id) && onFatTrunk(node.id))
+      .map((node) => node.id)
+    if (trunkEnds.length > 0) {
+      const minDeg = Math.min(...trunkEnds.map(degreeOf))
+      const peripheral = trunkEnds.filter((id) => degreeOf(id) === minDeg)
+      const ecc = new Map(peripheral.map((id) => [id, eccOf(id)]))
+      let maxEcc = -1
+      for (const value of ecc.values()) maxEcc = Math.max(maxEcc, value)
+      roots = peripheral.filter((id) => ecc.get(id) === maxEcc)
+    }
+  }
+  if (roots.length === 0) {
+    // Lowest device tier among non-sink, degree-bearing nodes — but a leaf
+    // class (AP/CPE or deeper) never seeds: a network whose "best" tier is its
+    // access points has no hierarchy information, and rooting at the leaves is
+    // exactly the inversion bug. Fall through to degree instead.
+    const LEAF_TIER = 50
+    let bestTier = Number.POSITIVE_INFINITY
+    for (const node of graph.nodes) {
+      if (degreeOf(node.id) === 0 || sinks.has(node.id)) continue
+      const tier = tierOf(node.id)
+      if (tier !== undefined && tier < LEAF_TIER) bestTier = Math.min(bestTier, tier)
+    }
+    if (Number.isFinite(bestTier)) {
+      roots = graph.nodes
+        .filter(
+          (node) => tierOf(node.id) === bestTier && degreeOf(node.id) > 0 && !sinks.has(node.id),
+        )
+        .map((node) => node.id)
+    }
   }
   if (roots.length === 0) {
     const best = [...graph.nodes].sort(

--- a/libs/@shumoku/core/src/observation/resolve.test.ts
+++ b/libs/@shumoku/core/src/observation/resolve.test.ts
@@ -2229,6 +2229,33 @@ describe('resolve()', () => {
       expect(out.nodes[0]?.label).toBe('Curated Router')
     })
   })
+
+  describe('port label invariant', () => {
+    it('a folded port always has a string label (falls back to ifName)', () => {
+      // A source enumerated a port with an interface name but no `label`
+      // (e.g. a link referenced a bare interface name). NodePort.label is a
+      // required string that layout/render `.trim()`, so the fold must supply
+      // one rather than leaking undefined.
+      const labelless = {
+        id: 'Ethernet13',
+        identity: { ifName: 'Ethernet13' },
+      } as unknown as NetworkGraph['nodes'][number]['ports'][number]
+      const snap: SnapshotEntry = {
+        sourceId: 'cvcue',
+        capturedAt: 1,
+        status: 'ok',
+        graph: {
+          ...emptyGraph(),
+          nodes: [{ id: 'sw1', label: 'sw', identity: { chassisId: 'aa' }, ports: [labelless] }],
+        },
+      }
+      const out = resolve(emptyGraph(), [snap])
+      const port = out.nodes[0]?.ports?.[0]
+      expect(port).toBeDefined()
+      expect(typeof port?.label).toBe('string')
+      expect(port?.label).toBe('Ethernet13')
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/libs/@shumoku/core/src/observation/resolve.ts
+++ b/libs/@shumoku/core/src/observation/resolve.ts
@@ -978,6 +978,14 @@ function foldPortCluster(members: PortMember[]): NodePort {
   // doesn't survive via the base copy.
   folded.attachments = attachments.length > 0 ? attachments : undefined
   folded.suppressedAttachments = suppressed.length > 0 ? suppressed : undefined
+
+  // NodePort.label is a required string; layout & rendering `.trim()` it. When a
+  // link referenced a bare interface name and no contribution enumerated the
+  // port with a label, none of the members carry one — fall back to the
+  // interface name so the invariant holds and consumers never hit undefined.
+  if (typeof folded.label !== 'string') {
+    folded.label = folded.interfaceName ?? folded.identity?.ifName ?? ''
+  }
   return folded
 }
 

--- a/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
@@ -51,7 +51,7 @@
   const ph = $derived(port.size.height)
   const labelPos = $derived(computePortLabelPosition(port))
 
-  const hasLabel = $derived(port.label.trim().length > 0)
+  const hasLabel = $derived((port.label ?? '').trim().length > 0)
   const verticalLabel = $derived(
     port.labelOrientation === 'vertical' && (port.side === 'top' || port.side === 'bottom'),
   )

--- a/libs/plugins/arista-cv-cue/package.json
+++ b/libs/plugins/arista-cv-cue/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "shumoku-plugin-arista-cv-cue",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Arista CV-CUE (CloudVision Cognitive Unified Edge) Wi-Fi data source plugin for Shumoku. Polls the CV-CUE Open API for APs, switches, and events.",
+  "license": "AGPL-3.0-only",
+  "author": "konoe-akitoshi",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
+    "directory": "libs/plugins/arista-cv-cue"
+  },
+  "homepage": "https://www.shumoku.dev/",
+  "bugs": {
+    "url": "https://github.com/konoe-akitoshi/shumoku/issues"
+  },
+  "keywords": [
+    "arista",
+    "cv-cue",
+    "cloudvision",
+    "wifi",
+    "wireless",
+    "network",
+    "shumoku",
+    "plugin"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "format": "biome check --write ."
+  },
+  "dependencies": {
+    "@shumoku/core": "workspace:*"
+  },
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libs/plugins/arista-cv-cue/src/api.ts
+++ b/libs/plugins/arista-cv-cue/src/api.ts
@@ -1,0 +1,173 @@
+/**
+ * CV-CUE Open API client.
+ *
+ * CV-CUE authenticates by **session**, not bearer: `POST /session` with the
+ * API key credentials returns a `JSESSIONID` cookie that every subsequent
+ * request must send back (plus a `Version` header). The session idles out
+ * after ~1h, so we re-login transparently on 401 and refresh a bit early.
+ *
+ * The base URL is operator-supplied (CV-CUE is a documented, multi-tenant
+ * product with per-tenant hosts), so we require HTTPS and never log the key.
+ */
+
+import type { AristaCvCueConfig, CvSessionResponse } from './types.js'
+
+/** CV-CUE serves the latest version of each module when asked for `latest`. */
+const VERSION_HEADER = 'latest'
+
+/** Refresh the session a little before the server's ~1h idle timeout. */
+const SESSION_TTL_MS = 50 * 60 * 1000
+
+export class AristaCvCueApi {
+  private cookie: string | null = null
+  private sessionExpiresAt = 0
+  private pendingAuth: Promise<string> | null = null
+
+  constructor(private readonly config: AristaCvCueConfig) {
+    if (!/^https:\/\//i.test(config.baseUrl)) {
+      throw new Error('Arista CV-CUE `baseUrl` must be an https:// URL')
+    }
+  }
+
+  /** GET a JSON resource, re-authenticating once if the session lapsed. */
+  async get<T>(path: string, query?: Record<string, string | number | undefined>): Promise<T> {
+    return this.request<T>('GET', this.withQuery(path, query))
+  }
+
+  /**
+   * Follow CV-CUE's `startindex` / `pagesize` paging to exhaustion, returning
+   * the concatenation of `extract(page)` across pages. Bounded so a runaway
+   * `totalCount` can't spin forever.
+   */
+  async getPaged<T, E extends { totalCount?: number }>(
+    path: string,
+    extract: (page: E) => T[],
+    query?: Record<string, string | number | undefined>,
+    opts?: { pageSize?: number; maxItems?: number },
+  ): Promise<T[]> {
+    const pageSize = opts?.pageSize ?? 200
+    const maxItems = opts?.maxItems ?? 5000
+    const out: T[] = []
+    let startIndex = 0
+    while (out.length < maxItems) {
+      const page = await this.get<E>(path, { ...query, startindex: startIndex, pagesize: pageSize })
+      const items = extract(page)
+      out.push(...items)
+      const total = page.totalCount ?? out.length
+      if (items.length < pageSize || out.length >= total) break
+      startIndex += pageSize
+    }
+    return out.slice(0, maxItems)
+  }
+
+  /** Raw passthrough for the dev-only native API endpoint. */
+  async nativeApi(method: string, params: Record<string, unknown>): Promise<unknown> {
+    const path =
+      typeof params['path'] === 'string' ? (params['path'] as string) : '/manageddevices/aps'
+    return this.request<unknown>(method, path, params['body'])
+  }
+
+  // ------------------------------------------------------------------
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${this.config.baseUrl}${path.startsWith('/') ? path : `/${path}`}`
+    const send = async (cookie: string): Promise<Response> => {
+      const init: RequestInit = {
+        method,
+        headers: {
+          Cookie: cookie,
+          Version: VERSION_HEADER,
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+      }
+      if (body !== undefined && method !== 'GET') {
+        init.body = typeof body === 'string' ? body : JSON.stringify(body)
+      }
+      return fetch(url, init)
+    }
+
+    let cookie = await this.ensureSession()
+    let resp = await send(cookie)
+    if (resp.status === 401) {
+      // Session idled out or was invalidated — drop it and log in once more.
+      this.cookie = null
+      cookie = await this.ensureSession()
+      resp = await send(cookie)
+    }
+    if (!resp.ok) {
+      throw new Error(`Arista CV-CUE ${method} ${path} → HTTP ${resp.status}`)
+    }
+    if (resp.status === 204) return undefined as T
+    return (await resp.json()) as T
+  }
+
+  /** Return a live session cookie, deduping concurrent logins. */
+  private async ensureSession(): Promise<string> {
+    if (this.cookie && this.sessionExpiresAt > Date.now()) return this.cookie
+    if (!this.pendingAuth) {
+      this.pendingAuth = this.login().finally(() => {
+        this.pendingAuth = null
+      })
+    }
+    this.cookie = await this.pendingAuth
+    this.sessionExpiresAt = Date.now() + SESSION_TTL_MS
+    return this.cookie
+  }
+
+  /** POST the API-key credentials and capture the JSESSIONID cookie. */
+  private async login(): Promise<string> {
+    const url = this.withQuery(
+      `${this.config.baseUrl}/session`,
+      this.config.customerId ? { CID: this.config.customerId } : undefined,
+    )
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { Version: VERSION_HEADER, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'apikeycredentials',
+        keyId: this.config.keyId,
+        keyValue: this.config.keyValue,
+      }),
+    })
+    if (!resp.ok) {
+      // Never echo the key back; the status is enough to diagnose.
+      throw new Error(`Arista CV-CUE session login failed: HTTP ${resp.status}`)
+    }
+    const cookie = extractJSessionId(resp)
+    if (!cookie) {
+      throw new Error('Arista CV-CUE login succeeded but no JSESSIONID cookie was returned')
+    }
+    // Touch the body so an unexpected shape (non-JSON) fails here, loudly.
+    ;(await resp.json()) as CvSessionResponse
+    return cookie
+  }
+
+  private withQuery(path: string, query?: Record<string, string | number | undefined>): string {
+    const merged: Record<string, string | number | undefined> = {
+      locationid: this.config.locationId ?? 0,
+      ...query,
+    }
+    const qs = Object.entries(merged)
+      .filter(([, v]) => v !== undefined)
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+      .join('&')
+    if (!qs) return path
+    return `${path}${path.includes('?') ? '&' : '?'}${qs}`
+  }
+}
+
+/**
+ * Pull the `JSESSIONID=...` pair out of the login response's Set-Cookie
+ * header(s). Uses `getSetCookie()` (array) when available (undici/Node/Bun),
+ * falling back to the combined `set-cookie` header.
+ */
+function extractJSessionId(resp: Response): string | null {
+  const headers = resp.headers as Headers & { getSetCookie?: () => string[] }
+  const raw = headers.getSetCookie?.() ?? [resp.headers.get('set-cookie') ?? '']
+  for (const line of raw) {
+    const m = line.match(/JSESSIONID=([^;]+)/)
+    if (m?.[1]) return `JSESSIONID=${m[1]}`
+  }
+  return null
+}

--- a/libs/plugins/arista-cv-cue/src/index.ts
+++ b/libs/plugins/arista-cv-cue/src/index.ts
@@ -42,7 +42,7 @@ export function register(registry: PluginRegistryInterface): void {
     {
       type: 'arista-cv-cue',
       displayName: 'Arista CV-CUE',
-      capabilities: ['hosts', 'metrics', 'alerts'],
+      capabilities: ['topology', 'hosts', 'metrics', 'alerts'],
       configSchema,
     },
     (config) => {

--- a/libs/plugins/arista-cv-cue/src/index.ts
+++ b/libs/plugins/arista-cv-cue/src/index.ts
@@ -1,0 +1,54 @@
+export { AristaCvCuePlugin } from './plugin.js'
+export type { AristaCvCueConfig } from './types.js'
+
+import type { PluginConfigSchema, PluginRegistryInterface } from '@shumoku/core'
+import { AristaCvCuePlugin } from './plugin.js'
+
+/** Self-description: the host renders this form and validates config from it. */
+const configSchema: PluginConfigSchema = {
+  type: 'object',
+  required: ['baseUrl', 'keyId', 'keyValue'],
+  properties: {
+    baseUrl: {
+      type: 'string',
+      format: 'uri',
+      title: 'API base URL',
+      placeholder: 'https://awm17001-c4.srv.wifi.arista.com/wifi/api',
+      help: 'The CV-CUE Open API base, ending in /wifi/api (per tenant/region).',
+    },
+    keyId: {
+      type: 'string',
+      title: 'API key ID',
+      placeholder: 'KEY-XXXXXXXX-NN',
+      help: 'From CV-CUE → Manage API Keys.',
+    },
+    keyValue: { type: 'string', secret: true, title: 'API key value' },
+    customerId: {
+      type: 'string',
+      title: 'Customer ID (CID)',
+      help: 'Only needed when the key has access to more than one customer.',
+    },
+    locationId: {
+      type: 'number',
+      title: 'Location ID',
+      default: 0,
+      help: 'Scope queries to a location subtree. 0 is the root.',
+    },
+  },
+}
+
+export function register(registry: PluginRegistryInterface): void {
+  registry.registerDescriptor(
+    {
+      type: 'arista-cv-cue',
+      displayName: 'Arista CV-CUE',
+      capabilities: ['hosts', 'metrics', 'alerts'],
+      configSchema,
+    },
+    (config) => {
+      const plugin = new AristaCvCuePlugin()
+      plugin.initialize(config)
+      return plugin
+    },
+  )
+}

--- a/libs/plugins/arista-cv-cue/src/plugin.test.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { AristaCvCuePlugin, eventToAlert, mapEventSeverity } from './plugin.js'
+
+describe('mapEventSeverity', () => {
+  it('translates CV-CUE tokens to the neutral scale', () => {
+    expect(mapEventSeverity('CRITICAL')).toBe('critical')
+    expect(mapEventSeverity('HIGH')).toBe('high')
+    expect(mapEventSeverity('MEDIUM')).toBe('medium')
+    expect(mapEventSeverity('LOW')).toBe('low')
+    expect(mapEventSeverity('INFO')).toBe('info')
+    expect(mapEventSeverity('OK')).toBe('ok')
+  })
+
+  it('is case-insensitive and defaults unknown tokens to info', () => {
+    expect(mapEventSeverity('high')).toBe('high')
+    expect(mapEventSeverity('weird')).toBe('info')
+    expect(mapEventSeverity(undefined)).toBe('info')
+  })
+})
+
+describe('eventToAlert', () => {
+  it('maps LIVE events to active and EXPIRED/INSTANTANEOUS to resolved', () => {
+    expect(
+      eventToAlert({ id: 1, activityStatus: 'LIVE', eventSeverity: 'HIGH', startTime: 1000 })
+        .status,
+    ).toBe('active')
+    expect(
+      eventToAlert({ id: 2, activityStatus: 'EXPIRED', startTime: 1, stopTime: 9 }).status,
+    ).toBe('resolved')
+    expect(eventToAlert({ id: 3, activityStatus: 'INSTANTANEOUS', startTime: 5 }).status).toBe(
+      'resolved',
+    )
+  })
+
+  it('carries title, severity, source and category label', () => {
+    const a = eventToAlert({
+      id: 11,
+      activityStatus: 'INSTANTANEOUS',
+      eventSeverity: 'HIGH',
+      summary: 'Authentication failed',
+      startTime: 42,
+      category: 71,
+    })
+    expect(a).toMatchObject({
+      id: '11',
+      severity: 'high',
+      title: 'Authentication failed',
+      source: 'arista-cv-cue',
+      startTime: 42,
+      labels: { category: '71' },
+    })
+  })
+})
+
+describe('AristaCvCuePlugin', () => {
+  it('advertises hosts/metrics/alerts and its type', () => {
+    const p = new AristaCvCuePlugin()
+    expect(p.type).toBe('arista-cv-cue')
+    expect([...p.capabilities].sort()).toEqual(['alerts', 'hosts', 'metrics'])
+  })
+
+  it('requires baseUrl, keyId and keyValue', () => {
+    const p = new AristaCvCuePlugin()
+    expect(() => p.initialize({ baseUrl: 'https://x/wifi/api' })).toThrow(/keyId/)
+    expect(() =>
+      p.initialize({ baseUrl: 'https://x/wifi/api', keyId: 'k', keyValue: 'v' }),
+    ).not.toThrow()
+  })
+
+  it('rejects a non-https base URL at construction', () => {
+    const p = new AristaCvCuePlugin()
+    expect(() =>
+      p.initialize({ baseUrl: 'http://insecure/wifi/api', keyId: 'k', keyValue: 'v' }),
+    ).toThrow(/https/)
+  })
+
+  it('returns empty metrics without a live API when nothing is mapped', async () => {
+    const p = new AristaCvCuePlugin()
+    p.initialize({ baseUrl: 'https://x/wifi/api', keyId: 'k', keyValue: 'v' })
+    const m = await p.pollMetrics({ nodes: {}, links: {} })
+    expect(m.nodes).toEqual({})
+    expect(m.links).toEqual({})
+  })
+})

--- a/libs/plugins/arista-cv-cue/src/plugin.test.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.test.ts
@@ -53,10 +53,10 @@ describe('eventToAlert', () => {
 })
 
 describe('AristaCvCuePlugin', () => {
-  it('advertises hosts/metrics/alerts and its type', () => {
+  it('advertises topology/hosts/metrics/alerts and its type', () => {
     const p = new AristaCvCuePlugin()
     expect(p.type).toBe('arista-cv-cue')
-    expect([...p.capabilities].sort()).toEqual(['alerts', 'hosts', 'metrics'])
+    expect([...p.capabilities].sort()).toEqual(['alerts', 'hosts', 'metrics', 'topology'])
   })
 
   it('requires baseUrl, keyId and keyValue', () => {

--- a/libs/plugins/arista-cv-cue/src/plugin.test.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.test.ts
@@ -79,13 +79,13 @@ describe('uplinkToLinkMetrics', () => {
     expect(m.inBps).toBeUndefined()
   })
 
-  it('reports link down for an inactive AP even when stale linkStatus says up', () => {
+  it('reports link status unknown for an inactive AP (absence of data, not a confirmed down)', () => {
     const m = uplinkToLinkMetrics({
       active: false,
       uplinkWiredInterfacesInfo: { lan1Data: uplink },
       radios: [{ downstreamUsage: 999, upstreamUsage: 999 }],
     })
-    expect(m).toEqual({ status: 'down' })
+    expect(m).toEqual({ status: 'unknown' })
   })
 
   it('reports link down from linkStatus', () => {

--- a/libs/plugins/arista-cv-cue/src/plugin.test.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.test.ts
@@ -57,6 +57,7 @@ describe('uplinkToLinkMetrics', () => {
 
   it('derives in/out throughput from radios (down→in, up→out)', () => {
     const m = uplinkToLinkMetrics({
+      active: true,
       uplinkWiredInterfacesInfo: { lan1Data: uplink },
       radios: [
         { downstreamUsage: 400, upstreamUsage: 100 },
@@ -70,6 +71,7 @@ describe('uplinkToLinkMetrics', () => {
 
   it('emits status only for an idle AP (no fake zero throughput)', () => {
     const m = uplinkToLinkMetrics({
+      active: true,
       uplinkWiredInterfacesInfo: { lan1Data: uplink },
       radios: [{ downstreamUsage: 0, upstreamUsage: 0 }],
     })
@@ -77,8 +79,18 @@ describe('uplinkToLinkMetrics', () => {
     expect(m.inBps).toBeUndefined()
   })
 
+  it('reports link down for an inactive AP even when stale linkStatus says up', () => {
+    const m = uplinkToLinkMetrics({
+      active: false,
+      uplinkWiredInterfacesInfo: { lan1Data: uplink },
+      radios: [{ downstreamUsage: 999, upstreamUsage: 999 }],
+    })
+    expect(m).toEqual({ status: 'down' })
+  })
+
   it('reports link down from linkStatus', () => {
     const m = uplinkToLinkMetrics({
+      active: true,
       uplinkWiredInterfacesInfo: { lan1Data: { ...uplink, linkStatus: 0 } },
       radios: [],
     })

--- a/libs/plugins/arista-cv-cue/src/plugin.test.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { AristaCvCuePlugin, eventToAlert, mapEventSeverity } from './plugin.js'
+import { AristaCvCuePlugin, eventToAlert, mapEventSeverity, uplinkToLinkMetrics } from './plugin.js'
 
 describe('mapEventSeverity', () => {
   it('translates CV-CUE tokens to the neutral scale', () => {
@@ -49,6 +49,40 @@ describe('eventToAlert', () => {
       startTime: 42,
       labels: { category: '71' },
     })
+  })
+})
+
+describe('uplinkToLinkMetrics', () => {
+  const uplink = { name: 'eth0', linkStatus: 1, linkSpeed: 1000, switchChassisId: 'aa' }
+
+  it('derives in/out throughput from radios (down→in, up→out)', () => {
+    const m = uplinkToLinkMetrics({
+      uplinkWiredInterfacesInfo: { lan1Data: uplink },
+      radios: [
+        { downstreamUsage: 400, upstreamUsage: 100 },
+        { downstreamUsage: 100, upstreamUsage: 50 },
+      ],
+    })
+    expect(m).toMatchObject({ status: 'up', inBps: 500, outBps: 150 })
+    // 500 bps over a 1000 Mbps link → ~0%
+    expect(m.utilization).toBeCloseTo((500 / 1_000_000_000) * 100)
+  })
+
+  it('emits status only for an idle AP (no fake zero throughput)', () => {
+    const m = uplinkToLinkMetrics({
+      uplinkWiredInterfacesInfo: { lan1Data: uplink },
+      radios: [{ downstreamUsage: 0, upstreamUsage: 0 }],
+    })
+    expect(m).toEqual({ status: 'up' })
+    expect(m.inBps).toBeUndefined()
+  })
+
+  it('reports link down from linkStatus', () => {
+    const m = uplinkToLinkMetrics({
+      uplinkWiredInterfacesInfo: { lan1Data: { ...uplink, linkStatus: 0 } },
+      radios: [],
+    })
+    expect(m.status).toBe('down')
   })
 })
 

--- a/libs/plugins/arista-cv-cue/src/plugin.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.ts
@@ -368,6 +368,11 @@ function switchToMetrics(s: CvSwitch): NodeMetrics {
  * radios actually report some (idle APs get status only, never a fake 0).
  */
 export function uplinkToLinkMetrics(d: CvManagedDevice): LinkMetrics {
+  // A disconnected AP's uplink record is a stale snapshot (43/47 inactive APs
+  // on the JANOG58 tenant still reported linkStatus=1), so the AP's own
+  // liveness gates the verdict: no live AP → the uplink is not passing
+  // traffic → down.
+  if (!d.active) return { status: 'down' }
   const uplink = primaryUplink(d)
   const status: LinkMetrics['status'] = uplink
     ? uplink.linkStatus === 1

--- a/libs/plugins/arista-cv-cue/src/plugin.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.ts
@@ -25,14 +25,19 @@ import type {
   DataSourcePlugin,
   DiscoveredMetric,
   Host,
+  HostItem,
   HostsCapable,
+  LinkMetrics,
   MetricsCapable,
   MetricsData,
   MetricsMapping,
+  NetworkGraph,
   NodeMetrics,
+  TopologyCapable,
 } from '@shumoku/core'
 import { buildIdentity, flattenObject, severityAtLeast } from '@shumoku/core'
 import { AristaCvCueApi } from './api.js'
+import { buildTopology, primaryUplink } from './topology.js'
 import type {
   AristaCvCueConfig,
   CvEvent,
@@ -46,11 +51,16 @@ import type {
 const ALERT_EVENT_LIMIT = 300
 
 export class AristaCvCuePlugin
-  implements DataSourcePlugin, HostsCapable, MetricsCapable, AlertsCapable
+  implements DataSourcePlugin, HostsCapable, MetricsCapable, AlertsCapable, TopologyCapable
 {
   readonly type = 'arista-cv-cue'
   readonly displayName = 'Arista CV-CUE'
-  readonly capabilities: readonly DataSourceCapability[] = ['hosts', 'metrics', 'alerts']
+  readonly capabilities: readonly DataSourceCapability[] = [
+    'topology',
+    'hosts',
+    'metrics',
+    'alerts',
+  ]
 
   private api: AristaCvCueApi | null = null
   private config: AristaCvCueConfig | null = null
@@ -86,6 +96,22 @@ export class AristaCvCuePlugin
   }
 
   // ============================================================
+  // TopologyCapable — AP↔switch wired topology
+  // ============================================================
+
+  /**
+   * Emit the wireless-edge topology CV-CUE knows that a wired-inventory source
+   * doesn't: managed APs, their LLDP uplink switches, and the AP↔switch links.
+   * Composition merges the shared switch onto the wired source's node by
+   * identity (chassisId / sysName).
+   */
+  async fetchTopology(): Promise<NetworkGraph> {
+    if (!this.api) return { version: '1.0.0', name: 'Arista CV-CUE', nodes: [], links: [] }
+    const [aps, switches] = await Promise.all([this.fetchAps(), this.fetchSwitches()])
+    return buildTopology(aps, switches)
+  }
+
+  // ============================================================
   // HostsCapable — APs + uplink switches
   // ============================================================
 
@@ -118,14 +144,41 @@ export class AristaCvCuePlugin
     return sw ? flattenObject(sw, 'cvcue') : []
   }
 
+  /**
+   * Per-host interface items for the link-mapping UI. An AP has exactly one
+   * mappable link — its wired uplink to the switch — so we expose that port as
+   * an in/out pair (mirroring the net.if.in/out convention other plugins use).
+   * The interface name matches the port `fetchTopology` puts on the link, so
+   * auto-map binds the AP↔switch link to this item.
+   */
+  async getHostItems(hostId: string): Promise<HostItem[]> {
+    if (!this.api) return []
+    const ap = (await this.fetchAps()).find((d) => apId(d) === hostId)
+    if (!ap) return []
+    const uplink = primaryUplink(ap)
+    if (!uplink) return []
+    const ifaceName = uplink.name || 'uplink'
+    return (['in', 'out'] as const).map((direction) => ({
+      id: `${hostId}:uplink:${direction}`,
+      hostId,
+      name: `${ifaceName} ${direction === 'in' ? 'received' : 'sent'}`,
+      key: `cvcue.uplink.${direction}`,
+      interfaceName: ifaceName,
+      direction,
+    }))
+  }
+
   // ============================================================
-  // MetricsCapable — per-node status from the inventory snapshot
+  // MetricsCapable — per-node status + AP↔switch link status
   // ============================================================
 
   async pollMetrics(mapping: MetricsMapping): Promise<MetricsData> {
     const metrics: MetricsData = { nodes: {}, links: {}, timestamp: Date.now() }
     const hasMappedHost = Object.values(mapping.nodes ?? {}).some((n) => n.hostId)
-    if (!hasMappedHost || !this.api) return metrics
+    const hasMappedLink = Object.values(mapping.links ?? {}).some(
+      (l) => l.monitoredNodeId && l.interface,
+    )
+    if ((!hasMappedHost && !hasMappedLink) || !this.api) return metrics
 
     const [aps, switches] = await Promise.all([this.fetchAps(), this.fetchSwitches()])
     const apById = new Map<string, CvManagedDevice>()
@@ -137,6 +190,7 @@ export class AristaCvCuePlugin
     const swById = new Map<string, CvSwitch>()
     for (const s of switches) if (s.chassisId) swById.set(s.chassisId, s)
 
+    // ---- Nodes ----
     for (const [nodeId, nodeMapping] of Object.entries(mapping.nodes || {})) {
       const hostId = nodeMapping.hostId
       if (!hostId) continue
@@ -149,6 +203,20 @@ export class AristaCvCuePlugin
       // Stay silent on ids that aren't ours — another source may own the node,
       // and emitting a fake status here would clobber the real one on merge.
       if (sw) metrics.nodes[nodeId] = switchToMetrics(sw)
+    }
+
+    // ---- Links ----
+    // A link's metrics come from the AP its `monitoredNodeId` maps to — the AP
+    // owns the wired-uplink telemetry. CV-CUE exposes link up/down and speed but
+    // not live throughput, so we emit status only (no fake utilization).
+    for (const [linkId, linkMapping] of Object.entries(mapping.links || {})) {
+      const monitoredNodeId = linkMapping.monitoredNodeId
+      if (!monitoredNodeId || !linkMapping.interface) continue
+      const hostId = mapping.nodes[monitoredNodeId]?.hostId
+      if (!hostId) continue
+      const ap = apById.get(hostId)
+      if (!ap) continue // not ours — let another source answer
+      metrics.links[linkId] = uplinkToLinkMetrics(ap)
     }
     return metrics
   }
@@ -267,6 +335,18 @@ function switchToMetrics(s: CvSwitch): NodeMetrics {
     status: (s.numAps ?? 0) > 0 ? 'up' : 'unknown',
     monitoring: 'healthy',
   }
+}
+
+/**
+ * Link metrics for an AP↔switch uplink. CV-CUE reports the wired link's up/down
+ * (`linkStatus`) and negotiated speed, but not live throughput — so we emit
+ * status (and rate when known) and deliberately leave utilization/bps undefined
+ * rather than pretend a 0.
+ */
+function uplinkToLinkMetrics(d: CvManagedDevice): LinkMetrics {
+  const uplink = primaryUplink(d)
+  const up = uplink?.linkStatus === 1
+  return { status: uplink ? (up ? 'up' : 'down') : 'unknown' }
 }
 
 export function eventToAlert(e: CvEvent): Alert {

--- a/libs/plugins/arista-cv-cue/src/plugin.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.ts
@@ -42,6 +42,7 @@ import type {
   AristaCvCueConfig,
   CvEvent,
   CvEventsResponse,
+  CvLocation,
   CvManagedDevice,
   CvManagedDevicesResponse,
   CvSwitch,
@@ -107,8 +108,12 @@ export class AristaCvCuePlugin
    */
   async fetchTopology(): Promise<NetworkGraph> {
     if (!this.api) return { version: '1.0.0', name: 'Arista CV-CUE', nodes: [], links: [] }
-    const [aps, switches] = await Promise.all([this.fetchAps(), this.fetchSwitches()])
-    return buildTopology(aps, switches)
+    const [aps, switches, locations] = await Promise.all([
+      this.fetchAps(),
+      this.fetchSwitches(),
+      this.fetchLocations(),
+    ])
+    return buildTopology(aps, switches, locations)
   }
 
   // ============================================================
@@ -266,6 +271,18 @@ export class AristaCvCuePlugin
     // `/switches` returns a plain array (no paging envelope).
     const resp = await this.api.get<CvSwitch[] | { switches?: CvSwitch[] }>('/switches')
     return Array.isArray(resp) ? resp : (resp.switches ?? [])
+  }
+
+  /** The location tree (root with nested children); undefined if unavailable. */
+  private async fetchLocations(): Promise<CvLocation | undefined> {
+    if (!this.api) return undefined
+    try {
+      return await this.api.get<CvLocation>('/locations')
+    } catch {
+      // Locations are only used to group APs into zone subgraphs — a failure
+      // here should degrade to an ungrouped (but still valid) topology.
+      return undefined
+    }
   }
 }
 

--- a/libs/plugins/arista-cv-cue/src/plugin.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.ts
@@ -338,15 +338,49 @@ function switchToMetrics(s: CvSwitch): NodeMetrics {
 }
 
 /**
- * Link metrics for an AP↔switch uplink. CV-CUE reports the wired link's up/down
- * (`linkStatus`) and negotiated speed, but not live throughput — so we emit
- * status (and rate when known) and deliberately leave utilization/bps undefined
- * rather than pretend a 0.
+ * Link metrics for an AP↔switch uplink.
+ *
+ * Status comes from the wired link's `linkStatus`. Throughput is derived from
+ * the AP's radios: all client traffic rides the single uplink, so the uplink
+ * load ≈ the sum of per-radio usage. `downstreamUsage` (network→client) is the
+ * bytes arriving at the AP → link `in`; `upstreamUsage` (client→network) leaves
+ * the AP → link `out`. Utilization is vs the negotiated wired speed.
+ *
+ * CV-CUE's usage figures refresh periodically (not per-second) and their unit
+ * is undocumented — read as bps by magnitude. We only emit throughput when the
+ * radios actually report some (idle APs get status only, never a fake 0).
  */
-function uplinkToLinkMetrics(d: CvManagedDevice): LinkMetrics {
+export function uplinkToLinkMetrics(d: CvManagedDevice): LinkMetrics {
   const uplink = primaryUplink(d)
-  const up = uplink?.linkStatus === 1
-  return { status: uplink ? (up ? 'up' : 'down') : 'unknown' }
+  const status: LinkMetrics['status'] = uplink
+    ? uplink.linkStatus === 1
+      ? 'up'
+      : 'down'
+    : 'unknown'
+
+  let inBps = 0
+  let outBps = 0
+  for (const r of d.radios ?? []) {
+    inBps += r.downstreamUsage ?? 0
+    outBps += r.upstreamUsage ?? 0
+  }
+  if (inBps === 0 && outBps === 0) return { status }
+
+  const capacityBps = (uplink?.linkSpeed ?? d.uplinkWiredInterfacesInfo?.sensorLinkSpeed ?? 0) * 1e6
+  const util = (bps: number): number | undefined =>
+    capacityBps > 0 ? Math.min(100, (bps / capacityBps) * 100) : undefined
+  const inUtil = util(inBps)
+  const outUtil = util(outBps)
+  return {
+    status,
+    inBps,
+    outBps,
+    ...(inUtil !== undefined ? { inUtilization: inUtil } : {}),
+    ...(outUtil !== undefined ? { outUtilization: outUtil } : {}),
+    ...(inUtil !== undefined && outUtil !== undefined
+      ? { utilization: Math.max(inUtil, outUtil) }
+      : {}),
+  }
 }
 
 export function eventToAlert(e: CvEvent): Alert {

--- a/libs/plugins/arista-cv-cue/src/plugin.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.ts
@@ -369,10 +369,13 @@ function switchToMetrics(s: CvSwitch): NodeMetrics {
  */
 export function uplinkToLinkMetrics(d: CvManagedDevice): LinkMetrics {
   // A disconnected AP's uplink record is a stale snapshot (43/47 inactive APs
-  // on the JANOG58 tenant still reported linkStatus=1), so the AP's own
-  // liveness gates the verdict: no live AP → the uplink is not passing
-  // traffic → down.
-  if (!d.active) return { status: 'down' }
+  // on the JANOG58 tenant still reported linkStatus=1), so we can't trust it.
+  // But an AP that isn't checking in is *absence of data*, not a confirmed link
+  // failure: report 'unknown' (renders idle/gray) rather than 'down' (red), so
+  // an unreachable AP doesn't masquerade as a downed uplink. The AP node itself
+  // still reports 'down' — that verdict is real (the controller sees it offline);
+  // the wired uplink's actual state simply isn't known while the AP is dark.
+  if (!d.active) return { status: 'unknown' }
   const uplink = primaryUplink(d)
   const status: LinkMetrics['status'] = uplink
     ? uplink.linkStatus === 1

--- a/libs/plugins/arista-cv-cue/src/plugin.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.ts
@@ -1,0 +1,315 @@
+/**
+ * Arista CV-CUE (CloudVision Cognitive Unified Edge) data-source plugin.
+ *
+ * CV-CUE can't push telemetry out, so metrics come from polling its Open API
+ * (`/wifi/api`). Modeled on the Aruba Instant On plugin: one inventory fetch
+ * feeds several capabilities.
+ *
+ * Plugin scope (v1):
+ *   - hosts: managed APs + LLDP-discovered uplink switches
+ *   - metrics: per-node up/down from device `active`, last-seen
+ *   - alerts: CV-CUE events mapped to our Alert shape
+ *   - nativeApi: dev-only raw passthrough
+ *
+ * Topology (AP↔switch edges via `uplinkWiredInterfacesInfo`) and live link
+ * throughput are a deliberate phase-2 follow-up.
+ */
+
+import type {
+  Alert,
+  AlertQueryOptions,
+  AlertSeverity,
+  AlertsCapable,
+  ConnectionResult,
+  DataSourceCapability,
+  DataSourcePlugin,
+  DiscoveredMetric,
+  Host,
+  HostsCapable,
+  MetricsCapable,
+  MetricsData,
+  MetricsMapping,
+  NodeMetrics,
+} from '@shumoku/core'
+import { buildIdentity, flattenObject, severityAtLeast } from '@shumoku/core'
+import { AristaCvCueApi } from './api.js'
+import type {
+  AristaCvCueConfig,
+  CvEvent,
+  CvEventsResponse,
+  CvManagedDevice,
+  CvManagedDevicesResponse,
+  CvSwitch,
+} from './types.js'
+
+/** How many recent events to scan when surfacing alerts. */
+const ALERT_EVENT_LIMIT = 300
+
+export class AristaCvCuePlugin
+  implements DataSourcePlugin, HostsCapable, MetricsCapable, AlertsCapable
+{
+  readonly type = 'arista-cv-cue'
+  readonly displayName = 'Arista CV-CUE'
+  readonly capabilities: readonly DataSourceCapability[] = ['hosts', 'metrics', 'alerts']
+
+  private api: AristaCvCueApi | null = null
+  private config: AristaCvCueConfig | null = null
+
+  initialize(config: unknown): void {
+    const c = config as Partial<AristaCvCueConfig>
+    if (!c.baseUrl || !c.keyId || !c.keyValue) {
+      throw new Error('Arista CV-CUE plugin requires `baseUrl`, `keyId`, and `keyValue` in config')
+    }
+    this.config = c as AristaCvCueConfig
+    this.api = new AristaCvCueApi(this.config)
+  }
+
+  dispose(): void {
+    this.config = null
+    this.api = null
+  }
+
+  async testConnection(): Promise<ConnectionResult> {
+    if (!this.api) return { success: false, message: 'Plugin not initialized' }
+    try {
+      const page = await this.api.get<CvManagedDevicesResponse>('/manageddevices/aps', {
+        pagesize: 1,
+      })
+      const total = page.totalCount ?? page.managedDevices?.length ?? 0
+      return {
+        success: true,
+        message: `Connected to Arista CV-CUE (${total} managed AP${total === 1 ? '' : 's'})`,
+      }
+    } catch (err) {
+      return { success: false, message: err instanceof Error ? err.message : 'Connection failed' }
+    }
+  }
+
+  // ============================================================
+  // HostsCapable — APs + uplink switches
+  // ============================================================
+
+  async getHosts(): Promise<Host[]> {
+    if (!this.api) return []
+    const [aps, switches] = await Promise.all([this.fetchAps(), this.fetchSwitches()])
+    const out: Host[] = []
+    for (const d of aps) {
+      const host = apToHost(d)
+      if (host) out.push(host)
+    }
+    for (const s of switches) {
+      const host = switchToHost(s)
+      if (host) out.push(host)
+    }
+    return out
+  }
+
+  /**
+   * Dump every primitive field of the AP's inventory record for the node-detail
+   * "All metrics" panel. Passthrough by design — new CV-CUE fields surface
+   * automatically and an empty list genuinely means "no record for this id".
+   */
+  async discoverMetrics(hostId: string): Promise<DiscoveredMetric[]> {
+    if (!this.api) return []
+    const aps = await this.fetchAps()
+    const ap = aps.find((d) => apId(d) === hostId)
+    if (ap) return flattenObject(ap, 'cvcue')
+    const sw = (await this.fetchSwitches()).find((s) => s.chassisId === hostId)
+    return sw ? flattenObject(sw, 'cvcue') : []
+  }
+
+  // ============================================================
+  // MetricsCapable — per-node status from the inventory snapshot
+  // ============================================================
+
+  async pollMetrics(mapping: MetricsMapping): Promise<MetricsData> {
+    const metrics: MetricsData = { nodes: {}, links: {}, timestamp: Date.now() }
+    const hasMappedHost = Object.values(mapping.nodes ?? {}).some((n) => n.hostId)
+    if (!hasMappedHost || !this.api) return metrics
+
+    const [aps, switches] = await Promise.all([this.fetchAps(), this.fetchSwitches()])
+    const apById = new Map<string, CvManagedDevice>()
+    for (const d of aps) {
+      const id = apId(d)
+      if (id) apById.set(id, d)
+      if (d.macaddress) apById.set(d.macaddress, d)
+    }
+    const swById = new Map<string, CvSwitch>()
+    for (const s of switches) if (s.chassisId) swById.set(s.chassisId, s)
+
+    for (const [nodeId, nodeMapping] of Object.entries(mapping.nodes || {})) {
+      const hostId = nodeMapping.hostId
+      if (!hostId) continue
+      const ap = apById.get(hostId)
+      if (ap) {
+        metrics.nodes[nodeId] = apToMetrics(ap)
+        continue
+      }
+      const sw = swById.get(hostId)
+      // Stay silent on ids that aren't ours — another source may own the node,
+      // and emitting a fake status here would clobber the real one on merge.
+      if (sw) metrics.nodes[nodeId] = switchToMetrics(sw)
+    }
+    return metrics
+  }
+
+  // ============================================================
+  // AlertsCapable — CV-CUE events
+  // ============================================================
+
+  async getAlerts(options?: AlertQueryOptions): Promise<Alert[]> {
+    if (!this.api) return []
+    const events = await this.api.getPaged<CvEvent, CvEventsResponse>(
+      '/events',
+      (p) => p.eventList ?? [],
+      undefined,
+      { pageSize: 100, maxItems: ALERT_EVENT_LIMIT },
+    )
+    // CV-CUE's `deleted` flag is set on ~every event (a retention marker, not a
+    // "hide me" signal), so it isn't a filter. Active vs resolved comes from
+    // `activityStatus`; option filtering matches the other plugins.
+    const cutoff = Date.now() - (options?.timeRange ?? 3600) * 1000
+    const out: Alert[] = []
+    for (const e of events) {
+      const alert = eventToAlert(e)
+      if (options?.activeOnly && alert.status !== 'active') continue
+      if (options?.minSeverity && !severityAtLeast(alert.severity, options.minSeverity)) continue
+      // Keep active alerts regardless of age; window-filter the historical ones.
+      if (alert.status !== 'active' && alert.startTime < cutoff) continue
+      out.push(alert)
+    }
+    return out
+  }
+
+  // ============================================================
+  // Internals
+  // ============================================================
+
+  private async fetchAps(): Promise<CvManagedDevice[]> {
+    if (!this.api) return []
+    return this.api.getPaged<CvManagedDevice, CvManagedDevicesResponse>(
+      '/manageddevices/aps',
+      (p) => p.managedDevices ?? [],
+    )
+  }
+
+  private async fetchSwitches(): Promise<CvSwitch[]> {
+    if (!this.api) return []
+    // `/switches` returns a plain array (no paging envelope).
+    const resp = await this.api.get<CvSwitch[] | { switches?: CvSwitch[] }>('/switches')
+    return Array.isArray(resp) ? resp : (resp.switches ?? [])
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (upstream vocab → core vocab at the boundary)
+// ---------------------------------------------------------------------------
+
+/** Stable id for an AP: CV-CUE boxId, falling back to its MAC. */
+function apId(d: CvManagedDevice): string | undefined {
+  return d.boxId !== undefined ? String(d.boxId) : d.macaddress
+}
+
+function apToHost(d: CvManagedDevice): Host | null {
+  const id = apId(d)
+  if (!id) return null
+  // The AP `name` is operator-editable (a display string), so it stays out of
+  // sysName; the MAC + management IP are the stable machine keys.
+  const identity = buildIdentity({
+    mgmtIp: d.ipAddress,
+    mac: d.macaddress,
+    vendorIds: d.boxId !== undefined ? { 'cvcue-boxid': String(d.boxId) } : undefined,
+  })
+  return {
+    id,
+    name: d.name || id,
+    ...(d.name ? { displayName: d.name } : {}),
+    status: d.active ? 'up' : 'down',
+    ...(d.ipAddress ? { ip: d.ipAddress } : {}),
+    ...(identity ? { identity } : {}),
+  }
+}
+
+function switchToHost(s: CvSwitch): Host | null {
+  if (!s.chassisId) return null
+  // Switches are discovered via the LLDP neighbor of AP uplinks, so `name` is
+  // the switch's self-reported (LLDP) system name — a valid sysName. The
+  // chassis id is the strong cross-source key.
+  const identity = buildIdentity({
+    chassisId: s.chassisId,
+    ...(s.name ? { sysName: s.name } : {}),
+    vendorIds: { 'cvcue-switch-chassis': s.chassisId },
+  })
+  return {
+    id: s.chassisId,
+    name: s.name || s.chassisId,
+    // No direct health in the switch list; treat "has connected APs" as alive
+    // and otherwise leave it unknown rather than pretend.
+    status: (s.numAps ?? 0) > 0 ? 'up' : 'unknown',
+    ...(identity ? { identity } : {}),
+  }
+}
+
+function apToMetrics(d: CvManagedDevice): NodeMetrics {
+  const lastSeen =
+    typeof d.lastUpdateTime === 'number' && d.lastUpdateTime > 0 ? d.lastUpdateTime : undefined
+  return {
+    status: d.active ? 'up' : 'down',
+    // Cloud-managed: if we can read the inventory, our monitoring path is fine.
+    // The device's `active` flag carries the actual up/down verdict.
+    monitoring: 'healthy',
+    ...(lastSeen !== undefined ? { lastSeen } : {}),
+  }
+}
+
+function switchToMetrics(s: CvSwitch): NodeMetrics {
+  return {
+    status: (s.numAps ?? 0) > 0 ? 'up' : 'unknown',
+    monitoring: 'healthy',
+  }
+}
+
+export function eventToAlert(e: CvEvent): Alert {
+  // `LIVE` = an ongoing condition (an active alert). `EXPIRED` = a condition
+  // that has ended; `INSTANTANEOUS` = a point-in-time event. Neither of the
+  // latter is an ongoing alarm, so both map to `resolved`.
+  const active = (e.activityStatus ?? '').toUpperCase() === 'LIVE'
+  const endTime = typeof e.stopTime === 'number' && e.stopTime > 0 ? e.stopTime : undefined
+  return {
+    id: String(e.id ?? `${e.startTime ?? 0}-${e.minorType ?? ''}`),
+    severity: mapEventSeverity(e.eventSeverity),
+    title: e.summary || String(e.minorType ?? e.category ?? 'CV-CUE event'),
+    ...(e.description ? { description: e.description } : {}),
+    startTime: typeof e.startTime === 'number' ? e.startTime : Date.now(),
+    ...(!active && endTime !== undefined ? { endTime } : {}),
+    status: active ? 'active' : 'resolved',
+    source: 'arista-cv-cue',
+    ...(e.category ? { labels: { category: String(e.category) } } : {}),
+  }
+}
+
+/** CV-CUE severity token → core's neutral CVSS-style scale. */
+export function mapEventSeverity(raw: string | undefined): AlertSeverity {
+  switch ((raw ?? '').toUpperCase()) {
+    case 'CRITICAL':
+      return 'critical'
+    case 'HIGH':
+    case 'MAJOR':
+      return 'high'
+    case 'MEDIUM':
+    case 'AVERAGE':
+      return 'medium'
+    case 'LOW':
+    case 'MINOR':
+    case 'WARNING':
+      return 'low'
+    case 'INFO':
+    case 'INFORMATION':
+      return 'info'
+    case 'OK':
+    case 'NONE':
+      return 'ok'
+    default:
+      return 'info'
+  }
+}

--- a/libs/plugins/arista-cv-cue/src/topology.test.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.test.ts
@@ -67,6 +67,13 @@ describe('buildTopology', () => {
     expect(result.portsMissingIfName).toEqual([])
   })
 
+  it('drops the uplink link (but keeps the node) for an inactive AP — stale LLDP', () => {
+    const stale = { ...AP, active: false }
+    const g = buildTopology([stale], [SWITCH])
+    expect(g.nodes.filter((n) => n.spec?.type === 'access-point')).toHaveLength(1)
+    expect(g.links).toHaveLength(0)
+  })
+
   it('groups APs into nested location subgraphs (switches stay unparented)', () => {
     const ap = { ...AP, locationId: { type: 'locallocationid', id: 57 } }
     const locations = {

--- a/libs/plugins/arista-cv-cue/src/topology.test.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.test.ts
@@ -67,9 +67,33 @@ describe('buildTopology', () => {
     expect(result.portsMissingIfName).toEqual([])
   })
 
-  it('drops the uplink link (but keeps the node) for an inactive AP — stale LLDP', () => {
+  it('still emits an inactive AP that reports a real switch (link kept)', () => {
+    // A dormant AP whose last-known uplink is a real switch keeps its edge; its
+    // down/stale state is a poll-time concern (uplinkToLinkMetrics).
     const stale = { ...AP, active: false }
     const g = buildTopology([stale], [SWITCH])
+    expect(g.nodes.filter((n) => n.spec?.type === 'access-point')).toHaveLength(1)
+    expect(g.links).toHaveLength(1)
+  })
+
+  it('drops the phantom "localhost" uplink but keeps the AP node', () => {
+    // Pre-recabling APs report switchName:"localhost" — a switch that does not
+    // exist. We must not draw that cable (wrong + unroutable), but the AP still
+    // renders (it rejoins the fabric once it comes online and reports a real
+    // switch).
+    const phantom: CvManagedDevice = {
+      ...AP,
+      active: false,
+      uplinkWiredInterfacesInfo: {
+        lan1Data: {
+          name: 'eth0',
+          linkStatus: 1,
+          switchName: 'localhost',
+          switchChassisId: '00:00:00:00:00:00',
+        },
+      },
+    }
+    const g = buildTopology([phantom], [])
     expect(g.nodes.filter((n) => n.spec?.type === 'access-point')).toHaveLength(1)
     expect(g.links).toHaveLength(0)
   })

--- a/libs/plugins/arista-cv-cue/src/topology.test.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.test.ts
@@ -66,4 +66,25 @@ describe('buildTopology', () => {
     expect(result.nodesMissingIdentity).toEqual([])
     expect(result.portsMissingIfName).toEqual([])
   })
+
+  it('groups APs into nested location subgraphs (switches stay unparented)', () => {
+    const ap = { ...AP, locationId: { type: 'locallocationid', id: 57 } }
+    const locations = {
+      id: 0,
+      name: 'root',
+      children: [{ id: 32, name: 'kenbun', children: [{ id: 57, name: '1F' }] }],
+    }
+    const g = buildTopology([ap], [SWITCH], locations)
+    const apNode = g.nodes.find((n) => n.spec?.type === 'access-point')
+    const swNode = g.nodes.find((n) => n.spec?.type === 'l2-switch')
+    // AP parented into its floor; switch left unparented so it merges by identity.
+    expect(apNode?.parent).toBe('cvcue-loc:57')
+    expect(swNode?.parent).toBeUndefined()
+    // The floor subgraph is nested under the building, both carry region identity.
+    const floor = g.subgraphs?.find((s) => s.id === 'cvcue-loc:57')
+    const building = g.subgraphs?.find((s) => s.id === 'cvcue-loc:32')
+    expect(floor).toMatchObject({ label: '1F', parent: 'cvcue-loc:32', identity: { name: '1F' } })
+    expect(building).toMatchObject({ label: 'kenbun', identity: { name: 'kenbun' } })
+    expect(building?.parent).toBeUndefined()
+  })
 })

--- a/libs/plugins/arista-cv-cue/src/topology.test.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.test.ts
@@ -1,0 +1,69 @@
+import { validateTopologyIdentityContract } from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import { buildTopology } from './topology.js'
+import type { CvManagedDevice, CvSwitch } from './types.js'
+
+const AP: CvManagedDevice = {
+  boxId: 4,
+  name: 'j58-2f-pub-ap-02',
+  macaddress: '30:86:2D:83:BE:BF',
+  model: 'C-250',
+  vendorName: 'Arista',
+  ipAddress: '192.168.11.53',
+  active: true,
+  uplinkWiredInterfacesInfo: {
+    sensorLanPortName: 'LAN1',
+    sensorLinkSpeed: 10000,
+    lan1Data: {
+      name: 'eth0',
+      primaryInterface: true,
+      linkStatus: 1,
+      linkSpeed: 10000,
+      switchName: 'j58-test-AP-PoESW-01',
+      switchPortId: 'Ethernet13',
+      switchChassisId: 'e0:fa:5b:71:ff:75',
+      switchVendor: 'AristaNe',
+    },
+  },
+}
+
+const SWITCH: CvSwitch = {
+  name: 'j58-test-AP-PoESW-01',
+  vendor: 'AristaNe',
+  chassisId: 'e0:fa:5b:71:ff:75',
+  numAps: 48,
+}
+
+describe('buildTopology', () => {
+  it('emits AP + switch nodes and the AP↔switch link', () => {
+    const g = buildTopology([AP], [SWITCH])
+    expect(g.nodes).toHaveLength(2)
+    const ap = g.nodes.find((n) => n.spec?.type === 'access-point')
+    const sw = g.nodes.find((n) => n.spec?.type === 'l2-switch')
+    expect(ap?.identity).toMatchObject({ mgmtIp: '192.168.11.53', mac: '30:86:2D:83:BE:BF' })
+    expect(sw?.identity).toMatchObject({
+      chassisId: 'e0:fa:5b:71:ff:75',
+      sysName: 'j58-test-AP-PoESW-01',
+    })
+    expect(g.links).toHaveLength(1)
+    const link = g.links[0]
+    expect(link?.from.node).toBe(ap?.id)
+    expect(link?.from.port).toBe('eth0')
+    expect(link?.to.node).toBe(sw?.id)
+    expect(link?.to.port).toBe('Ethernet13')
+    expect(link?.rateBps).toBe(10_000 * 1_000_000)
+  })
+
+  it('does not duplicate a switch seeded by /switches and referenced by an uplink', () => {
+    const g = buildTopology([AP], [SWITCH])
+    const switches = g.nodes.filter((n) => n.spec?.type === 'l2-switch')
+    expect(switches).toHaveLength(1)
+  })
+
+  it('satisfies the topology identity contract', () => {
+    const g = buildTopology([AP], [SWITCH])
+    const result = validateTopologyIdentityContract(g)
+    expect(result.nodesMissingIdentity).toEqual([])
+    expect(result.portsMissingIfName).toEqual([])
+  })
+})

--- a/libs/plugins/arista-cv-cue/src/topology.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.ts
@@ -152,7 +152,14 @@ export function buildTopology(
       },
     })
 
-    const uplink = primaryUplink(ap)
+    // A disconnected AP's uplink info is a STALE snapshot — on the JANOG58
+    // tenant, 44 inactive APs all reported `switchName: "localhost"` and piled
+    // onto 7 phantom ports (their pre-recabling state), while every active AP
+    // reported a real, unique switch port. Drawing those would paint wrong
+    // cabling, so only live APs contribute links; the AP node itself stays
+    // (grouped in its zone, shown down) and the cable reappears on the next
+    // sync after the AP comes back.
+    const uplink = ap.active ? primaryUplink(ap) : undefined
     if (uplink?.switchChassisId) {
       ensureSwitch(uplink.switchChassisId, uplink.switchName, uplink.switchVendor)
       const speedMbps = uplink.linkSpeed ?? ap.uplinkWiredInterfacesInfo?.sensorLinkSpeed

--- a/libs/plugins/arista-cv-cue/src/topology.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.ts
@@ -5,9 +5,43 @@
  * identity (the shared PoE switch collapses onto the NetBox switch node).
  */
 
-import type { Link, NetworkGraph, Node } from '@shumoku/core'
+import type { Link, NetworkGraph, Node, Subgraph } from '@shumoku/core'
 import { buildIdentity, DeviceType } from '@shumoku/core'
-import type { CvManagedDevice, CvSwitch, CvUplinkLanData } from './types.js'
+import type {
+  CvLocation,
+  CvLocationRef,
+  CvManagedDevice,
+  CvSwitch,
+  CvUplinkLanData,
+} from './types.js'
+
+/** Extract the numeric location id from a `{ id }` ref or a bare number. */
+function locId(ref: CvLocationRef | number | undefined): number | undefined {
+  if (typeof ref === 'number') return ref
+  return ref?.id
+}
+
+interface LocInfo {
+  name: string
+  parent: number | undefined
+}
+
+/** Flatten the CV-CUE location tree into id → { name, parentId }. */
+function indexLocations(root: CvLocation | undefined): Map<number, LocInfo> {
+  const index = new Map<number, LocInfo>()
+  const walk = (node: CvLocation | undefined, parent: number | undefined): void => {
+    if (!node) return
+    const id = locId(node.id)
+    if (id !== undefined && id !== 0) index.set(id, { name: node.name ?? String(id), parent })
+    for (const child of node.children ?? []) walk(child, id)
+  }
+  walk(root, undefined)
+  return index
+}
+
+function locSubgraphId(id: number): string {
+  return `cvcue-loc:${id}`
+}
 
 /** Node id for a switch, derived from its (stable) LLDP chassis id. */
 function switchNodeId(chassisId: string): string {
@@ -32,10 +66,37 @@ export function primaryUplink(d: CvManagedDevice): CvUplinkLanData | undefined {
   return candidates.find((l) => l.switchChassisId) ?? candidates.find((l) => l.primaryInterface)
 }
 
-export function buildTopology(aps: CvManagedDevice[], switches: CvSwitch[]): NetworkGraph {
+export function buildTopology(
+  aps: CvManagedDevice[],
+  switches: CvSwitch[],
+  locations?: CvLocation,
+): NetworkGraph {
   const nodes: Node[] = []
   const links: Link[] = []
+  const subgraphs: Subgraph[] = []
   const emittedSwitch = new Set<string>()
+
+  // Location subgraphs so APs group into their floor/zone instead of floating.
+  // `identity: { name }` lets a wired source that names the same zone merge the
+  // box (once it exposes subgraph identity); until then these are CV-CUE boxes.
+  const locIndex = indexLocations(locations)
+  const emittedLoc = new Set<number>()
+  const ensureLocation = (id: number | undefined): string | undefined => {
+    if (id === undefined) return undefined
+    const info = locIndex.get(id)
+    if (!info) return undefined
+    if (!emittedLoc.has(id)) {
+      emittedLoc.add(id)
+      const parentSg = ensureLocation(info.parent) // materialize ancestors first
+      subgraphs.push({
+        id: locSubgraphId(id),
+        label: info.name,
+        identity: { name: info.name },
+        ...(parentSg ? { parent: parentSg } : {}),
+      })
+    }
+    return locSubgraphId(id)
+  }
 
   const ensureSwitch = (chassisId: string, name?: string, vendor?: string): void => {
     const key = chassisId.toLowerCase()
@@ -70,9 +131,14 @@ export function buildTopology(aps: CvManagedDevice[], switches: CvSwitch[]): Net
     const key = apKey(ap)
     if (!key) continue
     const nodeId = apNodeId(key)
+    // Group the AP into its floor/zone. Switches deliberately get NO parent so
+    // they merge onto the wired source's switch node (and keep its zone); the
+    // AP is the node the wired inventory doesn't have, so it needs a home here.
+    const parent = ensureLocation(locId(ap.locationId))
     nodes.push({
       id: nodeId,
       label: [ap.name || key],
+      ...(parent ? { parent } : {}),
       identity: buildIdentity({
         mgmtIp: ap.ipAddress,
         mac: ap.macaddress,
@@ -102,5 +168,11 @@ export function buildTopology(aps: CvManagedDevice[], switches: CvSwitch[]): Net
     }
   }
 
-  return { version: '1.0.0', name: 'Arista CV-CUE', nodes, links }
+  return {
+    version: '1.0.0',
+    name: 'Arista CV-CUE',
+    nodes,
+    links,
+    ...(subgraphs.length > 0 ? { subgraphs } : {}),
+  }
 }

--- a/libs/plugins/arista-cv-cue/src/topology.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.ts
@@ -1,0 +1,106 @@
+/**
+ * Build a CV-CUE topology fragment: managed APs, their LLDP-discovered uplink
+ * switches, and the AP↔switch wired links. This is the piece a wired-inventory
+ * source (NetBox, Zabbix) doesn't have; shumoku's composition merges it in by
+ * identity (the shared PoE switch collapses onto the NetBox switch node).
+ */
+
+import type { Link, NetworkGraph, Node } from '@shumoku/core'
+import { buildIdentity, DeviceType } from '@shumoku/core'
+import type { CvManagedDevice, CvSwitch, CvUplinkLanData } from './types.js'
+
+/** Node id for a switch, derived from its (stable) LLDP chassis id. */
+function switchNodeId(chassisId: string): string {
+  return `cvcue-sw:${chassisId.toLowerCase()}`
+}
+
+/** Node id for an AP. */
+function apNodeId(boxIdOrMac: string): string {
+  return `cvcue-ap:${boxIdOrMac}`
+}
+
+/** Stable id for an AP (boxId, else MAC) — the same key getHosts uses. */
+function apKey(d: CvManagedDevice): string | undefined {
+  return d.boxId !== undefined ? String(d.boxId) : d.macaddress
+}
+
+/** The AP's primary wired uplink (the LAN port that carries the switch link). */
+export function primaryUplink(d: CvManagedDevice): CvUplinkLanData | undefined {
+  const up = d.uplinkWiredInterfacesInfo
+  if (!up) return undefined
+  const candidates = [up.lan1Data, up.lan2Data].filter((l): l is CvUplinkLanData => !!l)
+  return candidates.find((l) => l.switchChassisId) ?? candidates.find((l) => l.primaryInterface)
+}
+
+export function buildTopology(aps: CvManagedDevice[], switches: CvSwitch[]): NetworkGraph {
+  const nodes: Node[] = []
+  const links: Link[] = []
+  const emittedSwitch = new Set<string>()
+
+  const ensureSwitch = (chassisId: string, name?: string, vendor?: string): void => {
+    const key = chassisId.toLowerCase()
+    if (emittedSwitch.has(key)) return
+    emittedSwitch.add(key)
+    nodes.push({
+      id: switchNodeId(chassisId),
+      label: [name || chassisId],
+      // chassisId is the LLDP chassis id (strong cross-source key); the LLDP
+      // system name is self-reported, so it's a valid sysName for merging onto
+      // a NetBox/Zabbix switch node.
+      identity: buildIdentity({
+        chassisId,
+        ...(name ? { sysName: name } : {}),
+        vendorIds: { 'cvcue-switch-chassis': chassisId },
+      }),
+      spec: {
+        kind: 'hardware',
+        type: DeviceType.L2Switch,
+        ...(vendor ? { vendor: vendor.toLowerCase() } : {}),
+      },
+    })
+  }
+
+  // Seed switch nodes from the /switches inventory (so switches with no AP in
+  // this scope still appear), then AP uplinks fill in / attach edges.
+  for (const s of switches) {
+    if (s.chassisId) ensureSwitch(s.chassisId, s.name, s.vendor)
+  }
+
+  for (const ap of aps) {
+    const key = apKey(ap)
+    if (!key) continue
+    const nodeId = apNodeId(key)
+    nodes.push({
+      id: nodeId,
+      label: [ap.name || key],
+      identity: buildIdentity({
+        mgmtIp: ap.ipAddress,
+        mac: ap.macaddress,
+        vendorIds: ap.boxId !== undefined ? { 'cvcue-boxid': String(ap.boxId) } : undefined,
+      }),
+      spec: {
+        kind: 'hardware',
+        type: DeviceType.AccessPoint,
+        ...(ap.model ? { model: ap.model.toLowerCase() } : {}),
+        ...(ap.vendorName ? { vendor: ap.vendorName.toLowerCase() } : {}),
+      },
+    })
+
+    const uplink = primaryUplink(ap)
+    if (uplink?.switchChassisId) {
+      ensureSwitch(uplink.switchChassisId, uplink.switchName, uplink.switchVendor)
+      const speedMbps = uplink.linkSpeed ?? ap.uplinkWiredInterfacesInfo?.sensorLinkSpeed
+      links.push({
+        id: `cvcue-link:${nodeId}`,
+        // The AP-side port name doubles as the mappable interface (getHostItems
+        // exposes the same name), so link metrics can bind to it.
+        from: { node: nodeId, port: uplink.name || 'uplink' },
+        to: { node: switchNodeId(uplink.switchChassisId), port: uplink.switchPortId || '' },
+        arrow: 'none',
+        ...(speedMbps ? { rateBps: speedMbps * 1_000_000 } : {}),
+      })
+    }
+  }
+
+  return { version: '1.0.0', name: 'Arista CV-CUE', nodes, links }
+}

--- a/libs/plugins/arista-cv-cue/src/topology.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.ts
@@ -152,15 +152,16 @@ export function buildTopology(
       },
     })
 
-    // A disconnected AP's uplink info is a STALE snapshot — on the JANOG58
-    // tenant, 44 inactive APs all reported `switchName: "localhost"` and piled
-    // onto 7 phantom ports (their pre-recabling state), while every active AP
-    // reported a real, unique switch port. Drawing those would paint wrong
-    // cabling, so only live APs contribute links; the AP node itself stays
-    // (grouped in its zone, shown down) and the cable reappears on the next
-    // sync after the AP comes back.
-    const uplink = ap.active ? primaryUplink(ap) : undefined
-    if (uplink?.switchChassisId) {
+    // Emit the AP's wired uplink — but skip the phantom `localhost` switch. An
+    // inactive AP's `uplinkWiredInterfacesInfo` is a frozen pre-recabling
+    // snapshot: 44 dormant APs all report `switchName:"localhost"` fanning into
+    // a handful of shared phantom ports, which is both wrong (that switch does
+    // not exist) and unroutable (many links into one port → Bezier curve storm).
+    // A live AP reports its real switch; only real uplinks become edges. APs
+    // left link-less this way still render (hideDisconnected is off for this
+    // topology) and rejoin the fabric once they come online.
+    const uplink = primaryUplink(ap)
+    if (uplink?.switchChassisId && uplink.switchName?.toLowerCase() !== 'localhost') {
       ensureSwitch(uplink.switchChassisId, uplink.switchName, uplink.switchVendor)
       const speedMbps = uplink.linkSpeed ?? ap.uplinkWiredInterfacesInfo?.sensorLinkSpeed
       links.push({

--- a/libs/plugins/arista-cv-cue/src/types.ts
+++ b/libs/plugins/arista-cv-cue/src/types.ts
@@ -75,8 +75,31 @@ export interface CvManagedDevice {
   /** CPU / memory utilization counters (units are CV-CUE-defined). */
   healthStats?: Record<string, number>
   radios?: unknown[]
-  /** Wired uplink info (LLDP neighbor switch + port), used for topology later. */
-  uplinkWiredInterfacesInfo?: Record<string, unknown>
+  /** Wired uplink info (LLDP neighbor switch + port), used for topology. */
+  uplinkWiredInterfacesInfo?: CvUplinkInfo
+}
+
+/** Per-LAN-port uplink detail; carries the LLDP neighbor switch/port. */
+export interface CvUplinkLanData {
+  /** AP-side interface name, e.g. `eth0`. */
+  name?: string
+  primaryInterface?: boolean
+  /** 1 = up. */
+  linkStatus?: number
+  /** Negotiated link speed in Mbps. */
+  linkSpeed?: number
+  /** LLDP neighbor (upstream switch). */
+  switchName?: string
+  switchPortId?: string
+  switchChassisId?: string
+  switchVendor?: string
+}
+
+export interface CvUplinkInfo {
+  sensorLanPortName?: string
+  sensorLinkSpeed?: number
+  lan1Data?: CvUplinkLanData
+  lan2Data?: CvUplinkLanData
 }
 
 // ----- Switches -----------------------------------------------------------

--- a/libs/plugins/arista-cv-cue/src/types.ts
+++ b/libs/plugins/arista-cv-cue/src/types.ts
@@ -74,9 +74,24 @@ export interface CvManagedDevice {
   numEthernetPorts?: number
   /** CPU / memory utilization counters (units are CV-CUE-defined). */
   healthStats?: Record<string, number>
-  radios?: unknown[]
+  radios?: CvRadio[]
   /** Wired uplink info (LLDP neighbor switch + port), used for topology. */
   uplinkWiredInterfacesInfo?: CvUplinkInfo
+}
+
+/**
+ * Per-radio live counters. `upstreamUsage` (client→network) and
+ * `downstreamUsage` (network→client) are CV-CUE's throughput figures; they
+ * refresh periodically (not per-second). Unit is undocumented — by magnitude it
+ * reads as bits-per-second, which is what the plugin assumes.
+ */
+export interface CvRadio {
+  radioId?: number
+  active?: boolean
+  operatingBand?: string
+  upstreamUsage?: number
+  downstreamUsage?: number
+  rfUtilization?: number
 }
 
 /** Per-LAN-port uplink detail; carries the LLDP neighbor switch/port. */

--- a/libs/plugins/arista-cv-cue/src/types.ts
+++ b/libs/plugins/arista-cv-cue/src/types.ts
@@ -50,11 +50,17 @@ export interface CvManagedDevicesResponse extends CvPaged {
   managedDevices?: CvManagedDevice[]
 }
 
+/** CV-CUE location reference — `{ type, id }` where `id` is the numeric node id. */
+export interface CvLocationRef {
+  type?: string
+  id?: number
+}
+
 export interface CvManagedDevice {
   /** Stable per-device id in CV-CUE. */
   boxId?: number
   name?: string
-  locationId?: number
+  locationId?: CvLocationRef
   macaddress?: string
   model?: string
   vendorName?: string
@@ -115,6 +121,17 @@ export interface CvUplinkInfo {
   sensorLinkSpeed?: number
   lan1Data?: CvUplinkLanData
   lan2Data?: CvUplinkLanData
+}
+
+// ----- Locations ----------------------------------------------------------
+
+/** A node in the CV-CUE location hierarchy (folder / floor). */
+export interface CvLocation {
+  /** `{ id }` where `id` is the numeric location node id. */
+  id?: CvLocationRef | number
+  name?: string
+  type?: string
+  children?: CvLocation[]
 }
 
 // ----- Switches -----------------------------------------------------------

--- a/libs/plugins/arista-cv-cue/src/types.ts
+++ b/libs/plugins/arista-cv-cue/src/types.ts
@@ -1,0 +1,121 @@
+/**
+ * Arista CV-CUE (CloudVision Cognitive Unified Edge) plugin types.
+ *
+ * Field names mirror the CV-CUE Open API (`/wifi/api`, product `wm`). Only the
+ * subset of fields the plugin actually reads is modeled; everything is optional
+ * except the config the operator must supply. The full record still flows to the
+ * "All metrics" panel via `flattenObject`, so unmodeled fields surface there.
+ */
+
+export interface AristaCvCueConfig {
+  /**
+   * API base URL, ending in `/wifi/api`, e.g.
+   * `https://awm17001-c4.srv.wifi.arista.com/wifi/api`. Per-tenant/region.
+   */
+  baseUrl: string
+  /** API key id from CV-CUE (Manage API Keys), e.g. `KEY-ATN571956-4368`. */
+  keyId: string
+  /** API key value (secret) paired with `keyId`. */
+  keyValue: string
+  /** Customer ID — only needed when the key spans more than one customer. */
+  customerId?: string
+  /** Location subtree to scope queries to. Defaults to `0` (root). */
+  locationId?: number
+}
+
+// ----- Session ------------------------------------------------------------
+
+/** Response body of a successful `POST /session`. */
+export interface CvSessionResponse {
+  sessionId?: string
+  timeout?: number
+  loginId?: string
+  role?: string
+  userType?: string
+}
+
+// ----- Paging -------------------------------------------------------------
+
+/** Common paging envelope fields CV-CUE list endpoints return. */
+export interface CvPaged {
+  totalCount?: number
+  nextLink?: string | null
+  previousLink?: string | null
+  pagingSessionId?: string | null
+}
+
+// ----- Managed devices (APs) ----------------------------------------------
+
+export interface CvManagedDevicesResponse extends CvPaged {
+  managedDevices?: CvManagedDevice[]
+}
+
+export interface CvManagedDevice {
+  /** Stable per-device id in CV-CUE. */
+  boxId?: number
+  name?: string
+  locationId?: number
+  macaddress?: string
+  model?: string
+  vendorName?: string
+  softwareVersion?: string
+  ipAddress?: string
+  /** True when the device is currently connected/managed. */
+  active?: boolean
+  /** e.g. `CONNECTED` / `DISCONNECTED`. */
+  connectionStatus?: string
+  /** Number of associated wireless clients. */
+  assocCount?: number
+  /** Epoch ms the device has been up since. */
+  upSince?: number
+  /** Epoch ms of the last record update. */
+  lastUpdateTime?: number
+  powerSource?: string
+  numEthernetPorts?: number
+  /** CPU / memory utilization counters (units are CV-CUE-defined). */
+  healthStats?: Record<string, number>
+  radios?: unknown[]
+  /** Wired uplink info (LLDP neighbor switch + port), used for topology later. */
+  uplinkWiredInterfacesInfo?: Record<string, unknown>
+}
+
+// ----- Switches -----------------------------------------------------------
+
+export interface CvSwitch {
+  name?: string
+  vendor?: string
+  /** LLDP chassis id (MAC) — the strong identity key for the switch. */
+  chassisId?: string
+  chassisIdSubType?: number
+  nodeId?: number
+  numAps?: number
+  numClients?: number
+  apDistributionByLinkSpeedsInMbps?: Array<{ linkSpeed?: number; numAps?: number }>
+  apDistributionByPoe?: Array<{ poeType?: string; numAps?: number }>
+}
+
+// ----- Events (alerts) ----------------------------------------------------
+
+export interface CvEventsResponse extends CvPaged {
+  eventList?: CvEvent[]
+}
+
+export interface CvEvent {
+  id?: number | string
+  majorType?: number | string
+  intermediateType?: number | string
+  minorType?: number | string
+  category?: string
+  summary?: string
+  description?: string
+  deleted?: boolean
+  /** Epoch ms. */
+  startTime?: number
+  /** Epoch ms; 0/absent while the event is still active. */
+  stopTime?: number
+  locationId?: number
+  readStatus?: string
+  activityStatus?: string
+  /** CV-CUE severity token: `CRITICAL` / `HIGH` / `MEDIUM` / `LOW` / `INFO`. */
+  eventSeverity?: string
+}

--- a/libs/plugins/arista-cv-cue/tsconfig.json
+++ b/libs/plugins/arista-cv-cue/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"],
+  "references": [{ "path": "../../@shumoku/core" }]
+}


### PR DESCRIPTION
Adds the **Arista CV-CUE** (CloudVision CUE) data source plugin and the layout / metrics-rendering work that surfaced while wiring it onto a real topology (JANOG58 tenant).

## Arista CV-CUE plugin
A new data source for the CV-CUE Wi-Fi Open API (session auth), providing:
- **topology** — APs and their AP↔switch uplinks (`TopologyCapable`), grouped into location subgraphs.
- **hosts / metrics / alerts** — device up/down, per-uplink link throughput derived from AP radios, and events → alerts.
- Robustness against the tenant's real data: ignores stale uplink snapshots from inactive APs, drops phantom `localhost` uplinks from dormant APs.
- **Inactive AP → uplink `unknown`, not `down`.** An AP that isn't checking in is *absence of data* about its wired uplink, not a confirmed failure — reporting `down` painted ~40 uplinks red purely because their APs were offline. Red is now reserved for a confirmed down (active AP, `linkStatus` down); the AP *node* still reports `down` (the controller genuinely sees it offline).

## Layout / rendering fixes (general)
- Diagram apex chosen from graph **structure first**, role hints second.
- Aggregate port **seating** for ports shared by multiple links (no overlap).
- Null-safe port labels in layout + render; a folded port always gets a string label.

## Metrics / overlay
- **Link auto-map consults every attached metrics source** (self-select), instead of only the first.
- **Weathermap overlay membership from mapping, not live-value presence.** The overlay used to render purely on `!!metrics`, conflating *membership* in the metrics layer (is this element mapped?) with *values* (what's flowing?). A mapped-but-idle link was indistinguishable from an unmapped one. Now composed in `InteractiveSvgDiagram` from the already-hydrated `linkMapping`/`nodeMapping` stores, giving three distinct states: unmapped → plain; mapped, no value → gray idle lane; mapped, live value → color + flow. Overlays stay pure renderers; behaviour is unchanged where the mapping store isn't hydrated.

## Test plan
- [x] Plugin unit tests (`arista-cv-cue`): topology + `uplinkToLinkMetrics` (incl. inactive-AP → `unknown`), 18 pass.
- [x] Core/renderer layout tests updated; `svelte-check` on `apps/server/web` clean.
- [x] Verified live against the JANOG58 CV-CUE tenant: previously-red inactive-AP uplinks now render gray; mapped-but-unpolled links show the idle overlay; unmapped links stay plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)