### PR TITLE
fix(netbox): style circuit links from the real leg cable, not a hardcoded smf

### DIFF
--- a/.changeset/netbox-circuit-cable-join.md
+++ b/.changeset/netbox-circuit-cable-join.md
@@ -1,0 +1,9 @@
+---
+'shumoku-plugin-netbox': patch
+---
+
+**netbox**: style circuit links from the real leg cable instead of a hardcoded
+`smf`. The circuit-termination API embeds only an abbreviated cable reference
+(no `type`), so the builder now joins it by id against the already-fetched
+cable list; when the type genuinely can't be resolved the link is left
+unstyled rather than pretending the fiber type is known.

--- a/libs/plugins/netbox/src/converter.test.ts
+++ b/libs/plugins/netbox/src/converter.test.ts
@@ -150,12 +150,14 @@ function mkTermination(
   device: string | null,
   port: string,
   portSpeed: number | null = 400_000_000,
+  cableId?: number,
 ): NetBoxCircuitTermination {
   return {
     id,
     term_side: id % 2 === 0 ? 'A' : 'Z',
     port_speed: portSpeed,
     circuit: { id: circuitId, cid },
+    ...(cableId !== undefined ? { cable: { id: cableId } } : {}),
     link_peers_type: device ? 'dcim.interface' : undefined,
     link_peers: device ? [{ name: port, device: { id: id * 100, name: device } }] : [],
   }
@@ -223,6 +225,51 @@ describe('convertToNetworkGraph: circuits', () => {
     // Identity contract holds for the synthesized node too.
     const { nodesMissingIdentity } = validateTopologyIdentityContract(graph)
     expect(nodesMissingIdentity).toEqual([])
+  })
+
+  it('styles a circuit link from the REAL cable type, joined by id', () => {
+    // The termination's embedded cable reference is abbreviated (no `type`);
+    // the full cable lives in the fetched cable list. The link must take its
+    // styling from that joined cable — never from an assumed default.
+    const devices = [mkDevice(1, 'edge-a', '10.0.0.1'), mkDevice(2, 'edge-b', '10.0.0.2')]
+    // The circuit-leg cable exists in the cable list but connects a device to a
+    // circuit termination, so the plain walker skips it (its endpoints are not
+    // both in the device set). It still must be found by the id join.
+    const legCable = { ...mkCable(90, 'not-a-device', 'x', 'also-not', 'y'), type: 'mmf-om3' }
+    const circuits = mkCircuitResp([mkCircuit(3, 'DF-02', 'Provider A')])
+    const terminations = mkTerminationResp([
+      mkTermination(30, 3, 'DF-02', 'edge-a', 'Ethernet1/1', 400_000_000, 90),
+      mkTermination(31, 3, 'DF-02', 'edge-b', 'Ethernet1/1', 400_000_000, 91),
+    ])
+    const graph = convertToNetworkGraph(
+      emptyDeviceResp(devices),
+      EMPTY_IFACE_RESP,
+      mkCableResp([legCable]),
+      {},
+      { circuits, terminations },
+    )
+    expect(graph.links).toHaveLength(1)
+    // mmf-om3 → green per CABLE_STYLES, taken from the real cable.
+    expect(graph.links[0]?.style?.stroke).toBe('#10b981')
+  })
+
+  it('leaves a circuit link unstyled when the leg cable type is unknown', () => {
+    // No cable reference on the terminations → no cable-type styling at all,
+    // instead of pretending the fiber type is known.
+    const devices = [mkDevice(1, 'edge-a', '10.0.0.1'), mkDevice(2, 'edge-b', '10.0.0.2')]
+    const circuits = mkCircuitResp([mkCircuit(4, 'DF-03', 'Provider A')])
+    const terminations = mkTerminationResp([
+      mkTermination(40, 4, 'DF-03', 'edge-a', 'Ethernet1/1'),
+      mkTermination(41, 4, 'DF-03', 'edge-b', 'Ethernet1/1'),
+    ])
+    const graph = convertToNetworkGraph(
+      emptyDeviceResp(devices),
+      EMPTY_IFACE_RESP,
+      mkCableResp([]),
+      {},
+      { circuits, terminations },
+    )
+    expect(graph.links[0]?.style?.stroke).toBeUndefined()
   })
 
   it('ignores circuits gracefully when circuitData is absent', () => {

--- a/libs/plugins/netbox/src/converter.ts
+++ b/libs/plugins/netbox/src/converter.ts
@@ -102,6 +102,8 @@ interface CircuitEndpoint {
   device: string
   port: string
   speed: number | null
+  /** Type of the real cable at this end (joined from the fetched cable list). */
+  cableType?: string
 }
 
 // ============================================
@@ -203,6 +205,7 @@ export function convertToNetworkGraph(
     const circuitResult = buildCircuitConnections(
       circuitData.circuits,
       circuitData.terminations,
+      cableResp,
       devices,
       deviceTagMap,
       deviceInfoMap,
@@ -429,11 +432,18 @@ function createConnection(
 function buildCircuitConnections(
   circuitResp: NetBoxCircuitResponse,
   terminationResp: NetBoxCircuitTerminationResponse,
+  cableResp: NetBoxCableResponse,
   devices: Map<string, DeviceData>,
   deviceTagMap: Map<string, string>,
   deviceInfoMap: Map<string, Omit<DeviceInfo, 'name' | 'tags' | 'rack'>>,
   tagMapping: Record<string, TagMapping>,
 ): { connections: ConnectionData[]; providerNodes: Node[] } {
+  // The termination's embedded cable reference is abbreviated (no `type`), but
+  // the full cable is already in the fetched cable list — the walker skipped it
+  // because one end isn't a device. Join by id to style the link from the REAL
+  // cable instead of assuming anything about it.
+  const cableById = new Map(cableResp.results.map((c) => [c.id, c]))
+
   // Group each circuit's cabled device endpoints by circuit id.
   const endpointsByCircuit = new Map<number, CircuitEndpoint[]>()
   for (const term of terminationResp.results) {
@@ -443,7 +453,12 @@ function buildCircuitConnections(
     const deviceName = peer?.device?.name
     if (!deviceName) continue
     const list = endpointsByCircuit.get(circuitId) ?? []
-    list.push({ device: deviceName, port: peer.name, speed: term.port_speed ?? null })
+    list.push({
+      device: deviceName,
+      port: peer.name,
+      speed: term.port_speed ?? null,
+      cableType: term.cable ? cableById.get(term.cable.id)?.type : undefined,
+    })
     endpointsByCircuit.set(circuitId, list)
   }
 
@@ -523,7 +538,9 @@ function makeCircuitConnection(
     dstPort: b.port,
     dstLevel: ordered ? dstLevel : srcLevel,
     dstTag: ordered ? dstTag : srcTag,
-    cableType: 'smf',
+    // Style from the real cable at either end — never assumed. Empty string =
+    // unknown, which applyCableStyle treats as "no cable-type styling".
+    cableType: src.cableType ?? dst.cableType ?? '',
     cableLabel: label,
     speed: src.speed ?? dst.speed,
     vlans: [],

--- a/libs/plugins/netbox/src/types.ts
+++ b/libs/plugins/netbox/src/types.ts
@@ -207,6 +207,12 @@ export interface NetBoxCircuitTermination {
   term_side: 'A' | 'Z'
   port_speed?: number | null // kbps
   circuit?: { id: number; cid: string; provider?: NetBoxProvider }
+  /**
+   * Abbreviated reference to the cable connecting this termination to a device
+   * interface. NetBox summarizes nested objects, so `type` is NOT included —
+   * join against the full cable list (already fetched) by id to get it.
+   */
+  cable?: { id: number; label?: string }
   link_peers_type?: string // e.g. 'dcim.interface'
   link_peers?: Array<{
     name: string


### PR DESCRIPTION
## Summary
Circuit links (cross-site fibers / provider uplinks imported in #607) were styled as if the fiber were always single-mode (`smf`). The NetBox circuit-termination API embeds only an abbreviated cable reference with no `type`, so the builder had nothing real to go on and hardcoded it.

Join the termination's cable id against the already-fetched cable list to recover the real leg's cable type, and when the type genuinely can't be resolved, leave the link **unstyled** rather than asserting a fiber type we don't actually know — the same "don't claim what you can't verify" principle applied to link styling.

## Test plan
- [x] `netbox` unit tests (converter): 10 pass
- [x] typecheck + `biome` clean on the changed files