### PR TITLE
fix(netbox): give synthesized provider nodes one handoff port per circuit

### DIFF
--- a/.changeset/netbox-provider-ports.md
+++ b/.changeset/netbox-provider-ports.md
@@ -1,0 +1,11 @@
+---
+'shumoku-plugin-netbox': patch
+---
+
+**netbox**: synthesized provider boundary nodes now expose one handoff port per
+circuit landing on them, and circuit links reference that port. Previously the
+provider side of an uplink was a portless endpoint (`port: ''`), so two uplinks
+to the same provider converged on the bare node — violating the LinkEndpoint
+contract ("must reference an existing port") and the 1-port-=-1-link invariant.
+Port id = the circuit's `cid` (stable across rescans; `ifName` defaults to it
+on ingest, satisfying the identity contract).

--- a/libs/plugins/netbox/src/converter.test.ts
+++ b/libs/plugins/netbox/src/converter.test.ts
@@ -222,9 +222,47 @@ describe('convertToNetworkGraph: circuits', () => {
     expect(graph.links).toHaveLength(1)
     // Active circuit is solid, not dashed.
     expect(graph.links[0]?.type).not.toBe('dashed')
+    // The provider hands the circuit off on its own synthesized port, and the
+    // link endpoint references it (LinkEndpoint contract: port must exist).
+    expect(provider?.ports?.map((p) => p.id)).toEqual(['UPLINK-01'])
+    const providerEnd = [graph.links[0]?.from, graph.links[0]?.to].find(
+      (e) => e?.node === 'provider:provider-b',
+    )
+    expect(providerEnd?.port).toBe('UPLINK-01')
     // Identity contract holds for the synthesized node too.
-    const { nodesMissingIdentity } = validateTopologyIdentityContract(graph)
+    const { nodesMissingIdentity, portsMissingIfName } = validateTopologyIdentityContract(graph)
     expect(nodesMissingIdentity).toEqual([])
+    expect(portsMissingIfName).toEqual([])
+  })
+
+  it('gives one provider node a distinct port per circuit landing on it', () => {
+    // Two uplinks to the SAME provider: one node, two ports, two links —
+    // never two lines converging on a portless node ("1 port = 1 link").
+    const devices = [mkDevice(1, 'edge-a', '10.0.0.1'), mkDevice(2, 'edge-b', '10.0.0.2')]
+    const circuits = mkCircuitResp([
+      mkCircuit(5, 'UPLINK-01', 'Provider B'),
+      mkCircuit(6, 'UPLINK-02', 'Provider B'),
+    ])
+    const terminations = mkTerminationResp([
+      mkTermination(50, 5, 'UPLINK-01', 'edge-a', 'Ethernet32/1'),
+      mkTermination(51, 5, 'UPLINK-01', null, ''),
+      mkTermination(60, 6, 'UPLINK-02', 'edge-b', 'Ethernet32/1'),
+      mkTermination(61, 6, 'UPLINK-02', null, ''),
+    ])
+    const graph = convertToNetworkGraph(
+      emptyDeviceResp(devices),
+      EMPTY_IFACE_RESP,
+      mkCableResp([]),
+      {},
+      { circuits, terminations },
+    )
+    const providers = graph.nodes.filter((n) => n.id.startsWith('provider:'))
+    expect(providers).toHaveLength(1)
+    expect(providers[0]?.ports?.map((p) => p.id).sort()).toEqual(['UPLINK-01', 'UPLINK-02'])
+    const providerEnds = graph.links
+      .flatMap((l) => [l.from, l.to])
+      .filter((e) => e.node === 'provider:provider-b')
+    expect(providerEnds.map((e) => e.port).sort()).toEqual(['UPLINK-01', 'UPLINK-02'])
   })
 
   it('styles a circuit link from the REAL cable type, joined by id', () => {

--- a/libs/plugins/netbox/src/converter.ts
+++ b/libs/plugins/netbox/src/converter.ts
@@ -465,7 +465,7 @@ function buildCircuitConnections(
   const circuitById = new Map(circuitResp.results.map((c) => [c.id, c]))
   const connections: ConnectionData[] = []
   const providerNodes: Node[] = []
-  const seenProviders = new Set<string>()
+  const providerNodeById = new Map<string, Node>()
 
   const ensureRegistered = (ep: CircuitEndpoint, tag: string): void => {
     registerDevice(devices, ep.device, tag, ep.port, [], ep.speed, deviceInfoMap.get(ep.device))
@@ -495,14 +495,26 @@ function buildCircuitConnections(
       const srcTag = deviceTagMap.get(src.device) ?? 'other'
       ensureRegistered(src, srcTag)
       const providerId = `provider:${circuit?.provider?.slug ?? provider}`
-      if (!seenProviders.has(providerId)) {
-        seenProviders.add(providerId)
-        providerNodes.push(makeProviderNode(providerId, provider))
+      let providerNode = providerNodeById.get(providerId)
+      if (!providerNode) {
+        providerNode = makeProviderNode(providerId, provider)
+        providerNodeById.set(providerId, providerNode)
+        providerNodes.push(providerNode)
       }
+      // One synthesized handoff port per circuit. A port models exactly one
+      // cable termination (LinkEndpoint contract: "must reference an existing
+      // port"), and the provider really does hand each circuit off on its own
+      // port — two uplinks to one provider must not converge on a portless
+      // node. Identity ifName defaults to the port id on ingest.
+      const portId = cid || `circuit-${circuitId}`
+      providerNode.ports = [
+        ...(providerNode.ports ?? []),
+        { id: portId, label: portId, role: 'wan', connectors: [] },
+      ]
       connections.push(
         makeCircuitConnection(
           src,
-          { device: providerId, port: '', speed: src.speed },
+          { device: providerId, port: portId, speed: src.speed },
           srcTag,
           'other',
           tagMapping,


### PR DESCRIPTION
## What

The provider side of an uplink circuit was a portless endpoint (`port: ''`), so two uplinks to the same provider converged on the bare node — the two lines attached to the node box with no distinct attachment points.

Provider boundary nodes now expose **one synthesized handoff port per circuit** landing on them (port id = the circuit's `cid`, role `wan`), and the circuit link endpoint references that port.

## Why

- `LinkEndpoint`'s documented contract says the port "must reference an existing port" — an empty port on a node with no ports leaned on undefined-but-tolerated behavior.
- The 1-port-=-1-link invariant (`interaction.ts`): a physical port models exactly one cable termination. The provider really does hand each circuit off on its own physical port, so the model should say so.
- Visually, two uplinks now attach at two distinct port stubs instead of converging on one point.

## Verification

- 11 unit tests passing, including two new ones: provider port synthesis + endpoint reference, and "same provider, two circuits → one node, two ports, two links".
- Identity contract holds (`ifName` defaults to the port id on ingest; cid is stable across rescans).
- Verified end-to-end against a live NetBox instance and confirmed in the rendered diagram: the provider node draws two separate port stubs, one per uplink.

## Notes

- Package: `shumoku-plugin-netbox` (patch changeset included).
- Follow-up to #607 / #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)