### PR TITLE
fix(netbox): keep synthesized provider nodes in scope via an Upstream region

### DIFF
--- a/.changeset/netbox-provider-region.md
+++ b/.changeset/netbox-provider-region.md
@@ -1,0 +1,12 @@
+---
+'shumoku-plugin-netbox': patch
+---
+
+**netbox**: place synthesized provider boundary nodes in an "Upstream" region so
+they survive scoped resolution. A parentless node is dropped under the deployed
+default `scope_mode: auto` (which closes the world to the topology source's
+regions and drops any node outside one), so upstream provider nodes and their
+uplink links vanished on a real deployment even though they rendered fine under
+`open` scope. The provider node now parents into a source-emitted `upstream`
+subgraph, making it a member of a closed region — and grouping upstream
+providers together, matching how a physical diagram draws them.

--- a/libs/plugins/netbox/src/converter.test.ts
+++ b/libs/plugins/netbox/src/converter.test.ts
@@ -311,6 +311,10 @@ describe('convertToNetworkGraph: circuits', () => {
     const provider = graph.nodes.find((n) => n.id === 'provider:provider-b')
     expect(provider).toBeDefined()
     expect(provider?.spec).toMatchObject({ kind: 'hardware', type: 'internet' })
+    // Boundary node lives in a source-emitted region so closed/auto scope keeps
+    // it (a parentless node is dropped under the deployed default scope_mode).
+    expect(provider?.parent).toBe('upstream')
+    expect(graph.subgraphs?.some((s) => s.id === 'upstream')).toBe(true)
     expect(graph.links).toHaveLength(1)
     // Active circuit is solid, not dashed.
     expect(graph.links[0]?.type).not.toBe('dashed')

--- a/libs/plugins/netbox/src/converter.ts
+++ b/libs/plugins/netbox/src/converter.ts
@@ -98,6 +98,9 @@ interface DeviceInfo {
   status?: DeviceStatusValue
 }
 
+/** Region that holds synthesized provider boundary nodes (keeps them in scope). */
+const UPSTREAM_SUBGRAPH_ID = 'upstream'
+
 /** A circuit end resolved to the device interface it is cabled to. */
 interface CircuitEndpoint {
   device: string
@@ -202,6 +205,7 @@ export function convertToNetworkGraph(
   // any synthesized provider boundary nodes. Registers circuit-only devices
   // into `devices` before nodes/subgraphs are built below.
   const providerNodes: Node[] = []
+  const providerSubgraphs: Subgraph[] = []
   if (circuitData) {
     const circuitResult = buildCircuitConnections(
       circuitData.circuits,
@@ -214,10 +218,12 @@ export function convertToNetworkGraph(
     )
     connections.push(...circuitResult.connections)
     providerNodes.push(...circuitResult.providerNodes)
+    providerSubgraphs.push(...circuitResult.providerSubgraphs)
   }
 
   // Build graph components
   const subgraphs = buildSubgraphsByGroupBy(devices, tagMapping, groupBy)
+  if (providerSubgraphs.length > 0) subgraphs.push(...providerSubgraphs)
   const nodes = buildNodes(devices, tagMapping, groupBy, useRoleForType, colorByStatus)
   if (providerNodes.length > 0) nodes.push(...providerNodes)
   const links = buildLinks(connections, showPorts, colorByCableType)
@@ -445,7 +451,7 @@ function buildCircuitConnections(
   deviceTagMap: Map<string, string>,
   deviceInfoMap: Map<string, Omit<DeviceInfo, 'name' | 'tags' | 'rack'>>,
   tagMapping: Record<string, TagMapping>,
-): { connections: ConnectionData[]; providerNodes: Node[] } {
+): { connections: ConnectionData[]; providerNodes: Node[]; providerSubgraphs: Subgraph[] } {
   // The termination's embedded cable reference is abbreviated (no `type`), but
   // the full cable is already in the fetched cable list — the walker skipped it
   // because one end isn't a device. Join by id to style the link from the REAL
@@ -505,7 +511,13 @@ function buildCircuitConnections(
       const providerId = `provider:${circuit?.provider?.slug ?? provider}`
       let providerNode = providerNodeById.get(providerId)
       if (!providerNode) {
+        // Give the boundary node a home region. Under scope_mode auto/closed
+        // (the default), resolve() closes the world to the topology source's
+        // regions and drops any node NOT inside one — a parentless synthesized
+        // node vanishes on the deployed default even though it renders under
+        // open scope. Membership in this source-emitted region keeps it in.
         providerNode = makeProviderNode(providerId, provider)
+        providerNode.parent = UPSTREAM_SUBGRAPH_ID
         providerNodeById.set(providerId, providerNode)
         providerNodes.push(providerNode)
       }
@@ -533,7 +545,12 @@ function buildCircuitConnections(
     }
   }
 
-  return { connections, providerNodes }
+  // Emit the upstream region only when it actually holds a provider node, so a
+  // topology with no synthesized providers gains no empty box.
+  const providerSubgraphs: Subgraph[] =
+    providerNodes.length > 0 ? [{ id: UPSTREAM_SUBGRAPH_ID, label: 'Upstream' }] : []
+
+  return { connections, providerNodes, providerSubgraphs }
 }
 
 function makeCircuitConnection(


### PR DESCRIPTION
## What

A synthesized provider boundary node (the upstream cloud created for a circuit whose far end is a provider, not an owned device) was created with **no parent subgraph**. It now parents into a source-emitted `upstream` region.

## Why (this was a real bug, deploy-only)

Under the deployed default `scope_mode: auto`, `resolve()` closes the world to the topology source's regions and drops any node **not inside a closed region**. A parentless provider node isn't a member of any region, so it — and its uplink links — got dropped on the real deployment. It only rendered locally because that topology happened to be `scope_mode: open` (no scope filtering).

The input (NetBox circuits) and the plugin's conversion were both correct; the node was silently dropped downstream. Environment-dependent disappearance of correctly-imported data = a bug, not a scope tradeoff.

## Fix

Give the provider node a home region: a source-emitted `upstream` subgraph. Since scope closes to the topology source's own regions, this subgraph is closed too, and the provider is a member of a closed region → kept. It also groups upstream providers together, matching how a physical diagram draws them at the top.

## Verification

Drove core `resolve()` with the source's regions marked `scope:'closed'` (the `auto` mechanism):

- **without a parent** (old): provider + its uplink drop -> `nodes=1, links=0`
- **with the `upstream` parent** (fix): both survive -> `nodes=2, links=1`, provider resolved under `netbox:upstream`

17 unit tests passing (added asserts: provider `parent === 'upstream'` and the subgraph is emitted). tsc + biome clean.

## Notes

- Package: `shumoku-plugin-netbox` (patch changeset included).
- Follow-up to #607 / #611. Also worth a separate look: core's scoped `resolve()` drops a scope-source's own parentless nodes fairly aggressively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)