### PR TITLE
fix(plugin-arista-cv-cue): prefer the primary LAN port for the AP uplink

### DIFF
--- a/libs/plugins/arista-cv-cue/src/plugin.ts
+++ b/libs/plugins/arista-cv-cue/src/plugin.ts
@@ -218,8 +218,8 @@ export class AristaCvCuePlugin
 
     // ---- Links ----
     // A link's metrics come from the AP its `monitoredNodeId` maps to — the AP
-    // owns the wired-uplink telemetry. CV-CUE exposes link up/down and speed but
-    // not live throughput, so we emit status only (no fake utilization).
+    // owns the wired-uplink status and the aggregate radio-usage telemetry used
+    // as its approximate throughput.
     for (const [linkId, linkMapping] of Object.entries(mapping.links || {})) {
       const monitoredNodeId = linkMapping.monitoredNodeId
       if (!monitoredNodeId || !linkMapping.interface) continue

--- a/libs/plugins/arista-cv-cue/src/topology.test.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.test.ts
@@ -1,6 +1,6 @@
 import { validateTopologyIdentityContract } from '@shumoku/core'
 import { describe, expect, it } from 'vitest'
-import { buildTopology } from './topology.js'
+import { buildTopology, primaryUplink } from './topology.js'
 import type { CvManagedDevice, CvSwitch } from './types.js'
 
 const AP: CvManagedDevice = {
@@ -33,6 +33,35 @@ const SWITCH: CvSwitch = {
   chassisId: 'e0:fa:5b:71:ff:75',
   numAps: 48,
 }
+
+describe('primaryUplink', () => {
+  it('prefers the primary LAN port over stale LLDP data on an earlier port', () => {
+    const uplink = primaryUplink({
+      uplinkWiredInterfacesInfo: {
+        lan1Data: {
+          name: 'eth0',
+          primaryInterface: false,
+          switchName: 'localhost',
+          switchChassisId: 'e0:fa:5b:71:ff:75',
+        },
+        lan2Data: {
+          name: 'eth1',
+          primaryInterface: true,
+          switchName: 'j58-1f-ten-sw-02',
+          switchPortId: 'Ethernet13',
+          switchChassisId: '2c:dd:e9:f6:af:89',
+        },
+      },
+    })
+
+    expect(uplink).toMatchObject({
+      name: 'eth1',
+      primaryInterface: true,
+      switchName: 'j58-1f-ten-sw-02',
+      switchPortId: 'Ethernet13',
+    })
+  })
+})
 
 describe('buildTopology', () => {
   it('emits AP + switch nodes and the AP↔switch link', () => {

--- a/libs/plugins/arista-cv-cue/src/topology.ts
+++ b/libs/plugins/arista-cv-cue/src/topology.ts
@@ -63,7 +63,11 @@ export function primaryUplink(d: CvManagedDevice): CvUplinkLanData | undefined {
   const up = d.uplinkWiredInterfacesInfo
   if (!up) return undefined
   const candidates = [up.lan1Data, up.lan2Data].filter((l): l is CvUplinkLanData => !!l)
-  return candidates.find((l) => l.switchChassisId) ?? candidates.find((l) => l.primaryInterface)
+  // CV-CUE can retain LLDP data on an inactive/non-primary LAN port. Prefer
+  // the port explicitly marked primary; otherwise the first port carrying a
+  // real switch identity would incorrectly win merely because LAN1 is listed
+  // before LAN2 (for example eth0 over the active eth1 uplink).
+  return candidates.find((l) => l.primaryInterface) ?? candidates.find((l) => l.switchChassisId)
 }
 
 export function buildTopology(


### PR DESCRIPTION
## Problem
`primaryUplink()` chose the **first** LAN port carrying a `switchChassisId`. On an AP with a stale LLDP snapshot on LAN1 (`eth0` still pointing at a phantom `localhost`), that port would win over the AP's **actual active uplink** on LAN2 (`eth1`) — drawing the wrong AP↔switch edge.

## Fix
Prefer the port flagged `primaryInterface: true` first; fall back to the first port with a switch identity only when none is marked primary.

## Test
New `primaryUplink` test: `eth1` (primary, real switch) wins over `eth0` (non-primary, stale `localhost`). Full suite: 19 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)