### PR TITLE
fix(server): exempt metrics-mapped nodes from hide-disconnected

### DIFF
--- a/apps/server/api/src/services/derive-worker.ts
+++ b/apps/server/api/src/services/derive-worker.ts
@@ -32,6 +32,13 @@ export interface DeriveRequest {
   snapshots: SnapshotEntry[]
   scope?: ScopeFilter
   hideDisconnected: boolean
+  /**
+   * Identity keys (`key=value`, registry format) of nodes with a metrics
+   * binding — never hidden by the display filter, even at degree 0 (a
+   * monitored device that goes down must stay on the map). Keys, not ids:
+   * pre-flip node ids in here are resolver-minted and unmatchable.
+   */
+  mappedNodeKeys?: string[]
 }
 
 declare var self: Worker
@@ -41,7 +48,9 @@ self.onmessage = async (event: MessageEvent) => {
   try {
     self.postMessage({ type: 'progress', stage: 'resolve' })
     const resolvedGraph = resolveObservations(req.authored, req.snapshots, { scope: req.scope })
-    const graph = req.hideDisconnected ? filterDisconnected(resolvedGraph) : resolvedGraph
+    const graph = req.hideDisconnected
+      ? filterDisconnected(resolvedGraph, new Set(req.mappedNodeKeys ?? []))
+      : resolvedGraph
 
     self.postMessage({ type: 'progress', stage: 'icons' })
     let iconDimensions = new Map<string, { width: number; height: number }>()

--- a/apps/server/api/src/services/display-filter.test.ts
+++ b/apps/server/api/src/services/display-filter.test.ts
@@ -50,4 +50,36 @@ describe('filterDisconnected', () => {
     }
     expect(filterDisconnected(g)).toBe(g)
   })
+
+  it('keeps a degree-0 node whose identity matches a metrics binding (monitored ≠ noise)', () => {
+    // A monitored AP that goes down loses its stale-LLDP uplink and drops to
+    // degree 0 — it must stay on the map to show its red status. Matching is
+    // by identity keys (registry format), NOT node ids: pre-flip Worker ids
+    // are resolver-minted and unrelated to entity ids.
+    const g: NetworkGraph = {
+      version: '1',
+      nodes: [
+        {
+          ...node('discovered:0', 'discovered-only'),
+          identity: { mgmtIp: '192.168.11.131', vendorIds: { 'cvcue-boxid': '3' } },
+        },
+        { ...node('junk', 'discovered-only'), identity: { mgmtIp: '10.0.0.99' } },
+        node('a', 'discovered-only'),
+        node('b', 'discovered-only'),
+      ],
+      links: [{ id: 'l0', from: { node: 'a' }, to: { node: 'b' } }],
+    }
+    const out = filterDisconnected(g, new Set(['mgmtIp=192.168.11.131']))
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(['a', 'b', 'discovered:0'])
+  })
+
+  it('matches sysName case-insensitively (registry stores it lowercased)', () => {
+    const g: NetworkGraph = {
+      version: '1',
+      nodes: [{ ...node('lonely', 'discovered-only'), identity: { sysName: 'SW-Core-01' } }],
+      links: [],
+    }
+    const out = filterDisconnected(g, new Set(['sysName=sw-core-01']))
+    expect(out.nodes.map((n) => n.id)).toEqual(['lonely'])
+  })
 })

--- a/apps/server/api/src/services/display-filter.ts
+++ b/apps/server/api/src/services/display-filter.ts
@@ -10,7 +10,27 @@
  * may be linked by another, so a per-source evaluation would wrongly drop it.
  */
 
-import type { NetworkGraph } from '@shumoku/core'
+import type { Identity, NetworkGraph } from '@shumoku/core'
+
+/**
+ * Node identity → `key=value` strings, MIRRORING the registry's storage format
+ * (`gatherNodeKeys` + `normalizeKeyValue` in entity-registry.ts: sysName/mgmtIp
+ * lowercased, vendor namespaced as `vendor:<ns>`). Deliberately re-derived here
+ * instead of importing the registry: this runs inside the derive Worker, which
+ * must stay a pure-compute module with no DB import chain. If the registry's
+ * key format changes, change this with it.
+ */
+export function nodeIdentityKeyStrings(identity: Identity | undefined): string[] {
+  if (!identity) return []
+  const out: string[] = []
+  if (identity.chassisId) out.push(`chassisId=${identity.chassisId.trim()}`)
+  for (const [ns, v] of Object.entries(identity.vendorIds ?? {})) {
+    out.push(`vendor:${ns}=${v.trim()}`)
+  }
+  if (identity.mgmtIp) out.push(`mgmtIp=${identity.mgmtIp.trim().toLowerCase()}`)
+  if (identity.sysName) out.push(`sysName=${identity.sysName.trim().toLowerCase()}`)
+  return out
+}
 
 /**
  * Drop every node that has no incident link (degree 0).
@@ -23,10 +43,23 @@ import type { NetworkGraph } from '@shumoku/core'
  * disconnected; an operator who wants to keep a standalone planned node just
  * leaves the toggle off.
  *
+ * The one exception is `keepIdentityKeys`: nodes with a metrics binding.
+ * Binding a node to a metrics source is an explicit operator act of "watch
+ * this device", so its health must stay visible. Without it a monitored AP
+ * that goes DOWN loses its uplink (a dead device's LLDP edge is suppressed as
+ * stale), drops to degree 0, and vanishes from the map at exactly the moment
+ * its red status matters — hide-disconnected would erase the outage instead of
+ * showing it. The exemption matches by IDENTITY keys (not node ids): this
+ * filter runs pre-flip inside the Worker, where node ids are resolver-minted
+ * (`discovered:N`…) and relate to neither entity ids nor per-source local ids.
+ *
  * Pure: returns a new graph; never mutates the input. A degree-0 node has no
  * links by definition, so no link pruning is needed.
  */
-export function filterDisconnected(graph: NetworkGraph): NetworkGraph {
+export function filterDisconnected(
+  graph: NetworkGraph,
+  keepIdentityKeys?: ReadonlySet<string>,
+): NetworkGraph {
   const degree = new Map<string, number>()
   for (const link of graph.links) {
     const from = link.from?.node
@@ -35,7 +68,12 @@ export function filterDisconnected(graph: NetworkGraph): NetworkGraph {
     if (to) degree.set(to, (degree.get(to) ?? 0) + 1)
   }
 
-  const nodes = graph.nodes.filter((n) => (degree.get(n.id) ?? 0) > 0)
+  const isMapped = (identity: Identity | undefined): boolean => {
+    if (!keepIdentityKeys || keepIdentityKeys.size === 0) return false
+    return nodeIdentityKeyStrings(identity).some((k) => keepIdentityKeys.has(k))
+  }
+
+  const nodes = graph.nodes.filter((n) => (degree.get(n.id) ?? 0) > 0 || isMapped(n.identity))
 
   if (nodes.length === graph.nodes.length) return graph
   return { ...graph, nodes }

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -1629,6 +1629,7 @@ export class TopologyService {
     snapshots: SnapshotEntry[]
     scope?: ScopeFilter
     hideDisconnected: boolean
+    mappedNodeKeys: string[]
   } | null {
     const topology = this.get(topologyId)
     if (!topology) return null
@@ -1684,11 +1685,33 @@ export class TopologyService {
     // Topology-level scope criteria + the display filter run in the Worker:
     // scope is enforced post-merge by resolve; hideDisconnected runs on the
     // fully-merged graph — never per-source.
+    //
+    // Metrics-bound nodes are exempt from hide-disconnected: binding is an
+    // explicit "watch this device", and a monitored device that goes DOWN can
+    // legitimately drop to degree 0 (its stale LLDP uplink is suppressed) —
+    // hiding it would erase the outage exactly when it matters.
+    //
+    // The exemption travels as IDENTITY KEYS, not node ids: the filter runs
+    // inside the Worker BEFORE completeDerivation flips ids to entity ids, and
+    // pre-flip node ids are resolver-minted (`discovered:N`…) — unmatchable
+    // from here. The registry's identity keys (`entity_identity_key`) are the
+    // one namespace both sides share; the Worker re-derives the same
+    // `key=value` strings from each node's identity.
+    const mappedNodeKeys = this.db
+      .query<{ key: string; value: string }, [string]>(
+        `SELECT DISTINCT k.key, k.value FROM entity_identity_key k
+           JOIN metrics_mapping mm
+             ON mm.topology_id = k.topology_id AND mm.entity_id = k.entity_id
+          WHERE k.topology_id = ? AND k.kind = 'node' AND mm.kind = 'node'`,
+      )
+      .all(topologyId)
+      .map((r) => `${r.key}=${r.value}`)
     return {
       authored,
       snapshots,
       scope: topology.scope,
       hideDisconnected: authored.settings?.hideDisconnected === true,
+      mappedNodeKeys,
     }
   }
 


### PR DESCRIPTION
## Summary

hide-disconnected（度数0ノードの非表示）から**メトリクスマッピング済みノードを除外**する。

**問題**: 監視対象のデバイスがダウンすると、stale になった LLDP アップリンクが抑制されて度数0になり、hide-disconnected が**障害の瞬間にそのノードをマップから消してしまう**。赤ステータスを見せるべきタイミングで消えるのは逆。

**修正**: メトリクスバインドは運用者の明示的な「このデバイスを見張る」宣言なので、バインド済みノードは度数0でも残す。

**実装のポイント**: 除外指定はノード id ではなく **identity キー（`key=value`）** で Worker に渡す。display filter は derive Worker 内の**entity id フリップ前**に走るため、その時点のノード id はリゾルバ採番（`discovered:N`）で突合不能。両側で共有できる唯一の名前空間がレジストリの identity キー（`entity_identity_key`）なので、Worker 側で同じ形式のキー文字列を再導出して照合する（DB import 連鎖を避けるため registry は import しない）。

- `topology.ts`: derive リクエスト組み立て時に `entity_identity_key × metrics_mapping` の JOIN でマッピング済みノードのキーを収集
- `display-filter.ts`: `filterDisconnected(graph, keepIdentityKeys?)` — identity キーが一致するノードは度数0でも保持。`nodeIdentityKeyStrings()` を export
- `derive-worker.ts`: `DeriveRequest.mappedNodeKeys` を受けて filter に渡す

## Test plan

- [x] display-filter: 5 tests pass（マッピング済み度数0ノードの保持ケース追加）
- [x] server-api 全体: 97 tests pass
- [x] typecheck / biome lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)