### PR TITLE
feat(plugin-huawei-nce-campus): add Huawei iMaster NCE-Campus data source plugin

### DIFF
--- a/.changeset/huawei-nce-campus-plugin.md
+++ b/.changeset/huawei-nce-campus-plugin.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add the Huawei iMaster NCE-Campus bundled plugin (topology / hosts / metrics / alerts via the NBI). Private workspace package — no npm release.

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -31,6 +31,7 @@ COPY libs/@shumoku/plugin-sdk/package.json ./libs/@shumoku/plugin-sdk/
 COPY libs/plugins/arista-cv-cue/package.json ./libs/plugins/arista-cv-cue/
 COPY libs/plugins/aruba-instant-on/package.json ./libs/plugins/aruba-instant-on/
 COPY libs/plugins/grafana/package.json ./libs/plugins/grafana/
+COPY libs/plugins/huawei-nce-campus/package.json ./libs/plugins/huawei-nce-campus/
 COPY libs/plugins/netbox/package.json ./libs/plugins/netbox/
 COPY libs/plugins/network-scan/package.json ./libs/plugins/network-scan/
 COPY libs/plugins/prometheus/package.json ./libs/plugins/prometheus/

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -23,6 +23,7 @@
     "shumoku-plugin-arista-cv-cue": "workspace:*",
     "shumoku-plugin-aruba-instant-on": "workspace:*",
     "shumoku-plugin-grafana": "workspace:*",
+    "shumoku-plugin-huawei-nce-campus": "workspace:*",
     "shumoku-plugin-netbox": "workspace:*",
     "shumoku-plugin-prometheus": "workspace:*",
     "shumoku-plugin-network-scan": "workspace:*",

--- a/apps/server/api/src/plugins/index.ts
+++ b/apps/server/api/src/plugins/index.ts
@@ -7,6 +7,7 @@
 export { AristaCvCuePlugin } from 'shumoku-plugin-arista-cv-cue'
 export { ArubaInstantOnPlugin } from 'shumoku-plugin-aruba-instant-on'
 export { GrafanaPlugin } from 'shumoku-plugin-grafana'
+export { HuaweiNceCampusPlugin } from 'shumoku-plugin-huawei-nce-campus'
 // Re-export plugin classes from bundled plugins
 export { NetBoxPlugin } from 'shumoku-plugin-netbox'
 export { NetworkScanPlugin } from 'shumoku-plugin-network-scan'
@@ -35,6 +36,7 @@ export * from './types.js'
 import { register as registerAristaCvCue } from 'shumoku-plugin-arista-cv-cue'
 import { register as registerArubaInstantOn } from 'shumoku-plugin-aruba-instant-on'
 import { register as registerGrafana } from 'shumoku-plugin-grafana'
+import { register as registerHuaweiNceCampus } from 'shumoku-plugin-huawei-nce-campus'
 import { register as registerNetBox } from 'shumoku-plugin-netbox'
 import { register as registerNetworkScan } from 'shumoku-plugin-network-scan'
 import { register as registerPrometheus } from 'shumoku-plugin-prometheus'
@@ -51,6 +53,7 @@ export function registerBundledPlugins(): void {
   registerGrafana(pluginRegistry)
   registerArubaInstantOn(pluginRegistry)
   registerAristaCvCue(pluginRegistry)
+  registerHuaweiNceCampus(pluginRegistry)
   registerNetworkScan(pluginRegistry)
 
   console.log('[Plugins] Bundled plugins registered')

--- a/apps/server/docs/datasources.en.mdx
+++ b/apps/server/docs/datasources.en.mdx
@@ -97,6 +97,19 @@ Pull managed access points, uplink switches, per-device status, and events (aler
 | Customer ID (CID) | Optional — only when the key spans more than one customer |
 | Location ID | Optional — scope queries to a location subtree (`0` is the root) |
 
+## Huawei iMaster NCE-Campus
+
+Pull managed devices (APs, switches, AR routers, firewalls), LLDP-based device-to-device topology, per-device performance (CPU / memory / interface utilization), and current alarms from the northbound RESTful API (NBI, default port 18002) of a Huawei iMaster NCE-Campus controller. Devices are grouped into per-site subgraphs, and identity stamping (MAC / management IP) lets composition merge them with other sources such as NetBox.
+
+| Field | Description |
+|-------|-------------|
+| NBI base URL | The controller's NBI base URL, e.g. `https://nce.example.com:18002` |
+| Username | Third-party account attached to the NBI User Group role |
+| Password | The account's password |
+| Site ID | Optional — restrict to one site (UUID); blank polls every site the account can see |
+
+Create the third-party account under **System > User Management** on NCE-Campus with Type set to Third-party, and assign it the `NBI User Group` role.
+
 ## Network Scan
 
 Actively discover topology with no upstream inventory: seed-crawls the network over SNMP and LLDP, identifying devices, walking ports, and harvesting neighbor links.
@@ -112,7 +125,7 @@ Actively discover topology with no upstream inventory: seed-crawls the network o
 Additional data sources can be added via the plugin system. Navigate to **Plugins** in the sidebar to manage installed plugins.
 
 Plugins can be added from:
-- Built-in plugins (Manual, Zabbix, Prometheus, Grafana, NetBox, Aruba Instant On, Arista CV-CUE, Network Scan)
+- Built-in plugins (Manual, Zabbix, Prometheus, Grafana, NetBox, Aruba Instant On, Arista CV-CUE, Huawei iMaster NCE-Campus, Network Scan)
 - GitHub URL
 - Local file path
 - ZIP file upload

--- a/apps/server/docs/datasources.en.mdx
+++ b/apps/server/docs/datasources.en.mdx
@@ -99,7 +99,9 @@ Pull managed access points, uplink switches, per-device status, and events (aler
 
 ## Huawei iMaster NCE-Campus
 
-Pull managed devices (APs, switches, AR routers, firewalls), LLDP-based device-to-device topology, per-device performance (CPU / memory / interface utilization), and current alarms from the northbound RESTful API (NBI, default port 18002) of a Huawei iMaster NCE-Campus controller. Devices are grouped into per-site subgraphs, and identity stamping (MAC / management IP) lets composition merge them with other sources such as NetBox.
+Pull managed devices (APs, switches, AR routers, firewalls), device-to-device topology (the controller's own topology API, falling back to LLDP neighbors), per-device performance (CPU / memory / interface utilization), link status, and current alarms from the northbound RESTful API (NBI, default port 18002) of a Huawei iMaster NCE-Campus controller. Devices are grouped into per-site subgraphs, and identity stamping (MAC / management IP) lets composition merge them with other sources such as NetBox.
+
+Note: NBI tokens are bound to the client IP that created them, so the server's source IP toward the controller must be stable (mind NAT / proxies).
 
 | Field | Description |
 |-------|-------------|

--- a/apps/server/docs/datasources.ja.mdx
+++ b/apps/server/docs/datasources.ja.mdx
@@ -106,7 +106,9 @@ Arista CV-CUE（CloudVision Cognitive Unified Edge）の Wi-Fi Open API から�
 
 ## Huawei iMaster NCE-Campus
 
-Huawei iMaster NCE-Campus コントローラの北向き RESTful API（NBI、既定ポート 18002）から、管理下のデバイス（AP・スイッチ・AR ルータ・ファイアウォール）・LLDP ベースのデバイス間トポロジ・デバイス別パフォーマンス（CPU / メモリ / インターフェース使用率）・現在アラームを取得します。デバイスはサイト単位のサブグラフにグループ化され、MAC / 管理 IP の identity で NetBox 等の他ソースとマージできます。
+Huawei iMaster NCE-Campus コントローラの北向き RESTful API（NBI、既定ポート 18002）から、管理下のデバイス（AP・スイッチ・AR ルータ・ファイアウォール）・デバイス間トポロジ（コントローラのトポロジ API を優先し、LLDP ネイバーにフォールバック）・デバイス別パフォーマンス（CPU / メモリ / インターフェース使用率）・リンク状態・現在アラームを取得します。デバイスはサイト単位のサブグラフにグループ化され、MAC / 管理 IP の identity で NetBox 等の他ソースとマージできます。
+
+トークンは発行時のクライアント IP に束縛されるため、NAT やプロキシ経由でコントローラへアクセスする構成では送信元 IP が固定される必要があります。
 
 | フィールド | 説明 |
 |-----------|------|

--- a/apps/server/docs/datasources.ja.mdx
+++ b/apps/server/docs/datasources.ja.mdx
@@ -104,6 +104,19 @@ Arista CV-CUE（CloudVision Cognitive Unified Edge）の Wi-Fi Open API から�
 | Customer ID (CID) | 任意 — キーが複数カスタマーにアクセスできる場合のみ |
 | Location ID | 任意 — クエリを特定のロケーション配下に限定（`0` がルート） |
 
+## Huawei iMaster NCE-Campus
+
+Huawei iMaster NCE-Campus コントローラの北向き RESTful API（NBI、既定ポート 18002）から、管理下のデバイス（AP・スイッチ・AR ルータ・ファイアウォール）・LLDP ベースのデバイス間トポロジ・デバイス別パフォーマンス（CPU / メモリ / インターフェース使用率）・現在アラームを取得します。デバイスはサイト単位のサブグラフにグループ化され、MAC / 管理 IP の identity で NetBox 等の他ソースとマージできます。
+
+| フィールド | 説明 |
+|-----------|------|
+| NBI base URL | コントローラの NBI ベース URL（例: `https://nce.example.com:18002`） |
+| Username | NBI User Group ロールを付与したサードパーティアカウント |
+| Password | アカウントのパスワード |
+| Site ID | 任意 — 1 サイト（UUID）に限定。空欄の場合はアカウントが参照できる全サイトをポーリング |
+
+サードパーティアカウントは NCE-Campus の **System > User Management** で Type を Third-party にして作成し、`NBI User Group` ロールを割り当ててください。
+
 ## Network Scan
 
 上流のインベントリなしでトポロジーを能動的に発見します。SNMP と LLDP でネットワークをシードクロールし、デバイスの特定・ポートの列挙・ネイバーリンクの収集を行います。
@@ -119,7 +132,7 @@ Arista CV-CUE（CloudVision Cognitive Unified Edge）の Wi-Fi Open API から�
 プラグインシステムで追加のデータソースを導入できます。サイドバーの **Plugins** からインストール済みプラグインを管理できます。
 
 プラグインの追加方法:
-- ビルトインプラグイン（Manual、Zabbix、Prometheus、Grafana、NetBox、Aruba Instant On、Arista CV-CUE、Network Scan）
+- ビルトインプラグイン（Manual、Zabbix、Prometheus、Grafana、NetBox、Aruba Instant On、Arista CV-CUE、Huawei iMaster NCE-Campus、Network Scan）
 - GitHub URL
 - ローカルファイルパス
 - ZIP ファイルアップロード

--- a/bun.lock
+++ b/bun.lock
@@ -120,6 +120,7 @@
         "shumoku-plugin-arista-cv-cue": "workspace:*",
         "shumoku-plugin-aruba-instant-on": "workspace:*",
         "shumoku-plugin-grafana": "workspace:*",
+        "shumoku-plugin-huawei-nce-campus": "workspace:*",
         "shumoku-plugin-netbox": "workspace:*",
         "shumoku-plugin-network-scan": "workspace:*",
         "shumoku-plugin-prometheus": "workspace:*",
@@ -264,6 +265,13 @@
     "libs/plugins/grafana": {
       "name": "shumoku-plugin-grafana",
       "version": "0.2.25",
+      "dependencies": {
+        "@shumoku/core": "workspace:*",
+      },
+    },
+    "libs/plugins/huawei-nce-campus": {
+      "name": "shumoku-plugin-huawei-nce-campus",
+      "version": "0.1.0",
       "dependencies": {
         "@shumoku/core": "workspace:*",
       },
@@ -1694,6 +1702,8 @@
     "shumoku-plugin-aruba-instant-on": ["shumoku-plugin-aruba-instant-on@workspace:libs/plugins/aruba-instant-on"],
 
     "shumoku-plugin-grafana": ["shumoku-plugin-grafana@workspace:libs/plugins/grafana"],
+
+    "shumoku-plugin-huawei-nce-campus": ["shumoku-plugin-huawei-nce-campus@workspace:libs/plugins/huawei-nce-campus"],
 
     "shumoku-plugin-netbox": ["shumoku-plugin-netbox@workspace:libs/plugins/netbox"],
 

--- a/libs/plugins/huawei-nce-campus/package.json
+++ b/libs/plugins/huawei-nce-campus/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "shumoku-plugin-huawei-nce-campus",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Huawei iMaster NCE-Campus data source plugin for Shumoku. Polls the NCE-Campus northbound RESTful API (NBI) for devices, LLDP topology, performance metrics, and alarms.",
+  "license": "AGPL-3.0-only",
+  "author": "konoe-akitoshi",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/konoe-akitoshi/shumoku.git",
+    "directory": "libs/plugins/huawei-nce-campus"
+  },
+  "homepage": "https://www.shumoku.dev/",
+  "bugs": {
+    "url": "https://github.com/konoe-akitoshi/shumoku/issues"
+  },
+  "keywords": [
+    "huawei",
+    "imaster",
+    "nce-campus",
+    "campus",
+    "network",
+    "shumoku",
+    "plugin"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "format": "biome check --write ."
+  },
+  "dependencies": {
+    "@shumoku/core": "workspace:*"
+  },
+  "devDependencies": {},
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libs/plugins/huawei-nce-campus/src/api.ts
+++ b/libs/plugins/huawei-nce-campus/src/api.ts
@@ -1,0 +1,155 @@
+/**
+ * iMaster NCE-Campus NBI client.
+ *
+ * NCE-Campus authenticates with a session token: `POST /controller/v2/tokens`
+ * with the third-party account's username/password returns a `token_id` that
+ * every subsequent request sends in the `X-ACCESS-TOKEN` header. The expiry is
+ * sliding (each use extends it), so we refresh on a conservative timer and
+ * re-login transparently on 401.
+ *
+ * The base URL is operator-supplied (typically `https://<controller>:18002`),
+ * so we require HTTPS and never log the credentials.
+ */
+
+import type { HuaweiNceCampusConfig, NcePagedResponse, NceTokenResponse } from './types.js'
+
+/** Re-login this long after obtaining a token (server default idle is longer). */
+const TOKEN_TTL_MS = 20 * 60 * 1000
+
+/** Page size for the v3 `pageIndex`/`pageSize` list endpoints. */
+const PAGE_SIZE = 100
+
+/** Upper bound on items fetched through paging, so a bad total can't spin. */
+const MAX_ITEMS = 10_000
+
+export class HuaweiNceCampusApi {
+  private token: string | null = null
+  private tokenExpiresAt = 0
+  private pendingAuth: Promise<string> | null = null
+
+  constructor(private readonly config: HuaweiNceCampusConfig) {
+    if (!/^https:\/\//i.test(config.baseUrl)) {
+      throw new Error('Huawei NCE-Campus `baseUrl` must be an https:// URL')
+    }
+  }
+
+  /** GET a JSON resource, re-authenticating once if the token lapsed. */
+  async get<T>(path: string, query?: Record<string, string | number | undefined>): Promise<T> {
+    return this.request<T>('GET', withQuery(path, query))
+  }
+
+  /** POST a JSON body, re-authenticating once if the token lapsed. */
+  async post<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>('POST', path, body)
+  }
+
+  /**
+   * Follow the v3 `pageIndex`/`pageSize` paging to exhaustion, concatenating
+   * `data` across pages. `pageIndex` is 1-based; the envelope's `totalRecords`
+   * bounds the walk, with a hard item cap as a backstop.
+   */
+  async getPaged<T>(
+    path: string,
+    query?: Record<string, string | number | undefined>,
+  ): Promise<T[]> {
+    const out: T[] = []
+    let pageIndex = 1
+    while (out.length < MAX_ITEMS) {
+      const page = await this.get<NcePagedResponse<T>>(path, {
+        ...query,
+        pageIndex,
+        pageSize: PAGE_SIZE,
+      })
+      const items = page.data ?? []
+      out.push(...items)
+      const total = page.totalRecords ?? out.length
+      if (items.length < PAGE_SIZE || out.length >= total) break
+      pageIndex += 1
+    }
+    return out.slice(0, MAX_ITEMS)
+  }
+
+  // ------------------------------------------------------------------
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${this.config.baseUrl}${path.startsWith('/') ? path : `/${path}`}`
+    const send = async (token: string): Promise<Response> => {
+      const init: RequestInit = {
+        method,
+        headers: {
+          'X-ACCESS-TOKEN': token,
+          Accept: 'application/json',
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+      }
+      if (body !== undefined && method !== 'GET') {
+        init.body = typeof body === 'string' ? body : JSON.stringify(body)
+      }
+      return fetch(url, init)
+    }
+
+    let token = await this.ensureToken()
+    let resp = await send(token)
+    if (resp.status === 401) {
+      // Token idled out or was revoked — drop it and log in once more.
+      this.token = null
+      token = await this.ensureToken()
+      resp = await send(token)
+    }
+    if (!resp.ok) {
+      throw new Error(`Huawei NCE-Campus ${method} ${path} → HTTP ${resp.status}`)
+    }
+    if (resp.status === 204) return undefined as T
+    return (await resp.json()) as T
+  }
+
+  /** Return a live token, deduping concurrent logins. */
+  private async ensureToken(): Promise<string> {
+    if (this.token && this.tokenExpiresAt > Date.now()) return this.token
+    if (!this.pendingAuth) {
+      this.pendingAuth = this.login().finally(() => {
+        this.pendingAuth = null
+      })
+    }
+    this.token = await this.pendingAuth
+    this.tokenExpiresAt = Date.now() + TOKEN_TTL_MS
+    return this.token
+  }
+
+  /** POST the credentials and capture the `token_id`. */
+  private async login(): Promise<string> {
+    const resp = await fetch(`${this.config.baseUrl}/controller/v2/tokens`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      body: JSON.stringify({
+        userName: this.config.userName,
+        password: this.config.password,
+      }),
+    })
+    if (!resp.ok) {
+      // Never echo the credentials back; the status is enough to diagnose.
+      throw new Error(`Huawei NCE-Campus token request failed: HTTP ${resp.status}`)
+    }
+    const parsed = (await resp.json()) as NceTokenResponse
+    const token = parsed.data?.token_id
+    if (!token) {
+      throw new Error(
+        `Huawei NCE-Campus token request succeeded but returned no token_id (errcode ${parsed.errcode ?? '?'})`,
+      )
+    }
+    return token
+  }
+}
+
+function withQuery(path: string, query?: Record<string, string | number | undefined>): string {
+  if (!query) return path
+  const qs = Object.entries(query)
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+    .join('&')
+  if (!qs) return path
+  return `${path}${path.includes('?') ? '&' : '?'}${qs}`
+}

--- a/libs/plugins/huawei-nce-campus/src/index.ts
+++ b/libs/plugins/huawei-nce-campus/src/index.ts
@@ -1,0 +1,47 @@
+export { HuaweiNceCampusPlugin } from './plugin.js'
+export type { HuaweiNceCampusConfig } from './types.js'
+
+import type { PluginConfigSchema, PluginRegistryInterface } from '@shumoku/core'
+import { HuaweiNceCampusPlugin } from './plugin.js'
+
+/** Self-description: the host renders this form and validates config from it. */
+const configSchema: PluginConfigSchema = {
+  type: 'object',
+  required: ['baseUrl', 'userName', 'password'],
+  properties: {
+    baseUrl: {
+      type: 'string',
+      format: 'uri',
+      title: 'NBI base URL',
+      placeholder: 'https://nce.example.com:18002',
+      help: 'The controller northbound API base (default port 18002).',
+    },
+    userName: {
+      type: 'string',
+      title: 'Username',
+      help: 'Third-party account attached to the NBI User Group role.',
+    },
+    password: { type: 'string', secret: true, title: 'Password' },
+    siteId: {
+      type: 'string',
+      title: 'Site ID',
+      help: 'Optional — scope topology and hosts to one site (UUID). Empty polls every site the account can see.',
+    },
+  },
+}
+
+export function register(registry: PluginRegistryInterface): void {
+  registry.registerDescriptor(
+    {
+      type: 'huawei-nce-campus',
+      displayName: 'Huawei iMaster NCE-Campus',
+      capabilities: ['topology', 'hosts', 'metrics', 'alerts'],
+      configSchema,
+    },
+    (config) => {
+      const plugin = new HuaweiNceCampusPlugin()
+      plugin.initialize(config)
+      return plugin
+    },
+  )
+}

--- a/libs/plugins/huawei-nce-campus/src/plugin.test.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import {
+  alarmToAlert,
+  deviceToHost,
+  interfacePerfToLinkMetrics,
+  mapAlarmSeverity,
+  mapDeviceStatus,
+  perfToNodeMetrics,
+} from './plugin.js'
+
+describe('mapDeviceStatus', () => {
+  it('maps controller status codes to host status', () => {
+    expect(mapDeviceStatus('0')).toBe('up') // normal
+    expect(mapDeviceStatus('1')).toBe('up') // alarm — device is still reachable
+    expect(mapDeviceStatus('3')).toBe('down') // offline
+    expect(mapDeviceStatus('4')).toBe('unknown') // not registered
+    expect(mapDeviceStatus(undefined)).toBe('unknown')
+  })
+})
+
+describe('deviceToHost', () => {
+  it('builds a host with identity from a device record', () => {
+    const host = deviceToHost({
+      id: 'dev-1',
+      name: 'campus-core-01',
+      esn: 'ESN123',
+      status: '0',
+      mac: '00:11:22:33:44:55',
+      ip: '10.0.0.2',
+    })
+    expect(host).toMatchObject({
+      id: 'dev-1',
+      name: 'campus-core-01',
+      displayName: 'campus-core-01',
+      status: 'up',
+      ip: '10.0.0.2',
+      identity: {
+        mgmtIp: '10.0.0.2',
+        mac: '00:11:22:33:44:55',
+        vendorIds: { 'nce-device-id': 'dev-1', 'nce-esn': 'ESN123' },
+      },
+    })
+  })
+
+  it('returns null for a record without an id', () => {
+    expect(deviceToHost({ name: 'ghost' })).toBeNull()
+  })
+})
+
+describe('perfToNodeMetrics', () => {
+  it('maps performance status codes and carries cpu/memory', () => {
+    expect(perfToNodeMetrics({ status: 0, cpuRate: 12, memoryRate: 40 })).toMatchObject({
+      status: 'up',
+      cpu: 12,
+      memory: 40,
+    })
+    expect(perfToNodeMetrics({ status: 1 }).status).toBe('up') // alarm
+    expect(perfToNodeMetrics({ status: 2 }).status).toBe('down') // faulty
+    expect(perfToNodeMetrics({ status: 3 }).status).toBe('down') // offline
+    expect(perfToNodeMetrics({ status: 4 }).status).toBe('unknown') // unregistered
+    expect(perfToNodeMetrics({}).status).toBe('unknown')
+  })
+})
+
+describe('interfacePerfToLinkMetrics', () => {
+  it('parses bandwidth-usage percentages into utilization', () => {
+    const m = interfacePerfToLinkMetrics({ inputBandwidth: '12.5', outBandwidth: '3' })
+    expect(m).toMatchObject({
+      status: 'up',
+      inUtilization: 12.5,
+      outUtilization: 3,
+      utilization: 12.5,
+    })
+  })
+
+  it('omits utilization when the NBI returns nothing parseable', () => {
+    const m = interfacePerfToLinkMetrics({ inputBandwidth: '', outBandwidth: 'n/a' })
+    expect(m.status).toBe('up')
+    expect(m.inUtilization).toBeUndefined()
+    expect(m.outUtilization).toBeUndefined()
+    expect(m.utilization).toBeUndefined()
+  })
+
+  it('clamps out-of-range percentages', () => {
+    const m = interfacePerfToLinkMetrics({ inputBandwidth: '250', outBandwidth: '-3' })
+    expect(m.inUtilization).toBe(100)
+    expect(m.outUtilization).toBe(0)
+  })
+})
+
+describe('mapAlarmSeverity', () => {
+  it('maps the 1–4 NCE scale to the neutral scale', () => {
+    expect(mapAlarmSeverity(1)).toBe('critical')
+    expect(mapAlarmSeverity(2)).toBe('high')
+    expect(mapAlarmSeverity(3)).toBe('medium')
+    expect(mapAlarmSeverity(4)).toBe('low')
+    expect(mapAlarmSeverity(undefined)).toBe('info')
+  })
+})
+
+describe('alarmToAlert', () => {
+  it('maps an uncleared alarm to an active alert', () => {
+    const alert = alarmToAlert({
+      csn: '28100132',
+      alarmName: 'Device offline',
+      alarmLevel: 1,
+      alarmResName: 'campus-core-01',
+      alarmCategory: 'communication',
+      latestOccurUtc: '1711029340291',
+      cleared: 0,
+      probableCause: 'The device lost its management channel.',
+    })
+    expect(alert).toMatchObject({
+      id: '28100132',
+      severity: 'critical',
+      title: 'Device offline',
+      startTime: 1711029340291,
+      status: 'active',
+      source: 'huawei-nce-campus',
+      labels: { category: 'communication', resource: 'campus-core-01' },
+    })
+    expect(alert.description).toContain('management channel')
+  })
+
+  it('maps a cleared alarm to resolved', () => {
+    const alert = alarmToAlert({ csn: '1', alarmName: 'x', cleared: 1 })
+    expect(alert.status).toBe('resolved')
+  })
+})

--- a/libs/plugins/huawei-nce-campus/src/plugin.test.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.test.ts
@@ -5,6 +5,7 @@ import {
   interfacePerfToLinkMetrics,
   mapAlarmSeverity,
   mapDeviceStatus,
+  mapLinkStatus,
   perfToNodeMetrics,
 } from './plugin.js'
 
@@ -85,6 +86,17 @@ describe('interfacePerfToLinkMetrics', () => {
     const m = interfacePerfToLinkMetrics({ inputBandwidth: '250', outBandwidth: '-3' })
     expect(m.inUtilization).toBe(100)
     expect(m.outUtilization).toBe(0)
+  })
+})
+
+describe('mapLinkStatus', () => {
+  it('maps the topology linkStatus enum to link status', () => {
+    expect(mapLinkStatus(0)).toBe('up') // normal
+    expect(mapLinkStatus(1)).toBe('unknown') // unknown
+    expect(mapLinkStatus(2)).toBe('down') // major fault
+    expect(mapLinkStatus(3)).toBe('down') // emergency fault
+    expect(mapLinkStatus(4)).toBe('down') // offline
+    expect(mapLinkStatus(5)).toBe('unknown') // not managed
   })
 })
 

--- a/libs/plugins/huawei-nce-campus/src/plugin.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.ts
@@ -6,10 +6,11 @@
  * controller can't push to us in v1.
  *
  * Plugin scope (v1):
- *   - topology: managed devices + LLDP-derived device↔device links, grouped by site
+ *   - topology: managed devices + the controller's own topology links
+ *     (LLDP-neighbor fallback), grouped by site
  *   - hosts: managed devices with up/down from controller status
  *   - metrics: per-node status/CPU/memory from basic performance; per-link
- *     utilization from interface performance
+ *     status from topology linkStatus + utilization from interface performance
  *   - alerts: current alarms mapped to our Alert shape
  */
 
@@ -47,6 +48,8 @@ import type {
   NceInterfacePerformanceResponse,
   NceLldpNeighbor,
   NceLldpResponse,
+  NceTopoLink,
+  NceTopoResponse,
 } from './types.js'
 
 /** Concurrent per-device NBI calls (LLDP / performance fan-out). */
@@ -57,6 +60,10 @@ const ALARM_LIMIT = 500
 
 /** Alarm scroll batch size. */
 const ALARM_BATCH = 100
+
+/** Page size and page cap for the topo-link cursor walk. */
+const TOPO_PAGE_LIMIT = 1000
+const TOPO_MAX_PAGES = 20
 
 export class HuaweiNceCampusPlugin
   implements DataSourcePlugin, TopologyCapable, HostsCapable, MetricsCapable, AlertsCapable
@@ -74,6 +81,8 @@ export class HuaweiNceCampusPlugin
   private config: HuaweiNceCampusConfig | null = null
   private devicesCache: { value: NceDevice[]; expiresAt: number } | null = null
   private devicesInFlight: Promise<NceDevice[]> | null = null
+  private topoLinksCache: { value: NceTopoLink[]; expiresAt: number } | null = null
+  private topoLinksInFlight: Promise<NceTopoLink[]> | null = null
 
   initialize(config: unknown): void {
     const c = config as Partial<HuaweiNceCampusConfig>
@@ -86,6 +95,8 @@ export class HuaweiNceCampusPlugin
     this.api = new HuaweiNceCampusApi(this.config)
     this.devicesCache = null
     this.devicesInFlight = null
+    this.topoLinksCache = null
+    this.topoLinksInFlight = null
   }
 
   dispose(): void {
@@ -93,6 +104,8 @@ export class HuaweiNceCampusPlugin
     this.api = null
     this.devicesCache = null
     this.devicesInFlight = null
+    this.topoLinksCache = null
+    this.topoLinksInFlight = null
   }
 
   async testConnection(): Promise<ConnectionResult> {
@@ -115,13 +128,20 @@ export class HuaweiNceCampusPlugin
   async fetchTopology(): Promise<NetworkGraph> {
     if (!this.api) return { version: '1.0.0', name: 'Huawei NCE-Campus', nodes: [], links: [] }
     const devices = await this.fetchDevices()
+
+    // Preferred link source: the controller's own topology (one cursor walk).
+    // Only when it yields nothing do we fan out to per-device LLDP tables —
+    // that's N calls and misses links the controller already knows about.
+    const topoLinks = await this.fetchTopoLinks()
     const neighborsByDeviceId = new Map<string, NceLldpNeighbor[]>()
-    await mapWithConcurrency(devices, FANOUT_CONCURRENCY, async (d) => {
-      if (!d.id) return
-      const neighbors = await this.fetchNeighbors(d.id)
-      if (neighbors.length > 0) neighborsByDeviceId.set(d.id, neighbors)
-    })
-    return buildTopology(devices, neighborsByDeviceId)
+    if (topoLinks.length === 0) {
+      await mapWithConcurrency(devices, FANOUT_CONCURRENCY, async (d) => {
+        if (!d.id) return
+        const neighbors = await this.fetchNeighbors(d.id)
+        if (neighbors.length > 0) neighborsByDeviceId.set(d.id, neighbors)
+      })
+    }
+    return buildTopology(devices, topoLinks, neighborsByDeviceId)
   }
 
   // ============================================================
@@ -155,19 +175,27 @@ export class HuaweiNceCampusPlugin
   }
 
   /**
-   * Per-host interface items for the link-mapping UI, derived from the LLDP
-   * neighbor table (the ports that actually carry inter-device links). The
-   * interface name matches the port `fetchTopology` puts on the link, so
-   * auto-map binds each link to its device-side port.
+   * Per-host interface items for the link-mapping UI — the ports that
+   * actually carry inter-device links. The interface names match the ports
+   * `fetchTopology` puts on the links, so auto-map binds each link to its
+   * device-side port.
    */
   async getHostItems(hostId: string): Promise<HostItem[]> {
     if (!this.api) return []
-    const neighbors = await this.fetchNeighbors(hostId)
+    // Ports that carry inter-device links: this device's ends of the topo
+    // links, plus its LLDP local ports (covers the fallback topology too).
+    const ifNames: string[] = []
+    for (const l of await this.fetchTopoLinks()) {
+      if (l.leftFdn === hostId && l.aPortName) ifNames.push(l.aPortName)
+      if (l.rightFdn === hostId && l.zPortName) ifNames.push(l.zPortName)
+    }
+    for (const n of await this.fetchNeighbors(hostId)) {
+      if (n.localIfName) ifNames.push(n.localIfName)
+    }
     const seen = new Set<string>()
     const out: HostItem[] = []
-    for (const n of neighbors) {
-      const ifName = n.localIfName
-      if (!ifName || seen.has(ifName)) continue
+    for (const ifName of ifNames) {
+      if (seen.has(ifName)) continue
       seen.add(ifName)
       for (const direction of ['in', 'out'] as const) {
         out.push({
@@ -216,15 +244,23 @@ export class HuaweiNceCampusPlugin
     })
 
     // ---- Links ----
+    // Status comes from the controller topology's linkStatus (one cursor
+    // walk); utilization from the per-interface performance counters.
+    const statusByPort = linkEntries.length > 0 ? await this.fetchTopoLinkStatus() : new Map()
     await mapWithConcurrency(linkEntries, FANOUT_CONCURRENCY, async ([linkId, linkMapping]) => {
       const monitoredNodeId = linkMapping.monitoredNodeId
       const iface = linkMapping.interface
       if (!monitoredNodeId || !iface) return
       const hostId = mapping.nodes[monitoredNodeId]?.hostId
       if (!hostId || !known.has(hostId)) return
+      const topoStatus = statusByPort.get(`${hostId}|${iface}`)
       const ifPerf = await this.fetchInterfacePerformance(hostId, iface)
-      if (!ifPerf) return
-      metrics.links[linkId] = interfacePerfToLinkMetrics(ifPerf)
+      if (!ifPerf && topoStatus === undefined) return
+      const sample = ifPerf ? interfacePerfToLinkMetrics(ifPerf) : { status: 'unknown' as const }
+      metrics.links[linkId] = {
+        ...sample,
+        ...(topoStatus !== undefined ? { status: mapLinkStatus(topoStatus) } : {}),
+      }
     })
 
     return metrics
@@ -286,6 +322,68 @@ export class HuaweiNceCampusPlugin
     } finally {
       if (this.devicesInFlight === request) this.devicesInFlight = null
     }
+  }
+
+  /**
+   * Walk the controller topology's link list to exhaustion (cursor paging).
+   * Scoped to `siteId` when configured — `parentResId` takes an organization
+   * or site UUID. Failures degrade to an empty list so callers fall back to
+   * LLDP rather than losing the whole topology.
+   */
+  private async fetchTopoLinks(): Promise<NceTopoLink[]> {
+    if (!this.api) return []
+    const now = Date.now()
+    if (this.topoLinksCache && this.topoLinksCache.expiresAt > now) {
+      return this.topoLinksCache.value
+    }
+    if (this.topoLinksInFlight) return this.topoLinksInFlight
+
+    const request = this.walkTopoLinks()
+    this.topoLinksInFlight = request
+    try {
+      const value = await request
+      // getHostItems is called once per mapped host in an auto-map burst;
+      // reuse one topology walk across that burst.
+      this.topoLinksCache = { value, expiresAt: Date.now() + 10_000 }
+      return value
+    } finally {
+      if (this.topoLinksInFlight === request) this.topoLinksInFlight = null
+    }
+  }
+
+  private async walkTopoLinks(): Promise<NceTopoLink[]> {
+    if (!this.api) return []
+    const out: NceTopoLink[] = []
+    try {
+      let marker: string | undefined
+      for (let page = 0; page < TOPO_MAX_PAGES; page++) {
+        const resp = await this.api.get<NceTopoResponse>(
+          '/controller/campus/v1/networkresource/topomanager/device/node',
+          {
+            limit: TOPO_PAGE_LIMIT,
+            ...(this.config?.siteId ? { parentResId: this.config.siteId } : {}),
+            ...(marker ? { marker } : {}),
+          },
+        )
+        out.push(...(resp.linkData?.linkData ?? []))
+        if (!resp.linkData?.hasNext || !resp.linkData.marker) break
+        marker = resp.linkData.marker
+      }
+    } catch {
+      return []
+    }
+    return out
+  }
+
+  /** Live link status per device port: `<deviceId>|<port>` → linkStatus. */
+  private async fetchTopoLinkStatus(): Promise<Map<string, number>> {
+    const statusByPort = new Map<string, number>()
+    for (const l of await this.fetchTopoLinks()) {
+      if (l.linkStatus === undefined) continue
+      if (l.leftFdn && l.aPortName) statusByPort.set(`${l.leftFdn}|${l.aPortName}`, l.linkStatus)
+      if (l.rightFdn && l.zPortName) statusByPort.set(`${l.rightFdn}|${l.zPortName}`, l.linkStatus)
+    }
+    return statusByPort
   }
 
   private async fetchNeighbors(deviceId: string): Promise<NceLldpNeighbor[]> {
@@ -423,6 +521,24 @@ function parsePercent(raw: string | undefined): number | undefined {
   const value = Number.parseFloat(raw)
   if (!Number.isFinite(value)) return undefined
   return Math.min(100, Math.max(0, value))
+}
+
+/**
+ * Topology linkStatus → link status.
+ * `0` normal is up; `2` major fault, `3` emergency fault, and `4` offline are
+ * down; `1` unknown and `5` not managed carry no verdict.
+ */
+export function mapLinkStatus(status: number): 'up' | 'down' | 'unknown' {
+  switch (status) {
+    case 0:
+      return 'up'
+    case 2:
+    case 3:
+    case 4:
+      return 'down'
+    default:
+      return 'unknown'
+  }
 }
 
 /** NCE alarm severity (1–4) → core's neutral CVSS-style scale. */

--- a/libs/plugins/huawei-nce-campus/src/plugin.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.ts
@@ -1,0 +1,461 @@
+/**
+ * Huawei iMaster NCE-Campus data-source plugin.
+ *
+ * NCE-Campus is Huawei's campus SDN controller (cloud or on-prem). It exposes
+ * a northbound RESTful API (NBI, port 18002) that this plugin polls — the
+ * controller can't push to us in v1.
+ *
+ * Plugin scope (v1):
+ *   - topology: managed devices + LLDP-derived device↔device links, grouped by site
+ *   - hosts: managed devices with up/down from controller status
+ *   - metrics: per-node status/CPU/memory from basic performance; per-link
+ *     utilization from interface performance
+ *   - alerts: current alarms mapped to our Alert shape
+ */
+
+import type {
+  Alert,
+  AlertQueryOptions,
+  AlertSeverity,
+  AlertsCapable,
+  ConnectionResult,
+  DataSourceCapability,
+  DataSourcePlugin,
+  DiscoveredMetric,
+  Host,
+  HostItem,
+  HostsCapable,
+  LinkMetrics,
+  MetricsCapable,
+  MetricsData,
+  MetricsMapping,
+  NetworkGraph,
+  NodeMetrics,
+  TopologyCapable,
+} from '@shumoku/core'
+import { buildIdentity, flattenObject, mapWithConcurrency, severityAtLeast } from '@shumoku/core'
+import { HuaweiNceCampusApi } from './api.js'
+import { buildTopology } from './topology.js'
+import type {
+  HuaweiNceCampusConfig,
+  NceAlarm,
+  NceAlarmScrollResponse,
+  NceDevice,
+  NceDevicePerformance,
+  NceDevicePerformanceResponse,
+  NceInterfacePerformance,
+  NceInterfacePerformanceResponse,
+  NceLldpNeighbor,
+  NceLldpResponse,
+} from './types.js'
+
+/** Concurrent per-device NBI calls (LLDP / performance fan-out). */
+const FANOUT_CONCURRENCY = 5
+
+/** Upper bound on current alarms pulled per poll. */
+const ALARM_LIMIT = 500
+
+/** Alarm scroll batch size. */
+const ALARM_BATCH = 100
+
+export class HuaweiNceCampusPlugin
+  implements DataSourcePlugin, TopologyCapable, HostsCapable, MetricsCapable, AlertsCapable
+{
+  readonly type = 'huawei-nce-campus'
+  readonly displayName = 'Huawei iMaster NCE-Campus'
+  readonly capabilities: readonly DataSourceCapability[] = [
+    'topology',
+    'hosts',
+    'metrics',
+    'alerts',
+  ]
+
+  private api: HuaweiNceCampusApi | null = null
+  private config: HuaweiNceCampusConfig | null = null
+  private devicesCache: { value: NceDevice[]; expiresAt: number } | null = null
+  private devicesInFlight: Promise<NceDevice[]> | null = null
+
+  initialize(config: unknown): void {
+    const c = config as Partial<HuaweiNceCampusConfig>
+    if (!c.baseUrl || !c.userName || !c.password) {
+      throw new Error(
+        'Huawei NCE-Campus plugin requires `baseUrl`, `userName`, and `password` in config',
+      )
+    }
+    this.config = c as HuaweiNceCampusConfig
+    this.api = new HuaweiNceCampusApi(this.config)
+    this.devicesCache = null
+    this.devicesInFlight = null
+  }
+
+  dispose(): void {
+    this.config = null
+    this.api = null
+    this.devicesCache = null
+    this.devicesInFlight = null
+  }
+
+  async testConnection(): Promise<ConnectionResult> {
+    if (!this.api) return { success: false, message: 'Plugin not initialized' }
+    try {
+      const devices = await this.fetchDevices()
+      return {
+        success: true,
+        message: `Connected to iMaster NCE-Campus (${devices.length} device${devices.length === 1 ? '' : 's'})`,
+      }
+    } catch (err) {
+      return { success: false, message: err instanceof Error ? err.message : 'Connection failed' }
+    }
+  }
+
+  // ============================================================
+  // TopologyCapable — devices + LLDP links, grouped by site
+  // ============================================================
+
+  async fetchTopology(): Promise<NetworkGraph> {
+    if (!this.api) return { version: '1.0.0', name: 'Huawei NCE-Campus', nodes: [], links: [] }
+    const devices = await this.fetchDevices()
+    const neighborsByDeviceId = new Map<string, NceLldpNeighbor[]>()
+    await mapWithConcurrency(devices, FANOUT_CONCURRENCY, async (d) => {
+      if (!d.id) return
+      const neighbors = await this.fetchNeighbors(d.id)
+      if (neighbors.length > 0) neighborsByDeviceId.set(d.id, neighbors)
+    })
+    return buildTopology(devices, neighborsByDeviceId)
+  }
+
+  // ============================================================
+  // HostsCapable
+  // ============================================================
+
+  async getHosts(): Promise<Host[]> {
+    if (!this.api) return []
+    const devices = await this.fetchDevices()
+    const out: Host[] = []
+    for (const d of devices) {
+      const host = deviceToHost(d)
+      if (host) out.push(host)
+    }
+    return out
+  }
+
+  /**
+   * Dump every primitive field of the device's inventory + basic performance
+   * records for the node-detail "All metrics" panel. Passthrough by design —
+   * new NBI fields surface automatically.
+   */
+  async discoverMetrics(hostId: string): Promise<DiscoveredMetric[]> {
+    if (!this.api) return []
+    const device = (await this.fetchDevices()).find((d) => d.id === hostId)
+    if (!device) return []
+    const out = flattenObject(device, 'nce')
+    const perf = await this.fetchPerformance(hostId)
+    if (perf) out.push(...flattenObject(perf, 'nce.perf'))
+    return out
+  }
+
+  /**
+   * Per-host interface items for the link-mapping UI, derived from the LLDP
+   * neighbor table (the ports that actually carry inter-device links). The
+   * interface name matches the port `fetchTopology` puts on the link, so
+   * auto-map binds each link to its device-side port.
+   */
+  async getHostItems(hostId: string): Promise<HostItem[]> {
+    if (!this.api) return []
+    const neighbors = await this.fetchNeighbors(hostId)
+    const seen = new Set<string>()
+    const out: HostItem[] = []
+    for (const n of neighbors) {
+      const ifName = n.localIfName
+      if (!ifName || seen.has(ifName)) continue
+      seen.add(ifName)
+      for (const direction of ['in', 'out'] as const) {
+        out.push({
+          id: `${hostId}:${ifName}:${direction}`,
+          hostId,
+          name: `${ifName} ${direction === 'in' ? 'received' : 'sent'}`,
+          key: `nce.if.${direction}`,
+          interfaceName: ifName,
+          interfaceIdentity: buildIdentity({ ifName }),
+          direction,
+        })
+      }
+    }
+    return out
+  }
+
+  // ============================================================
+  // MetricsCapable
+  // ============================================================
+
+  async pollMetrics(mapping: MetricsMapping): Promise<MetricsData> {
+    const metrics: MetricsData = { nodes: {}, links: {}, timestamp: Date.now() }
+    if (!this.api) return metrics
+
+    // Which devices do we need performance for? Mapped nodes, plus the devices
+    // that own a mapped link's interface.
+    const nodeEntries = Object.entries(mapping.nodes ?? {}).filter(([, m]) => m.hostId)
+    const linkEntries = Object.entries(mapping.links ?? {}).filter(
+      (e) => e[1].monitoredNodeId && e[1].interface,
+    )
+    if (nodeEntries.length === 0 && linkEntries.length === 0) return metrics
+
+    const devices = await this.fetchDevices()
+    const known = new Set<string>()
+    for (const d of devices) if (d.id) known.add(d.id)
+
+    // ---- Nodes ----
+    await mapWithConcurrency(nodeEntries, FANOUT_CONCURRENCY, async ([nodeId, nodeMapping]) => {
+      const hostId = nodeMapping.hostId
+      // Stay silent on ids that aren't ours — another source may own the node,
+      // and emitting a fake status here would clobber the real one on merge.
+      if (!hostId || !known.has(hostId)) return
+      const perf = await this.fetchPerformance(hostId)
+      if (!perf) return
+      metrics.nodes[nodeId] = perfToNodeMetrics(perf)
+    })
+
+    // ---- Links ----
+    await mapWithConcurrency(linkEntries, FANOUT_CONCURRENCY, async ([linkId, linkMapping]) => {
+      const monitoredNodeId = linkMapping.monitoredNodeId
+      const iface = linkMapping.interface
+      if (!monitoredNodeId || !iface) return
+      const hostId = mapping.nodes[monitoredNodeId]?.hostId
+      if (!hostId || !known.has(hostId)) return
+      const ifPerf = await this.fetchInterfacePerformance(hostId, iface)
+      if (!ifPerf) return
+      metrics.links[linkId] = interfacePerfToLinkMetrics(ifPerf)
+    })
+
+    return metrics
+  }
+
+  // ============================================================
+  // AlertsCapable — current alarms
+  // ============================================================
+
+  async getAlerts(options?: AlertQueryOptions): Promise<Alert[]> {
+    if (!this.api) return []
+    const alarms: NceAlarm[] = []
+    let iterator: string | undefined
+    while (alarms.length < ALARM_LIMIT) {
+      const page = await this.api.post<NceAlarmScrollResponse>(
+        '/v1/perfservice/alarms/current-alarms/action/scroll',
+        { alarmParamInput: { size: ALARM_BATCH, ...(iterator ? { iterator } : {}) } },
+      )
+      const items = page.data ?? []
+      alarms.push(...items)
+      if (items.length < ALARM_BATCH || !page.iterator) break
+      iterator = page.iterator
+    }
+
+    const cutoff = Date.now() - (options?.timeRange ?? 3600) * 1000
+    const out: Alert[] = []
+    for (const a of alarms) {
+      const alert = alarmToAlert(a)
+      if (options?.activeOnly && alert.status !== 'active') continue
+      if (options?.minSeverity && !severityAtLeast(alert.severity, options.minSeverity)) continue
+      // Keep active alerts regardless of age; window-filter the cleared ones.
+      if (alert.status !== 'active' && alert.startTime < cutoff) continue
+      out.push(alert)
+    }
+    return out
+  }
+
+  // ============================================================
+  // Internals
+  // ============================================================
+
+  private async fetchDevices(): Promise<NceDevice[]> {
+    if (!this.api) return []
+    const now = Date.now()
+    if (this.devicesCache && this.devicesCache.expiresAt > now) return this.devicesCache.value
+    if (this.devicesInFlight) return this.devicesInFlight
+
+    const request = this.api.getPaged<NceDevice>(
+      '/controller/campus/v3/devices',
+      this.config?.siteId ? { siteId: this.config.siteId } : undefined,
+    )
+    this.devicesInFlight = request
+    try {
+      const value = await request
+      // Mapping/auto-map asks once per mapped host. Reuse the same inventory
+      // snapshot across that burst instead of re-listing per host.
+      this.devicesCache = { value, expiresAt: Date.now() + 10_000 }
+      return value
+    } finally {
+      if (this.devicesInFlight === request) this.devicesInFlight = null
+    }
+  }
+
+  private async fetchNeighbors(deviceId: string): Promise<NceLldpNeighbor[]> {
+    if (!this.api) return []
+    try {
+      const resp = await this.api.get<NceLldpResponse>(
+        `/controller/campus/v1/networkresource/topomanager/device/${encodeURIComponent(deviceId)}/neighbors`,
+      )
+      return resp.data?.lldp ?? []
+    } catch {
+      // A device that can't answer LLDP (offline, unsupported) degrades to a
+      // link-less node rather than failing the whole topology.
+      return []
+    }
+  }
+
+  private async fetchPerformance(deviceId: string): Promise<NceDevicePerformance | undefined> {
+    if (!this.api) return undefined
+    try {
+      const resp = await this.api.get<NceDevicePerformanceResponse>(
+        `/controller/campus/v1/performanceservice/basicperformance/device/${encodeURIComponent(deviceId)}`,
+      )
+      return resp.data?.[0]
+    } catch {
+      return undefined
+    }
+  }
+
+  private async fetchInterfacePerformance(
+    deviceId: string,
+    interfaceName: string,
+  ): Promise<NceInterfacePerformance | undefined> {
+    if (!this.api) return undefined
+    try {
+      const resp = await this.api.get<NceInterfacePerformanceResponse>(
+        `/controller/campus/v1/performanceservice/basicperformance/interfaceperformance/device/${encodeURIComponent(deviceId)}`,
+        { interfaceName },
+      )
+      for (const entry of resp.data ?? []) {
+        const packets = entry.interfacePackets
+        const list = Array.isArray(packets) ? packets : packets ? [packets] : []
+        const match = list.find((p) => !p.interfaceName || p.interfaceName === interfaceName)
+        if (match) return match
+      }
+      return undefined
+    } catch {
+      return undefined
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (upstream vocab → core vocab at the boundary)
+// ---------------------------------------------------------------------------
+
+/**
+ * Controller device status → host status.
+ * `0` normal and `1` alarm are both reachable devices; `3` offline is down;
+ * `4` not registered means the controller has never seen it.
+ */
+export function mapDeviceStatus(status: string | undefined): 'up' | 'down' | 'unknown' {
+  switch (status) {
+    case '0':
+    case '1':
+      return 'up'
+    case '3':
+      return 'down'
+    default:
+      return 'unknown'
+  }
+}
+
+export function deviceToHost(d: NceDevice): Host | null {
+  if (!d.id) return null
+  const identity = buildIdentity({
+    mgmtIp: d.ip || d.manageIp,
+    mac: d.mac,
+    vendorIds: {
+      'nce-device-id': d.id,
+      ...(d.esn ? { 'nce-esn': d.esn } : {}),
+    },
+  })
+  return {
+    id: d.id,
+    name: d.name || d.id,
+    ...(d.name ? { displayName: d.name } : {}),
+    status: mapDeviceStatus(d.status),
+    ...(d.ip || d.manageIp ? { ip: d.ip || d.manageIp } : {}),
+    ...(identity ? { identity } : {}),
+  }
+}
+
+/**
+ * Basic performance record → node metrics.
+ * `status`: 0 normal / 1 alarm are up; 2 faulty / 3 offline are down;
+ * 4 unregistered is unknown.
+ */
+export function perfToNodeMetrics(p: NceDevicePerformance): NodeMetrics {
+  const status =
+    p.status === 0 || p.status === 1 ? 'up' : p.status === 2 || p.status === 3 ? 'down' : 'unknown'
+  return {
+    status,
+    // Controller-mediated: if the NBI answers, our monitoring path is fine.
+    // The record's `status` carries the actual device verdict.
+    monitoring: 'healthy',
+    ...(typeof p.cpuRate === 'number' ? { cpu: p.cpuRate } : {}),
+    ...(typeof p.memoryRate === 'number' ? { memory: p.memoryRate } : {}),
+    ...(typeof p.timestamp === 'number' && p.timestamp > 0 ? { lastSeen: p.timestamp } : {}),
+  }
+}
+
+/**
+ * Interface performance record → link metrics. `inputBandwidth`/`outBandwidth`
+ * are the NBI's bandwidth-usage percentages (strings); traffic counters are
+ * incremental bytes per collection period, so they don't convert to a stable
+ * bps without the period length — utilization is the honest signal here.
+ */
+export function interfacePerfToLinkMetrics(p: NceInterfacePerformance): LinkMetrics {
+  const inUtil = parsePercent(p.inputBandwidth)
+  const outUtil = parsePercent(p.outBandwidth)
+  return {
+    // The controller only reports counters for interfaces it can read — the
+    // record's existence is the "link alive" signal the NBI gives us.
+    status: 'up',
+    ...(inUtil !== undefined ? { inUtilization: inUtil } : {}),
+    ...(outUtil !== undefined ? { outUtilization: outUtil } : {}),
+    ...(inUtil !== undefined || outUtil !== undefined
+      ? { utilization: Math.max(inUtil ?? 0, outUtil ?? 0) }
+      : {}),
+  }
+}
+
+function parsePercent(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw === '') return undefined
+  const value = Number.parseFloat(raw)
+  if (!Number.isFinite(value)) return undefined
+  return Math.min(100, Math.max(0, value))
+}
+
+/** NCE alarm severity (1–4) → core's neutral CVSS-style scale. */
+export function mapAlarmSeverity(level: number | undefined): AlertSeverity {
+  switch (level) {
+    case 1:
+      return 'critical'
+    case 2:
+      return 'high'
+    case 3:
+      return 'medium'
+    case 4:
+      return 'low'
+    default:
+      return 'info'
+  }
+}
+
+export function alarmToAlert(a: NceAlarm): Alert {
+  const occurred = Number(a.latestOccurUtc)
+  return {
+    id: a.csn || `${a.alarmId ?? 'nce'}-${a.latestOccurUtc ?? '0'}`,
+    severity: mapAlarmSeverity(a.alarmLevel),
+    title: a.alarmName || a.alarmId || 'NCE-Campus alarm',
+    ...(a.probableCause || a.additionalInformation
+      ? { description: [a.probableCause, a.additionalInformation].filter(Boolean).join(' — ') }
+      : {}),
+    startTime: Number.isFinite(occurred) && occurred > 0 ? occurred : Date.now(),
+    status: a.cleared === 1 ? 'resolved' : 'active',
+    source: 'huawei-nce-campus',
+    labels: {
+      ...(a.alarmCategory ? { category: a.alarmCategory } : {}),
+      ...(a.alarmResName ? { resource: a.alarmResName } : {}),
+    },
+  }
+}

--- a/libs/plugins/huawei-nce-campus/src/topology.test.ts
+++ b/libs/plugins/huawei-nce-campus/src/topology.test.ts
@@ -1,0 +1,117 @@
+import { validateTopologyIdentityContract } from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import { buildTopology, mapDeviceType } from './topology.js'
+import type { NceDevice, NceLldpNeighbor } from './types.js'
+
+const CORE_SW: NceDevice = {
+  id: 'dev-core',
+  name: 'campus-core-01',
+  esn: '2102351234567890',
+  deviceModel: 'S5735-L24T4S-A1',
+  neType: 'S5735-L24T4S-A1',
+  deviceType: 'LSW',
+  status: '0',
+  siteId: 'site-1',
+  siteName: 'HQ',
+  mac: '00:11:22:33:44:55',
+  ip: '10.0.0.2',
+}
+
+const AP: NceDevice = {
+  id: 'dev-ap',
+  name: 'f2-ap-01',
+  esn: '2102351234567891',
+  deviceType: 'AP',
+  status: '0',
+  siteId: 'site-1',
+  siteName: 'HQ',
+  mac: '66:77:88:99:aa:bb',
+  ip: '10.0.0.30',
+}
+
+/** LLDP as seen from both ends of the same wire. */
+const NEIGHBORS = new Map<string, NceLldpNeighbor[]>([
+  [
+    'dev-core',
+    [
+      {
+        localIfName: 'GigabitEthernet0/0/1',
+        remoteIfName: 'GigabitEthernet0/0/0',
+        sysName: 'f2-ap-01',
+        remoteMac: '66:77:88:99:AA:BB',
+      },
+    ],
+  ],
+  [
+    'dev-ap',
+    [
+      {
+        localIfName: 'GigabitEthernet0/0/0',
+        remoteIfName: 'GigabitEthernet0/0/1',
+        sysName: 'campus-core-01',
+        remoteMac: '00:11:22:33:44:55',
+      },
+    ],
+  ],
+])
+
+describe('mapDeviceType', () => {
+  it('maps NCE device classes to core device types', () => {
+    expect(mapDeviceType('AP')).toBe('access-point')
+    expect(mapDeviceType('AR')).toBe('router')
+    expect(mapDeviceType('FW')).toBe('firewall')
+    expect(mapDeviceType('LSW')).toBe('l2-switch')
+    expect(mapDeviceType(undefined)).toBe('l2-switch')
+  })
+})
+
+describe('buildTopology', () => {
+  it('emits device nodes with identity and a site subgraph', () => {
+    const g = buildTopology([CORE_SW, AP], new Map())
+    expect(g.nodes).toHaveLength(2)
+    const sw = g.nodes.find((n) => n.spec?.type === 'l2-switch')
+    expect(sw?.identity).toMatchObject({
+      mgmtIp: '10.0.0.2',
+      mac: '00:11:22:33:44:55',
+      vendorIds: { 'nce-device-id': 'dev-core', 'nce-esn': '2102351234567890' },
+    })
+    expect(sw?.parent).toBe('nce-site:site-1')
+    expect(g.subgraphs).toEqual([{ id: 'nce-site:site-1', label: 'HQ', identity: { name: 'HQ' } }])
+  })
+
+  it('collapses the bidirectional LLDP pair into one link with both ports', () => {
+    const g = buildTopology([CORE_SW, AP], NEIGHBORS)
+    expect(g.links).toHaveLength(1)
+    const link = g.links[0]
+    const ports = [link?.from.port, link?.to.port].sort()
+    expect(ports).toEqual(['GigabitEthernet0/0/0', 'GigabitEthernet0/0/1'])
+    const ends = [link?.from.node, link?.to.node].sort()
+    expect(ends).toEqual(['nce:dev-ap', 'nce:dev-core'])
+  })
+
+  it('matches peers by MAC case-insensitively even when sysName differs', () => {
+    const renamed = { ...AP, name: 'operator renamed this' }
+    const g = buildTopology([CORE_SW, renamed], NEIGHBORS)
+    // dev-core's neighbor entry still finds the AP via remoteMac.
+    expect(g.links).toHaveLength(1)
+  })
+
+  it('drops neighbors outside the managed inventory', () => {
+    const foreign = new Map<string, NceLldpNeighbor[]>([
+      [
+        'dev-core',
+        [{ localIfName: 'GE0/0/24', sysName: 'isp-router', remoteMac: 'de:ad:be:ef:00:01' }],
+      ],
+    ])
+    const g = buildTopology([CORE_SW], foreign)
+    expect(g.links).toHaveLength(0)
+    expect(g.nodes).toHaveLength(1)
+  })
+
+  it('satisfies the topology identity contract', () => {
+    const g = buildTopology([CORE_SW, AP], NEIGHBORS)
+    const result = validateTopologyIdentityContract(g)
+    expect(result.nodesMissingIdentity).toEqual([])
+    expect(result.portsMissingIfName).toEqual([])
+  })
+})

--- a/libs/plugins/huawei-nce-campus/src/topology.test.ts
+++ b/libs/plugins/huawei-nce-campus/src/topology.test.ts
@@ -1,7 +1,7 @@
 import { validateTopologyIdentityContract } from '@shumoku/core'
 import { describe, expect, it } from 'vitest'
 import { buildTopology, mapDeviceType } from './topology.js'
-import type { NceDevice, NceLldpNeighbor } from './types.js'
+import type { NceDevice, NceLldpNeighbor, NceTopoLink } from './types.js'
 
 const CORE_SW: NceDevice = {
   id: 'dev-core',
@@ -65,9 +65,21 @@ describe('mapDeviceType', () => {
   })
 })
 
+/** The same wire as NEIGHBORS, but from the controller's topology linkData. */
+const TOPO_LINKS: NceTopoLink[] = [
+  {
+    label: 'campus-core-01_GigabitEthernet0/0/1_f2-ap-01_GigabitEthernet0/0/0',
+    leftFdn: 'dev-core',
+    rightFdn: 'dev-ap',
+    aPortName: 'GigabitEthernet0/0/1',
+    zPortName: 'GigabitEthernet0/0/0',
+    linkStatus: 0,
+  },
+]
+
 describe('buildTopology', () => {
   it('emits device nodes with identity and a site subgraph', () => {
-    const g = buildTopology([CORE_SW, AP], new Map())
+    const g = buildTopology([CORE_SW, AP], [], new Map())
     expect(g.nodes).toHaveLength(2)
     const sw = g.nodes.find((n) => n.spec?.type === 'l2-switch')
     expect(sw?.identity).toMatchObject({
@@ -80,7 +92,7 @@ describe('buildTopology', () => {
   })
 
   it('collapses the bidirectional LLDP pair into one link with both ports', () => {
-    const g = buildTopology([CORE_SW, AP], NEIGHBORS)
+    const g = buildTopology([CORE_SW, AP], [], NEIGHBORS)
     expect(g.links).toHaveLength(1)
     const link = g.links[0]
     const ports = [link?.from.port, link?.to.port].sort()
@@ -91,7 +103,7 @@ describe('buildTopology', () => {
 
   it('matches peers by MAC case-insensitively even when sysName differs', () => {
     const renamed = { ...AP, name: 'operator renamed this' }
-    const g = buildTopology([CORE_SW, renamed], NEIGHBORS)
+    const g = buildTopology([CORE_SW, renamed], [], NEIGHBORS)
     // dev-core's neighbor entry still finds the AP via remoteMac.
     expect(g.links).toHaveLength(1)
   })
@@ -103,13 +115,49 @@ describe('buildTopology', () => {
         [{ localIfName: 'GE0/0/24', sysName: 'isp-router', remoteMac: 'de:ad:be:ef:00:01' }],
       ],
     ])
-    const g = buildTopology([CORE_SW], foreign)
+    const g = buildTopology([CORE_SW], [], foreign)
     expect(g.links).toHaveLength(0)
     expect(g.nodes).toHaveLength(1)
   })
 
   it('satisfies the topology identity contract', () => {
-    const g = buildTopology([CORE_SW, AP], NEIGHBORS)
+    const g = buildTopology([CORE_SW, AP], [], NEIGHBORS)
+    const result = validateTopologyIdentityContract(g)
+    expect(result.nodesMissingIdentity).toEqual([])
+    expect(result.portsMissingIfName).toEqual([])
+  })
+
+  it('builds links from the controller topology linkData (preferred path)', () => {
+    const g = buildTopology([CORE_SW, AP], TOPO_LINKS, new Map())
+    expect(g.links).toHaveLength(1)
+    const link = g.links[0]
+    expect(link?.from).toEqual({ node: 'nce:dev-core', port: 'GigabitEthernet0/0/1' })
+    expect(link?.to).toEqual({ node: 'nce:dev-ap', port: 'GigabitEthernet0/0/0' })
+  })
+
+  it('prefers topo links over LLDP when both are supplied', () => {
+    const g = buildTopology([CORE_SW, AP], TOPO_LINKS, NEIGHBORS)
+    // The same wire must not be drawn twice (once per source).
+    expect(g.links).toHaveLength(1)
+    expect(g.links[0]?.from.port).toBe('GigabitEthernet0/0/1')
+  })
+
+  it('drops topo links whose ends are not both managed devices', () => {
+    const siteLink: NceTopoLink[] = [
+      { leftFdn: 'dev-core', rightFdn: 'site-1', aPortName: 'GE0/0/24', zPortName: '' },
+    ]
+    const g = buildTopology([CORE_SW, AP], siteLink, new Map())
+    expect(g.links).toHaveLength(0)
+  })
+
+  it('collapses duplicate topo link records for the same wire', () => {
+    const dup = [...TOPO_LINKS, { ...TOPO_LINKS[0] }] as NceTopoLink[]
+    const g = buildTopology([CORE_SW, AP], dup, new Map())
+    expect(g.links).toHaveLength(1)
+  })
+
+  it('satisfies the topology identity contract on the topo-link path', () => {
+    const g = buildTopology([CORE_SW, AP], TOPO_LINKS, new Map())
     const result = validateTopologyIdentityContract(g)
     expect(result.nodesMissingIdentity).toEqual([])
     expect(result.portsMissingIfName).toEqual([])

--- a/libs/plugins/huawei-nce-campus/src/topology.ts
+++ b/libs/plugins/huawei-nce-campus/src/topology.ts
@@ -1,0 +1,136 @@
+/**
+ * Build an NCE-Campus topology fragment: managed devices (APs, switches,
+ * routers, firewalls), grouped into their sites, with device↔device links
+ * recovered from each device's LLDP neighbor table. Identity stamping lets
+ * shumoku's composition merge these nodes with other sources (NetBox, Zabbix)
+ * by MAC / management IP / sysName.
+ */
+
+import type { Link, NetworkGraph, Node, Subgraph } from '@shumoku/core'
+import { buildIdentity, DeviceType } from '@shumoku/core'
+import type { NceDevice, NceLldpNeighbor } from './types.js'
+
+/** Node id for a device, derived from its NCE UUID. */
+export function deviceNodeId(deviceId: string): string {
+  return `nce:${deviceId}`
+}
+
+function siteSubgraphId(siteId: string): string {
+  return `nce-site:${siteId}`
+}
+
+/** NCE device class → core device type. */
+export function mapDeviceType(deviceType: string | undefined): DeviceType {
+  switch ((deviceType ?? '').toUpperCase()) {
+    case 'AP':
+      return DeviceType.AccessPoint
+    case 'AR':
+      return DeviceType.Router
+    case 'FW':
+      return DeviceType.Firewall
+    default:
+      // LSW (LAN switch) and anything unrecognized.
+      return DeviceType.L2Switch
+  }
+}
+
+const normalizeMac = (mac: string): string => mac.toLowerCase()
+
+export function buildTopology(
+  devices: NceDevice[],
+  neighborsByDeviceId: Map<string, NceLldpNeighbor[]>,
+): NetworkGraph {
+  const nodes: Node[] = []
+  const links: Link[] = []
+  const subgraphs: Subgraph[] = []
+  const emittedSite = new Set<string>()
+
+  // Neighbor entries reference peers by self-reported sysName and MAC; index
+  // the managed inventory by both so an edge can land on the peer's node.
+  const byName = new Map<string, NceDevice>()
+  const byMac = new Map<string, NceDevice>()
+  for (const d of devices) {
+    if (d.name) byName.set(d.name, d)
+    if (d.mac) byMac.set(normalizeMac(d.mac), d)
+  }
+
+  const ensureSite = (d: NceDevice): string | undefined => {
+    if (!d.siteId) return undefined
+    if (!emittedSite.has(d.siteId)) {
+      emittedSite.add(d.siteId)
+      const label = d.siteName || d.siteId
+      subgraphs.push({
+        id: siteSubgraphId(d.siteId),
+        label,
+        identity: { name: label },
+      })
+    }
+    return siteSubgraphId(d.siteId)
+  }
+
+  for (const d of devices) {
+    if (!d.id) continue
+    const parent = ensureSite(d)
+    // The NCE device `name` is operator-editable (a display string), so it
+    // stays out of sysName. MAC + management IP are the stable machine keys;
+    // the ESN and NCE UUID ride along as vendor ids.
+    const identity = buildIdentity({
+      mgmtIp: d.ip || d.manageIp,
+      mac: d.mac,
+      vendorIds: {
+        'nce-device-id': d.id,
+        ...(d.esn ? { 'nce-esn': d.esn } : {}),
+      },
+    })
+    nodes.push({
+      id: deviceNodeId(d.id),
+      label: [d.name || d.id],
+      ...(parent ? { parent } : {}),
+      ...(identity ? { identity } : {}),
+      spec: {
+        kind: 'hardware',
+        type: mapDeviceType(d.deviceType),
+        vendor: 'huawei',
+        ...(d.neType || d.deviceModel
+          ? { model: (d.neType || d.deviceModel || '').toLowerCase() }
+          : {}),
+      },
+    })
+  }
+
+  // LLDP edges. Both ends report the same physical wire, so a canonical
+  // endpoint-sorted key collapses the A→B / B→A duplicates.
+  const emittedLink = new Set<string>()
+  for (const [deviceId, neighbors] of neighborsByDeviceId) {
+    const fromNode = deviceNodeId(deviceId)
+    for (const n of neighbors) {
+      if (!n.localIfName) continue
+      const peer =
+        (n.remoteMac ? byMac.get(normalizeMac(n.remoteMac)) : undefined) ??
+        (n.sysName ? byName.get(n.sysName) : undefined)
+      // Neighbors outside the managed inventory (upstream carrier gear, phones)
+      // are dropped in v1 — an edge to a node we can't identify would neither
+      // merge nor render usefully.
+      if (!peer?.id || peer.id === deviceId) continue
+      const a = `${deviceId}|${n.localIfName}`
+      const b = `${peer.id}|${n.remoteIfName ?? ''}`
+      const key = a < b ? `${a}~${b}` : `${b}~${a}`
+      if (emittedLink.has(key)) continue
+      emittedLink.add(key)
+      links.push({
+        id: `nce-link:${key}`,
+        from: { node: fromNode, port: n.localIfName },
+        to: { node: deviceNodeId(peer.id), port: n.remoteIfName || '' },
+        arrow: 'none',
+      })
+    }
+  }
+
+  return {
+    version: '1.0.0',
+    name: 'Huawei NCE-Campus',
+    nodes,
+    links,
+    ...(subgraphs.length > 0 ? { subgraphs } : {}),
+  }
+}

--- a/libs/plugins/huawei-nce-campus/src/topology.ts
+++ b/libs/plugins/huawei-nce-campus/src/topology.ts
@@ -1,14 +1,17 @@
 /**
  * Build an NCE-Campus topology fragment: managed devices (APs, switches,
- * routers, firewalls), grouped into their sites, with device↔device links
- * recovered from each device's LLDP neighbor table. Identity stamping lets
+ * routers, firewalls), grouped into their sites, with device↔device links.
+ *
+ * Links come from the controller's own topology (`topomanager/device/node`
+ * linkData — one call, ports + status included) when it returns any, falling
+ * back to each device's LLDP neighbor table otherwise. Identity stamping lets
  * shumoku's composition merge these nodes with other sources (NetBox, Zabbix)
- * by MAC / management IP / sysName.
+ * by MAC / management IP.
  */
 
 import type { Link, NetworkGraph, Node, Subgraph } from '@shumoku/core'
 import { buildIdentity, DeviceType } from '@shumoku/core'
-import type { NceDevice, NceLldpNeighbor } from './types.js'
+import type { NceDevice, NceLldpNeighbor, NceTopoLink } from './types.js'
 
 /** Node id for a device, derived from its NCE UUID. */
 export function deviceNodeId(deviceId: string): string {
@@ -38,6 +41,7 @@ const normalizeMac = (mac: string): string => mac.toLowerCase()
 
 export function buildTopology(
   devices: NceDevice[],
+  topoLinks: NceTopoLink[],
   neighborsByDeviceId: Map<string, NceLldpNeighbor[]>,
 ): NetworkGraph {
   const nodes: Node[] = []
@@ -98,31 +102,57 @@ export function buildTopology(
     })
   }
 
-  // LLDP edges. Both ends report the same physical wire, so a canonical
-  // endpoint-sorted key collapses the A→B / B→A duplicates.
+  const knownDevice = new Set<string>()
+  for (const d of devices) if (d.id) knownDevice.add(d.id)
   const emittedLink = new Set<string>()
-  for (const [deviceId, neighbors] of neighborsByDeviceId) {
-    const fromNode = deviceNodeId(deviceId)
-    for (const n of neighbors) {
-      if (!n.localIfName) continue
-      const peer =
-        (n.remoteMac ? byMac.get(normalizeMac(n.remoteMac)) : undefined) ??
-        (n.sysName ? byName.get(n.sysName) : undefined)
-      // Neighbors outside the managed inventory (upstream carrier gear, phones)
-      // are dropped in v1 — an edge to a node we can't identify would neither
-      // merge nor render usefully.
-      if (!peer?.id || peer.id === deviceId) continue
-      const a = `${deviceId}|${n.localIfName}`
-      const b = `${peer.id}|${n.remoteIfName ?? ''}`
-      const key = a < b ? `${a}~${b}` : `${b}~${a}`
-      if (emittedLink.has(key)) continue
-      emittedLink.add(key)
-      links.push({
-        id: `nce-link:${key}`,
-        from: { node: fromNode, port: n.localIfName },
-        to: { node: deviceNodeId(peer.id), port: n.remoteIfName || '' },
-        arrow: 'none',
-      })
+
+  // Preferred: the controller's own topology links. leftFdn/rightFdn are the
+  // end nodes' resIds — for device nodes, the same UUID the device list
+  // returns — with the ports in aPortName/zPortName. Links whose ends aren't
+  // both managed devices (site/organization container nodes, unmanaged gear)
+  // are dropped: an edge to a node we can't identify would neither merge nor
+  // render usefully.
+  for (const l of topoLinks) {
+    if (!l.leftFdn || !l.rightFdn) continue
+    if (!knownDevice.has(l.leftFdn) || !knownDevice.has(l.rightFdn)) continue
+    if (l.leftFdn === l.rightFdn) continue
+    const a = `${l.leftFdn}|${l.aPortName ?? ''}`
+    const b = `${l.rightFdn}|${l.zPortName ?? ''}`
+    const key = a < b ? `${a}~${b}` : `${b}~${a}`
+    if (emittedLink.has(key)) continue
+    emittedLink.add(key)
+    links.push({
+      id: `nce-link:${key}`,
+      from: { node: deviceNodeId(l.leftFdn), port: l.aPortName || '' },
+      to: { node: deviceNodeId(l.rightFdn), port: l.zPortName || '' },
+      arrow: 'none',
+    })
+  }
+
+  // Fallback: LLDP neighbor tables (used when the topo API returned no usable
+  // links). Both ends report the same physical wire, so a canonical
+  // endpoint-sorted key collapses the A→B / B→A duplicates.
+  if (links.length === 0) {
+    for (const [deviceId, neighbors] of neighborsByDeviceId) {
+      const fromNode = deviceNodeId(deviceId)
+      for (const n of neighbors) {
+        if (!n.localIfName) continue
+        const peer =
+          (n.remoteMac ? byMac.get(normalizeMac(n.remoteMac)) : undefined) ??
+          (n.sysName ? byName.get(n.sysName) : undefined)
+        if (!peer?.id || peer.id === deviceId) continue
+        const a = `${deviceId}|${n.localIfName}`
+        const b = `${peer.id}|${n.remoteIfName ?? ''}`
+        const key = a < b ? `${a}~${b}` : `${b}~${a}`
+        if (emittedLink.has(key)) continue
+        emittedLink.add(key)
+        links.push({
+          id: `nce-link:${key}`,
+          from: { node: fromNode, port: n.localIfName },
+          to: { node: deviceNodeId(peer.id), port: n.remoteIfName || '' },
+          arrow: 'none',
+        })
+      }
     }
   }
 

--- a/libs/plugins/huawei-nce-campus/src/types.ts
+++ b/libs/plugins/huawei-nce-campus/src/types.ts
@@ -1,0 +1,214 @@
+/**
+ * Huawei iMaster NCE-Campus plugin types.
+ *
+ * Field names mirror the NCE-Campus northbound RESTful API (NBI,
+ * V300R024C00). Only the subset the plugin reads is modeled; everything is
+ * optional except the config the operator must supply. Full records still
+ * flow to the "All metrics" panel via `flattenObject`, so unmodeled fields
+ * surface there.
+ */
+
+export interface HuaweiNceCampusConfig {
+  /**
+   * NBI base URL of the controller, e.g. `https://nce.example.com:18002`.
+   * All API paths (`/controller/...`, `/v1/...`) are appended to this.
+   */
+  baseUrl: string
+  /** Third-party (NBI User Group) account name. */
+  userName: string
+  /** Password paired with `userName`. */
+  password: string
+  /** Optional site ID (UUID) to scope topology/hosts to a single site. */
+  siteId?: string
+}
+
+// ----- Auth -----------------------------------------------------------------
+
+/** Response body of `POST /controller/v2/tokens`. */
+export interface NceTokenResponse {
+  errcode?: string
+  errmsg?: string
+  data?: {
+    token_id?: string
+    /** UTC expiry, `yyyy-MM-dd HH:mm:ss`. Sliding — refreshed on use. */
+    expiredDate?: string
+  }
+}
+
+// ----- Paging ---------------------------------------------------------------
+
+/** Envelope of the v3 list endpoints (`/controller/campus/v3/...`). */
+export interface NcePagedResponse<T> {
+  errcode?: string
+  errmsg?: string
+  totalRecords?: number
+  pageIndex?: number
+  pageSize?: number
+  data?: T[]
+}
+
+// ----- Sites ----------------------------------------------------------------
+
+/** One site from `GET /controller/campus/v3/sites`. */
+export interface NceSite {
+  id?: string
+  tenantId?: string
+  name?: string
+  organizationId?: string
+  organizationName?: string
+  description?: string
+  type?: string[]
+}
+
+// ----- Devices --------------------------------------------------------------
+
+/**
+ * One device from `GET /controller/campus/v3/devices`.
+ * `status`: 0 = normal, 1 = alarm, 3 = offline, 4 = not registered.
+ */
+export interface NceDevice {
+  /** Device UUID — the stable NCE-side id. */
+  id?: string
+  /** Device name shown on the controller UI (operator-editable). */
+  name?: string
+  /** Equipment serial number. */
+  esn?: string
+  deviceModel?: string
+  /** Device class: `AP`, `AR`, `FW`, or `LSW`. */
+  deviceType?: string
+  status?: string
+  siteId?: string
+  siteName?: string
+  mac?: string
+  ip?: string
+  manageIp?: string
+  /** Device model string (per the doc, corresponds to "Device Model"). */
+  neType?: string
+  version?: string
+  vendor?: string
+  description?: string
+  tenantId?: string
+  tenantName?: string
+  registerTime?: string
+  startupTime?: string
+  tags?: string[]
+  uptime?: string
+}
+
+// ----- LLDP neighbors -------------------------------------------------------
+
+/** One LLDP neighbor entry of a device. */
+export interface NceLldpNeighbor {
+  /** Local interface the neighbor was heard on, e.g. `GigabitEthernet0/0/1`. */
+  localIfName?: string
+  /** Neighbor's port, as the neighbor reports it. */
+  remoteIfName?: string
+  /** Neighbor's self-reported system name. */
+  sysName?: string
+  sysDescription?: string
+  remoteMac?: string
+  sysCapEnabled?: string
+  sysCapSupported?: string
+}
+
+/** Envelope of `GET .../topomanager/device/{deviceId}/neighbors`. */
+export interface NceLldpResponse {
+  errcode?: string
+  errmsg?: string
+  totalRecords?: number
+  pageIndex?: number
+  pageSize?: number
+  data?: {
+    lldp?: NceLldpNeighbor[]
+  }
+}
+
+// ----- Performance ----------------------------------------------------------
+
+/**
+ * One record from `GET .../basicperformance/device/{deviceId}`.
+ * `status`: 0 = normal, 1 = alarm, 2 = faulty, 3 = offline, 4 = unregistered.
+ */
+export interface NceDevicePerformance {
+  id?: string
+  name?: string
+  esn?: string
+  deviceIp?: string
+  neType?: string
+  status?: number
+  /** Total traffic volume, bytes. */
+  traffic?: number
+  /** Number of connected terminals. */
+  onlineUsers?: number
+  /** CPU usage, percent. */
+  cpuRate?: number
+  /** Memory usage, percent. */
+  memoryRate?: number
+  upwardSpeed?: number
+  downwardSpeed?: number
+  mac?: string
+  timestamp?: number
+}
+
+/** Envelope of `GET .../basicperformance/device/{deviceId}`. */
+export interface NceDevicePerformanceResponse {
+  errcode?: string
+  errmsg?: string
+  data?: NceDevicePerformance[]
+}
+
+/** Per-interface counters from `GET .../interfaceperformance/device/{deviceId}`. */
+export interface NceInterfacePerformance {
+  interfaceName?: string
+  /** Bandwidth usage in the outbound direction (percent, as a string). */
+  outBandwidth?: string
+  /** Bandwidth usage in the inbound direction (percent, as a string). */
+  inputBandwidth?: string
+  /** Uplink traffic, incremental bytes over the last collection period. */
+  upwardTraffic?: number
+  /** Downlink traffic, incremental bytes over the last collection period. */
+  downwardTraffic?: number
+}
+
+/** Envelope of `GET .../interfaceperformance/device/{deviceId}`. */
+export interface NceInterfacePerformanceResponse {
+  errcode?: string
+  errmsg?: string
+  data?: Array<{
+    mac?: string
+    interfacePackets?: NceInterfacePerformance | NceInterfacePerformance[]
+  }>
+}
+
+// ----- Alarms ---------------------------------------------------------------
+
+/**
+ * One current alarm from `POST /v1/perfservice/alarms/current-alarms/action/scroll`.
+ * `alarmLevel`: 1 = critical, 2 = major, 3 = minor, 4 = warning.
+ * `cleared`: 0 = uncleared, 1 = cleared.
+ */
+export interface NceAlarm {
+  csn?: string
+  alarmName?: string
+  alarmLevel?: number
+  alarmId?: string
+  alarmResId?: string
+  alarmResName?: string
+  /** Last occurrence time — epoch milliseconds, as a string. */
+  latestOccurUtc?: string
+  alarmCategory?: string
+  additionalInformation?: string
+  cleared?: number
+  probableCause?: string
+  repairAction?: string
+  alarmGroupId?: string
+}
+
+/** Envelope of the current-alarm scroll endpoint. */
+export interface NceAlarmScrollResponse {
+  errcode?: string
+  errmsg?: string
+  /** Opaque cursor; pass back to fetch the next batch. */
+  iterator?: string
+  data?: NceAlarm[]
+}

--- a/libs/plugins/huawei-nce-campus/src/types.ts
+++ b/libs/plugins/huawei-nce-campus/src/types.ts
@@ -123,6 +123,45 @@ export interface NceLldpResponse {
   }
 }
 
+// ----- Topology (topomanager) -------------------------------------------------
+
+/**
+ * One link from `GET .../topomanager/device/node`.
+ * `leftFdn`/`rightFdn` are the resIds of the two end nodes — for device nodes
+ * this is the same UUID `/controller/campus/v3/devices` returns as `id`.
+ * `linkStatus`: 0 = normal, 1 = unknown, 2 = major fault, 3 = emergency fault,
+ * 4 = offline, 5 = not managed.
+ */
+export interface NceTopoLink {
+  label?: string
+  resId?: string
+  topoId?: number
+  typeId?: string
+  leftFdn?: string
+  rightFdn?: string
+  /** Port of the `leftFdn` end. */
+  aPortName?: string
+  /** Port of the `rightFdn` end. */
+  zPortName?: string
+  linkStatus?: number
+}
+
+/** Envelope of `GET .../topomanager/device/node`. */
+export interface NceTopoResponse {
+  errcode?: string
+  errmsg?: string | null
+  nodeData?: {
+    nodeData?: unknown[]
+    hasNext?: boolean
+    marker?: string
+  }
+  linkData?: {
+    linkData?: NceTopoLink[]
+    hasNext?: boolean
+    marker?: string
+  }
+}
+
 // ----- Performance ----------------------------------------------------------
 
 /**

--- a/libs/plugins/huawei-nce-campus/tsconfig.json
+++ b/libs/plugins/huawei-nce-campus/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"],
+  "references": [{ "path": "../../@shumoku/core" }]
+}


### PR DESCRIPTION
## Summary

Adds a bundled data-source plugin for **Huawei iMaster NCE-Campus** (campus SDN controller), polling its northbound RESTful API (NBI, V300R024C00, default port 18002).

### Capabilities
- **topology** — managed devices (AP / LSW / AR / FW) as nodes, grouped into per-site subgraphs. Links come from the controller's own topology API (`topomanager/device/node` linkData — `leftFdn`/`rightFdn` are the end devices' UUIDs, ports in `aPortName`/`zPortName`), falling back to per-device LLDP neighbor tables when it returns nothing. Identity stamping (MAC / mgmt IP / ESN vendorIds) for cross-source merge.
- **hosts** — devices with controller status mapped to up/down/unknown (0 normal & 1 alarm → up, 3 offline → down, 4 unregistered → unknown).
- **metrics** — node CPU/memory/status from the basic-performance API; link status from topology `linkStatus` (0 normal → up, 2/3 faults & 4 offline → down) plus utilization from per-interface bandwidth-usage counters.
- **alerts** — current alarms via the scroll API, severity 1–4 mapped to the neutral scale (critical/high/medium/low).

### Auth
`POST /controller/v2/tokens` (third-party NBI User Group account) → sliding-expiry token sent as `X-ACCESS-TOKEN`; transparent re-login on 401. Tokens are IP-bound (documented in datasources docs).

### Notes
- Implemented from the vendor NBI documentation; not yet verified against a live controller.
- Package is `private: true` (bundled only, no npm release) — changeset is an empty entry.
- Docs: `datasources.{ja,en}.mdx` updated in the same PR.

## Test plan
- [x] 22 unit tests in the plugin (status/severity/linkStatus mapping, topo-link + LLDP topology building, identity contract on both paths)
- [x] `apps/server/api` typecheck + full test suite (153 pass)
- [x] biome + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)