### PR TITLE
Helm ChartをOCI Artifactとして公開できるようにする

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -1,5 +1,5 @@
 # git-cliff configuration for Shumoku product (Server / Editor) release notes.
-# Used by the Docker (server-v*) and Editor (editor-v*) release workflows to
+# Used by the Server (server-v*) and Editor (editor-v*) release workflows to
 # generate path-scoped, conventional-commit-grouped notes. npm library changes
 # are intentionally NOT included here — they ship with their own Changesets
 # CHANGELOGs. Pass --include-path / --tag-pattern on the CLI per product.

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -31,10 +31,3 @@ jobs:
 
       - name: Render default configuration
         run: helm template shumoku apps/server/chart/shumoku > /dev/null
-
-      - name: Render HTTPRoute configuration
-        run: |
-          helm template shumoku apps/server/chart/shumoku \
-            --set httpRoute.enabled=true \
-            --set httpRoute.parentRefs[0].name=public \
-            > /dev/null

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -1,0 +1,40 @@
+name: Helm Chart CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/server/chart/shumoku/**"
+      - ".github/workflows/helm-chart-ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/server/chart/shumoku/**"
+      - ".github/workflows/helm-chart-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: latest # TODO: miseなどを導入して、リポジトリレベルでhelm versionを管理した方が良さそう
+
+      - name: Lint chart
+        run: helm lint apps/server/chart/shumoku
+
+      - name: Render default configuration
+        run: helm template shumoku apps/server/chart/shumoku > /dev/null
+
+      - name: Render HTTPRoute configuration
+        run: |
+          helm template shumoku apps/server/chart/shumoku \
+            --set httpRoute.enabled=true \
+            --set httpRoute.parentRefs[0].name=public \
+            > /dev/null

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -3,7 +3,7 @@ name: Server Release
 on:
   push:
     branches: [main]
-    tags: ['server-v*.*.*']
+    tags: ["server-v*.*.*"]
   pull_request:
     branches: [main]
 
@@ -288,7 +288,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -302,7 +302,7 @@ jobs:
           helm package apps/server/chart/shumoku --destination dist
 
       - name: Log in to Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Server Release
 
 on:
   push:
@@ -31,6 +31,12 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - name: Setup Bun
+        if: startsWith(github.ref, 'refs/tags/server-v')
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
       - name: Resolve build information
         id: build
         shell: bash
@@ -54,19 +60,7 @@ jobs:
       - name: Verify release version
         if: steps.build.outputs.release == 'true'
         shell: bash
-        run: |
-          package_version="${{ steps.build.outputs.version }}"
-          tag_version="${GITHUB_REF_NAME#server-v}"
-
-          if [[ ! "$tag_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$ ]]; then
-            echo "::error::Server release tags must use server-vX.Y.Z or server-vX.Y.Z-beta.N"
-            exit 1
-          fi
-
-          if [[ "$tag_version" != "$package_version" ]]; then
-            echo "::error::Tag server-v${tag_version} does not match @shumoku/server ${package_version}"
-            exit 1
-          fi
+        run: bun run version:server:check-release "$GITHUB_REF_NAME"
 
   # Build each architecture on its OWN native runner (arm64 on ubuntu-24.04-arm),
   # so there is no QEMU emulation. On release, each arch is pushed by digest and
@@ -286,9 +280,48 @@ jobs:
           # immutable index digest so every tag pointing at it is covered.
           cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
 
+  publish-chart:
+    needs: [setup, merge]
+    if: needs.setup.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: latest # TODO: miseなどを導入して、リポジトリレベルでhelm versionを管理した方が良さそう
+
+      - name: Lint and package chart
+        shell: bash
+        run: |
+          helm lint apps/server/chart/shumoku
+          helm package apps/server/chart/shumoku --destination dist
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish chart
+        shell: bash
+        run: |
+          shopt -s nullglob
+          packages=(dist/*.tgz)
+          if [[ "${#packages[@]}" -ne 1 ]]; then
+            echo "::error::Expected exactly one packaged chart, found ${#packages[@]}"
+            exit 1
+          fi
+          helm push "${packages[0]}" "oci://${REGISTRY}/${{ github.repository_owner }}/charts"
+
   release:
     if: startsWith(github.ref, 'refs/tags/server-v')
-    needs: merge
+    needs: [merge, publish-chart]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -34,7 +34,7 @@ Configure via environment variables (pin a version and use port 80 for productio
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/konoe-akitoshi/shumoku/main/apps/server/scripts/install.sh \
-  | SHUMOKU_VERSION=0.1.4 SHUMOKU_PORT=80 sh
+  | SHUMOKU_VERSION=0.1.5-beta.5 SHUMOKU_PORT=80 sh
 ```
 
 Knobs: `SHUMOKU_VERSION` (default `latest`), `SHUMOKU_PORT` (default `8080`),
@@ -63,7 +63,7 @@ For production, pin an exact version rather than `latest`:
 
 ```bash
 docker run -d -p 8080:8080 -v shumoku-data:/data \
-  ghcr.io/konoe-akitoshi/shumoku:0.1.1
+  ghcr.io/konoe-akitoshi/shumoku:0.1.5-beta.5
 ```
 
 Test the newest beta without changing `latest`:
@@ -87,7 +87,7 @@ docker compose up -d
 Or pass them inline for a one-off:
 
 ```bash
-SHUMOKU_VERSION=0.1.4 docker compose up -d
+SHUMOKU_VERSION=0.1.5-beta.5 docker compose up -d
 SHUMOKU_PORT=80 docker compose up -d    # production port
 DEMO_MODE=true docker compose up -d     # preload a sample network
 ```
@@ -262,10 +262,11 @@ docker compose up -d            # recreate after an upgrade
 
 ### Kubernetes (Helm)
 
-A Helm chart is provided under [`chart/shumoku`](chart/shumoku):
+A Helm chart is available as an OCI artifact in GitHub Container Registry:
 
 ```bash
-helm install shumoku ./chart/shumoku
+helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku \
+  --version 0.1.5-beta.5
 ```
 
 ### Systemd (Linux)

--- a/apps/server/docs/helm-chart.md
+++ b/apps/server/docs/helm-chart.md
@@ -12,20 +12,20 @@ Shumoku Server を Kubernetes にデプロイするための Helm chart です�
 
 ```bash
 # デフォルト設定でインストール
-helm install shumoku apps/server/chart/shumoku
+helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku
 
-# namespace を指定してインストール
-helm install shumoku apps/server/chart/shumoku -n shumoku --create-namespace
+# namespace を作成してインストール
+helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku --namespace shumoku --create-namespace
 
 # values ファイルを指定してインストール
-helm install shumoku apps/server/chart/shumoku -f my-values.yaml
+helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku -f my-values.yaml
 ```
 
-Production deployments should pin an exact Server release:
+本番環境へのデプロイでは、以下のようにChartのバージョンを固定することを推奨します。
 
 ```bash
-helm upgrade --install shumoku apps/server/chart/shumoku \
-  --set image.tag=0.1.1
+helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku \
+  --version 0.1.5-beta.5
 ```
 
 ## Configuration
@@ -146,17 +146,18 @@ resources:
 chart の動作確認には以下のコマンドが使えます。
 
 ```bash
-# テンプレートの構文チェック
-helm lint apps/server/chart/shumoku
+# Chart の情報を確認
+helm show chart oci://ghcr.io/konoe-akitoshi/charts/shumoku
 
 # レンダリング結果のプレビュー（クラスタ不要）
-helm template test apps/server/chart/shumoku
+helm template test oci://ghcr.io/konoe-akitoshi/charts/shumoku
 
 # config や ingress 有効時のプレビュー
-helm template test apps/server/chart/shumoku -f my-values.yaml
+helm template test oci://ghcr.io/konoe-akitoshi/charts/shumoku \
+  --version 0.1.5-beta.5 --values my-values.yaml
 
 # dry-run でインストールをシミュレーション（クラスタ必要）
-helm install shumoku apps/server/chart/shumoku --dry-run
+helm install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku --dry-run
 
 # インストール後の状態確認
 helm status shumoku

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -54,7 +54,8 @@ bun run version:editor 0.2.0-beta.1
 bun run version:products:check
 ```
 
-The Server command also synchronizes the Helm chart. Both commands synchronize
+The Server command also synchronizes the Helm chart and server versions in
+`apps/server/README.md` and `apps/server/docs/helm-chart.md`. Both commands synchronize
 the corresponding workspace entry in `bun.lock`. API and web implementation
 workspaces remain at `0.0.0`.
 
@@ -65,20 +66,20 @@ Server release tags are product-qualified:
 ```bash
 # Beta
 bun run version:server 0.2.0-beta.1
-git add apps/server/package.json apps/server/chart/shumoku/Chart.yaml bun.lock
+git add apps/server/package.json apps/server/chart/shumoku/Chart.yaml apps/server/README.md apps/server/docs/helm-chart.md bun.lock
 git commit -m "chore(server): release 0.2.0-beta.1"
 git tag -a server-v0.2.0-beta.1 -m "Shumoku Server 0.2.0-beta.1"
 git push origin HEAD server-v0.2.0-beta.1
 
 # Stable
 bun run version:server 0.2.0
-git add apps/server/package.json apps/server/chart/shumoku/Chart.yaml bun.lock
+git add apps/server/package.json apps/server/chart/shumoku/Chart.yaml apps/server/README.md apps/server/docs/helm-chart.md bun.lock
 git commit -m "chore(server): release 0.2.0"
 git tag -a server-v0.2.0 -m "Shumoku Server 0.2.0"
 git push origin HEAD server-v0.2.0
 ```
 
-The Docker workflow verifies that the tag matches
+The Server Release workflow verifies that the tag matches
 `apps/server/package.json`.
 
 | Release | GHCR tags changed | GitHub Release |

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build:packages": "turbo run build --filter='./libs/**' --filter=@shumoku/cli",
     "version:server": "bun scripts/product-version.ts server",
     "version:server:check": "bun scripts/product-version.ts server --check",
+    "version:server:check-release": "bun scripts/product-version.ts server --check-release",
     "version:editor": "bun scripts/product-version.ts editor",
     "version:editor:check": "bun scripts/product-version.ts editor --check",
     "version:products:check": "bun run version:server:check && bun run version:editor:check",

--- a/scripts/product-version.ts
+++ b/scripts/product-version.ts
@@ -6,6 +6,12 @@ interface ProductConfig {
   packagePath: string
   workspacePath: string
   chartPath?: string
+  documentation?: DocumentationConfig[]
+}
+
+interface DocumentationConfig {
+  path: string
+  versionPatterns: RegExp[]
 }
 
 interface PackageManifest {
@@ -22,6 +28,23 @@ const products: Record<ProductName, ProductConfig> = {
     packagePath: 'apps/server/package.json',
     workspacePath: 'apps/server',
     chartPath: 'apps/server/chart/shumoku/Chart.yaml',
+    documentation: [
+      {
+        path: 'apps/server/README.md',
+        versionPatterns: [
+          /(?<prefix>SHUMOKU_VERSION=)(?<version>\d+\.\d+\.\d+(?:-beta\.\d+)?)/g,
+          /(?<prefix>ghcr\.io\/konoe-akitoshi\/shumoku:)(?<version>\d+\.\d+\.\d+(?:-beta\.\d+)?)/g,
+          /(?<prefix>--version\s+)(?<version>\d+\.\d+\.\d+(?:-beta\.\d+)?)/g,
+        ],
+      },
+      {
+        path: 'apps/server/docs/helm-chart.md',
+        versionPatterns: [
+          /(?<prefix>--version\s+)(?<version>\d+\.\d+\.\d+(?:-beta\.\d+)?)/g,
+          /(?<prefix>image\.tag=)(?<version>\d+\.\d+\.\d+(?:-beta\.\d+)?)/g,
+        ],
+      },
+    ],
   },
   editor: {
     packagePath: 'apps/editor/package.json',
@@ -67,6 +90,32 @@ async function readLockVersion(workspacePath: string): Promise<string | undefine
   return version
 }
 
+async function readDocumentationVersions(
+  documentation: DocumentationConfig[],
+): Promise<Map<string, string>> {
+  const versions = new Map<string, string>()
+
+  for (const document of documentation) {
+    const content = await readFile(document.path, 'utf8')
+    for (const pattern of document.versionPatterns) {
+      const matches = [...content.matchAll(pattern)]
+      if (matches.length === 0) {
+        continue
+      }
+      for (const [index, match] of matches.entries()) {
+        const version = match.groups?.version
+        if (!version) {
+          // version groupを定義し忘れない限りここには来ないはず
+          throw new Error('version pattern must include a named "version" group')
+        }
+        versions.set(`${document.path}#${pattern.source}:${index + 1}`, version)
+      }
+    }
+  }
+
+  return versions
+}
+
 async function checkProduct(product: ProductName): Promise<void> {
   const config = products[product]
   const expected = await readProductVersion(config)
@@ -79,6 +128,11 @@ async function checkProduct(product: ProductName): Promise<void> {
     const chart = await readChartVersions(config.chartPath)
     versions.set(`${config.chartPath}#version`, chart.version)
     versions.set(`${config.chartPath}#appVersion`, chart.appVersion)
+  }
+  if (config.documentation) {
+    for (const [reference, version] of await readDocumentationVersions(config.documentation)) {
+      versions.set(reference, version)
+    }
   }
 
   const mismatches = [...versions].filter(([, version]) => version && version !== expected)
@@ -136,17 +190,40 @@ async function setProductVersion(product: ProductName, version: string): Promise
     await writeFile(config.chartPath, updatedChart)
   }
 
+  for (const document of config.documentation ?? []) {
+    let content = await readFile(document.path, 'utf8')
+    for (const pattern of document.versionPatterns) {
+      content = content.replace(pattern, `$<prefix>${version}`)
+    }
+    await writeFile(document.path, content)
+  }
+
   await updateLockfile(config.workspacePath, version)
   await checkProduct(product)
 }
 
+async function checkReleaseTag(product: ProductName, tag: string): Promise<void> {
+  await checkProduct(product)
+  const version = await readProductVersion(products[product])
+  const expectedTag = `${product}-v${version}`
+  if (tag !== expectedTag) {
+    throw new Error(`${product} release tag must be ${expectedTag}, received ${tag}`)
+  }
+}
+
 const product = getProduct(Bun.argv[2])
 const argument = Bun.argv[3]
+const releaseTag = Bun.argv[4]
 
 if (argument === '--check') {
   await checkProduct(product)
+} else if (argument === '--check-release') {
+  if (!releaseTag) throw new Error('Release tag is required')
+  await checkReleaseTag(product, releaseTag)
 } else if (argument) {
   await setProductVersion(product, argument.replace(/^(?:server|editor)-v/, ''))
 } else {
-  throw new Error('Usage: bun scripts/product-version.ts <server|editor> <X.Y.Z[-beta.N]|--check>')
+  throw new Error(
+    'Usage: bun scripts/product-version.ts <server|editor> <X.Y.Z[-beta.N]|--check|--check-release TAG>',
+  )
 }


### PR DESCRIPTION
## Summary
Helm ChartをOCI Artifactとして公開できるようにしました

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Detail

- Helm ChartをOCI Artifactとして公開できるようにした
  - 具体的には、Helm pakageをghcr.ioにアップロードしたり、version・appVersionのバージョンアップを自動化するリリースWorkflowを追加した
- 👆に関連して、Helm Chartを用いたshumokuのインストールに関するドキュメントを追加した

## Screenshots

N/A

## Breaking changes

None.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My commits are signed off for the DCO (`git commit -s`)
- [x] My code follows the project's code style (`bun run lint`)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`bun run test`)
- [-] I added a changeset if I changed a published package (`bun run changeset`)
- [x] I have updated the documentation if needed

## Validation

- `bun run version:server:check-release server-v0.1.5-beta.5`
- `helm lint apps/server/chart/shumoku`
- `helm template shumoku apps/server/chart/shumoku`
- `bun x biome check .github/cliff.toml .github/workflows/helm-chart-ci.yml .github/workflows/server-release.yml apps/server/README.md apps/server/docs/helm-chart.md docs/releasing.md package.json scripts/product-version.ts`

## 補足
- tag切ってリリースしないとHelm Chartもリリースされません
- GitHub Actionsは全然試してません！動かなかったらごめん！！！
