### PR TITLE
fix(web): stop swallowing fatal YAML parse errors in the Manual source editor

### DIFF
--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -134,12 +134,30 @@
     return lines.join('\n')
   }
 
+  /**
+   * Parse YAML into a NetworkGraph, or throw if the YAML was unparseable.
+   *
+   * YamlParser.parse() never throws on its own — a fatal syntax error (e.g. an
+   * unquoted multi-line label) is caught internally and returned as a
+   * look-alike empty graph (`{nodes: [], links: []}`) plus a `PARSE_ERROR`
+   * warning. Every caller here used to read only `.graph` and drop
+   * `.warnings`, so a broken paste silently "succeeded" as an empty diagram —
+   * and, on save, silently replaced the source's last-good content. Surfacing
+   * `PARSE_ERROR` as a thrown error lets the existing try/catch around each
+   * call site do its job instead.
+   */
+  function parseYamlOrThrow(text: string): NetworkGraph {
+    const result = new YamlParser().parse(text)
+    const fatal = result.warnings?.find((w) => w.code === 'PARSE_ERROR')
+    if (fatal) throw new Error(`Invalid YAML: ${fatal.message}`)
+    return result.graph
+  }
+
   function switchMode(mode: 'yaml' | 'json') {
     if (mode === editorMode) return
     try {
       if (mode === 'json') {
-        const result = new YamlParser().parse(yamlContent)
-        jsonContent = JSON.stringify(result.graph, null, 2)
+        jsonContent = JSON.stringify(parseYamlOrThrow(yamlContent), null, 2)
       } else {
         const graph = JSON.parse(jsonContent)
         yamlContent = graphToYaml(graph)
@@ -181,7 +199,7 @@
   /** Parse the active editor pane (YAML or JSON) into a NetworkGraph. */
   function manualGraphFromEditor(): NetworkGraph {
     return editorMode === 'yaml'
-      ? new YamlParser().parse(yamlContent).graph
+      ? parseYamlOrThrow(yamlContent)
       : (JSON.parse(jsonContent) as NetworkGraph)
   }
 


### PR DESCRIPTION
## Problem

Saving content in the Manual data source editor (`/datasources/[id]`) can **silently destroy the source's previously-saved topology** if the pasted YAML has a fatal syntax error — for example, a multi-line `label:` written as an unquoted plain scalar continued on the next line:

```yaml
nodes:
  - id: segment-mgmt
    label: Management / VLAN 10
10.153.0.0/24        # unindented continuation — not valid block-scalar or plain-scalar syntax
```

`js-yaml` throws `YAMLException: can not read a block mapping entry; a multiline key may not be an implicit key` on input like this. The UI, however, reports a successful save, and on reload the Manual source's content has been replaced by an empty graph — every previously-saved node and link is gone.

## Root cause

`YamlParser.parse()` (`libs/@shumoku/core/src/parser/parser.ts`) never throws. A fatal parse error is caught internally and converted into a return value that's shape-identical to a legitimately-empty document:

```ts
return {
  graph: { version: '2.0.0', nodes: [], links: [] },
  warnings: [{ code: 'PARSE_ERROR', message: ..., severity: 'error' }],
}
```

Both call sites in the Manual editor (`apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte`) read only `.graph` and discard `.warnings`:

```ts
function manualGraphFromEditor(): NetworkGraph {
  return editorMode === 'yaml'
    ? new YamlParser().parse(yamlContent).graph   // .warnings dropped
    : (JSON.parse(jsonContent) as NetworkGraph)
}
```

`handleSave()` then hard-codes `status: 'ok'` on every Manual save:

```ts
await api.topologies.sources.recordObservation(topoId, id, manualGraphFromEditor(), 'ok')
```

Server-side, `POST /:topologyId/sources/:sourceId/observation` only validates that `graph.nodes`/`graph.links` are *arrays* (an empty array passes trivially), and `ObservationsService.record() → materializeContribution() → ingestGraph()` performs an unconditional `DELETE FROM contribution_source WHERE topology_id=? AND source_id=?` before inserting the new (now empty) rows — with no gate on `status` other than `'failed'`.

Net effect: a single malformed paste wipes the source's entire prior contribution, with the UI reporting success at every step.

## Fix

`ParseWarning.code === 'PARSE_ERROR'` already uniquely identifies the fatal-parse-failure branch (as opposed to non-fatal per-item warnings like `MISSING_NODE_ID`, which the parser recovers from by synthesizing a fallback id and continues, correctly, without dropping the whole graph). This PR adds a small wrapper that checks for that existing signal and throws:

```ts
function parseYamlOrThrow(text: string): NetworkGraph {
  const result = new YamlParser().parse(text)
  const fatal = result.warnings?.find((w) => w.code === 'PARSE_ERROR')
  if (fatal) throw new Error(`Invalid YAML: ${fatal.message}`)
  return result.graph
}
```

...and uses it at both existing call sites (`switchMode`'s YAML↔JSON toggle, and `manualGraphFromEditor`). Both are already wrapped in `try/catch` blocks that set the existing `error` state — so a broken paste now fails loudly in the UI and the save is never attempted, instead of silently overwriting good data.

This is a minimal, surgical change:
- No change to `YamlParser`'s public contract or return shape.
- No change to observation/contribution status semantics.
- No behavior change for legitimately-empty or partially-invalid (per-item-warning) YAML — only a genuine `PARSE_ERROR` now blocks the save.

## Out of scope (noted for maintainers, not touched here)

While tracing this I found one adjacent, independent inconsistency that's worth a maintainer decision but isn't needed to fix this bug:

`db/migrations/008_topology_observations.sql` documents the `status` column contract as `empty: succeeded but found nothing; do not retract`, but `ObservationsService.materializeContribution()` only special-cases `status === 'failed'` — an `'empty'` status is currently treated identically to `'ok'` (full replace via `ingestGraph()`). With this PR's fix, a genuine parse failure never reaches this code path at all (it throws client-side before `recordObservation()` is called), so this doesn't affect the bug being fixed here. Flagging it separately in case it's worth a follow-up.

## Testing

- `apps/server/web`: `bun run typecheck` passes on the changed file (pre-existing, unrelated errors in `@shumoku/renderer`-dependent files remain, none touched by this change).
- `bunx biome check` on the changed file: clean.
- `libs/@shumoku/core` full test suite: 394/394 passing (untouched by this PR; confirms the parser's existing `PARSE_ERROR` signal this fix relies on is stable).
- `apps/server/api/test/db/manual-source.test.ts`: 6/6 passing (untouched by this PR; confirms the save/observation path this fix protects is unaffected).

Repro steps and full trace of the bug are in the PR — happy to add a regression test if you'd like it scoped to a particular layer (e.g. a `parser.test.ts` asserting `PARSE_ERROR` is emitted for this exact multi-line-label shape — I noticed there's currently no dedicated test file for `YamlParser` at all).
