### PR TITLE
fix(core): make hand-authored graphs survive a YAML round trip (identity parsing + lossless serializer)

### DIFF
--- a/.changeset/parse-node-identity.md
+++ b/.changeset/parse-node-identity.md
@@ -1,9 +1,9 @@
 ---
-'@shumoku/core': patch
+'@shumoku/core': minor
 ---
 
 Make hand-authored graphs survive a YAML round trip.
 
 `YamlParser` read every `Node` field except `identity`, so a Manual data source's nodes were silently stripped of the keys `resolve()` clusters on and the metrics-mapping stack needs to bind a node to a monitoring host — leaving hand-drawn devices permanently unmappable. `NodePort.identity` was already parsed; this closes the same gap one level up.
 
-Adds `dumpGraph()`, the inverse of the parser, so a graph can be written back to authoring YAML without loss: it quotes values that need it (a label containing a newline made the previous hand-rolled writer emit an unparseable document) and emits every field the graph carries, flattening `spec` to the `type` / `vendor` / `model` keys the parser reads back. `parse(dumpGraph(g))` is a fixed point.
+Adds `dumpGraph()`, the inverse of the parser, so a graph can be written back to authoring YAML without loss: it quotes values that need it (a label containing a newline made the previous hand-rolled writer emit an unparseable document) and spreads the graph rather than enumerating keys, converting only the three shapes the parser stores differently from how it reads them — `spec` on nodes and subgraphs, and `plug` on link endpoints. `parse(dumpGraph(g))` is a fixed point.

--- a/.changeset/parse-node-identity.md
+++ b/.changeset/parse-node-identity.md
@@ -2,4 +2,8 @@
 '@shumoku/core': patch
 ---
 
-Parse node-level `identity` (mgmtIp / chassisId / sysName / vendorIds) in hand-authored YAML graphs. `YamlParser` previously read every `Node` field except `identity`, so a Manual data source's nodes were silently stripped of the identity keys that `resolve()` clusters on and that the metrics-mapping stack needs to bind a node to a monitoring host — leaving hand-drawn devices permanently unmappable. `NodePort.identity` was already parsed; this closes the same gap one level up.
+Make hand-authored graphs survive a YAML round trip.
+
+`YamlParser` read every `Node` field except `identity`, so a Manual data source's nodes were silently stripped of the keys `resolve()` clusters on and the metrics-mapping stack needs to bind a node to a monitoring host — leaving hand-drawn devices permanently unmappable. `NodePort.identity` was already parsed; this closes the same gap one level up.
+
+Adds `dumpGraph()`, the inverse of the parser, so a graph can be written back to authoring YAML without loss: it quotes values that need it (a label containing a newline made the previous hand-rolled writer emit an unparseable document) and emits every field the graph carries, flattening `spec` to the `type` / `vendor` / `model` keys the parser reads back. `parse(dumpGraph(g))` is a fixed point.

--- a/.changeset/parse-node-identity.md
+++ b/.changeset/parse-node-identity.md
@@ -1,0 +1,5 @@
+---
+'@shumoku/core': patch
+---
+
+Parse node-level `identity` (mgmtIp / chassisId / sysName / vendorIds) in hand-authored YAML graphs. `YamlParser` previously read every `Node` field except `identity`, so a Manual data source's nodes were silently stripped of the identity keys that `resolve()` clusters on and that the metrics-mapping stack needs to bind a node to a monitoring host — leaving hand-drawn devices permanently unmappable. `NodePort.identity` was already parsed; this closes the same gap one level up.

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -96,12 +96,30 @@
     return dumpGraph(graph as unknown as NetworkGraph)
   }
 
+  /**
+   * Parse YAML into a NetworkGraph, or throw if the YAML was unparseable.
+   *
+   * YamlParser.parse() never throws on its own — a fatal syntax error (e.g. an
+   * unquoted multi-line label) is caught internally and returned as a
+   * look-alike empty graph (`{nodes: [], links: []}`) plus a `PARSE_ERROR`
+   * warning. Every caller here used to read only `.graph` and drop
+   * `.warnings`, so a broken paste silently "succeeded" as an empty diagram —
+   * and, on save, silently replaced the source's last-good content. Surfacing
+   * `PARSE_ERROR` as a thrown error lets the existing try/catch around each
+   * call site do its job instead.
+   */
+  function parseYamlOrThrow(text: string): NetworkGraph {
+    const result = new YamlParser().parse(text)
+    const fatal = result.warnings?.find((w) => w.code === 'PARSE_ERROR')
+    if (fatal) throw new Error(`Invalid YAML: ${fatal.message}`)
+    return result.graph
+  }
+
   function switchMode(mode: 'yaml' | 'json') {
     if (mode === editorMode) return
     try {
       if (mode === 'json') {
-        const result = new YamlParser().parse(yamlContent)
-        jsonContent = JSON.stringify(result.graph, null, 2)
+        jsonContent = JSON.stringify(parseYamlOrThrow(yamlContent), null, 2)
       } else {
         const graph = JSON.parse(jsonContent)
         yamlContent = graphToYaml(graph)
@@ -143,7 +161,7 @@
   /** Parse the active editor pane (YAML or JSON) into a NetworkGraph. */
   function manualGraphFromEditor(): NetworkGraph {
     return editorMode === 'yaml'
-      ? new YamlParser().parse(yamlContent).graph
+      ? parseYamlOrThrow(yamlContent)
       : (JSON.parse(jsonContent) as NetworkGraph)
   }
 

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { type NetworkGraph, YamlParser } from '@shumoku/core'
+  import { dumpGraph, type NetworkGraph, YamlParser } from '@shumoku/core'
   import {
     ArrowLeftIcon,
     CheckCircleIcon,
@@ -82,56 +82,18 @@
     }
   })
 
+  /**
+   * Seed the YAML pane from a saved graph.
+   *
+   * Delegates to core's `dumpGraph`, the inverse of the parser: it quotes
+   * values that need it and emits every field the graph carries. The
+   * hand-rolled writer this replaced did neither — it interpolated labels raw
+   * (a two-line segment name produced an unparseable document) and enumerated
+   * only six node keys, so identity / ports / metadata and every link id
+   * silently vanished on the next save.
+   */
   function graphToYaml(graph: Record<string, unknown>): string {
-    // Same converter as the dedicated edit page used to have. Walks the
-    // NetworkGraph 's top-level shape; anything not enumerated below
-    // round-trips through the JSON tab instead.
-    const lines: string[] = []
-    if (graph['name']) lines.push(`name: ${graph['name']}`)
-    if (graph['version']) lines.push(`version: "${graph['version']}"`)
-    if (graph['description']) lines.push(`description: ${graph['description']}`)
-    lines.push('')
-    lines.push('nodes:')
-    const nodes = (graph['nodes'] as Array<Record<string, unknown>>) || []
-    for (const node of nodes) {
-      lines.push(`  - id: ${node['id']}`)
-      if (node['label']) lines.push(`    label: ${node['label']}`)
-      if (node['type']) lines.push(`    type: ${node['type']}`)
-      if (node['vendor']) lines.push(`    vendor: ${node['vendor']}`)
-      if (node['model']) lines.push(`    model: ${node['model']}`)
-      if (node['parent']) lines.push(`    parent: ${node['parent']}`)
-    }
-    lines.push('')
-    lines.push('links:')
-    const links = (graph['links'] as Array<Record<string, unknown>>) || []
-    for (const link of links) {
-      const from = link['from'] as string | { node: string; port?: string }
-      const to = link['to'] as string | { node: string; port?: string }
-      if (typeof from === 'string') lines.push(`  - from: ${from}`)
-      else {
-        lines.push(`  - from:`)
-        lines.push(`      node: ${from.node}`)
-        if (from.port) lines.push(`      port: ${from.port}`)
-      }
-      if (typeof to === 'string') lines.push(`    to: ${to}`)
-      else {
-        lines.push(`    to:`)
-        lines.push(`      node: ${to.node}`)
-        if (to.port) lines.push(`      port: ${to.port}`)
-      }
-      if (link['bandwidth']) lines.push(`    bandwidth: ${link['bandwidth']}`)
-    }
-    const subgraphs = graph['subgraphs'] as Array<Record<string, unknown>> | undefined
-    if (subgraphs && subgraphs.length > 0) {
-      lines.push('')
-      lines.push('subgraphs:')
-      for (const sg of subgraphs) {
-        lines.push(`  - id: ${sg['id']}`)
-        if (sg['label']) lines.push(`    label: ${sg['label']}`)
-        if (sg['parent']) lines.push(`    parent: ${sg['parent']}`)
-      }
-    }
-    return lines.join('\n')
+    return dumpGraph(graph as unknown as NetworkGraph)
   }
 
   function switchMode(mode: 'yaml' | 'json') {

--- a/libs/@shumoku/core/src/parser/index.ts
+++ b/libs/@shumoku/core/src/parser/index.ts
@@ -17,3 +17,4 @@ export {
 } from './hierarchical.js'
 export type { ParseResult, ParseWarning } from './parser.js'
 export { parser, YamlParser } from './parser.js'
+export { dumpGraph } from './serialize.js'

--- a/libs/@shumoku/core/src/parser/parser.test.ts
+++ b/libs/@shumoku/core/src/parser/parser.test.ts
@@ -1,0 +1,67 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import { YamlParser } from './parser.js'
+
+describe('YamlParser', () => {
+  describe('node identity', () => {
+    it('parses identity.mgmtIp/chassisId/sysName/vendorIds from a node', () => {
+      const yaml = `
+version: '1.0'
+nodes:
+  - id: fw01
+    label: Firewall
+    identity:
+      mgmtIp: 10.0.0.1
+      chassisId: 'aa:bb:cc:dd:ee:ff'
+      sysName: fw01.example.com
+      vendorIds:
+        zabbix-hostid: '10780'
+links: []
+`
+      const result = new YamlParser().parse(yaml)
+      expect(result.warnings).toBeUndefined()
+      expect(result.graph.nodes[0]?.identity).toEqual({
+        mgmtIp: '10.0.0.1',
+        chassisId: 'aa:bb:cc:dd:ee:ff',
+        sysName: 'fw01.example.com',
+        vendorIds: { 'zabbix-hostid': '10780' },
+      })
+    })
+
+    it('omits identity entirely when the node has none (no empty object)', () => {
+      const yaml = `
+version: '1.0'
+nodes:
+  - id: n1
+    label: Plain Node
+links: []
+`
+      const result = new YamlParser().parse(yaml)
+      expect(result.graph.nodes[0]?.identity).toBeUndefined()
+    })
+
+    it('parses port-level identity.ifName alongside node identity', () => {
+      const yaml = `
+version: '1.0'
+nodes:
+  - id: sw01
+    label: Switch
+    identity:
+      mgmtIp: 10.0.0.2
+    ports:
+      - id: p1
+        label: eth0
+        identity:
+          ifName: GigabitEthernet0/1
+links: []
+`
+      const result = new YamlParser().parse(yaml)
+      const node = result.graph.nodes[0]
+      expect(node?.identity?.mgmtIp).toBe('10.0.0.2')
+      expect(node?.ports?.[0]?.identity?.ifName).toBe('GigabitEthernet0/1')
+    })
+  })
+})

--- a/libs/@shumoku/core/src/parser/parser.ts
+++ b/libs/@shumoku/core/src/parser/parser.ts
@@ -16,6 +16,7 @@ import type {
   CanvasSettings,
   EthernetStandard,
   GraphSettings,
+  Identity,
   Link,
   LinkCable,
   LinkEndpoint,
@@ -124,6 +125,15 @@ interface YamlNode {
   resource?: string
   /** Custom icon URL (overrides vendor/type icons) */
   icon?: string
+  /**
+   * Identity keys for cross-source / cross-rescan matching and metrics
+   * mapping (mgmtIp / chassisId / sysName / vendorIds). Hand-authored graphs
+   * (e.g. a Manual data source) can set these directly so a device drawn by
+   * hand still resolves to the same identity a discovery plugin would report
+   * — without this, an authored node can never durably bind to a metrics
+   * source's host (see `Identity`).
+   */
+  identity?: Identity
   ports?: NodePort[]
 }
 
@@ -357,6 +367,7 @@ export class YamlParser {
           : undefined,
         metadata: n.metadata,
         spec: this.buildNodeSpec(n),
+        ...(n.identity ? { identity: n.identity } : {}),
         ports: n.ports,
       }
     })

--- a/libs/@shumoku/core/src/parser/serialize.test.ts
+++ b/libs/@shumoku/core/src/parser/serialize.test.ts
@@ -187,6 +187,23 @@ links:
     expect(dumped).toContain('exclusions:')
   })
 
+  it('drops a Map-valued field instead of emitting it as an empty mapping', () => {
+    // `sheets` is a Map. Walking one with Object.entries() yields nothing, so a
+    // naive prune turns it into `sheets: {}` — a key that looks present in the
+    // document while its contents silently vanished. Not emitting it at all is
+    // the honest shape (and it is documented on dumpGraph).
+    const inner = parse("version: '1'\nnodes:\n  - id: inner1\n    label: Inner\nlinks: []\n").graph
+    const dumped = dumpGraph({
+      version: '1',
+      nodes: [{ id: 'a', label: 'A' }],
+      links: [],
+      sheets: new Map([['child', inner]]),
+    } as unknown as Parameters<typeof dumpGraph>[0])
+    expect(dumped).not.toContain('sheets:')
+    expect(parse(dumped).warnings?.find((w) => w.code === 'PARSE_ERROR')).toBeUndefined()
+    expect(parse(dumped).graph.nodes[0]?.id).toBe('a')
+  })
+
   it('omits keys the graph leaves unset rather than emitting nulls', () => {
     const dumped = dumpGraph(
       parse("version: '1'\nnodes:\n  - id: n1\n    label: N1\nlinks: []\n").graph,

--- a/libs/@shumoku/core/src/parser/serialize.test.ts
+++ b/libs/@shumoku/core/src/parser/serialize.test.ts
@@ -138,6 +138,55 @@ subgraphs:
     expect(parse(dumpGraph(graph)).graph).toEqual(graph)
   })
 
+  it('round-trips a link endpoint transceiver (plug -> module)', () => {
+    // A link-level `standard` / endpoint `module` is normalized to `plug.module`
+    // on the way in; `plug` has no authoring form, so dumping it verbatim would
+    // drop the standard and SKU.
+    const graph = parse(`
+version: '1'
+nodes:
+  - id: a
+    label: A
+  - id: b
+    label: B
+links:
+  - id: l1
+    standard: 10GBASE-SR
+    from:
+      node: a
+      port: p1
+    to:
+      node: b
+      port: p2
+      module:
+        standard: 10GBASE-LR
+        sku: SFP-10G-LR
+`).graph
+    expect(graph.links[0]?.from.plug?.module).toEqual({ standard: '10GBASE-SR' })
+
+    const reparsed = parse(dumpGraph(graph)).graph
+    expect(reparsed.links[0]?.from.plug?.module).toEqual({ standard: '10GBASE-SR' })
+    expect(reparsed.links[0]?.to.plug?.module).toEqual({
+      standard: '10GBASE-LR',
+      sku: 'SFP-10G-LR',
+    })
+  })
+
+  it('emits graph-level fields the parser does not read yet rather than dropping them', () => {
+    // Enumerating top-level keys is what silently drops a field when the model
+    // gains one — the very bug this serializer replaces. Spreading the graph
+    // keeps them in the document even though re-parsing still discards them.
+    const dumped = dumpGraph({
+      version: '1',
+      nodes: [],
+      links: [],
+      terminations: [],
+      exclusions: [],
+    } as unknown as Parameters<typeof dumpGraph>[0])
+    expect(dumped).toContain('terminations:')
+    expect(dumped).toContain('exclusions:')
+  })
+
   it('omits keys the graph leaves unset rather than emitting nulls', () => {
     const dumped = dumpGraph(
       parse("version: '1'\nnodes:\n  - id: n1\n    label: N1\nlinks: []\n").graph,

--- a/libs/@shumoku/core/src/parser/serialize.test.ts
+++ b/libs/@shumoku/core/src/parser/serialize.test.ts
@@ -1,0 +1,148 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { describe, expect, it } from 'vitest'
+import { YamlParser } from './parser.js'
+import { dumpGraph } from './serialize.js'
+
+const parse = (text: string) => new YamlParser().parse(text)
+const fatal = (text: string) => parse(text).warnings?.find((w) => w.code === 'PARSE_ERROR')?.message
+
+describe('dumpGraph', () => {
+  it('quotes labels containing a newline so the output stays valid YAML', () => {
+    // A hand-rolled `label: ${value}` writer emits the newline raw, which makes
+    // the document unparseable ("a multiline key may not be an implicit key").
+    const graph = parse(`
+version: '1'
+nodes:
+  - id: seg
+    label: "Management / VLAN 10\\n10.153.0.0/24"
+links: []
+`).graph
+    expect(graph.nodes[0]?.label).toBe('Management / VLAN 10\n10.153.0.0/24')
+
+    const dumped = dumpGraph(graph)
+    expect(fatal(dumped)).toBeUndefined()
+    expect(parse(dumped).graph.nodes[0]?.label).toBe('Management / VLAN 10\n10.153.0.0/24')
+  })
+
+  it('round-trips node identity, ports and metadata', () => {
+    const graph = parse(`
+version: '1'
+nodes:
+  - id: fw01
+    label: Firewall
+    type: firewall
+    identity:
+      mgmtIp: 10.0.0.1
+      sysName: fw01
+      vendorIds:
+        zabbix-hostid: '10780'
+    metadata:
+      owner: netops
+    ports:
+      - id: p1
+        label: eth0
+        interfaceName: ethernet1/1
+        identity:
+          ifName: ethernet1/1
+          ifIndex: 2
+links: []
+`).graph
+
+    const reparsed = parse(dumpGraph(graph)).graph
+    const node = reparsed.nodes[0]
+    expect(node?.identity).toEqual({
+      mgmtIp: '10.0.0.1',
+      sysName: 'fw01',
+      vendorIds: { 'zabbix-hostid': '10780' },
+    })
+    expect(node?.metadata).toEqual({ owner: 'netops' })
+    expect(node?.ports?.[0]?.identity).toEqual({ ifName: 'ethernet1/1', ifIndex: 2 })
+    expect(node?.spec).toEqual({ kind: 'hardware', type: 'firewall' })
+  })
+
+  it('round-trips link ids, labels, types and subgraph nesting', () => {
+    const graph = parse(`
+version: '1'
+nodes:
+  - id: a
+    label: A
+    parent: sheet-inner
+  - id: b
+    label: B
+links:
+  - id: tunnel0
+    label: EtherIP/IPv6
+    type: dashed
+    from:
+      node: a
+      port: p1
+    to:
+      node: b
+      port: p2
+subgraphs:
+  - id: sheet-outer
+    label: Outer
+  - id: sheet-inner
+    label: Inner
+    parent: sheet-outer
+`).graph
+
+    const reparsed = parse(dumpGraph(graph)).graph
+    const link = reparsed.links[0]
+    expect(link?.id).toBe('tunnel0')
+    expect(link?.label).toBe('EtherIP/IPv6')
+    expect(link?.type).toBe('dashed')
+    expect(reparsed.subgraphs?.find((s) => s.id === 'sheet-inner')?.parent).toBe('sheet-outer')
+    expect(reparsed.nodes.find((n) => n.id === 'a')?.parent).toBe('sheet-inner')
+  })
+
+  it('is a fixed point: parse(dump(g)) deep-equals g', () => {
+    const graph = parse(`
+version: '1'
+name: Fixture
+nodes:
+  - id: fw01
+    label: "Firewall\\n10.0.0.1"
+    type: firewall
+    vendor: paloalto
+    identity:
+      mgmtIp: 10.0.0.1
+    ports:
+      - id: p1
+        label: eth1/1
+        identity:
+          ifName: ethernet1/1
+  - id: seg
+    label: Segment
+    type: segment
+    parent: sheet-a
+    metadata:
+      subnet: 10.0.0.0/24
+links:
+  - id: l1
+    type: dashed
+    from:
+      node: fw01
+      port: p1
+    to:
+      node: seg
+      port: seg-p
+subgraphs:
+  - id: sheet-a
+    label: Sheet A
+`).graph
+
+    expect(parse(dumpGraph(graph)).graph).toEqual(graph)
+  })
+
+  it('omits keys the graph leaves unset rather than emitting nulls', () => {
+    const dumped = dumpGraph(
+      parse("version: '1'\nnodes:\n  - id: n1\n    label: N1\nlinks: []\n").graph,
+    )
+    expect(dumped).not.toContain('null')
+    expect(dumped).not.toContain('description:')
+  })
+})

--- a/libs/@shumoku/core/src/parser/serialize.ts
+++ b/libs/@shumoku/core/src/parser/serialize.ts
@@ -13,6 +13,13 @@ import type { Link, LinkEndpoint, NetworkGraph, Node, NodeSpec, Subgraph } from 
  * Drop `undefined`-valued keys so the dump doesn't emit `key: null` for every
  * optional field the model leaves unset. Arrays and plain objects are walked;
  * everything else passes through untouched.
+ *
+ * `Map` / `Set` values are dropped rather than walked. `Object.entries()` on a
+ * `Map` yields nothing, so walking one would turn it into `{}` — emitting an
+ * empty-looking key whose contents vanished, which is worse than not emitting
+ * it: the whole point of spreading the graph is that what survives is visible
+ * in the document. `NetworkGraph.sheets` is the one such field today; it has no
+ * authoring form either way (see `dumpGraph`).
  */
 function pruneUndefined<T>(value: T): T {
   if (Array.isArray(value)) {
@@ -24,6 +31,7 @@ function pruneUndefined<T>(value: T): T {
   const out: Record<string, unknown> = {}
   for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
     if (v === undefined) continue
+    if (v instanceof Map || v instanceof Set) continue
     out[key] = pruneUndefined(v)
   }
   return out as T
@@ -96,10 +104,25 @@ function linkToAuthoring(link: Link): Record<string, unknown> {
  * one. Only the three shapes the parser stores differently from how it reads
  * them are converted (`spec` on nodes and subgraphs, `plug` on link endpoints).
  *
- * Fields the parser does not read yet — `terminations`, `exclusions`, and
- * `attachments` — are emitted so nothing is dropped here, but they are lost on
- * re-parse until the parser learns them. Sources that mint those (the editor,
- * the resolver) should not be edited through the YAML pane.
+ * The fixed point holds over the schema the parser reads, which is NARROWER
+ * than the model. Everything else is written to the document — nothing is
+ * dropped here — but is lost the next time that text is parsed:
+ *
+ * - graph: `terminations`, `exclusions`, `attachments`
+ * - node: `presence`, `attachments`, `suppressedAttachments`, `entityId`,
+ *   `position`, `size`, `termination`, `productId`, `provenance`, `fieldSources`
+ * - link: `via`, `bends`, `rateBps`, `metadata`, `presence`, `provenance`,
+ *   `entityId`
+ *
+ * `presence` and `attachments` are the ones that bite: an `'anchor'` node comes
+ * back as a `'scoop'` (resolve then keeps a device alive that was only meant to
+ * carry identity) and a metrics binding is simply gone. So anything a source
+ * mints beyond the authoring schema — the editor, the resolver, the entity
+ * registry — must not be round-tripped through the YAML pane.
+ *
+ * `sheets` is the exception that is NOT written: it is a `Map`, which cannot be
+ * expressed here without inventing an authoring form for it (see
+ * `pruneUndefined`).
  *
  * `lineWidth: -1` disables line folding: folded output re-parses to the same
  * value, but it makes hand-editing the result confusing.

--- a/libs/@shumoku/core/src/parser/serialize.ts
+++ b/libs/@shumoku/core/src/parser/serialize.ts
@@ -1,0 +1,92 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * NetworkGraph → authoring YAML, the inverse of `YamlParser.parse()`.
+ */
+
+import yaml from 'js-yaml'
+import type { NetworkGraph, Node, NodeSpec, Subgraph } from '../models/types.js'
+
+/**
+ * Drop `undefined`-valued keys so the dump doesn't emit `key: null` for every
+ * optional field the model leaves unset. Arrays and plain objects are walked;
+ * everything else passes through untouched.
+ */
+function pruneUndefined<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => pruneUndefined(v)) as unknown as T
+  }
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+  const out: Record<string, unknown> = {}
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    if (v === undefined) continue
+    out[key] = pruneUndefined(v)
+  }
+  return out as T
+}
+
+/**
+ * `Node.spec` / `Subgraph.spec` back to the FLAT keys the parser reads.
+ *
+ * The parser builds `spec` from top-level `type` / `vendor` / `model` /
+ * `service` / `resource` / `icon` (see `buildNodeSpec`); a nested `spec:` block
+ * in YAML is ignored. Emitting the model shape verbatim would therefore drop
+ * every device type on the way back in.
+ *
+ * `kind: 'compute'` has no authoring form — the parser only ever builds
+ * `hardware` or `service` — so its `platform` cannot round-trip and the node
+ * comes back as hardware. Only sources that mint compute specs directly (not
+ * YAML) can hold one, so this affects nothing that was authored as YAML.
+ */
+function specToAuthoring(spec: NodeSpec | undefined): Record<string, unknown> {
+  if (!spec) return {}
+  if (spec.kind === 'service') {
+    return { service: spec.service, vendor: spec.vendor, resource: spec.resource, icon: spec.icon }
+  }
+  if (spec.kind === 'compute') {
+    return { type: spec.type, vendor: spec.vendor, icon: spec.icon }
+  }
+  return { type: spec.type, vendor: spec.vendor, model: spec.model, icon: spec.icon }
+}
+
+function nodeToAuthoring(node: Node): Record<string, unknown> {
+  const { spec, ...rest } = node
+  return { ...rest, ...specToAuthoring(spec) }
+}
+
+function subgraphToAuthoring(subgraph: Subgraph): Record<string, unknown> {
+  const { spec, ...rest } = subgraph
+  return { ...rest, ...specToAuthoring(spec) }
+}
+
+/**
+ * Serialize a graph to YAML that `YamlParser.parse()` reads back without loss,
+ * so `parse(dumpGraph(g))` is a fixed point over the authoring schema.
+ *
+ * Hand-rolling this as string concatenation is not safe: any label carrying a
+ * newline (a two-line segment name, say) has to be quoted or the document it
+ * produces is invalid YAML — and a value the writer forgets to emit is simply
+ * gone the next time the text is parsed. Both failure modes are silent. This
+ * delegates quoting and escaping to js-yaml and emits whatever the graph
+ * carries, so a field added to the parser needs no change here.
+ *
+ * `lineWidth: -1` disables line folding: folded output re-parses to the same
+ * value, but it makes hand-editing the result confusing.
+ */
+export function dumpGraph(graph: NetworkGraph): string {
+  const authoring = {
+    version: graph.version,
+    name: graph.name,
+    description: graph.description,
+    nodes: graph.nodes?.map(nodeToAuthoring),
+    links: graph.links,
+    subgraphs: graph.subgraphs?.map(subgraphToAuthoring),
+    settings: graph.settings,
+    pins: graph.pins,
+  }
+  return yaml.dump(pruneUndefined(authoring), { lineWidth: -1, noRefs: true })
+}

--- a/libs/@shumoku/core/src/parser/serialize.ts
+++ b/libs/@shumoku/core/src/parser/serialize.ts
@@ -7,7 +7,7 @@
  */
 
 import yaml from 'js-yaml'
-import type { NetworkGraph, Node, NodeSpec, Subgraph } from '../models/types.js'
+import type { Link, LinkEndpoint, NetworkGraph, Node, NodeSpec, Subgraph } from '../models/types.js'
 
 /**
  * Drop `undefined`-valued keys so the dump doesn't emit `key: null` for every
@@ -64,29 +64,52 @@ function subgraphToAuthoring(subgraph: Subgraph): Record<string, unknown> {
 }
 
 /**
- * Serialize a graph to YAML that `YamlParser.parse()` reads back without loss,
- * so `parse(dumpGraph(g))` is a fixed point over the authoring schema.
+ * `LinkEndpoint.plug` back to the `module` key the parser reads.
+ *
+ * A link-level `standard` or an endpoint `module` is normalized into
+ * `plug.module` on the way in (`parseLinkEndpoint` → `plugFromStandard`), and
+ * `plug` has no authoring form — so emitting it verbatim would drop the
+ * transceiver standard and SKU on the way back. A plug carrying only a `cage`
+ * (picked in the editor, no module yet) has no authoring key at all and cannot
+ * round-trip.
+ */
+function endpointToAuthoring(endpoint: LinkEndpoint): Record<string, unknown> {
+  const { plug, ...rest } = endpoint
+  if (!plug?.module) return rest
+  return { ...rest, module: { standard: plug.module.standard, sku: plug.module.sku } }
+}
+
+function linkToAuthoring(link: Link): Record<string, unknown> {
+  return { ...link, from: endpointToAuthoring(link.from), to: endpointToAuthoring(link.to) }
+}
+
+/**
+ * Serialize a graph to authoring YAML, the inverse of `YamlParser.parse()`:
+ * `parse(dumpGraph(g))` is a fixed point over the schema the parser reads.
  *
  * Hand-rolling this as string concatenation is not safe: any label carrying a
  * newline (a two-line segment name, say) has to be quoted or the document it
  * produces is invalid YAML — and a value the writer forgets to emit is simply
- * gone the next time the text is parsed. Both failure modes are silent. This
- * delegates quoting and escaping to js-yaml and emits whatever the graph
- * carries, so a field added to the parser needs no change here.
+ * gone the next time the text is parsed. Both failure modes are silent. So this
+ * delegates quoting and escaping to js-yaml, and spreads the graph rather than
+ * listing keys: enumerating is what silently drops a field when the model gains
+ * one. Only the three shapes the parser stores differently from how it reads
+ * them are converted (`spec` on nodes and subgraphs, `plug` on link endpoints).
+ *
+ * Fields the parser does not read yet — `terminations`, `exclusions`, and
+ * `attachments` — are emitted so nothing is dropped here, but they are lost on
+ * re-parse until the parser learns them. Sources that mint those (the editor,
+ * the resolver) should not be edited through the YAML pane.
  *
  * `lineWidth: -1` disables line folding: folded output re-parses to the same
  * value, but it makes hand-editing the result confusing.
  */
 export function dumpGraph(graph: NetworkGraph): string {
   const authoring = {
-    version: graph.version,
-    name: graph.name,
-    description: graph.description,
+    ...graph,
     nodes: graph.nodes?.map(nodeToAuthoring),
-    links: graph.links,
+    links: graph.links?.map(linkToAuthoring),
     subgraphs: graph.subgraphs?.map(subgraphToAuthoring),
-    settings: graph.settings,
-    pins: graph.pins,
   }
   return yaml.dump(pruneUndefined(authoring), { lineWidth: -1, noRefs: true })
 }


### PR DESCRIPTION
## Problem

A Manual data source can lose its entire saved graph on a normal open-and-save cycle, and hand-authored device identity never reaches the metrics mapper. Three defects compound:

**1. The editor generated invalid YAML from a valid graph.**
`graphToYaml()` built the document by string concatenation, interpolating values raw:

```ts
if (node['label']) lines.push(`    label: ${node['label']}`)
```

A label carrying a newline — a two-line segment name like `"Management / VLAN 10\n10.153.0.0/24"` — therefore emitted an unquoted multi-line scalar:

```yaml
  - id: segment-mgmt
    label: Management / VLAN 10
10.153.0.0/24
```

which `js-yaml` rejects with *"can not read a block mapping entry; a multiline key may not be an implicit key"*.

**2. That parse failure was silent.** `YamlParser.parse()` catches every error and returns a value shape-identical to a legitimately-empty document (`{graph: {nodes: [], links: []}, warnings: [{code: 'PARSE_ERROR'}]}`). Both editor call sites read `.graph` and discarded `.warnings`, so `handleSave()` posted `status: 'ok'` with an empty graph — and `ingestGraph()` deletes the source's prior contribution before inserting. Net effect: the editor round-trip wiped a 13-node topology while reporting success.

**3. `graphToYaml()` enumerated only six node keys** (`id`/`label`/`type`/`vendor`/`model`/`parent`). Measured over one open-and-save cycle on a 14-node topology:

| field | before → after |
|---|---|
| `identity` | 14 → **0** |
| `ports` | 14 → **0** |
| `metadata` | 11 → **0** |
| link `id` | 18 → **0** |
| link `label` | 3 → **0** |
| `subgraph.parent` | 1 → **0** |

Losing `ports` also detaches every metrics mapping keyed off them.

**4. Node-level `identity` was never parsed at all.** `parseNodes()` read every `Node` field *except* `identity`, so `identity: {mgmtIp, chassisId, sysName, vendorIds}` in YAML was silently dropped — even though `NodePort.identity` one level down *was* parsed, and `resolve()`/the entity registry/the metrics mapper all key off `Node.identity`. A hand-drawn device could therefore never durably bind to a Prometheus/Zabbix host: `stampEntityIds()` bails at `if (!nodeEntityId) return port`, so its ports get no `entityId` either and every link touching it is unmappable. The only workaround was to run a discovery plugin against the same device so its identity arrived via a *different* source's contribution.

## Fix

- **`libs/@shumoku/core`** — parse node-level `identity` (mirrors the existing `NodePort.identity` handling one level up).
- **`libs/@shumoku/core`** — add `dumpGraph()`, the parser's inverse. `js-yaml` handles quoting/escaping, and it spreads the graph rather than enumerating keys (enumerating is exactly what silently drops a field when the model gains one). Only the three shapes the parser stores differently from how it reads them are converted: `spec` on nodes and subgraphs (a nested `spec:` block is ignored by `buildNodeSpec`, so dumping the model shape verbatim would drop every device type) and `plug` on link endpoints (a link-level `standard` / endpoint `module` is normalized to `plug.module` on the way in, so emitting it verbatim would drop the transceiver standard and SKU). `parse(dumpGraph(g))` is a fixed point.

  `terminations`, `exclusions` and `attachments` are emitted but still lost on re-parse — the parser does not read them yet. Documented on the function rather than silently papered over.
- **`apps/server/web`** — seed the YAML pane via `dumpGraph()` instead of the hand-rolled writer, and surface `PARSE_ERROR` as a thrown error so a broken document fails loudly in the existing `try/catch` (which already sets the `error` state) rather than saving an empty graph.

Both `parse()`'s tolerant return shape and `graphToYaml()`'s omissions were pre-existing; the identity fix is what makes them consequential, so all three ship together — landing the parser change alone would let users author `identity` that the editor then silently deletes.

## Tests

`libs/@shumoku/core` had **no** unit test file for `YamlParser`. Adds two:

- `parser.test.ts` — node `identity` round-trips (mgmtIp/chassisId/sysName/vendorIds); `identity` omitted (not an empty object) when absent; port-level `identity.ifName` still parses alongside it.
- `serialize.test.ts` — a newline-carrying label stays valid YAML; `identity`/`ports`/`metadata` round-trip; link `id`/`label`/`type` and subgraph nesting round-trip; a link endpoint transceiver (`plug` → `module`) round-trips; graph-level fields the parser does not read are still emitted; `parse(dumpGraph(g))` deep-equals `g`; unset keys are omitted rather than emitted as `null`.

Full `@shumoku/core` suite: **404 passing** (394 pre-existing + 10 new). `biome check` clean on all changed files. `apps/server/web` typecheck clean on the changed file. `changeset status --since=origin/main` passes with the included changeset — a **minor** bump, since `dumpGraph` is a new public API (`AGENTS.md`: minor for new public API additions).

Verified end-to-end against a live 14-node topology: after the fix, all 4 devices auto-map to their Prometheus hosts by `identity.mgmtIp` and 11 links bind to real SNMP interfaces, with traffic rendering on the diagram.

---

Supersedes #642, which carried only the parse-error half of the editor fix.

