### PR TITLE
fix(scripts): read bun.lock without Bun.JSONC so release commands run locally

### DIFF
--- a/scripts/product-version.ts
+++ b/scripts/product-version.ts
@@ -79,10 +79,84 @@ async function readChartVersions(
   return { version, appVersion }
 }
 
+/**
+ * Parse `bun.lock`, which is JSONC (trailing commas, occasionally comments).
+ *
+ * `Bun.JSONC.parse` would do this, but it does not exist in the bun the root
+ * `packageManager` pins, so reaching for it made the release scripts fail
+ * locally while CI — which installs `bun-version: latest` — kept passing (#634).
+ * Stripping the JSONC-only syntax ourselves keeps this runnable on whatever bun
+ * the repo is pinned to.
+ */
+function parseJsonc(text: string): unknown {
+  const chars = [...text]
+  let out = ''
+  let inString = false
+  let inLineComment = false
+  let inBlockComment = false
+  // Set when the current character consumed the one after it (an escape pair,
+  // or a two-character comment delimiter), so the loop skips it.
+  let skipNext = false
+
+  for (const [i, char] of chars.entries()) {
+    if (skipNext) {
+      skipNext = false
+      continue
+    }
+    const next = chars[i + 1]
+
+    if (inLineComment) {
+      if (char === '\n') {
+        inLineComment = false
+        out += char
+      }
+      continue
+    }
+    if (inBlockComment) {
+      if (char === '*' && next === '/') {
+        inBlockComment = false
+        skipNext = true
+      }
+      continue
+    }
+    if (inString) {
+      out += char
+      // A backslash escapes the next character, so `\"` does not close the
+      // string — copy the pair and step over it.
+      if (char === '\\') {
+        out += next ?? ''
+        skipNext = true
+        continue
+      }
+      if (char === '"') inString = false
+      continue
+    }
+    if (char === '"') {
+      inString = true
+      out += char
+      continue
+    }
+    if (char === '/' && next === '/') {
+      inLineComment = true
+      skipNext = true
+      continue
+    }
+    if (char === '/' && next === '*') {
+      inBlockComment = true
+      skipNext = true
+      continue
+    }
+    out += char
+  }
+
+  // Trailing commas: `,` followed only by whitespace before a closer.
+  return JSON.parse(out.replace(/,(?=\s*[}\]])/g, ''))
+}
+
 async function readLockVersion(workspacePath: string): Promise<string | undefined> {
   if (!(await Bun.file('bun.lock').exists())) return undefined
 
-  const lockfile = Bun.JSONC.parse(await readFile('bun.lock', 'utf8')) as BunLockfile
+  const lockfile = parseJsonc(await readFile('bun.lock', 'utf8')) as BunLockfile
   const version = lockfile.workspaces?.[workspacePath]?.version
   if (!version) {
     throw new Error(`bun.lock does not contain a version for ${workspacePath}`)


### PR DESCRIPTION
## Problem

`bun run version:server` / `version:editor` crash before doing anything:

```
TypeError: undefined is not an object (evaluating 'Bun.JSONC.parse')
      at readLockVersion (scripts/product-version.ts:85:24)
```

`readLockVersion()` reads `bun.lock` with `Bun.JSONC.parse`, an API that does not exist in the bun the root `package.json` pins (`"packageManager": "bun@1.3.4"`).

CI never catches it. The workflows install `oven-sh/setup-bun` with `bun-version: latest`, which has the API, so `version:products:check` passes while the same command is unrunnable locally — **only someone actually cutting a release hits it**. Cutting `server-v0.1.5` required a preload shim to work around it, and it blocked this release too.

See #634.

## Fix

Parse the JSONC in `bun.lock` directly — walk the text, drop line/block comments and trailing commas, then `JSON.parse` — so the release scripts run on whatever bun the repo pins rather than on whatever bun happens to be installed.

The scanner tracks string state, so a `//` inside a string literal, an escaped quote (`\\"`), and a comment marker inside a value are all left alone.

## Verification

Edge cases exercised directly against the new function:

| input | result |
|---|---|
| `{"a":1,}` | `{"a":1}` |
| `{"a":1 // hi\n}` | `{"a":1}` |
| `{/**/"a":1}` / `{"a":1/**/}` | `{"a":1}` |
| `{"a":"x\\"y"}` | `{"a":"x\\"y"}` |
| `{"a":"http://x//y"}` | preserved |
| `{"a":"/* not a comment */"}` | preserved |
| nested trailing commas | stripped at every level |

End to end: `bun run version:server 0.1.5-beta.6` now completes and synchronizes `apps/server/package.json`, `Chart.yaml` (version + appVersion), `apps/server/README.md`, `apps/server/docs/helm-chart.md` and `bun.lock` consistently; `bun run version:products:check` passes afterwards. `biome check` clean.

## Scope

This is half of #634. The other half — CI pinning `bun-version` instead of `latest`, so the local/CI skew cannot silently return — is **not** addressed here, so the issue stays open.