### PR TITLE
docs: document node identity and ports in the YAML reference

### DIFF
--- a/apps/docs/content/docs/npm/yaml-reference.en.mdx
+++ b/apps/docs/content/docs/npm/yaml-reference.en.mdx
@@ -178,6 +178,76 @@ service: ec2
 resource: instances
 ```
 
+### ports
+
+Declare ports when you want links to attach to a specific interface on the device.
+
+```yaml
+nodes:
+  - id: sw-1
+    label: "Switch 1"
+    type: l2-switch
+    ports:
+      - id: p1
+        label: "Gi1/0/1"
+        interfaceName: GigabitEthernet1/0/1
+```
+
+| Field | Description |
+|-------|-------------|
+| `id` | Identifier links refer to. Unique within the node |
+| `label` | Name shown on the diagram (e.g. `Gi1/0/1`) |
+| `interfaceName` | Full OS / API interface name |
+| `identity` | Keys used to match monitoring data (see below) |
+
+**Ports referenced by a link are created automatically.** The example below produces `p1` and `ge-0/0/1` without a `ports` block, so declare ports explicitly only when you want to give them a `label`, an `interfaceName` or an `identity`.
+
+```yaml
+links:
+  - from: { node: fw-1, port: p1 }
+    to: { node: sw-1, port: ge-0/0/1 }
+```
+
+### identity
+
+**Keys that tie a device you drew by hand to the same device a monitoring system observed.** Use these when combining hand-authored topology with a data source such as Zabbix or Prometheus.
+
+```yaml
+nodes:
+  - id: fw-1
+    label: "Firewall"
+    type: firewall
+    identity:
+      mgmtIp: 10.0.0.1
+      chassisId: "aa:bb:cc:dd:ee:ff"
+      sysName: fw01.example.com
+      vendorIds:
+        zabbix-hostid: "10780"
+    ports:
+      - id: p1
+        label: "eth1/1"
+        identity:
+          ifName: GigabitEthernet1/0/1
+```
+
+| Field | Level | Description |
+|-------|-------|-------------|
+| `mgmtIp` | node | Management IP (v4 or v6, as a string) |
+| `chassisId` | node | LLDP chassisId (MAC or vendor string) |
+| `sysName` | node | SNMP sysName |
+| `vendorIds` | node | Source-specific ids (e.g. `zabbix-hostid`) |
+| `ifName` | port | Interface name. The strong port key |
+| `ifIndex` | port | ifIndex. Weak — it can change across reboots |
+| `mac` | port | Interface MAC |
+
+**Without these, a hand-drawn device never binds durably to a monitoring host.** Matching falls back to names alone, which breaks the moment a display name changes. One key is enough; `mgmtIp` is the most reliable.
+
+<Callout type="warn">
+  `sysName` must be the name the device **reports about itself**. Do not put an operational display name ("Core Switch #1") here — that belongs in `label`.
+
+  A `sysName` that disagrees with what the data source reports registers the same device **twice, as two separate devices**.
+</Callout>
+
 ---
 
 ## Links

--- a/apps/docs/content/docs/npm/yaml-reference.ja.mdx
+++ b/apps/docs/content/docs/npm/yaml-reference.ja.mdx
@@ -178,6 +178,76 @@ service: ec2
 resource: instances
 ```
 
+### ports (ポート)
+
+リンクの接続先を機器のポート単位で表したい場合に書きます。
+
+```yaml
+nodes:
+  - id: sw-1
+    label: "Switch 1"
+    type: l2-switch
+    ports:
+      - id: p1
+        label: "Gi1/0/1"
+        interfaceName: GigabitEthernet1/0/1
+```
+
+| フィールド | 説明 |
+|-----------|------|
+| `id` | リンクから参照する識別子。ノード内で一意 |
+| `label` | 図に表示される名前（`Gi1/0/1` など） |
+| `interfaceName` | OS / API 上の完全なインターフェース名 |
+| `identity` | 監視データとの同定キー（後述） |
+
+**リンクが参照したポートは自動生成されます。** 以下のように `ports` を書かなくても `p1` / `ge-0/0/1` は作られるので、`label` や `interfaceName`、`identity` を持たせたいときだけ明示的に書けば十分です。
+
+```yaml
+links:
+  - from: { node: fw-1, port: p1 }
+    to: { node: sw-1, port: ge-0/0/1 }
+```
+
+### identity (同定キー)
+
+**手で描いた機器を、監視システムが観測した同じ機器と結びつけるためのキー**です。Zabbix や Prometheus などのデータソースと併用するときに使います。
+
+```yaml
+nodes:
+  - id: fw-1
+    label: "Firewall"
+    type: firewall
+    identity:
+      mgmtIp: 10.0.0.1
+      chassisId: "aa:bb:cc:dd:ee:ff"
+      sysName: fw01.example.com
+      vendorIds:
+        zabbix-hostid: "10780"
+    ports:
+      - id: p1
+        label: "eth1/1"
+        identity:
+          ifName: GigabitEthernet1/0/1
+```
+
+| フィールド | 階層 | 説明 |
+|-----------|------|------|
+| `mgmtIp` | ノード | 管理 IP（v4 / v6 の文字列） |
+| `chassisId` | ノード | LLDP の chassisId（MAC またはベンダー文字列） |
+| `sysName` | ノード | SNMP の sysName |
+| `vendorIds` | ノード | データソース固有の ID（`zabbix-hostid` など） |
+| `ifName` | ポート | インターフェース名。ポートの主キー |
+| `ifIndex` | ポート | ifIndex。再起動で変わりうるため補助的 |
+| `mac` | ポート | インターフェースの MAC |
+
+**これを書かないと、手描きの機器は監視ホストに恒久的に結びつきません。** 名前の一致だけに頼ることになり、表示名を変えた時点で対応が切れます。1つでも書けば同定できます（`mgmtIp` が最も確実です）。
+
+<Callout type="warn">
+  `sysName` には**機器が自分で名乗っている値**を書いてください。運用上の表示名（「コアスイッチ1号機」など）を入れてはいけません。表示名は `label` に書きます。
+
+  データソースが報告する sysName と食い違う値を入れると、同じ機器が**別々の機器として二重に登録されます**。
+</Callout>
+
 ---
 
 ## Links


### PR DESCRIPTION
Closes #644.

## Why

#643 made node-level `identity` parseable from authoring YAML. That moved the identity contract from something only plugin authors follow to something **end users can now get wrong** — and the reference documented neither `identity` nor `ports` (the latter has been parseable for a long time).

The semantic rule for `sysName` lived only in `docs/plugin-authoring.md`, which is written for plugin authors. Nothing enforces it at runtime either: `validateTopologyIdentityContract` is a pure validator called only from plugin tests, and the observation ingest path validates only that `nodes` / `links` are arrays. So documentation is currently the only guard.

## What

Adds to the Nodes section of `yaml-reference` (ja and en):

- **`ports`** — the fields worth setting (`id` / `label` / `interfaceName` / `identity`), plus the fact that ports referenced by a link are synthesized automatically, so a `ports` block is only needed to attach a label, an interface name or an identity.
- **`identity`** — the node keys (`mgmtIp` / `chassisId` / `sysName` / `vendorIds`) and port keys (`ifName` / `ifIndex` / `mac`), why they matter (without one, a hand-drawn device never binds durably to a monitoring host), and a warning callout for `sysName`: it is the name the device reports about itself, never an operational display name, because a polluted sysName registers one device twice (#581).

## Verification

The documented examples were run through the parser rather than written from the types:

```
warnings      = undefined
fw.identity   = {"mgmtIp":"10.0.0.1","chassisId":"aa:bb:cc:dd:ee:ff","sysName":"fw01.example.com","vendorIds":{"zabbix-hostid":"10780"}}
fw.port.ident = {"ifName":"GigabitEthernet1/0/1"}
sw.ports      = [{"id":"p1","label":"Gi1/0/1"},{"id":"ge-0/0/1","label":"ge-0/0/1"}]
```

The last line confirms the auto-synthesis claim — `ge-0/0/1` exists on `sw-1` although only the link mentions it.

`bun run build --filter=@shumoku/docs` passes.

## Note

Japanese is the source of truth per CLAUDE.md, but this page already has an `.en.mdx`, so an en-only gap would have been real rather than falling back. Both are updated.