### PR TITLE
feat(plugin-huawei-nce-campus): take links from Link Management, anchor unnamed far ends, trust linkstatus

### DIFF
--- a/libs/plugins/huawei-nce-campus/src/plugin.test.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.test.ts
@@ -7,6 +7,7 @@ import {
   mapDeviceStatus,
   mapLinkStatus,
   perfToNodeMetrics,
+  uplinkThroughput,
 } from './plugin.js'
 
 describe('mapDeviceStatus', () => {
@@ -86,6 +87,30 @@ describe('interfacePerfToLinkMetrics', () => {
     const m = interfacePerfToLinkMetrics({ inputBandwidth: '250', outBandwidth: '-3' })
     expect(m.inUtilization).toBe(100)
     expect(m.outUtilization).toBe(0)
+  })
+})
+
+describe('uplinkThroughput', () => {
+  it('maps device speeds onto the uplink, device->network as out', () => {
+    expect(uplinkThroughput({ upwardSpeed: 3379224, downwardSpeed: 1003386 })).toEqual({
+      outBps: 3379224,
+      inBps: 1003386,
+    })
+  })
+
+  it('fills the missing direction with zero when only one is reported', () => {
+    expect(uplinkThroughput({ upwardSpeed: 500 })).toEqual({ outBps: 500, inBps: 0 })
+  })
+
+  it('returns nothing when the controller reports neither', () => {
+    // An idle or not-yet-collected device must get status only — a fabricated
+    // zero would read as "measured, and it is zero".
+    expect(uplinkThroughput({})).toBeUndefined()
+    expect(uplinkThroughput({ cpuRate: 5 })).toBeUndefined()
+  })
+
+  it('keeps a genuine zero', () => {
+    expect(uplinkThroughput({ upwardSpeed: 0, downwardSpeed: 0 })).toEqual({ outBps: 0, inBps: 0 })
   })
 })
 

--- a/libs/plugins/huawei-nce-campus/src/plugin.test.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.test.ts
@@ -5,6 +5,7 @@ import {
   interfacePerfToLinkMetrics,
   mapAlarmSeverity,
   mapDeviceStatus,
+  mapLinkStatus,
   perfToNodeMetrics,
 } from './plugin.js'
 
@@ -85,6 +86,18 @@ describe('interfacePerfToLinkMetrics', () => {
     const m = interfacePerfToLinkMetrics({ inputBandwidth: '250', outBandwidth: '-3' })
     expect(m.inUtilization).toBe(100)
     expect(m.outUtilization).toBe(0)
+  })
+})
+
+describe('mapLinkStatus', () => {
+  it('maps the Link Management status enum', () => {
+    expect(mapLinkStatus(0)).toBe('up') // normal
+    expect(mapLinkStatus(2)).toBe('down') // major
+    expect(mapLinkStatus(3)).toBe('down') // critical
+    expect(mapLinkStatus(4)).toBe('down') // offline — a record whose endpoint left
+    expect(mapLinkStatus(6)).toBe('down') // faulty
+    expect(mapLinkStatus(1)).toBe('unknown') // unknown
+    expect(mapLinkStatus(5)).toBe('unknown') // unmanaged
   })
 })
 

--- a/libs/plugins/huawei-nce-campus/src/plugin.test.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.test.ts
@@ -5,7 +5,6 @@ import {
   interfacePerfToLinkMetrics,
   mapAlarmSeverity,
   mapDeviceStatus,
-  mapLinkStatus,
   perfToNodeMetrics,
 } from './plugin.js'
 
@@ -86,17 +85,6 @@ describe('interfacePerfToLinkMetrics', () => {
     const m = interfacePerfToLinkMetrics({ inputBandwidth: '250', outBandwidth: '-3' })
     expect(m.inUtilization).toBe(100)
     expect(m.outUtilization).toBe(0)
-  })
-})
-
-describe('mapLinkStatus', () => {
-  it('maps the topology linkStatus enum to link status', () => {
-    expect(mapLinkStatus(0)).toBe('up') // normal
-    expect(mapLinkStatus(1)).toBe('unknown') // unknown
-    expect(mapLinkStatus(2)).toBe('down') // major fault
-    expect(mapLinkStatus(3)).toBe('down') // emergency fault
-    expect(mapLinkStatus(4)).toBe('down') // offline
-    expect(mapLinkStatus(5)).toBe('unknown') // not managed
   })
 })
 

--- a/libs/plugins/huawei-nce-campus/src/plugin.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.ts
@@ -244,19 +244,25 @@ export class HuaweiNceCampusPlugin
     })
 
     // ---- Links ----
-    // Utilization comes from the per-interface performance counters. The link
-    // list's `linkstatus` is deliberately NOT used: the live tenant reports 4
-    // ("offline" per the enum) for links that are demonstrably carrying
-    // traffic, so trusting it would paint healthy links red.
+    // Status comes from the link list, utilization from the per-interface
+    // performance counters. The controller retains a link record after its
+    // endpoint disappears, so without `linkstatus` every historical wire would
+    // render as live.
+    const statusByPort = linkEntries.length > 0 ? await this.fetchLinkStatusByPort() : new Map()
     await mapWithConcurrency(linkEntries, FANOUT_CONCURRENCY, async ([linkId, linkMapping]) => {
       const monitoredNodeId = linkMapping.monitoredNodeId
       const iface = linkMapping.interface
       if (!monitoredNodeId || !iface) return
       const hostId = mapping.nodes[monitoredNodeId]?.hostId
       if (!hostId || !known.has(hostId)) return
+      const reported = statusByPort.get(`${hostId}|${iface}`)
       const ifPerf = await this.fetchInterfacePerformance(hostId, iface)
-      if (!ifPerf) return
-      metrics.links[linkId] = interfacePerfToLinkMetrics(ifPerf)
+      if (!ifPerf && reported === undefined) return
+      const sample = ifPerf ? interfacePerfToLinkMetrics(ifPerf) : { status: 'unknown' as const }
+      metrics.links[linkId] = {
+        ...sample,
+        ...(reported !== undefined ? { status: mapLinkStatus(reported) } : {}),
+      }
     })
 
     return metrics
@@ -346,6 +352,17 @@ export class HuaweiNceCampusPlugin
     } finally {
       if (this.linksInFlight === request) this.linksInFlight = null
     }
+  }
+
+  /** Reported link state per device port: `<deviceId>|<port>` → linkstatus. */
+  private async fetchLinkStatusByPort(): Promise<Map<string, number>> {
+    const byPort = new Map<string, number>()
+    for (const l of await this.fetchNetworkLinks()) {
+      if (l.linkstatus === undefined) continue
+      if (l.anedn && l.aportname) byPort.set(`${l.anedn}|${l.aportname}`, l.linkstatus)
+      if (l.znedn && l.zportname) byPort.set(`${l.znedn}|${l.zportname}`, l.linkstatus)
+    }
+    return byPort
   }
 
   private async walkNetworkLinks(): Promise<NceNetworkLink[]> {
@@ -503,6 +520,28 @@ function parsePercent(raw: string | undefined): number | undefined {
   const value = Number.parseFloat(raw)
   if (!Number.isFinite(value)) return undefined
   return Math.min(100, Math.max(0, value))
+}
+
+/**
+ * Link Management `linkstatus` → link status.
+ *
+ * `0` normal is up; `2` major, `3` critical, `4` offline and `6` faulty are
+ * down; `1` unknown and `5` unmanaged carry no verdict. Records outlive their
+ * endpoints (the controller stores no observation time), so a stale wire shows
+ * up here as `4` — which is exactly how it should render.
+ */
+export function mapLinkStatus(status: number): 'up' | 'down' | 'unknown' {
+  switch (status) {
+    case 0:
+      return 'up'
+    case 2:
+    case 3:
+    case 4:
+    case 6:
+      return 'down'
+    default:
+      return 'unknown'
+  }
 }
 
 /** NCE alarm severity (1–4) → core's neutral CVSS-style scale. */

--- a/libs/plugins/huawei-nce-campus/src/plugin.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.ts
@@ -6,11 +6,11 @@
  * controller can't push to us in v1.
  *
  * Plugin scope (v1):
- *   - topology: managed devices + the controller's own topology links
+ *   - topology: managed devices + the controller's reported links
  *     (LLDP-neighbor fallback), grouped by site
  *   - hosts: managed devices with up/down from controller status
  *   - metrics: per-node status/CPU/memory from basic performance; per-link
- *     status from topology linkStatus + utilization from interface performance
+ *     utilization from interface performance
  *   - alerts: current alarms mapped to our Alert shape
  */
 
@@ -48,8 +48,8 @@ import type {
   NceInterfacePerformanceResponse,
   NceLldpNeighbor,
   NceLldpResponse,
-  NceTopoLink,
-  NceTopoResponse,
+  NceNetworkLink,
+  NceNetworkLinkResponse,
 } from './types.js'
 
 /** Concurrent per-device NBI calls (LLDP / performance fan-out). */
@@ -61,9 +61,9 @@ const ALARM_LIMIT = 500
 /** Alarm scroll batch size. */
 const ALARM_BATCH = 100
 
-/** Page size and page cap for the topo-link cursor walk. */
-const TOPO_PAGE_LIMIT = 1000
-const TOPO_MAX_PAGES = 20
+/** Page size and page cap for the Link Management walk. */
+const LINK_PAGE_SIZE = 200
+const LINK_MAX_PAGES = 25
 
 export class HuaweiNceCampusPlugin
   implements DataSourcePlugin, TopologyCapable, HostsCapable, MetricsCapable, AlertsCapable
@@ -81,8 +81,8 @@ export class HuaweiNceCampusPlugin
   private config: HuaweiNceCampusConfig | null = null
   private devicesCache: { value: NceDevice[]; expiresAt: number } | null = null
   private devicesInFlight: Promise<NceDevice[]> | null = null
-  private topoLinksCache: { value: NceTopoLink[]; expiresAt: number } | null = null
-  private topoLinksInFlight: Promise<NceTopoLink[]> | null = null
+  private linksCache: { value: NceNetworkLink[]; expiresAt: number } | null = null
+  private linksInFlight: Promise<NceNetworkLink[]> | null = null
 
   initialize(config: unknown): void {
     const c = config as Partial<HuaweiNceCampusConfig>
@@ -95,8 +95,8 @@ export class HuaweiNceCampusPlugin
     this.api = new HuaweiNceCampusApi(this.config)
     this.devicesCache = null
     this.devicesInFlight = null
-    this.topoLinksCache = null
-    this.topoLinksInFlight = null
+    this.linksCache = null
+    this.linksInFlight = null
   }
 
   dispose(): void {
@@ -104,8 +104,8 @@ export class HuaweiNceCampusPlugin
     this.api = null
     this.devicesCache = null
     this.devicesInFlight = null
-    this.topoLinksCache = null
-    this.topoLinksInFlight = null
+    this.linksCache = null
+    this.linksInFlight = null
   }
 
   async testConnection(): Promise<ConnectionResult> {
@@ -129,19 +129,19 @@ export class HuaweiNceCampusPlugin
     if (!this.api) return { version: '1.0.0', name: 'Huawei NCE-Campus', nodes: [], links: [] }
     const devices = await this.fetchDevices()
 
-    // Preferred link source: the controller's own topology (one cursor walk).
-    // Only when it yields nothing do we fan out to per-device LLDP tables —
-    // that's N calls and misses links the controller already knows about.
-    const topoLinks = await this.fetchTopoLinks()
+    // Preferred link source: Link Management — one paged call that names both
+    // endpoints by device UUID. Only when it yields nothing do we fan out to
+    // per-device LLDP tables; that's N calls and some tenants answer none.
+    const networkLinks = await this.fetchNetworkLinks()
     const neighborsByDeviceId = new Map<string, NceLldpNeighbor[]>()
-    if (topoLinks.length === 0) {
+    if (networkLinks.length === 0) {
       await mapWithConcurrency(devices, FANOUT_CONCURRENCY, async (d) => {
         if (!d.id) return
         const neighbors = await this.fetchNeighbors(d.id)
         if (neighbors.length > 0) neighborsByDeviceId.set(d.id, neighbors)
       })
     }
-    return buildTopology(devices, topoLinks, neighborsByDeviceId)
+    return buildTopology(devices, networkLinks, neighborsByDeviceId)
   }
 
   // ============================================================
@@ -182,12 +182,12 @@ export class HuaweiNceCampusPlugin
    */
   async getHostItems(hostId: string): Promise<HostItem[]> {
     if (!this.api) return []
-    // Ports that carry inter-device links: this device's ends of the topo
+    // Ports that carry inter-device links: this device's ends of the reported
     // links, plus its LLDP local ports (covers the fallback topology too).
     const ifNames: string[] = []
-    for (const l of await this.fetchTopoLinks()) {
-      if (l.leftFdn === hostId && l.aPortName) ifNames.push(l.aPortName)
-      if (l.rightFdn === hostId && l.zPortName) ifNames.push(l.zPortName)
+    for (const l of await this.fetchNetworkLinks()) {
+      if (l.anedn === hostId && l.aportname) ifNames.push(l.aportname)
+      if (l.znedn === hostId && l.zportname) ifNames.push(l.zportname)
     }
     for (const n of await this.fetchNeighbors(hostId)) {
       if (n.localIfName) ifNames.push(n.localIfName)
@@ -244,23 +244,19 @@ export class HuaweiNceCampusPlugin
     })
 
     // ---- Links ----
-    // Status comes from the controller topology's linkStatus (one cursor
-    // walk); utilization from the per-interface performance counters.
-    const statusByPort = linkEntries.length > 0 ? await this.fetchTopoLinkStatus() : new Map()
+    // Utilization comes from the per-interface performance counters. The link
+    // list's `linkstatus` is deliberately NOT used: the live tenant reports 4
+    // ("offline" per the enum) for links that are demonstrably carrying
+    // traffic, so trusting it would paint healthy links red.
     await mapWithConcurrency(linkEntries, FANOUT_CONCURRENCY, async ([linkId, linkMapping]) => {
       const monitoredNodeId = linkMapping.monitoredNodeId
       const iface = linkMapping.interface
       if (!monitoredNodeId || !iface) return
       const hostId = mapping.nodes[monitoredNodeId]?.hostId
       if (!hostId || !known.has(hostId)) return
-      const topoStatus = statusByPort.get(`${hostId}|${iface}`)
       const ifPerf = await this.fetchInterfacePerformance(hostId, iface)
-      if (!ifPerf && topoStatus === undefined) return
-      const sample = ifPerf ? interfacePerfToLinkMetrics(ifPerf) : { status: 'unknown' as const }
-      metrics.links[linkId] = {
-        ...sample,
-        ...(topoStatus !== undefined ? { status: mapLinkStatus(topoStatus) } : {}),
-      }
+      if (!ifPerf) return
+      metrics.links[linkId] = interfacePerfToLinkMetrics(ifPerf)
     })
 
     return metrics
@@ -325,65 +321,51 @@ export class HuaweiNceCampusPlugin
   }
 
   /**
-   * Walk the controller topology's link list to exhaustion (cursor paging).
-   * Scoped to `siteId` when configured — `parentResId` takes an organization
-   * or site UUID. Failures degrade to an empty list so callers fall back to
-   * LLDP rather than losing the whole topology.
+   * The controller's network link list, deduped behind a short cache.
+   *
+   * Link Management (`/rest/openapi/network/link`) is used rather than the
+   * topology API (`topomanager/device/node`): the latter returns nothing
+   * unless queried per site via `parentResId`, and even then leaves the port
+   * names null, which would leave links unmappable to interfaces. Failures
+   * degrade to an empty list so callers fall back to LLDP.
    */
-  private async fetchTopoLinks(): Promise<NceTopoLink[]> {
+  private async fetchNetworkLinks(): Promise<NceNetworkLink[]> {
     if (!this.api) return []
     const now = Date.now()
-    if (this.topoLinksCache && this.topoLinksCache.expiresAt > now) {
-      return this.topoLinksCache.value
-    }
-    if (this.topoLinksInFlight) return this.topoLinksInFlight
+    if (this.linksCache && this.linksCache.expiresAt > now) return this.linksCache.value
+    if (this.linksInFlight) return this.linksInFlight
 
-    const request = this.walkTopoLinks()
-    this.topoLinksInFlight = request
+    const request = this.walkNetworkLinks()
+    this.linksInFlight = request
     try {
       const value = await request
       // getHostItems is called once per mapped host in an auto-map burst;
-      // reuse one topology walk across that burst.
-      this.topoLinksCache = { value, expiresAt: Date.now() + 10_000 }
+      // reuse one walk across that burst.
+      this.linksCache = { value, expiresAt: Date.now() + 10_000 }
       return value
     } finally {
-      if (this.topoLinksInFlight === request) this.topoLinksInFlight = null
+      if (this.linksInFlight === request) this.linksInFlight = null
     }
   }
 
-  private async walkTopoLinks(): Promise<NceTopoLink[]> {
+  private async walkNetworkLinks(): Promise<NceNetworkLink[]> {
     if (!this.api) return []
-    const out: NceTopoLink[] = []
+    const out: NceNetworkLink[] = []
     try {
-      let marker: string | undefined
-      for (let page = 0; page < TOPO_MAX_PAGES; page++) {
-        const resp = await this.api.get<NceTopoResponse>(
-          '/controller/campus/v1/networkresource/topomanager/device/node',
-          {
-            limit: TOPO_PAGE_LIMIT,
-            ...(this.config?.siteId ? { parentResId: this.config.siteId } : {}),
-            ...(marker ? { marker } : {}),
-          },
-        )
-        out.push(...(resp.linkData?.linkData ?? []))
-        if (!resp.linkData?.hasNext || !resp.linkData.marker) break
-        marker = resp.linkData.marker
+      for (let page = 0; page < LINK_MAX_PAGES; page++) {
+        const resp = await this.api.get<NceNetworkLinkResponse>('/rest/openapi/network/link', {
+          start: page * LINK_PAGE_SIZE,
+          size: LINK_PAGE_SIZE,
+        })
+        const items = resp.data ?? []
+        out.push(...items)
+        const total = resp.size ?? out.length
+        if (items.length < LINK_PAGE_SIZE || out.length >= total) break
       }
     } catch {
       return []
     }
     return out
-  }
-
-  /** Live link status per device port: `<deviceId>|<port>` → linkStatus. */
-  private async fetchTopoLinkStatus(): Promise<Map<string, number>> {
-    const statusByPort = new Map<string, number>()
-    for (const l of await this.fetchTopoLinks()) {
-      if (l.linkStatus === undefined) continue
-      if (l.leftFdn && l.aPortName) statusByPort.set(`${l.leftFdn}|${l.aPortName}`, l.linkStatus)
-      if (l.rightFdn && l.zPortName) statusByPort.set(`${l.rightFdn}|${l.zPortName}`, l.linkStatus)
-    }
-    return statusByPort
   }
 
   private async fetchNeighbors(deviceId: string): Promise<NceLldpNeighbor[]> {
@@ -521,24 +503,6 @@ function parsePercent(raw: string | undefined): number | undefined {
   const value = Number.parseFloat(raw)
   if (!Number.isFinite(value)) return undefined
   return Math.min(100, Math.max(0, value))
-}
-
-/**
- * Topology linkStatus → link status.
- * `0` normal is up; `2` major fault, `3` emergency fault, and `4` offline are
- * down; `1` unknown and `5` not managed carry no verdict.
- */
-export function mapLinkStatus(status: number): 'up' | 'down' | 'unknown' {
-  switch (status) {
-    case 0:
-      return 'up'
-    case 2:
-    case 3:
-    case 4:
-      return 'down'
-    default:
-      return 'unknown'
-  }
 }
 
 /** NCE alarm severity (1–4) → core's neutral CVSS-style scale. */

--- a/libs/plugins/huawei-nce-campus/src/plugin.ts
+++ b/libs/plugins/huawei-nce-campus/src/plugin.ts
@@ -232,22 +232,34 @@ export class HuaweiNceCampusPlugin
     const known = new Set<string>()
     for (const d of devices) if (d.id) known.add(d.id)
 
+    // Device performance is read once per device and used for both the node
+    // sample and its uplink's throughput, rather than fetched twice.
+    const perfByDevice = new Map<string, NceDevicePerformance>()
+    const perfFor = async (hostId: string): Promise<NceDevicePerformance | undefined> => {
+      const hit = perfByDevice.get(hostId)
+      if (hit) return hit
+      const fetched = await this.fetchPerformance(hostId)
+      if (fetched) perfByDevice.set(hostId, fetched)
+      return fetched
+    }
+
     // ---- Nodes ----
     await mapWithConcurrency(nodeEntries, FANOUT_CONCURRENCY, async ([nodeId, nodeMapping]) => {
       const hostId = nodeMapping.hostId
       // Stay silent on ids that aren't ours — another source may own the node,
       // and emitting a fake status here would clobber the real one on merge.
       if (!hostId || !known.has(hostId)) return
-      const perf = await this.fetchPerformance(hostId)
+      const perf = await perfFor(hostId)
       if (!perf) return
       metrics.nodes[nodeId] = perfToNodeMetrics(perf)
     })
 
     // ---- Links ----
-    // Status comes from the link list, utilization from the per-interface
-    // performance counters. The controller retains a link record after its
-    // endpoint disappears, so without `linkstatus` every historical wire would
-    // render as live.
+    // Status comes from the link list; the controller retains a link record
+    // after its endpoint disappears, so without `linkstatus` every historical
+    // wire would render as live. Throughput comes from the device record —
+    // an AP's whole load crosses its single uplink — because the per-interface
+    // utilization fields come back null on live hardware.
     const statusByPort = linkEntries.length > 0 ? await this.fetchLinkStatusByPort() : new Map()
     await mapWithConcurrency(linkEntries, FANOUT_CONCURRENCY, async ([linkId, linkMapping]) => {
       const monitoredNodeId = linkMapping.monitoredNodeId
@@ -257,10 +269,12 @@ export class HuaweiNceCampusPlugin
       if (!hostId || !known.has(hostId)) return
       const reported = statusByPort.get(`${hostId}|${iface}`)
       const ifPerf = await this.fetchInterfacePerformance(hostId, iface)
-      if (!ifPerf && reported === undefined) return
+      const throughput = uplinkThroughput((await perfFor(hostId)) ?? {})
+      if (!ifPerf && reported === undefined && !throughput) return
       const sample = ifPerf ? interfacePerfToLinkMetrics(ifPerf) : { status: 'unknown' as const }
       metrics.links[linkId] = {
         ...sample,
+        ...(throughput ?? {}),
         ...(reported !== undefined ? { status: mapLinkStatus(reported) } : {}),
       }
     })
@@ -490,15 +504,43 @@ export function perfToNodeMetrics(p: NceDevicePerformance): NodeMetrics {
     monitoring: 'healthy',
     ...(typeof p.cpuRate === 'number' ? { cpu: p.cpuRate } : {}),
     ...(typeof p.memoryRate === 'number' ? { memory: p.memoryRate } : {}),
-    ...(typeof p.timestamp === 'number' && p.timestamp > 0 ? { lastSeen: p.timestamp } : {}),
+    // `timestamp` is when the controller last collected performance, not when
+    // it last saw the device — but it is the freshest observation time we get,
+    // and it stops advancing once collection stops.
+    ...(typeof p.timestamp === 'number' && p.timestamp > 0 ? { lastSeen: p.timestamp * 1000 } : {}),
   }
 }
 
 /**
- * Interface performance record → link metrics. `inputBandwidth`/`outBandwidth`
- * are the NBI's bandwidth-usage percentages (strings); traffic counters are
- * incremental bytes per collection period, so they don't convert to a stable
- * bps without the period length — utilization is the honest signal here.
+ * Uplink throughput for a device, from its performance record.
+ *
+ * An AP has one wired uplink, so everything it sends and receives crosses that
+ * link: the device-level `upwardSpeed` / `downwardSpeed` are the link's rates.
+ * `upwardSpeed` is device→network, i.e. the link's `out`.
+ *
+ * These refresh on the controller's collection cycle (the record's `timestamp`
+ * held still across a 20s re-read), so they are a periodic sample, not a live
+ * gauge. Returns undefined when the controller reports neither, so an idle or
+ * uncollected device gets status only rather than a fabricated zero.
+ */
+export function uplinkThroughput(
+  p: NceDevicePerformance,
+): { inBps: number; outBps: number } | undefined {
+  const outBps = typeof p.upwardSpeed === 'number' ? p.upwardSpeed : undefined
+  const inBps = typeof p.downwardSpeed === 'number' ? p.downwardSpeed : undefined
+  if (inBps === undefined && outBps === undefined) return undefined
+  return { inBps: inBps ?? 0, outBps: outBps ?? 0 }
+}
+
+/**
+ * Interface performance record → link metrics.
+ *
+ * `inputBandwidth`/`outBandwidth` are utilization percentages, but a live AP
+ * returns them as `null` — only the byte counters are populated, and those are
+ * increments over an unstated collection window, so they don't convert to bps.
+ * Throughput therefore comes from the device record instead (see
+ * {@link uplinkThroughput}); this function contributes utilization when the
+ * controller does fill it in.
  */
 export function interfacePerfToLinkMetrics(p: NceInterfacePerformance): LinkMetrics {
   const inUtil = parsePercent(p.inputBandwidth)

--- a/libs/plugins/huawei-nce-campus/src/topology.test.ts
+++ b/libs/plugins/huawei-nce-campus/src/topology.test.ts
@@ -1,7 +1,7 @@
 import { validateTopologyIdentityContract } from '@shumoku/core'
 import { describe, expect, it } from 'vitest'
 import { buildTopology, mapDeviceType } from './topology.js'
-import type { NceDevice, NceLldpNeighbor, NceTopoLink } from './types.js'
+import type { NceDevice, NceLldpNeighbor, NceNetworkLink } from './types.js'
 
 const CORE_SW: NceDevice = {
   id: 'dev-core',
@@ -65,15 +65,24 @@ describe('mapDeviceType', () => {
   })
 })
 
-/** The same wire as NEIGHBORS, but from the controller's topology linkData. */
-const TOPO_LINKS: NceTopoLink[] = [
+/**
+ * The same wire as NEIGHBORS, but from the Link Management list. Both ends
+ * carry a port DN distinct from the port name, which is how NCE marks a port
+ * it actually holds an entity for.
+ */
+const NETWORK_LINKS: NceNetworkLink[] = [
   {
-    label: 'campus-core-01_GigabitEthernet0/0/1_f2-ap-01_GigabitEthernet0/0/0',
-    leftFdn: 'dev-core',
-    rightFdn: 'dev-ap',
-    aPortName: 'GigabitEthernet0/0/1',
-    zPortName: 'GigabitEthernet0/0/0',
-    linkStatus: 0,
+    linkname: 'campus-core-01_GigabitEthernet0/0/1_f2-ap-01_GigabitEthernet0/0/0',
+    anedn: 'dev-core',
+    anename: 'campus-core-01',
+    aportname: 'GigabitEthernet0/0/1',
+    aportdn: 'be38b832-3a60-3042-8d6f-b36f127f889e',
+    znedn: 'dev-ap',
+    znename: 'f2-ap-01',
+    zportname: 'GigabitEthernet0/0/0',
+    zportdn: '7c1de4a9-91b0-4f0e-9a3f-2b6c0d5e1f88',
+    linktype: 1,
+    speed: '1000',
   },
 ]
 
@@ -205,37 +214,117 @@ describe('buildTopology', () => {
     expect(result.portsMissingIfName).toEqual([])
   })
 
-  it('builds links from the controller topology linkData (preferred path)', () => {
-    const g = buildTopology([CORE_SW, AP], TOPO_LINKS, new Map())
+  it('builds links from the Link Management list (preferred path)', () => {
+    const g = buildTopology([CORE_SW, AP], NETWORK_LINKS, new Map())
     expect(g.links).toHaveLength(1)
     const link = g.links[0]
     expect(link?.from).toEqual({ node: 'nce:dev-core', port: 'GigabitEthernet0/0/1' })
     expect(link?.to).toEqual({ node: 'nce:dev-ap', port: 'GigabitEthernet0/0/0' })
+    // speed is Mbit/s in the NBI.
+    expect(link?.rateBps).toBe(1_000 * 1_000_000)
   })
 
-  it('prefers topo links over LLDP when both are supplied', () => {
-    const g = buildTopology([CORE_SW, AP], TOPO_LINKS, NEIGHBORS)
+  it('prefers reported links over LLDP when both are available', () => {
+    const g = buildTopology([CORE_SW, AP], NETWORK_LINKS, NEIGHBORS)
     // The same wire must not be drawn twice (once per source).
     expect(g.links).toHaveLength(1)
     expect(g.links[0]?.from.port).toBe('GigabitEthernet0/0/1')
   })
 
-  it('drops topo links whose ends are not both managed devices', () => {
-    const siteLink: NceTopoLink[] = [
-      { leftFdn: 'dev-core', rightFdn: 'site-1', aPortName: 'GE0/0/24', zPortName: '' },
+  it('emits a peer node for a link whose far end NCE does not manage', () => {
+    // The live tenant reports AP uplinks into a `VirtualDevice` placeholder
+    // that carries no address; dropping those would drop most of the topology.
+    const toUnmanaged: NceNetworkLink[] = [
+      {
+        anedn: 'dev-ap',
+        aportname: 'MultiGE0/0/0',
+        aportdn: 'be38b832-3a60-3042-8d6f-b36f127f889e',
+        znedn: 'b15a3dd9-bf64-4791-a590-7237349d2030',
+        znename: 'VirtualDevice',
+        zneip: '0.0.0.0',
+        zportname: 'port1.0.5',
+        zportdn: 'port1.0.5',
+      },
     ]
-    const g = buildTopology([CORE_SW, AP], siteLink, new Map())
+    const g = buildTopology([AP], toUnmanaged, new Map())
+    const peer = g.nodes.find((n) => n.id.startsWith('nce-lldp:'))
+    expect(peer).toMatchObject({ label: ['VirtualDevice'], parent: 'nce-site:site-1' })
+    // 0.0.0.0 is a placeholder, never a management address.
+    expect(peer?.identity?.mgmtIp).toBeUndefined()
+    expect(peer?.identity?.vendorIds).toEqual({
+      'nce-device-id': 'b15a3dd9-bf64-4791-a590-7237349d2030',
+    })
+    expect(g.links).toHaveLength(1)
+    // The AP's port is a real entity and stays; the placeholder's is not, so
+    // the far end gets its own anchor instead of a port other links share.
+    expect(g.links[0]?.from.port).toBe('MultiGE0/0/0')
+    expect(g.links[0]?.to.port).toBe('uplink:dev-ap')
+    expect(peer?.ports).toEqual([{ id: 'uplink:dev-ap', label: '', connectors: [] }])
+  })
+
+  it('gives each uplink its own anchor when all claim one phantom port', () => {
+    // Verbatim shape of the live OMM site: four APs, one synthetic peer, and
+    // the same non-entity `port1.0.5` on every far end. Sharing one endpoint
+    // id collapses all four edges onto a single point in the layout.
+    const aps = ['ap1', 'ap2', 'ap3', 'ap4'].map((id) => ({ ...AP, id, name: id }))
+    const fanIn: NceNetworkLink[] = aps.map((d) => ({
+      anedn: d.id,
+      aportname: 'MultiGE0/0/0',
+      aportdn: `dn-${d.id}`,
+      znedn: 'virtual-1',
+      znename: 'VirtualDevice',
+      zportname: 'port1.0.5',
+      zportdn: 'port1.0.5',
+    }))
+    const g = buildTopology(aps, fanIn, new Map())
+    expect(g.links).toHaveLength(4)
+    const anchors = g.links.map((l) => l.to.port)
+    expect(new Set(anchors).size).toBe(4) // four distinct anchors, no collision
+    expect(anchors).toEqual(['uplink:ap1', 'uplink:ap2', 'uplink:ap3', 'uplink:ap4'])
+    const peers = g.nodes.filter((n) => n.id.startsWith('nce-lldp:'))
+    expect(peers).toHaveLength(1)
+    // Declared on the peer so the layout can place them; unnamed because we
+    // genuinely don't know the far-end port.
+    expect(peers[0]?.ports?.map((p) => p.id)).toEqual(anchors)
+    expect(peers[0]?.ports?.every((p) => p.label === '')).toBe(true)
+  })
+
+  it('reuses one anchor per reporting device across re-syncs', () => {
+    // Anchor ids must be derived from stable input, not generated, or every
+    // sync churns the port entities behind metrics bindings.
+    const link: NceNetworkLink[] = [
+      {
+        anedn: 'dev-ap',
+        aportname: 'MultiGE0/0/0',
+        aportdn: 'dn-a',
+        znedn: 'virtual-1',
+        znename: 'VirtualDevice',
+        zportname: 'port1.0.5',
+        zportdn: 'port1.0.5',
+      },
+    ]
+    const first = buildTopology([AP], link, new Map())
+    const second = buildTopology([AP], link, new Map())
+    expect(first.links[0]?.to.port).toBe(second.links[0]?.to.port)
+    expect(first.links[0]?.id).toBe(second.links[0]?.id)
+  })
+
+  it('drops a link whose reporting end is not a managed device', () => {
+    const orphan: NceNetworkLink[] = [
+      { anedn: 'not-managed', aportname: 'GE0/0/24', znedn: 'dev-core', zportname: 'GE0/0/1' },
+    ]
+    const g = buildTopology([CORE_SW, AP], orphan, new Map())
     expect(g.links).toHaveLength(0)
   })
 
-  it('collapses duplicate topo link records for the same wire', () => {
-    const dup = [...TOPO_LINKS, { ...TOPO_LINKS[0] }] as NceTopoLink[]
+  it('collapses duplicate link records for the same wire', () => {
+    const dup = [...NETWORK_LINKS, { ...NETWORK_LINKS[0] }] as NceNetworkLink[]
     const g = buildTopology([CORE_SW, AP], dup, new Map())
     expect(g.links).toHaveLength(1)
   })
 
-  it('satisfies the topology identity contract on the topo-link path', () => {
-    const g = buildTopology([CORE_SW, AP], TOPO_LINKS, new Map())
+  it('satisfies the topology identity contract on the reported-link path', () => {
+    const g = buildTopology([CORE_SW, AP], NETWORK_LINKS, new Map())
     const result = validateTopologyIdentityContract(g)
     expect(result.nodesMissingIdentity).toEqual([])
     expect(result.portsMissingIfName).toEqual([])

--- a/libs/plugins/huawei-nce-campus/src/topology.ts
+++ b/libs/plugins/huawei-nce-campus/src/topology.ts
@@ -2,16 +2,16 @@
  * Build an NCE-Campus topology fragment: managed devices (APs, switches,
  * routers, firewalls), grouped into their sites, with device↔device links.
  *
- * Links come from the controller's own topology (`topomanager/device/node`
- * linkData — one call, ports + status included) when it returns any, falling
- * back to each device's LLDP neighbor table otherwise. Identity stamping lets
+ * Links come from Link Management (`/rest/openapi/network/link` — one paged
+ * call naming both endpoints by device UUID) when it returns any, falling back
+ * to each device's LLDP neighbor table otherwise. Identity stamping lets
  * shumoku's composition merge these nodes with other sources (NetBox, Zabbix)
  * by MAC / management IP.
  */
 
 import type { Link, NetworkGraph, Node, Subgraph } from '@shumoku/core'
 import { buildIdentity, DeviceType } from '@shumoku/core'
-import type { NceDevice, NceLldpNeighbor, NceTopoLink } from './types.js'
+import type { NceDevice, NceLldpNeighbor, NceNetworkLink } from './types.js'
 
 /** Node id for a device, derived from its NCE UUID. */
 export function deviceNodeId(deviceId: string): string {
@@ -44,7 +44,7 @@ export function mapDeviceType(deviceType: string | undefined): DeviceType {
  */
 const normalizeMac = (mac: string): string => mac.toLowerCase().replace(/[^0-9a-f]/g, '')
 
-/** Node id for an LLDP-discovered device that NCE does not manage. */
+/** Node id for a peer NCE reports a link to but does not manage. */
 function neighborNodeId(key: string): string {
   return `nce-lldp:${key}`
 }
@@ -62,9 +62,25 @@ export function mapNeighborType(neighbor: NceLldpNeighbor): DeviceType {
   return DeviceType.L2Switch
 }
 
+/**
+ * The port name only when NCE actually holds a port entity for it.
+ *
+ * A managed port's DN is a UUID; a port NCE never resolved has its DN set to
+ * the name itself — the string came straight off the neighbour's LLDP TLV.
+ * Such a "port" is not exclusive: the live tenant fans four AP uplinks into
+ * one `port1.0.5` on a synthetic peer, and anchoring four edges to a single
+ * port leaves the router no way to separate them (they cross, loop, and miss
+ * the port badge). Anchoring to the node instead renders honestly: we know
+ * the AP's port, we do not know the far end's.
+ */
+function realPortName(name: string | undefined, dn: string | undefined): string {
+  if (!name) return ''
+  return dn && dn !== name ? name : ''
+}
+
 export function buildTopology(
   devices: NceDevice[],
-  topoLinks: NceTopoLink[],
+  networkLinks: NceNetworkLink[],
   neighborsByDeviceId: Map<string, NceLldpNeighbor[]>,
 ): NetworkGraph {
   const nodes: Node[] = []
@@ -137,65 +153,122 @@ export function buildTopology(
   for (const d of devices) if (d.id) knownDevice.add(d.id)
   const emittedLink = new Set<string>()
 
-  // Preferred: the controller's own topology links. leftFdn/rightFdn are the
-  // end nodes' resIds — for device nodes, the same UUID the device list
-  // returns — with the ports in aPortName/zPortName. Links whose ends aren't
-  // both managed devices (site/organization container nodes, unmanaged gear)
-  // are dropped: an edge to a node we can't identify would neither merge nor
-  // render usefully.
-  for (const l of topoLinks) {
-    if (!l.leftFdn || !l.rightFdn) continue
-    if (!knownDevice.has(l.leftFdn) || !knownDevice.has(l.rightFdn)) continue
-    if (l.leftFdn === l.rightFdn) continue
-    const a = `${l.leftFdn}|${l.aPortName ?? ''}`
-    const b = `${l.rightFdn}|${l.zPortName ?? ''}`
+  // A peer NCE reports a link to but does not manage — a WLAN-only tenant's
+  // uplink switches, or the controller's own `VirtualDevice` placeholder.
+  // Emitting them is the point: the AP↔switch edge is the topology NCE knows
+  // that a wired source doesn't, and identity lets composition merge the real
+  // ones onto the NetBox/Zabbix node instead of duplicating them.
+  //
+  // Parent each into the site of the device that reported it. Emitting site
+  // subgraphs makes this source's scope closed, and the resolver drops
+  // in-scope-source nodes belonging to none of its regions — an unparented
+  // peer would be discarded along with its link.
+  const peerNodes = new Map<string, Node>()
+  const ensurePeerNode = (
+    key: string,
+    label: string,
+    reportedBy: string,
+    identity: Parameters<typeof buildIdentity>[0],
+    type: DeviceType,
+  ): Node => {
+    const existing = peerNodes.get(key)
+    if (existing) return existing
+    const parent = siteOfDevice.get(reportedBy)
+    const node: Node = {
+      id: neighborNodeId(key),
+      label: [label],
+      ...(parent ? { parent } : {}),
+      identity: buildIdentity(identity),
+      spec: { kind: 'hardware', type },
+    }
+    peerNodes.set(key, node)
+    nodes.push(node)
+    return node
+  }
+
+  /**
+   * An anchor on a peer whose real port NCE doesn't know.
+   *
+   * Every endpoint needs a port id, and endpoints that share one share an
+   * anchor: four AP uplinks all reported against `port1.0.5` (or all left
+   * blank) collapse onto a single point, so the router draws four crossing
+   * lines into one badge. Give each link its own anchor instead, keyed by the
+   * device that reported it — unique per link and stable across syncs, unlike
+   * core's `ensurePorts`, whose anonymous ids are regenerated every time and
+   * would churn the port entities. The label stays empty because we genuinely
+   * do not know this port's name.
+   */
+  const anchorOnPeer = (peer: Node, reportedBy: string): string => {
+    const id = `uplink:${reportedBy}`
+    if (!peer.ports?.some((p) => p.id === id)) {
+      peer.ports = [...(peer.ports ?? []), { id, label: '', connectors: [] }]
+    }
+    return id
+  }
+
+  // Preferred link source: Link Management (`/rest/openapi/network/link`).
+  // One call, and both ends carry the managed device's UUID plus a port name —
+  // the topology API needs a per-site walk and still leaves ports null on some
+  // deployments.
+  for (const l of networkLinks) {
+    const aId = l.anedn
+    const zId = l.znedn
+    if (!aId || !zId || aId === zId) continue
+    // The A end is expected to be managed (that's whose link table this is);
+    // an unmanaged A end has no site to anchor the pair to, so skip it.
+    if (!knownDevice.has(aId)) continue
+    const fromNode = deviceNodeId(aId)
+    const peer = knownDevice.has(zId)
+      ? undefined
+      : ensurePeerNode(
+          zId,
+          l.znename || zId,
+          aId,
+          {
+            // 0.0.0.0 is the controller's placeholder for "no address".
+            mgmtIp: l.zneip && l.zneip !== '0.0.0.0' ? l.zneip : undefined,
+            sysName: l.znename,
+            vendorIds: { 'nce-device-id': zId },
+          },
+          DeviceType.L2Switch,
+        )
+    const toNode = peer ? peer.id : deviceNodeId(zId)
+    const aPort = realPortName(l.aportname, l.aportdn)
+    const namedZPort = realPortName(l.zportname, l.zportdn)
+    const zPort = namedZPort || (peer ? anchorOnPeer(peer, aId) : '')
+    const a = `${aId}|${aPort}`
+    const b = `${zId}|${zPort}`
     const key = a < b ? `${a}~${b}` : `${b}~${a}`
     if (emittedLink.has(key)) continue
     emittedLink.add(key)
+    const speedMbps = Number.parseFloat(l.speed ?? '')
     links.push({
       id: `nce-link:${key}`,
-      from: { node: deviceNodeId(l.leftFdn), port: l.aPortName || '' },
-      to: { node: deviceNodeId(l.rightFdn), port: l.zPortName || '' },
+      from: { node: fromNode, port: aPort },
+      to: { node: toNode, port: zPort },
       arrow: 'none',
+      ...(Number.isFinite(speedMbps) && speedMbps > 0 ? { rateBps: speedMbps * 1_000_000 } : {}),
     })
   }
 
-  // Fallback: LLDP neighbor tables (used when the topo API returned no usable
-  // links). Both ends report the same physical wire, so a canonical
-  // endpoint-sorted key collapses the A→B / B→A duplicates.
-  //
-  // A WLAN-only tenant manages APs but not the switches they uplink into, so
-  // most neighbours are NOT in the inventory. Emitting a node for them is the
-  // whole point: the AP↔switch edge is the topology NCE knows that a wired
-  // source doesn't, and identity (MAC/chassisId) lets composition merge that
-  // switch onto the NetBox/Zabbix node instead of duplicating it.
-  const emittedNeighbor = new Set<string>()
-  const ensureNeighbor = (n: NceLldpNeighbor, discoveredBy: string): string | undefined => {
+  // Fallback: LLDP neighbor tables. Both ends report the same physical wire, so
+  // a canonical endpoint-sorted key collapses the A→B / B→A duplicates.
+  const ensureLldpPeer = (n: NceLldpNeighbor, discoveredBy: string): Node | undefined => {
     const key = n.remoteMac ? normalizeMac(n.remoteMac) : n.sysName?.toLowerCase()
     if (!key) return undefined // nothing identifying — an edge to it can't merge
-    const nodeId = neighborNodeId(key)
-    if (emittedNeighbor.has(key)) return nodeId
-    emittedNeighbor.add(key)
-    // Parent it into the site of the AP that heard it. Emitting site subgraphs
-    // makes this source's scope closed, and the resolver drops in-scope-source
-    // nodes that sit in none of its regions — an unparented neighbour would be
-    // discarded along with its link. The AP's site is also the truthful answer:
-    // that's where the switch this AP plugs into physically lives.
-    const parent = siteOfDevice.get(discoveredBy)
-    nodes.push({
-      id: nodeId,
-      label: [n.sysName || n.remoteMac || key],
-      ...(parent ? { parent } : {}),
-      identity: buildIdentity({
+    return ensurePeerNode(
+      key,
+      n.sysName || n.remoteMac || key,
+      discoveredBy,
+      {
         chassisId: n.remoteMac,
         mac: n.remoteMac,
         // LLDP sysName is the peer's own claim about itself — a valid sysName
         // even when Huawei switches report their ESN there.
         sysName: n.sysName,
-      }),
-      spec: { kind: 'hardware', type: mapNeighborType(n) },
-    })
-    return nodeId
+      },
+      mapNeighborType(n),
+    )
   }
 
   if (links.length === 0) {
@@ -203,19 +276,23 @@ export function buildTopology(
       const fromNode = deviceNodeId(deviceId)
       for (const n of neighbors) {
         if (!n.localIfName) continue
-        const peer = resolvePeer(n)
-        if (peer?.id === deviceId) continue // self-report; not a wire
-        const toNode = peer?.id ? deviceNodeId(peer.id) : ensureNeighbor(n, deviceId)
-        if (!toNode) continue
+        const managed = resolvePeer(n)
+        if (managed?.id === deviceId) continue // self-report; not a wire
+        const peer = managed?.id ? undefined : ensureLldpPeer(n, deviceId)
+        if (!managed?.id && !peer) continue
+        const toNode = managed?.id ? deviceNodeId(managed.id) : (peer?.id ?? '')
+        // Same anchor rule as above: an unnamed far end gets its own anchor so
+        // several neighbours of one peer don't pile onto a single point.
+        const zPort = n.remoteIfName || (peer ? anchorOnPeer(peer, deviceId) : '')
         const a = `${deviceId}|${n.localIfName}`
-        const b = `${peer?.id ?? toNode}|${n.remoteIfName ?? ''}`
+        const b = `${managed?.id ?? toNode}|${zPort}`
         const key = a < b ? `${a}~${b}` : `${b}~${a}`
         if (emittedLink.has(key)) continue
         emittedLink.add(key)
         links.push({
           id: `nce-link:${key}`,
           from: { node: fromNode, port: n.localIfName },
-          to: { node: toNode, port: n.remoteIfName || '' },
+          to: { node: toNode, port: zPort },
           arrow: 'none',
         })
       }

--- a/libs/plugins/huawei-nce-campus/src/types.ts
+++ b/libs/plugins/huawei-nce-campus/src/types.ts
@@ -128,43 +128,64 @@ export interface NceLldpResponse {
   }
 }
 
-// ----- Topology (topomanager) -------------------------------------------------
+// ----- Links (Link Management) ----------------------------------------------
 
 /**
- * One link from `GET .../topomanager/device/node`.
- * `leftFdn`/`rightFdn` are the resIds of the two end nodes — for device nodes
- * this is the same UUID `/controller/campus/v3/devices` returns as `id`.
- * `linkStatus`: 0 = normal, 1 = unknown, 2 = major fault, 3 = emergency fault,
- * 4 = offline, 5 = not managed.
+ * One link from `GET /rest/openapi/network/link`.
+ *
+ * Preferred over the topology API (`topomanager/device/node`): both ends carry
+ * the managed device's UUID (`anedn` / `znedn`, the same id `/v3/devices`
+ * returns) plus a port name. The topology API returns nothing unless queried
+ * per site via `parentResId`, and even then leaves the port names null on some
+ * deployments, which would leave links unmappable to interfaces.
  */
-export interface NceTopoLink {
-  label?: string
-  resId?: string
-  topoId?: number
-  typeId?: string
-  leftFdn?: string
-  rightFdn?: string
-  /** Port of the `leftFdn` end. */
-  aPortName?: string
-  /** Port of the `rightFdn` end. */
-  zPortName?: string
-  linkStatus?: number
+export interface NceNetworkLink {
+  linkdn?: string
+  /** Composite name, e.g. `ap-01_MultiGE0/0/0_sw-01_GE0/0/1`. */
+  linkname?: string
+  /** A-end device UUID / name / management IP. */
+  anedn?: string
+  anename?: string
+  aneip?: string
+  aportname?: string
+  /**
+   * A-end port DN. A real port is a UUID here; when the DN merely repeats
+   * `aportname`, NCE holds no port entity — the string came straight off an
+   * LLDP TLV. See {@link NceNetworkLink.zportdn}.
+   */
+  aportdn?: string
+  /** Z-end device UUID / name / management IP. `0.0.0.0` means "no address". */
+  znedn?: string
+  znename?: string
+  zneip?: string
+  zportname?: string
+  /**
+   * Z-end port DN. Same rule as `aportdn`: `zportdn === zportname` means the
+   * port does not exist as an entity, so several links can claim it at once
+   * (the live tenant fans four AP uplinks into one such `port1.0.5`).
+   */
+  zportdn?: string
+  /** 1 LLDP, 2 side-by-side, 3 MACARP, 4 CDP, 5 IP, 6 Eth-Trunk, 99 manual. */
+  linktype?: number
+  /**
+   * 0 normal, 1 unknown, 2 major, 3 critical, 4 offline, 5 unmanaged, 6 faulty
+   * — but the live tenant reports 4 for links demonstrably carrying traffic,
+   * so the plugin does not derive link status from it.
+   */
+  linkstatus?: number
+  /** Link speed in Mbit/s, as a string. */
+  speed?: string
 }
 
-/** Envelope of `GET .../topomanager/device/node`. */
-export interface NceTopoResponse {
-  errcode?: string
-  errmsg?: string | null
-  nodeData?: {
-    nodeData?: unknown[]
-    hasNext?: boolean
-    marker?: string
-  }
-  linkData?: {
-    linkData?: NceTopoLink[]
-    hasNext?: boolean
-    marker?: string
-  }
+/** Envelope of `GET /rest/openapi/network/link`. */
+export interface NceNetworkLinkResponse {
+  /** 0 = success. */
+  code?: number
+  description?: string
+  data?: NceNetworkLink[]
+  /** Total links matching the query. */
+  size?: number
+  totalPage?: number
 }
 
 // ----- Performance ----------------------------------------------------------

--- a/libs/plugins/huawei-nce-campus/src/types.ts
+++ b/libs/plugins/huawei-nce-campus/src/types.ts
@@ -168,11 +168,18 @@ export interface NceNetworkLink {
   /** 1 LLDP, 2 side-by-side, 3 MACARP, 4 CDP, 5 IP, 6 Eth-Trunk, 99 manual. */
   linktype?: number
   /**
-   * 0 normal, 1 unknown, 2 major, 3 critical, 4 offline, 5 unmanaged, 6 faulty
-   * — but the live tenant reports 4 for links demonstrably carrying traffic,
-   * so the plugin does not derive link status from it.
+   * 0 normal, 1 unknown, 2 major, 3 critical, 4 offline, 5 unmanaged, 6 faulty.
+   *
+   * Verified against a live tenant: the two links whose AP was up read 0, the
+   * seven whose AP was offline read 4. The controller keeps a link record after
+   * its endpoint goes away — with no timestamp — so this field (with
+   * `anestate` / `znestate`) is the only way to tell a live wire from one that
+   * was merely observed at some point in the past.
    */
   linkstatus?: number
+  /** A-end / Z-end NE state: 0 unmanaged, 1 online, 2 offline, 3 unknown. */
+  anestate?: number
+  znestate?: number
   /** Link speed in Mbit/s, as a string. */
   speed?: string
 }


### PR DESCRIPTION
## Summary

Follow-up to #629, driven entirely by two live NCE-Campus tenants. The plugin produced **zero links** on one of them; this makes it produce the links the controller actually has, and render them honestly.

### 1. Link Management replaces the topology API as the link source

`/rest/openapi/network/link` — one paged call. Both ends carry the same device UUID `/v3/devices` returns, plus port names and speed.

The topology API (`topomanager/device/node`) is dropped: it returns **nothing** unless queried per site via `parentResId`, and even then leaves `aPortName`/`zPortName` **null** on a live deployment, which leaves links unmappable to interfaces. LLDP fan-out stays as the fallback for tenants that answer neither.

### 2. Each unnamed far end gets its own anchor

A port whose DN merely repeats its name is not an entity in NCE. One tenant fans four AP uplinks into a single such `port1.0.5` on a synthetic peer. Every endpoint needs a port id, and endpoints that share one **share an anchor** — the layout then collapses all four edges onto a single point and the router draws crossing lines that miss the port badge (measured: four edges terminating at the same coordinate, lateral offsets ±4/±12 on an 8×8 port box).

Each link now gets its own anchor on the peer, keyed by the reporting device — unique per link and stable across syncs, unlike core's `ensurePorts`, whose generated ids change every run and would churn the port entities behind metrics bindings.

### 3. `linkstatus` is used again

The earlier "the controller reports 4 for links carrying traffic" note was a misreading: in that tenant *every* link's endpoint was offline, so 4 was correct. Verified on a tenant with live devices — links whose AP is up read 0, links whose AP is offline read 4.

This matters because Link Management **keeps a link record after its endpoint disappears** and stores no observation time. Without the status, a wire pulled months ago is indistinguishable from one passing traffic.

## Field notes

- Peers are keyed by the controller's UUID, not the reported name: three physically distinct switches all report `IS230-10TP-AC(V1)` (a model number, not a hostname) and two of them claim the same `GE0/0/7`. Name-keying would have merged them.
- MAC comparison ignores separators — the device list returns `50-04-01-02-14-80`, LLDP returns `CC:D8:1F:9F:D4:17`.
- A neighbour's `sysName` is often the peer's ESN, so that is matched too.

## Test plan

- [x] 29 unit tests, including the four-uplinks-one-phantom-port case and anchor stability across re-syncs
- [x] Verified end to end against two live tenants (39 and 65 devices): links render, anchors no longer collide, live vs. historical wires distinguishable
- [x] typecheck + biome clean

## Known limits (not addressed here)

Neither tenant exposes an AP→AC association, building/floor regions are undefined, and one tenant has LLDP off on every AP — so its NBI yields no wired topology at all. That is a data-availability limit on the controller side, not something the plugin can fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
