### PR TITLE
refactor(core/layout): remove the lateral-ramp grammar left behind by the HA hull

### DIFF
--- a/.changeset/remove-lateral-ramp.md
+++ b/.changeset/remove-lateral-ramp.md
@@ -1,0 +1,5 @@
+---
+'@shumoku/core': patch
+---
+
+Remove the `lateral-ramp` routing grammar. PR #625 replaced the redundancy wire notation with the glasses hull plus a normal link, but the router kept its own under-loop notation for same-tier peer links, so two notations described one idea. The surviving one also broke on close ports: its fixed 14px stubs overshoot each other when the two ports are less than 28px apart, producing a self-crossing path. Peer edges now fall through to the default port-anchored bezier.

--- a/libs/@shumoku/core/src/layout/composite/composite.test.ts
+++ b/libs/@shumoku/core/src/layout/composite/composite.test.ts
@@ -380,10 +380,12 @@ describe('applyOctilinearRoutes', () => {
     const plan = buildCompositeRoutingPlan(buildLayoutProblem(graph), comp, edges)
 
     expect(plan.combs.size).toBe(0)
-    expect(plan.rampEdges.size).toBeGreaterThan(0)
     expect(plan.gutterEdges.size).toBe(0)
   })
-  it('only uses lateral ramps for explicitly allowed peer edges', () => {
+  it('leaves a side-port peer edge to the default bezier', () => {
+    // Redundancy is drawn as the glasses hull since #625, so the router has no
+    // peer-wire notation: a left/right port pair keeps `route` undefined and
+    // SvgEdge falls back to the port-anchored bezier.
     const port = (
       nodeId: string,
       id: string,
@@ -398,36 +400,29 @@ describe('applyOctilinearRoutes', () => {
       side,
       size: { width: 8, height: 8 },
     })
-    const edge = (): ResolvedEdge => {
-      const fromPort = port('left-peer', 'peer', 0, 0, 'right')
-      const toPort = port('right-peer', 'peer', 120, 0, 'left')
-      return {
-        id: 'e-peer',
-        fromPortId: fromPort.id,
-        toPortId: toPort.id,
-        fromPort,
-        toPort,
-        fromNodeId: 'left-peer',
-        toNodeId: 'right-peer',
-        fromEndpoint: { node: 'left-peer', port: fromPort.label },
-        toEndpoint: { node: 'right-peer', port: toPort.label },
-        points: [fromPort.absolutePosition, toPort.absolutePosition],
-        width: 2,
-        link: {
-          from: { node: 'left-peer', port: fromPort.label },
-          to: { node: 'right-peer', port: toPort.label },
-        },
-      }
+    const fromPort = port('left-peer', 'peer', 0, 0, 'right')
+    const toPort = port('right-peer', 'peer', 120, 0, 'left')
+    const edge: ResolvedEdge = {
+      id: 'e-peer',
+      fromPortId: fromPort.id,
+      toPortId: toPort.id,
+      fromPort,
+      toPort,
+      fromNodeId: 'left-peer',
+      toNodeId: 'right-peer',
+      fromEndpoint: { node: 'left-peer', port: fromPort.label },
+      toEndpoint: { node: 'right-peer', port: toPort.label },
+      points: [fromPort.absolutePosition, toPort.absolutePosition],
+      width: 2,
+      link: {
+        from: { node: 'left-peer', port: fromPort.label },
+        to: { node: 'right-peer', port: toPort.label },
+      },
     }
 
-    const blocked = new Map<string, ResolvedEdge>([['e-peer', edge()]])
-    applyOctilinearRoutes(blocked)
-    expect(blocked.get('e-peer')?.route).toBeUndefined()
-
-    const allowed = new Map<string, ResolvedEdge>([['e-peer', edge()]])
-    applyOctilinearRoutes(allowed, { routingPlan: { rampEdges: new Set(['e-peer']) } })
-    expect(allowed.get('e-peer')?.route?.kind).toBe('polyline')
-    expect(allowed.get('e-peer')?.points).toHaveLength(6)
+    const edges = new Map<string, ResolvedEdge>([['e-peer', edge]])
+    applyOctilinearRoutes(edges)
+    expect(edges.get('e-peer')?.route).toBeUndefined()
   })
 
   it('keeps short one-row links out of subgraph gutters', () => {

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -585,17 +585,12 @@ export interface OctilinearRoutingPlan {
    * don't fit the clean vertical case fall back to normal classification.
    */
   combs?: ReadonlyMap<string, readonly string[]>
-  /**
-   * Edge ids that may use the lateral "ramp" grammar. Ramps are a semantic
-   * notation for same-tier peer links, not a generic side-port fallback.
-   */
-  rampEdges?: ReadonlySet<string>
   /** Edge ids that may use long subgraph gutter bypasses. */
   gutterEdges?: ReadonlySet<string>
 }
 
 export interface OctilinearOptions {
-  /** Semantic routing grammar permissions (combs / ramps / gutters). */
+  /** Semantic routing grammar permissions (combs / gutters). */
   routingPlan?: OctilinearRoutingPlan
   /** Treat |dx| up to this as a straight (near-vertical) run. */
   straightTolerance?: number
@@ -650,7 +645,6 @@ export function applyOctilinearRoutes(
   const clearance = options.trackClearance ?? 3
   const gutterMinSpan = options.gutterMinSpan ?? 160
   const combs = options.routingPlan?.combs
-  const rampEdges = options.routingPlan?.rampEdges
   const gutterEdges = options.routingPlan?.gutterEdges
   // node boxes as routing obstacles + per-edge exemptions
   const nodeBoxes = (options.nodeObstacles ?? []).map((o) => ({
@@ -664,23 +658,11 @@ export function applyOctilinearRoutes(
   for (const e of edges.values()) endpointsOf.set(e.id, [e.fromNodeId, e.toNodeId])
 
   // -- classify ------------------------------------------------------------------
-  // bottom→top pairs route vertically; side-port peers (left/right at similar
-  // height) route as under-loops ("ramps" — the v3 redundancy/peer notation).
-  interface RampRoute {
-    id: string
-    x1: number
-    y1: number
-    dir1: number
-    x2: number
-    y2: number
-    dir2: number
-    half: number
-    busY: number
-  }
+  // Only bottom→top pairs are routed here. Side-port peers keep the default
+  // port-anchored bezier: since #625 a redundancy pair is drawn as the hull
+  // plus a NORMAL link, so there is no longer a peer wire notation to emit.
   const straights: OrthRoute[] = []
   const orths: OrthRoute[] = []
-  const ramps: RampRoute[] = []
-  const isSidePort = (side: string): boolean => side === 'left' || side === 'right'
   const sortedEdges = [...edges.values()].sort((a, b) => (a.id < b.id ? -1 : 1))
 
   // -- org-chart combs (v3 §47⑤): primary fan-outs share one trunk + bus ----
@@ -832,25 +814,6 @@ export function applyOctilinearRoutes(
         : edge.toPort
     const lower = upper === edge.fromPort ? edge.toPort : edge.fromPort
     const half = Math.max(0.5, edge.width / 2)
-    if (
-      rampEdges?.has(edge.id) === true &&
-      isSidePort(upper.side) &&
-      isSidePort(lower.side) &&
-      Math.abs(lower.absolutePosition.y - upper.absolutePosition.y) <= 80
-    ) {
-      ramps.push({
-        id: edge.id,
-        x1: upper.absolutePosition.x,
-        y1: upper.absolutePosition.y,
-        dir1: upper.side === 'right' ? 1 : -1,
-        x2: lower.absolutePosition.x,
-        y2: lower.absolutePosition.y,
-        dir2: lower.side === 'right' ? 1 : -1,
-        half,
-        busY: 0,
-      })
-      continue
-    }
     if (upper.side !== 'bottom' || lower.side !== 'top') continue
     const x1 = upper.absolutePosition.x
     const y1 = upper.absolutePosition.y
@@ -1022,23 +985,6 @@ export function applyOctilinearRoutes(
       },
     })
   }
-  // ramp buses share the SAME allocator (separate allocators collide)
-  for (const ramp of ramps) {
-    const bottom = Math.max(ramp.y1, ramp.y2)
-    requests.push({
-      id: `ramp:${ramp.id}`,
-      half: ramp.half,
-      exempt: new Set(endpointsOf.get(ramp.id) ?? []),
-      lo: Math.min(ramp.x1, ramp.x2) - 16,
-      hi: Math.max(ramp.x1, ramp.x2) + 16,
-      want: bottom + 30,
-      floor: bottom + 18,
-      ceil: bottom + 400,
-      assign: (y) => {
-        ramp.busY = y
-      },
-    })
-  }
   requests.sort((a, b) => a.want - b.want || (a.id < b.id ? -1 : 1))
   const placedTracks: { y: number; lo: number; hi: number; half: number }[] = []
   for (const request of requests) {
@@ -1098,22 +1044,6 @@ export function applyOctilinearRoutes(
       y1: route.trackY,
       y2: route.trackY2 ?? route.y2,
       half: route.half,
-    })
-  }
-  // ramp entry/exit stubs are short verticals too — unregistered, they
-  // got grazed by through-running lines
-  for (const ramp of ramps) {
-    placedVerticals.push({
-      x: ramp.x1 + ramp.dir1 * 14,
-      y1: Math.min(ramp.y1, ramp.busY),
-      y2: Math.max(ramp.y1, ramp.busY),
-      half: ramp.half,
-    })
-    placedVerticals.push({
-      x: ramp.x2 + ramp.dir2 * 14,
-      y1: Math.min(ramp.y2, ramp.busY),
-      y2: Math.max(ramp.y2, ramp.busY),
-      half: ramp.half,
     })
   }
   const verticalRuns = (route: OrthRoute, kind: 'straight' | 'orth') =>
@@ -1275,23 +1205,6 @@ export function applyOctilinearRoutes(
       edge.points = corner
       routed++
     }
-  }
-  for (const ramp of ramps) {
-    const edge = edges.get(ramp.id)
-    if (!edge) continue
-    const out1 = ramp.x1 + ramp.dir1 * 14
-    const out2 = ramp.x2 + ramp.dir2 * 14
-    const corner: Position[] = [
-      { x: ramp.x1, y: ramp.y1 },
-      { x: out1, y: ramp.y1 },
-      { x: out1, y: ramp.busY },
-      { x: out2, y: ramp.busY },
-      { x: out2, y: ramp.y2 },
-      { x: ramp.x2, y: ramp.y2 },
-    ]
-    edge.route = { kind: 'polyline', points: chamferCorners(corner, chamfer) }
-    edge.points = corner
-    routed++
   }
   return routed
 }

--- a/libs/@shumoku/core/src/layout/composite/routing-plan.ts
+++ b/libs/@shumoku/core/src/layout/composite/routing-plan.ts
@@ -12,8 +12,6 @@ export interface CompositeRoutingPlan {
   couplingEdges: Set<string>
   /** Parent id -> edge ids allowed to use shared comb bus grammar. */
   combs: Map<string, string[]>
-  /** Edge ids allowed to use same-tier lateral ramp grammar. */
-  rampEdges: Set<string>
   /** Edge ids allowed to use long through-traffic gutter grammar. */
   gutterEdges: Set<string>
 }
@@ -29,7 +27,6 @@ export function buildCompositeRoutingPlan(
   const plan: CompositeRoutingPlan = {
     couplingEdges: new Set<string>(),
     combs: new Map<string, string[]>(),
-    rampEdges: new Set<string>(),
     gutterEdges: new Set<string>(),
   }
 
@@ -41,7 +38,6 @@ export function buildCompositeRoutingPlan(
       plan.couplingEdges.add(edge.id)
       continue
     }
-    if (allows(edge, 'lateral-ramp')) plan.rampEdges.add(edge.id)
     if (allows(edge, 'long-gutter')) plan.gutterEdges.add(edge.id)
     if (!allows(edge, 'comb-bus')) continue
     const da = comp.depths.get(edge.fromNodeId)

--- a/libs/@shumoku/core/src/layout/problem.test.ts
+++ b/libs/@shumoku/core/src/layout/problem.test.ts
@@ -78,7 +78,7 @@ describe('buildLayoutProblem', () => {
     expect(problem.objectives.some((objective) => objective.kind === 'compactness')).toBe(true)
   })
 
-  it('classifies peer links as ramp-capable routing intent', () => {
+  it('classifies same-parent peer links as a same-tier peer intent', () => {
     const source: NetworkGraph = {
       name: 'peer-link',
       nodes: [
@@ -105,7 +105,10 @@ describe('buildLayoutProblem', () => {
     const intent = problem.routingIntents.find((candidate) => candidate.linkId === 'peer')
 
     expect(intent?.kind).toBe('same-tier-peer')
-    expect(intent?.allowedGrammars).toContain('lateral-ramp')
+    // A peer link is routed as an ordinary orthogonal edge. It used to also
+    // permit a 'lateral-ramp' under-loop, which was the pre-#625 notation for
+    // redundancy; redundancy is drawn as the hull now, so the wire is plain.
+    expect(intent?.allowedGrammars).toEqual(['direct-orthogonal'])
   })
   it('lets topology direction outrank soft device-tier hints', () => {
     const source: NetworkGraph = {

--- a/libs/@shumoku/core/src/layout/problem.ts
+++ b/libs/@shumoku/core/src/layout/problem.ts
@@ -62,7 +62,6 @@ export type LinkIntentKind =
 
 export type RoutingGrammar =
   | 'direct-orthogonal'
-  | 'lateral-ramp'
   | 'coupling-bridge'
   | 'long-gutter'
   | 'comb-bus'
@@ -897,7 +896,7 @@ function buildRoutingIntents(
         from: link.from,
         to: link.to,
         kind: 'same-tier-peer',
-        allowedGrammars: ['direct-orthogonal', 'lateral-ramp'],
+        allowedGrammars: ['direct-orthogonal'],
       }
     }
     if (fromRank !== undefined && toRank !== undefined && fromRank === toRank) {
@@ -907,9 +906,7 @@ function buildRoutingIntents(
         from: link.from,
         to: link.to,
         kind: sameGroup ? 'same-tier-peer' : 'unknown',
-        allowedGrammars: sameGroup
-          ? ['direct-orthogonal', 'lateral-ramp']
-          : ['independent-polyline'],
+        allowedGrammars: sameGroup ? ['direct-orthogonal'] : ['independent-polyline'],
       }
     }
     const rankSpan =


### PR DESCRIPTION
## Summary

`#625` replaced the redundancy wire notation with a solid glasses hull plus a **normal** link:

> Replace the parallel double-line rendering of `link.redundancy` with a solid glasses-shaped hull […] The redundancy link now renders as a NORMAL link

But it never touched the router. The `lateral-ramp` under-loop — described in the code as *"the v3 redundancy/peer notation"* — stayed behind, so two notations existed for one idea, and the surviving one kept being applied to same-tier peer links.

## Why remove rather than keep

**It claims something it cannot know.** A ramp is a peer/redundancy shape. It is granted to any `same-tier-peer` intent, which includes links that assert no redundancy at all. On a live NCE-Campus topology, an access-point uplink whose switch was mis-tiered into the AP row was drawn as a peer loop — exactly the kind of unevidenced claim #625 set out to stop making.

**It breaks on close ports.** Each end steps a fixed 14px out of its port before dropping to the bus lane:

```js
const out1 = ramp.x1 + ramp.dir1 * 14
const out2 = ramp.x2 + ramp.dir2 * 14
```

When the two ports are less than `2 × 14 = 28px` apart the stubs overshoot past each other, the crossing segment runs backwards and the path self-crosses. Observed on real data with a 24px gap:

```
M 2692.8 100 … L 2706.8 128 … L 2704.8 130 … L 2702.8 111.95 … L 2716.8 100
      out1 = 2706.8   out2 = 2702.8    <- out2 is left of out1
```

## What replaces it

Nothing new. The router already ignores side-port pairs (`if (upper.side !== 'bottom' || lower.side !== 'top') continue`), so these edges keep `route` undefined and `SvgEdge` falls back to the port-anchored bezier — the "normal link" #625 already specifies.

## Changes

- `problem.ts` — drop `'lateral-ramp'` from `RoutingGrammar`; both `same-tier-peer` intents now allow `['direct-orthogonal']`
- `routing-plan.ts` — drop `rampEdges`
- `router.ts` — drop the option, the local binding, the `RampRoute` type, the classification branch, the bus-allocator requests, the stub registration and the route emission; drop the now-unused `isSidePort`
- Two tests rewritten to assert the new behaviour (a side-port peer keeps `route` undefined)

The shared bus allocator and comb routing are untouched — ramps only borrowed that allocator.

## Test plan

- [x] `@shumoku/core`: 405 tests pass
- [x] Full monorepo build (21 packages)
- [x] `@shumoku/server-api`: 153 pass. One flaky failure (`entity retirement > last_seen_at advances…`) appears intermittently; verified it reproduces on `origin/main` with this branch's layout reverted, so it is pre-existing — the assertion is a strict `>` on two `Date.now()` reads.
- [x] Verified on a live topology: the affected edges lose the ramp route, the seven correctly-tiered links keep their polylines.

## Not fixed here

The reason those edges are same-tier in the first place is #653 — an `l2-switch` with a single link is placed in the access-point row. Until that is fixed those uplinks still render as long horizontal beziers rather than the vertical hierarchy edges they should be. This PR removes the duplicated notation; it does not change placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
