### PR TITLE
fix(core): don't root the rank tree at a leaf when every link is the same speed

### DIFF
--- a/.changeset/thick-donkeys-smoke.md
+++ b/.changeset/thick-donkeys-smoke.md
@@ -1,0 +1,11 @@
+---
+'@shumoku/core': patch
+---
+
+Stop treating link bandwidth as a hierarchy signal when every link runs at the
+same speed. On a uniform fabric — a campus access layer where each AP has an
+identical 1G uplink — the "most peripheral end of the fattest trunk" rule
+selected every node and then resolved to a leaf, seeding the rank root at an
+access point and rendering switches below or beside the APs they serve. The
+rule now requires the fat-trunk set to actually be a subset of the candidates;
+otherwise the device-tier rule decides, which already refuses to root at a leaf.

--- a/libs/@shumoku/core/src/layout/problem.test.ts
+++ b/libs/@shumoku/core/src/layout/problem.test.ts
@@ -200,6 +200,41 @@ describe('buildLayoutProblem', () => {
     }
   })
 
+  it('ignores bandwidth as a root signal when every link runs at the same speed', () => {
+    // A campus access fabric as a controller reports it: L2 switches, APs, and
+    // an identical 1G uplink on every wire. A uniform speed makes every node a
+    // "fat trunk end", so the peripheral-trunk heuristic would pick the lowest
+    // degree (an AP) and invert the map. Bandwidth is only evidence when some
+    // link is thinner than another; here the device tier must decide.
+    const rate = (from: string, to: string): Link => ({
+      from: { node: from, port: `to-${to}` },
+      to: { node: to, port: `to-${from}` },
+      rateBps: 1e9,
+    })
+    const source: NetworkGraph = {
+      name: 'uniform-1g-access',
+      nodes: [
+        { id: 'sw1', label: 'sw1', spec: { kind: 'hardware', type: DeviceType.L2Switch } },
+        { id: 'sw2', label: 'sw2', spec: { kind: 'hardware', type: DeviceType.L2Switch } },
+        { id: 'ap1', label: 'ap1', spec: { kind: 'hardware', type: DeviceType.AccessPoint } },
+        { id: 'ap2', label: 'ap2', spec: { kind: 'hardware', type: DeviceType.AccessPoint } },
+        { id: 'ap3', label: 'ap3', spec: { kind: 'hardware', type: DeviceType.AccessPoint } },
+      ],
+      // sw2/ap3 form their own island — controllers report per-device uplinks
+      // and the fabric between switches is often invisible. Each island still
+      // has to be tiered on its own, not flattened into one row.
+      links: [rate('sw1', 'ap1'), rate('sw1', 'ap2'), rate('sw2', 'ap3')],
+    }
+
+    const ranks = computeRoleDrivenRanks(source)
+
+    expect(ranks.get('sw1')).toBe(0)
+    expect(ranks.get('sw2')).toBe(0)
+    for (const ap of ['ap1', 'ap2', 'ap3']) {
+      expect(ranks.get(ap)).toBe(1)
+    }
+  })
+
   it('anchors the apex to the rank root, not raw cable direction', () => {
     // Inventory cables are undirected: from→to is arbitrary. Here every cable
     // is written leaf-first, so a direction-based heuristic would crown a

--- a/libs/@shumoku/core/src/layout/problem.ts
+++ b/libs/@shumoku/core/src/layout/problem.ts
@@ -472,10 +472,18 @@ export function computeRoleDrivenRanks(
     // No trustworthy boundary role — fall back to the physics: the WAN edge is
     // the most peripheral endpoint of the fattest trunks (lowest degree first;
     // the outer end of a fat pair has fewer legs than the aggregation side).
-    const trunkEnds = graph.nodes
-      .filter((node) => degreeOf(node.id) > 0 && !sinks.has(node.id) && onFatTrunk(node.id))
+    const candidates = graph.nodes
+      .filter((node) => degreeOf(node.id) > 0 && !sinks.has(node.id))
       .map((node) => node.id)
-    if (trunkEnds.length > 0) {
+    const trunkEnds = candidates.filter((id) => onFatTrunk(id))
+    // "Fattest" is only evidence when some link is thinner than another. A
+    // uniform fabric — every wire the same speed, as in a campus access layer
+    // where each AP has an identical 1G uplink — selects every candidate, and
+    // then "lowest degree, most peripheral" resolves to a leaf. Rooting at a
+    // leaf inverts the whole map, which is precisely what the device-tier rule
+    // below exists to prevent; let it decide instead of pre-empting it with a
+    // signal that carries no information.
+    if (trunkEnds.length > 0 && trunkEnds.length < candidates.length) {
       const minDeg = Math.min(...trunkEnds.map(degreeOf))
       const peripheral = trunkEnds.filter((id) => degreeOf(id) === minDeg)
       const ecc = new Map(peripheral.map((id) => [id, eccOf(id)]))


### PR DESCRIPTION
Fixes #653.

## What was wrong

On the live NCE-Campus topology, L2 switches rendered **beside or below** the access points they serve.

Root cause is in `buildLayoutProblem`'s root selection (`libs/@shumoku/core/src/layout/problem.ts`):

1. `BOUNDARY_TIER = 20` covers routers/firewalls only, so an all-switch/AP campus has no boundary device → `corroborated` is empty.
2. Control falls to the fat-trunk fallback, which fires on `maxBw > 0`. Every campus uplink is 1 Gbps, so `onFatTrunk()` is true for **every** node — the "fattest trunk" filter selects the whole candidate set and carries no signal.
3. The rule then takes the lowest degree (degree 1 = an AP) and highest eccentricity → **an AP becomes the BFS root at rank 0**, and the switch lands at rank 1, i.e. below it.
4. The guard that exists specifically to prevent this — the device-tier rule's `LEAF_TIER = 50`, commented *"rooting at the leaves is exactly the inversion bug"* — is unreachable, because the bandwidth branch already claimed the roots.

Disconnected `{AP, switch}` islands (the controller reports per-device uplinks; switch-to-switch wiring is often invisible) were also flattened into one row, since only reached nodes get a BFS rank and everything else defaults to 0. Rooting at the switches fixes that too — every island now has its own root.

## The fix

Require the fat-trunk set to be a **proper subset** of the candidates. Bandwidth is only evidence when some link is thinner than another; on a uniform fabric the rule now abstains and the device-tier rule decides.

## Verified on the live topology

Before: APs at `y = 100`, switches at `y = 100` and `328`; 9 edges with `dy = 0` (horizontal AP↔switch links).
After:

```
IS230-10TP-AC(V1)    l2-switch     y=100   (×15)
ap*                  access-point  y=328   (×31)
```

Every AP↔switch edge is now `dy = 148` — a vertical hierarchy edge. No `dy = 0` links remain.

## Tests

New regression test in `problem.test.ts` — a uniform-1G access fabric with two islands; asserts switches at rank 0 and APs at rank 1. Confirmed it fails without the guard (`sw1` gets rank 1) and passes with it. Full suite: 406 core tests, 39/39 turbo tasks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014batWzWC9HSikr4UTRnUsq