### PR TITLE
fix(server): proxy live metrics over the page origin

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "concurrently -k -n api,web -c blue,green \"bun run dev:api\" \"bun run dev:web\"",
     "dev:api": "cd api && NODE_ENV=development bun --watch src/index.ts",
-    "dev:web": "wait-on http://localhost:8080/api/health && cd web && bun run dev",
+    "dev:web": "wait-on http://127.0.0.1:8080/api/health && cd web && bun run dev",
     "build": "cd api && bun run build && cd ../web && bun run build",
     "start": "cd api && bun run start",
     "typecheck": "cd api && bun run typecheck && cd ../web && bun run check",

--- a/apps/server/web/src/lib/stores/metrics.test.ts
+++ b/apps/server/web/src/lib/stores/metrics.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { metricsStore } from './metrics'
+
+describe('metricsStore WebSocket connection', () => {
+  afterEach(() => {
+    metricsStore.disconnect()
+    vi.unstubAllGlobals()
+  })
+
+  it('uses a same-origin URL handled by the development proxy', () => {
+    let requestedUrl: string | URL | undefined
+
+    class WebSocketMock {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+
+      readonly readyState = WebSocketMock.CONNECTING
+      onopen = null
+      onmessage = null
+      onclose = null
+      onerror = null
+
+      constructor(url: string | URL) {
+        requestedUrl = url
+      }
+
+      close(): void {}
+    }
+
+    vi.stubGlobal('WebSocket', WebSocketMock)
+
+    metricsStore.connect()
+
+    expect(requestedUrl).toBe('/ws')
+  })
+})

--- a/apps/server/web/src/lib/stores/metrics.ts
+++ b/apps/server/web/src/lib/stores/metrics.ts
@@ -134,15 +134,6 @@ function createMetricsStore() {
   const g = getGlobal()
   const maxReconnectAttempts = 5
 
-  function getWebSocketUrl(): string {
-    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    // In development (Vite), connect directly to API server
-    // In production, use same host
-    const isDev = window.location.port === '5173'
-    const host = isDev ? 'localhost:8080' : window.location.host
-    return `${protocol}//${host}/ws`
-  }
-
   function cleanupWebSocket(): void {
     if (g.ws) {
       // Remove event handlers to prevent callbacks after cleanup
@@ -181,7 +172,7 @@ function createMetricsStore() {
     g.intentionalDisconnect = false
 
     try {
-      g.ws = new WebSocket(getWebSocketUrl())
+      g.ws = new WebSocket('/ws')
 
       g.ws.onopen = () => {
         g.reconnectAttempts = 0
@@ -274,9 +265,7 @@ function createMetricsStore() {
   // A public/shared viewer has no session, so it can't use the auth-gated `/ws`.
   // Instead it streams projected metrics from the token-scoped share endpoint.
   function getShareStreamUrl(token: string): string {
-    const isDev = window.location.port === '5173'
-    const origin = isDev ? 'http://localhost:8080' : window.location.origin
-    return `${origin}/api/share/topologies/${token}/metrics/stream`
+    return `/api/share/topologies/${token}/metrics/stream`
   }
 
   function disconnectShareStream(): void {

--- a/apps/server/web/vite.config.ts
+++ b/apps/server/web/vite.config.ts
@@ -6,15 +6,10 @@ export default defineConfig({
   plugins: [tailwindcss(), sveltekit()],
   server: {
     proxy: {
-      '/api': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-      },
+      '/api': 'http://127.0.0.1:8080',
       '/ws': {
-        target: 'http://localhost:8080',
+        target: 'ws://127.0.0.1:8080',
         ws: true,
-        changeOrigin: true,
-        rewriteWsOrigin: true,
       },
     },
   },


### PR DESCRIPTION
## Summary

- connect WebSocket and SSE clients through same-origin relative URLs
- proxy API and WebSocket development traffic to the IPv4 API endpoint
- remove rewriteWsOrigin and its unnecessary cross-origin behavior
- add a regression test for the same-origin WebSocket path

## Validation

- bun run test in apps/server/web: 83 tests passed
- pre-commit monorepo lint: passed
- pre-commit monorepo typecheck: 40 tasks passed
- server-web production build: passed

Fixes #650