### PR TITLE
fix(server): harden live connection recovery

### DIFF
--- a/apps/server/DEVELOPMENT.md
+++ b/apps/server/DEVELOPMENT.md
@@ -30,7 +30,7 @@ bun run dev    # API + Web UI を同時起動
 ```
 
 - **http://localhost:5173** にアクセス（Web開発サーバー、HMR有効）
-- APIリクエストは自動的に localhost:8080 にプロキシされる
+- API・WebSocketリクエストは自動的に `127.0.0.1:8080` にプロキシされる
 
 **個別に起動する場合**
 
@@ -267,7 +267,8 @@ export interface NativeApiCapable {
 ### 接続
 
 ```javascript
-const ws = new WebSocket('ws://localhost:8080/ws')
+// ブラウザではページと同一オリジンへ接続する（開発時はViteがAPIへプロキシする）
+const ws = new WebSocket('/ws')
 ```
 
 ### メッセージ

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -141,6 +141,6 @@ USER 1000
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:8080/api/health || exit 1
+  CMD curl -f http://127.0.0.1:8080/api/health || exit 1
 
 CMD ["bun", "run", "server.js"]

--- a/apps/server/api/src/html-generator.test.ts
+++ b/apps/server/api/src/html-generator.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { generateMetricsHtml } from './html-generator.js'
+import type { TopologyInstance, WeathermapConfig } from './types.js'
+
+const topology: TopologyInstance = {
+  name: 'test',
+  config: { name: 'test', file: 'test.yaml' },
+  graph: { name: 'Test topology', nodes: [], links: [] },
+  layout: {
+    nodes: new Map(),
+    links: new Map(),
+    subgraphs: new Map(),
+    bounds: { x: 0, y: 0, width: 0, height: 0 },
+  },
+  metrics: { nodes: {}, links: {}, timestamp: 0 },
+}
+
+const weathermap: WeathermapConfig = {
+  thresholds: [{ value: 0, color: '#73BF69' }],
+}
+
+describe('generateMetricsHtml', () => {
+  it('uses a same-origin WebSocket URL and keeps reconnecting', () => {
+    const html = generateMetricsHtml(topology, { weathermap })
+
+    expect(html).toContain("new WebSocket('/ws')")
+    expect(html).not.toContain('maxReconnectAttempts')
+    expect(html).not.toMatch(/new WebSocket\(['"]ws:/)
+  })
+})

--- a/apps/server/api/src/html-generator.ts
+++ b/apps/server/api/src/html-generator.ts
@@ -7,7 +7,6 @@ import { svg as svgRenderer } from '@shumoku/renderer-svg'
 import type { TopologyInstance, WeathermapConfig } from './types.js'
 
 interface HtmlGeneratorOptions {
-  wsUrl: string
   weathermap: WeathermapConfig
 }
 
@@ -22,7 +21,7 @@ export function generateMetricsHtml(
   const svgContent = svgRenderer.render(graph, layout, { renderMode: 'interactive' })
   const title = graph.name || instance.name
 
-  const metricsRuntimeScript = generateMetricsRuntimeScript(options)
+  const metricsRuntimeScript = generateMetricsRuntimeScript()
   const weathermapScript = generateWeathermapScript(options.weathermap)
 
   return `<!DOCTYPE html>
@@ -271,15 +270,12 @@ function interpolateColor(color1, color2, t) {
 `
 }
 
-function generateMetricsRuntimeScript(options: HtmlGeneratorOptions): string {
+function generateMetricsRuntimeScript(): string {
   return `
 // Metrics Runtime
 (function() {
-  var wsUrl = '${options.wsUrl}';
-  var topologyName = '${options.wsUrl.includes('/ws') ? '' : 'sample-network'}';
   var ws = null;
   var reconnectAttempts = 0;
-  var maxReconnectAttempts = 10;
   var pendingUpdates = new Map();
   var animFrameId = null;
 
@@ -300,7 +296,7 @@ function generateMetricsRuntimeScript(options: HtmlGeneratorOptions): string {
 
   function connect() {
     try {
-      ws = new WebSocket(wsUrl);
+      ws = new WebSocket('/ws');
 
       ws.onopen = function() {
         console.log('[Metrics] WebSocket connected');
@@ -349,12 +345,10 @@ function generateMetricsRuntimeScript(options: HtmlGeneratorOptions): string {
   }
 
   function scheduleReconnect() {
-    if (reconnectAttempts < maxReconnectAttempts) {
-      var delay = Math.min(1000 * Math.pow(2, reconnectAttempts), 30000);
-      reconnectAttempts++;
-      console.log('[Metrics] Reconnecting in ' + delay + 'ms (attempt ' + reconnectAttempts + ')');
-      setTimeout(connect, delay);
-    }
+    var delay = Math.min(1000 * Math.pow(2, Math.min(reconnectAttempts, 5)), 30000);
+    reconnectAttempts++;
+    console.log('[Metrics] Reconnecting in ' + delay + 'ms (attempt ' + reconnectAttempts + ')');
+    setTimeout(connect, delay);
   }
 
   function handleMetricsUpdate(data) {

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -109,9 +109,7 @@ export class Server {
         return c.html('<h1>Topology not found</h1>', 404)
       }
 
-      const wsUrl = `ws://${c.req.header('host')}/ws`
       const html = generateMetricsHtml(instance, {
-        wsUrl,
         weathermap: this.config.weathermap,
       })
       return c.html(html)

--- a/apps/server/compose.yaml
+++ b/apps/server/compose.yaml
@@ -26,7 +26,7 @@ services:
 
     # Health check
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/api/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080/api/health"]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/apps/server/web/src/lib/stores/metrics.test.ts
+++ b/apps/server/web/src/lib/stores/metrics.test.ts
@@ -1,36 +1,57 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { metricsStore } from './metrics'
 
+class WebSocketMock {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSED = 3
+  static instances: WebSocketMock[] = []
+
+  readyState = WebSocketMock.CONNECTING
+  onopen = null
+  onmessage = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror = null
+
+  constructor(readonly url: string | URL) {
+    WebSocketMock.instances.push(this)
+  }
+
+  close(): void {
+    this.readyState = WebSocketMock.CLOSED
+  }
+
+  failConnection(): void {
+    this.readyState = WebSocketMock.CLOSED
+    this.onclose?.({} as CloseEvent)
+  }
+}
+
 describe('metricsStore WebSocket connection', () => {
   afterEach(() => {
     metricsStore.disconnect()
+    WebSocketMock.instances = []
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
   it('uses a same-origin URL handled by the development proxy', () => {
-    let requestedUrl: string | URL | undefined
-
-    class WebSocketMock {
-      static readonly CONNECTING = 0
-      static readonly OPEN = 1
-
-      readonly readyState = WebSocketMock.CONNECTING
-      onopen = null
-      onmessage = null
-      onclose = null
-      onerror = null
-
-      constructor(url: string | URL) {
-        requestedUrl = url
-      }
-
-      close(): void {}
-    }
-
     vi.stubGlobal('WebSocket', WebSocketMock)
 
     metricsStore.connect()
 
-    expect(requestedUrl).toBe('/ws')
+    expect(WebSocketMock.instances[0]?.url).toBe('/ws')
+  })
+
+  it('keeps reconnecting after the previous five-attempt limit', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', WebSocketMock)
+    metricsStore.connect()
+
+    for (const expectedConnections of [2, 3, 4, 5, 6, 7]) {
+      WebSocketMock.instances.at(-1)?.failConnection()
+      await vi.runOnlyPendingTimersAsync()
+      expect(WebSocketMock.instances).toHaveLength(expectedConnections)
+    }
   })
 })

--- a/apps/server/web/src/lib/stores/metrics.ts
+++ b/apps/server/web/src/lib/stores/metrics.ts
@@ -132,7 +132,6 @@ function getGlobal(): MetricsGlobal {
 function createMetricsStore() {
   const { subscribe, set, update } = writable<MetricsState>(initialState)
   const g = getGlobal()
-  const maxReconnectAttempts = 5
 
   function cleanupWebSocket(): void {
     if (g.ws) {
@@ -222,11 +221,11 @@ function createMetricsStore() {
       clearTimeout(g.reconnectTimeout)
     }
 
-    if (g.reconnectAttempts < maxReconnectAttempts && !g.intentionalDisconnect) {
-      const delay = Math.min(1000 * 2 ** g.reconnectAttempts, 30000)
-      g.reconnectAttempts++
-      g.reconnectTimeout = setTimeout(connect, delay)
-    }
+    if (g.intentionalDisconnect) return
+
+    const delay = Math.min(1000 * 2 ** Math.min(g.reconnectAttempts, 5), 30000)
+    g.reconnectAttempts++
+    g.reconnectTimeout = setTimeout(connect, delay)
   }
 
   function disconnect(): void {


### PR DESCRIPTION
## Summary

Follow-up to #657.

- use the same-origin WebSocket path in the legacy generated topology view
- keep reconnecting with capped exponential backoff instead of giving up after five or ten attempts
- use the explicit IPv4 loopback address for Docker and Compose health checks
- update development documentation to match the Vite proxy architecture
- add regression coverage for generated HTML and reconnect attempts beyond the old limit

## Validation

- Server Web: 84 tests passed
- Server API unit: 98 tests passed
- Server API database/integration: 153 tests passed
- Server production build: passed
- monorepo lint and typecheck: 40 tasks passed
- changeset: not required; Server packages are private