### PR TITLE
fix(core): make the Node file resolver ESM-safe

### DIFF
--- a/.changeset/wise-pans-smile.md
+++ b/.changeset/wise-pans-smile.md
@@ -1,0 +1,5 @@
+---
+'@shumoku/core': patch
+---
+
+Fix the Node file resolver under ESM, and add a dedicated `@shumoku/core/parser/node` export.

--- a/apps/docs/content/docs/npm/multi-file.en.mdx
+++ b/apps/docs/content/docs/npm/multi-file.en.mdx
@@ -88,7 +88,7 @@ The CLI (`npx @shumoku/cli render`) currently parses the input as a single file 
 ```typescript
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { createNodeFileResolver, HierarchicalParser } from '@shumoku/core'
+import { createNodeFileResolver, HierarchicalParser } from '@shumoku/core/parser/node'
 import { renderGraphToHtmlHierarchical } from '@shumoku/renderer-html'
 
 const mainPath = resolve('main.yaml')

--- a/apps/docs/content/docs/npm/multi-file.ja.mdx
+++ b/apps/docs/content/docs/npm/multi-file.ja.mdx
@@ -88,7 +88,7 @@ CLI（`npx @shumoku/cli render`）は現在、入力を単一ファイルとし�
 ```typescript
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import { createNodeFileResolver, HierarchicalParser } from '@shumoku/core'
+import { createNodeFileResolver, HierarchicalParser } from '@shumoku/core/parser/node'
 import { renderGraphToHtmlHierarchical } from '@shumoku/renderer-html'
 
 const mainPath = resolve('main.yaml')

--- a/libs/@shumoku/core/package.json
+++ b/libs/@shumoku/core/package.json
@@ -37,6 +37,10 @@
       "types": "./dist/parser/index.d.ts",
       "import": "./dist/parser/index.js"
     },
+    "./parser/node": {
+      "types": "./dist/parser/node.d.ts",
+      "import": "./dist/parser/node.js"
+    },
     "./layout": {
       "types": "./dist/layout/index.d.ts",
       "import": "./dist/layout/index.js"

--- a/libs/@shumoku/core/src/parser/hierarchical.ts
+++ b/libs/@shumoku/core/src/parser/hierarchical.ts
@@ -529,14 +529,21 @@ export class HierarchicalParser {
  * Node.js file resolver implementation
  */
 export function createNodeFileResolver(): FileResolver {
+  const fs = globalThis.process?.getBuiltinModule('node:fs/promises')
+  const path = globalThis.process?.getBuiltinModule('node:path')
+
+  if (!fs || !path) {
+    throw new Error(
+      'createNodeFileResolver requires Node.js 20.16 or later, or a compatible Bun runtime',
+    )
+  }
+
   return {
-    async read(path: string): Promise<string> {
-      const fs = await import('node:fs/promises')
-      return fs.readFile(path, 'utf-8')
+    async read(filePath: string): Promise<string> {
+      return fs.readFile(filePath, 'utf-8')
     },
 
     resolve(basePath: string, relativePath: string): string {
-      const path = require('node:path')
       return path.resolve(path.dirname(basePath), relativePath)
     },
   }

--- a/libs/@shumoku/core/src/parser/node-resolver.test.ts
+++ b/libs/@shumoku/core/src/parser/node-resolver.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createNodeFileResolver as createLegacyResolver } from './index.js'
+import { createNodeFileResolver } from './node.js'
+
+let tempDirectory: string | undefined
+
+afterEach(async () => {
+  if (tempDirectory) {
+    await rm(tempDirectory, { recursive: true, force: true })
+    tempDirectory = undefined
+  }
+})
+
+describe('createNodeFileResolver', () => {
+  it('resolves and reads files in an ESM runtime', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'shumoku-node-resolver-'))
+    const parentPath = join(tempDirectory, 'main.yaml')
+    const childPath = join(tempDirectory, 'child.yaml')
+    await writeFile(childPath, 'name: Child\n', 'utf8')
+
+    const resolver = createNodeFileResolver()
+    const resolvedPath = resolver.resolve(parentPath, './child.yaml')
+
+    expect(resolvedPath).toBe(childPath)
+    await expect(resolver.read(resolvedPath)).resolves.toBe('name: Child\n')
+  })
+
+  it('keeps the existing root export working', () => {
+    const resolver = createLegacyResolver()
+
+    expect(resolver.resolve('/tmp/main.yaml', './child.yaml')).toBe('/tmp/child.yaml')
+  })
+})

--- a/libs/@shumoku/core/src/parser/node.ts
+++ b/libs/@shumoku/core/src/parser/node.ts
@@ -1,0 +1,10 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Node.js entry point for hierarchical YAML parsing from the filesystem.
+ */
+
+export type { FileResolver, HierarchicalParseResult } from './hierarchical.js'
+export { createNodeFileResolver, HierarchicalParser } from './hierarchical.js'


### PR DESCRIPTION
## Summary

- replace CommonJS/dynamic Node built-in loading with `process.getBuiltinModule`
- add `@shumoku/core/parser/node` while preserving the existing root export
- update the English and Japanese multi-file documentation
- add Node ESM filesystem resolver regression tests
- include a patch changeset for `@shumoku/core`

## Validation

- core tests: 408 passed
- core build and typecheck: passed
- docs typecheck: passed
- Server Web and Editor Vite builds: passed
- Node ESM checks for both new and legacy imports: passed
- `node:fs/promises` Vite externalization warning: removed
- monorepo lint and typecheck: passed