### PR TITLE
ci(server): gate releases and prepare 0.1.6-beta.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Test
         run: bun run test
 
+      - name: Test release version ordering
+        run: bun test scripts/release-version-order.test.ts
+
   knip:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare-server-release.yml
+++ b/.github/workflows/prepare-server-release.yml
@@ -1,0 +1,65 @@
+name: Prepare Server Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Server version (X.Y.Z or X.Y.Z-beta.N)
+        required: true
+        type: string
+
+concurrency:
+  group: prepare-server-release
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  tag:
+    name: Validate and create release tag
+    runs-on: ubuntu-latest
+    environment: server-release
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Validate release
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          tag="server-v${VERSION}"
+          if git rev-parse --verify --quiet "refs/tags/${tag}"; then
+            echo "::error::${tag} already exists"
+            exit 1
+          fi
+          bun run version:server:check-release "$tag"
+
+      - name: Create and push annotated tag
+        env:
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          tag="server-v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "Shumoku Server ${VERSION}"
+          git push origin "$tag"
+
+      # Pushes made with GITHUB_TOKEN do not start another workflow. Dispatch
+      # the tag explicitly so server-release.yml performs the actual publish.
+      - name: Start Server Release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: gh workflow run server-release.yml --ref "server-v${VERSION}"

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -1,6 +1,7 @@
 name: Server Release
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     tags: ["server-v*.*.*"]
@@ -30,6 +31,8 @@ jobs:
       platforms: ${{ steps.build.outputs.platforms }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         if: startsWith(github.ref, 'refs/tags/server-v')

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -34,7 +34,7 @@ Configure via environment variables (pin a version and use port 80 for productio
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/konoe-akitoshi/shumoku/main/apps/server/scripts/install.sh \
-  | SHUMOKU_VERSION=0.1.5-beta.6 SHUMOKU_PORT=80 sh
+  | SHUMOKU_VERSION=0.1.6-beta.1 SHUMOKU_PORT=80 sh
 ```
 
 Knobs: `SHUMOKU_VERSION` (default `latest`), `SHUMOKU_PORT` (default `8080`),
@@ -63,7 +63,7 @@ For production, pin an exact version rather than `latest`:
 
 ```bash
 docker run -d -p 8080:8080 -v shumoku-data:/data \
-  ghcr.io/konoe-akitoshi/shumoku:0.1.5-beta.6
+  ghcr.io/konoe-akitoshi/shumoku:0.1.6-beta.1
 ```
 
 Test the newest beta without changing `latest`:
@@ -87,7 +87,7 @@ docker compose up -d
 Or pass them inline for a one-off:
 
 ```bash
-SHUMOKU_VERSION=0.1.5-beta.6 docker compose up -d
+SHUMOKU_VERSION=0.1.6-beta.1 docker compose up -d
 SHUMOKU_PORT=80 docker compose up -d    # production port
 DEMO_MODE=true docker compose up -d     # preload a sample network
 ```
@@ -266,7 +266,7 @@ A Helm chart is available as an OCI artifact in GitHub Container Registry:
 
 ```bash
 helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku \
-  --version 0.1.5-beta.6
+  --version 0.1.6-beta.1
 ```
 
 ### Systemd (Linux)

--- a/apps/server/chart/shumoku/Chart.yaml
+++ b/apps/server/chart/shumoku/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: shumoku
 description: Network topology visualization server
 type: application
-version: 0.1.5-beta.6
-appVersion: "0.1.5-beta.6"
+version: 0.1.6-beta.1
+appVersion: "0.1.6-beta.1"
 home: https://www.shumoku.dev/
 sources:
   - https://github.com/konoe-akitoshi/shumoku

--- a/apps/server/docs/helm-chart.md
+++ b/apps/server/docs/helm-chart.md
@@ -25,7 +25,7 @@ helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku -f my
 
 ```bash
 helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku \
-  --version 0.1.5-beta.6
+  --version 0.1.6-beta.1
 ```
 
 ## Configuration
@@ -154,7 +154,7 @@ helm template test oci://ghcr.io/konoe-akitoshi/charts/shumoku
 
 # config や ingress 有効時のプレビュー
 helm template test oci://ghcr.io/konoe-akitoshi/charts/shumoku \
-  --version 0.1.5-beta.6 --values my-values.yaml
+  --version 0.1.6-beta.1 --values my-values.yaml
 
 # dry-run でインストールをシミュレーション（クラスタ必要）
 helm install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku --dry-run

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shumoku/server",
-  "version": "0.1.5-beta.6",
+  "version": "0.1.6-beta.1",
   "private": true,
   "description": "Real-time network topology visualization server with Zabbix integration",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -96,7 +96,7 @@
     },
     "apps/server": {
       "name": "@shumoku/server",
-      "version": "0.1.5-beta.6",
+      "version": "0.1.6-beta.1",
       "dependencies": {
         "@shumoku/server-api": "workspace:*",
         "@shumoku/server-web": "workspace:*",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -63,24 +63,26 @@ workspaces remain at `0.0.0`.
 
 Server release tags are product-qualified:
 
+Prepare the version in a pull request:
+
 ```bash
-# Beta
+# Use X.Y.(Z+1)-beta.1 after X.Y.Z has become stable. Never publish another
+# X.Y.Z-beta.N after X.Y.Z.
 bun run version:server 0.2.0-beta.1
 git add apps/server/package.json apps/server/chart/shumoku/Chart.yaml apps/server/README.md apps/server/docs/helm-chart.md bun.lock
 git commit -m "chore(server): release 0.2.0-beta.1"
-git tag -a server-v0.2.0-beta.1 -m "Shumoku Server 0.2.0-beta.1"
-git push origin HEAD server-v0.2.0-beta.1
-
-# Stable
-bun run version:server 0.2.0
-git add apps/server/package.json apps/server/chart/shumoku/Chart.yaml apps/server/README.md apps/server/docs/helm-chart.md bun.lock
-git commit -m "chore(server): release 0.2.0"
-git tag -a server-v0.2.0 -m "Shumoku Server 0.2.0"
-git push origin HEAD server-v0.2.0
 ```
 
-The Server Release workflow verifies that the tag matches
-`apps/server/package.json`.
+After the version pull request is merged, open **Actions → Prepare Server
+Release → Run workflow**, enter the exact version, and approve the
+`server-release` environment if approval is configured. The workflow verifies
+that the version is newer than every existing Server release, creates the
+annotated tag, and starts the publishing workflow. Do not create Server release
+tags by hand.
+
+The Server Release workflow independently verifies that the tag matches
+`apps/server/package.json` and remains newer than every existing Server release,
+so a manually pushed stale tag cannot publish artifacts.
 
 | Release | GHCR tags changed | GitHub Release |
 |---------|-------------------|----------------|

--- a/scripts/product-version.ts
+++ b/scripts/product-version.ts
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises'
+import { readProductReleaseTags, validateProductReleaseOrder } from './release-version-order'
 
 type ProductName = 'server' | 'editor'
 
@@ -283,6 +284,7 @@ async function checkReleaseTag(product: ProductName, tag: string): Promise<void>
   if (tag !== expectedTag) {
     throw new Error(`${product} release tag must be ${expectedTag}, received ${tag}`)
   }
+  validateProductReleaseOrder(tag, readProductReleaseTags(product))
 }
 
 const product = getProduct(Bun.argv[2])

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -20,6 +20,11 @@ case "$product" in
     scope='apps/server/**'
     prefix='server-v'
     version="${tag#server-v}"
+    if [[ "$version" == *-beta.* ]]; then
+      channels='`:beta` · `:edge`'
+    else
+      channels='`:latest` · `:edge`'
+    fi
     header=$(cat <<EOF
 **${title} ${version}**
 
@@ -27,7 +32,7 @@ case "$product" in
 docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/${repo}:${version}
 \`\`\`
 
-Image: \`ghcr.io/${repo}:${version}\` · \`:latest\`
+Image: \`ghcr.io/${repo}:${version}\` · ${channels}
 EOF
 )
     ;;

--- a/scripts/release-version-order.test.ts
+++ b/scripts/release-version-order.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  compareProductReleaseVersions,
+  parseProductReleaseTag,
+  validateProductReleaseOrder,
+} from './release-version-order'
+
+describe('product release ordering', () => {
+  it('orders beta releases before their stable release', () => {
+    const beta = parseProductReleaseTag('server-v0.1.5-beta.6')
+    const stable = parseProductReleaseTag('server-v0.1.5')
+
+    expect(beta).not.toBeNull()
+    expect(stable).not.toBeNull()
+    if (!beta || !stable) return
+    expect(compareProductReleaseVersions(beta, stable)).toBe(-1)
+  })
+
+  it('rejects a beta published after the stable release of the same version', () => {
+    expect(() => validateProductReleaseOrder('server-v0.1.5-beta.6', ['server-v0.1.5'])).toThrow(
+      'must be newer than',
+    )
+  })
+
+  it('rejects a release behind a newer beta line', () => {
+    expect(() => validateProductReleaseOrder('server-v0.1.6', ['server-v0.1.7-beta.1'])).toThrow(
+      'server-v0.1.7-beta.1',
+    )
+  })
+
+  it('accepts the next beta line and its stable promotion', () => {
+    expect(() =>
+      validateProductReleaseOrder('server-v0.1.6-beta.1', [
+        'server-v0.1.5',
+        'server-v0.1.5-beta.6',
+      ]),
+    ).not.toThrow()
+    expect(() =>
+      validateProductReleaseOrder('server-v0.1.6', ['server-v0.1.6-beta.1']),
+    ).not.toThrow()
+  })
+
+  it('ignores the target tag while validating a tag-triggered workflow', () => {
+    expect(() =>
+      validateProductReleaseOrder('server-v0.1.6-beta.1', [
+        'server-v0.1.5',
+        'server-v0.1.6-beta.1',
+      ]),
+    ).not.toThrow()
+  })
+})

--- a/scripts/release-version-order.ts
+++ b/scripts/release-version-order.ts
@@ -1,0 +1,71 @@
+export interface ProductReleaseVersion {
+  core: [number, number, number]
+  beta?: number
+  tag: string
+}
+
+const releaseTagPattern = /^(server|editor)-v(\d+)\.(\d+)\.(\d+)(?:-beta\.(\d+))?$/
+
+export function parseProductReleaseTag(tag: string): ProductReleaseVersion | null {
+  const match = tag.match(releaseTagPattern)
+  if (!match) return null
+
+  const major = Number(match[2])
+  const minor = Number(match[3])
+  const patch = Number(match[4])
+  const beta = match[5] === undefined ? undefined : Number(match[5])
+
+  return {
+    core: [major, minor, patch],
+    ...(beta === undefined ? {} : { beta }),
+    tag,
+  }
+}
+
+export function compareProductReleaseVersions(
+  left: ProductReleaseVersion,
+  right: ProductReleaseVersion,
+): number {
+  for (const [index, value] of left.core.entries()) {
+    const rightValue = right.core[index]
+    if (rightValue === undefined) throw new Error('Invalid product release version core')
+    const difference = value - rightValue
+    if (difference !== 0) return Math.sign(difference)
+  }
+
+  if (left.beta === undefined && right.beta === undefined) return 0
+  if (left.beta === undefined) return 1
+  if (right.beta === undefined) return -1
+  return Math.sign(left.beta - right.beta)
+}
+
+export function validateProductReleaseOrder(targetTag: string, existingTags: string[]): void {
+  const target = parseProductReleaseTag(targetTag)
+  if (!target) throw new Error(`Invalid product release tag: ${targetTag}`)
+
+  const prefix = targetTag.slice(0, targetTag.indexOf('-v') + 2)
+  const previous = existingTags
+    .filter((tag) => tag !== targetTag && tag.startsWith(prefix))
+    .map(parseProductReleaseTag)
+    .filter((version): version is ProductReleaseVersion => version !== null)
+    .sort(compareProductReleaseVersions)
+    .at(-1)
+
+  if (previous && compareProductReleaseVersions(target, previous) <= 0) {
+    throw new Error(
+      `${targetTag} must be newer than the latest existing release tag ${previous.tag}`,
+    )
+  }
+}
+
+export function readProductReleaseTags(product: 'server' | 'editor'): string[] {
+  const result = Bun.spawnSync(['git', 'tag', '--list', `${product}-v*`])
+  if (result.exitCode !== 0) {
+    throw new Error(new TextDecoder().decode(result.stderr).trim() || 'Failed to read Git tags')
+  }
+  return new TextDecoder()
+    .decode(result.stdout)
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+}


### PR DESCRIPTION
## Summary

- add an approval-gated `Prepare Server Release` workflow as the supported tag creation path
- reject releases that are not newer than every existing product release tag
- keep the publish workflow protected against manually pushed stale tags
- render `:beta` / `:edge` for beta release notes and `:latest` / `:edge` for stable notes
- prepare Shumoku Server `0.1.6-beta.1`
- update the release runbook

The existing `server-v0.1.5-beta.6` release description has also been corrected, and the `server-release` GitHub Environment now requires owner approval and a protected branch.

## Validation

- release ordering tests: 5 passed
- stale `0.1.5-beta.6` after stable `0.1.5`: rejected
- `0.1.6-beta.1`: accepted
- beta/stable release-note channel output: verified
- workflow YAML parsing: passed
- product version synchronization: passed
- monorepo lint and typecheck: passed
- commit hooks: passed

## After merge

Run **Actions → Prepare Server Release** with `0.1.6-beta.1`, approve the `server-release` environment, and the workflow will create the tag and start the Server Release workflow.