### PR TITLE
fix(core): a routed wire terminates ON its ports — construction-time guarantee

### DIFF
--- a/.changeset/olive-pots-brake.md
+++ b/.changeset/olive-pots-brake.md
@@ -1,0 +1,17 @@
+---
+'@shumoku/core': patch
+---
+
+Make "a wire terminates ON its ports" a construction-time guarantee. Routed
+polylines used to detach from their ports whenever the corridor allocator
+shifted a vertical run — the shift was added to the terminal points too —
+and their point order was upper-port-first rather than from→to, silently
+breaking direction-sensitive consumers (weathermap lane direction, endpoint
+labels). Routes now exist only through the router's `emitRoute()`, which pins
+both terminals to the edge's own ports, normalizes direction to from→to, and
+reconnects shifted runs with 45° diagonals; port re-seating refreshes every
+edge's 2-point geometry (previously only couplings). The invariant is
+registered as the blocking `port-attachment` constraint (the registry's first
+incidence constraint) with a `findDetachedTerminals` finder, and the dead
+`checkLayoutInvariants` aggregate now delegates to `verifyLayoutConstraints`
+(deprecated).

--- a/apps/server/api/src/services/topology.ts
+++ b/apps/server/api/src/services/topology.ts
@@ -198,7 +198,10 @@ interface StoredLinkMapping {
 // v20: entity registry Phase 3 — node.id/link.id ON the resolved graph (+ layout
 // + resolved artifact) are flipped to their stable entity ids; old-id artifacts
 // must rebake so persisted references (metrics mapping, weathermap) key on ULIDs.
-const RESOLVER_VERSION = 21
+// v22: port-attachment — routed polylines terminate ON their ports (corridor
+// shifts no longer displace terminals) and run in from→to order; old artifacts
+// carry detached endpoints.
+const RESOLVER_VERSION = 22
 
 /** Persisted resolved-graph artifact row (Phase 3 materialization). */
 interface ResolvedGraphRow {

--- a/libs/@shumoku/core/README.md
+++ b/libs/@shumoku/core/README.md
@@ -45,7 +45,7 @@ console.log(layout.nodes.length, 'nodes placed')
 |------|-------------|
 | **Models** | `NetworkGraph`, `Node`, `Link`, `Subgraph`, `Port`, `NetworkSettings` |
 | **Parser** | `YamlParser` (single file), `HierarchicalParser` (multi-file `file:` references), `parser` (shared instance) |
-| **Layout** | `computeNetworkLayout()` (primary entry), `createEngine()`, `routeEdges()`, `checkLayoutInvariants()` |
+| **Layout** | `computeNetworkLayout()` (primary entry), `createEngine()`, `routeEdges()`, `verifyLayoutConstraints()` (registry-driven checks — `LAYOUT_CONSTRAINTS`) |
 | **Themes** | `lightTheme`, `darkTheme` presets; `createTheme()`, `mergeTheme()` utilities |
 | **Icons** | icon ID constants and dimension helpers |
 | **Fixtures** | `sampleNetwork` — a multi-file demo network used across the test suite |

--- a/libs/@shumoku/core/src/layout/composite/composite.test.ts
+++ b/libs/@shumoku/core/src/layout/composite/composite.test.ts
@@ -367,6 +367,41 @@ describe('applyOctilinearRoutes', () => {
     expect(findCollinearOverlaps(lines)).toHaveLength(0)
   })
 
+  it('pins every routed polyline ON its ports, in from→to order', async () => {
+    // Port-attachment (the one incidence constraint in LAYOUT_CONSTRAINTS).
+    // The fixture forces the corridor allocator to shift vertical runs
+    // (that is what the track-separation test above proves) — historically
+    // the shift displaced the TERMINALS too, detaching wires from their
+    // ports by the shift amount. emitRoute pins them by construction; this
+    // is the tripwire for any emitter that bypasses it.
+    const graph = fixture()
+    const result = layoutComposite(graph)
+    const ports = placePorts(result.nodes, graph.links, 'TB')
+    const edges = await routeEdges(result.nodes, ports, graph.links, result.subgraphs)
+    for (const edge of edges.values()) {
+      edge.width = Math.max(1, getLinkWidthForMode(edge.link, 'log'))
+    }
+    applyOctilinearRoutes(edges)
+    let checked = 0
+    for (const edge of edges.values()) {
+      if (!edge.route) continue
+      checked++
+      for (const points of [edge.route.points, edge.points]) {
+        const first = points[0]
+        const last = points[points.length - 1]
+        // exact position AND direction: [0] is the FROM port specifically
+        expect(first?.x).toBeCloseTo(edge.fromPort.absolutePosition.x, 5)
+        expect(first?.y).toBeCloseTo(edge.fromPort.absolutePosition.y, 5)
+        expect(last?.x).toBeCloseTo(edge.toPort.absolutePosition.x, 5)
+        expect(last?.y).toBeCloseTo(edge.toPort.absolutePosition.y, 5)
+      }
+      // route.points and points must not alias — mutating the drawing
+      // geometry (chamfered) must never corrupt the hit-test polyline
+      expect(edge.route.points).not.toBe(edge.points)
+    }
+    expect(checked).toBeGreaterThan(0)
+  })
+
   it('does not bundle searched primary fan-outs into comb buses', async () => {
     const result = await searchCompositeLayout(fixture(), { maxEvaluations: 1 })
     expect([...result.edges.values()].some((edge) => edge.route?.kind === 'bus')).toBe(false)

--- a/libs/@shumoku/core/src/layout/composite/router.ts
+++ b/libs/@shumoku/core/src/layout/composite/router.ts
@@ -233,8 +233,6 @@ export function alignPortsToPeers(
         'top',
       )
     }
-    // Keep the label midpoint / hit-test geometry on the seam.
-    edge.points = [{ ...edge.fromPort.absolutePosition }, { ...edge.toPort.absolutePosition }]
   }
 
   for (const edge of sortedForSeat) {
@@ -356,6 +354,16 @@ export function alignPortsToPeers(
   legalizeSameFaceLabelOrder(labelPorts, nodes, minWidths, minHeights)
   separatePortLabelBoxes(labelPorts, nodes, minWidths, minHeights)
   legalizeSameFaceLabelOrder(labelPorts, nodes, minWidths, minHeights)
+
+  // Every pass above may have moved port anchors, so the 2-point geometry
+  // seeded by routeEdges is stale for every edge — refresh it wholesale
+  // (from→to order, the port-attachment contract). Routed edges get their
+  // polylines rebuilt afterwards by applyOctilinearRoutes / emitRoute; the
+  // rest (bezier fallback) would otherwise feed stale points into bounds,
+  // label placement, scoring, and the constraint checks.
+  for (const edge of sortedForSeat) {
+    edge.points = [{ ...edge.fromPort.absolutePosition }, { ...edge.toPort.absolutePosition }]
+  }
   return { flipped, minWidths, minHeights }
 }
 
@@ -626,9 +634,72 @@ interface OrthRoute {
   half: number
   trackY: number
   shiftX: number
+  /** The port (x1,y1) was read from — the upper end. Fed to emitRoute so the
+   *  emitted polyline can be normalized to from→to regardless of which end
+   *  sits higher. */
+  start: ResolvedPort
   /** When set, route via the gutter column at this x (6-point bypass). */
   gutterX?: number
   trackY2?: number
+}
+
+/**
+ * The ONLY way a route reaches an edge (port-attachment constraint,
+ * `LAYOUT_CONSTRAINTS`). The terminals come from the edge's own ports — an
+ * emitter shapes the middle via `interior` but can never detach the ends —
+ * and the emitted polyline is normalized to from→to order: `points[0]` is
+ * always the source port, `points[last]` the destination port.
+ *
+ * `start` names the port the interior waypoints were built outward from
+ * (emitters work in upper→lower or parent→child space, not from→to); when
+ * it is the destination port the interior is reversed. Interior points that
+ * collapse onto a neighbour (< 0.5u) or sit collinearly on a straight run
+ * are dropped — terminals always survive.
+ */
+function emitRoute(
+  edge: ResolvedEdge,
+  start: ResolvedPort,
+  interior: readonly Position[],
+  chamfer: number,
+  bus?: { busId: string; branchIndex: number; branchCount: number },
+): void {
+  const inner = start === edge.fromPort ? [...interior] : [...interior].reverse()
+  const raw: Position[] = [
+    { ...edge.fromPort.absolutePosition },
+    ...inner.map((p) => ({ ...p })),
+    { ...edge.toPort.absolutePosition },
+  ]
+  // Dedupe: an interior point riding on its neighbour adds nothing. A
+  // terminal always wins the collision — replacing the interior duplicate
+  // keeps the endpoint verbatim (the old comb filter dropped the terminus).
+  const pts: Position[] = []
+  for (const [i, p] of raw.entries()) {
+    const prev = pts[pts.length - 1]
+    if (prev && Math.hypot(p.x - prev.x, p.y - prev.y) <= 0.5) {
+      if (i === raw.length - 1) pts[pts.length - 1] = p
+      continue
+    }
+    pts.push(p)
+  }
+  // Drop pass-through interior points (collinear, same direction) so a
+  // zero-shift staircase degenerates back to its canonical corner count.
+  for (let i = pts.length - 2; i >= 1; i--) {
+    const a = pts[i - 1]
+    const b = pts[i]
+    const c = pts[i + 1]
+    if (!a || !b || !c) continue
+    const abx = b.x - a.x
+    const aby = b.y - a.y
+    const bcx = c.x - b.x
+    const bcy = c.y - b.y
+    if (Math.abs(abx * bcy - aby * bcx) < 0.01 && abx * bcx + aby * bcy >= 0) {
+      pts.splice(i, 1)
+    }
+  }
+  edge.points = pts
+  edge.route = bus
+    ? { kind: 'bus', points: chamferCorners(pts, chamfer), ...bus }
+    : { kind: 'polyline', points: chamferCorners(pts, chamfer) }
 }
 
 /**
@@ -676,6 +747,8 @@ export function applyOctilinearRoutes(
     /** Global lane offset in the shared trunk corridor (whole comb,
      *  not per row group — groups share the trunk x). */
     lane: number
+    /** The parent-side port (px,py) was read from — see OrthRoute.start. */
+    start: ResolvedPort
   }
   interface CombRoute {
     id: string
@@ -715,6 +788,7 @@ export function applyOctilinearRoutes(
           cy: childPort.absolutePosition.y,
           half: Math.max(0.5, edge.width / 2),
           lane: 0,
+          start: parentPort,
         })
       }
       if (members.length < 2) continue
@@ -829,6 +903,7 @@ export function applyOctilinearRoutes(
       half,
       trackY: 0,
       shiftX: 0,
+      start: upper,
     }
     if (Math.abs(x2 - x1) <= straightTol) straights.push(route)
     else orths.push(route)
@@ -1121,43 +1196,61 @@ export function applyOctilinearRoutes(
     if (!edge) return true
     const t1 = route.trackY
     const t2 = route.trackY2 ?? route.y2 - 10
-    const corner: Position[] = [
-      { x: route.x1, y: route.y1 },
-      { x: route.x1, y: t1 },
-      { x: gutterX, y: t1 },
-      { x: gutterX, y: t2 },
-      { x: route.x2, y: t2 },
-      { x: route.x2, y: route.y2 },
-    ]
-    edge.route = { kind: 'polyline', points: chamferCorners(corner, chamfer) }
-    edge.points = corner
+    emitRoute(
+      edge,
+      route.start,
+      [
+        { x: route.x1, y: t1 },
+        { x: gutterX, y: t1 },
+        { x: gutterX, y: t2 },
+        { x: route.x2, y: t2 },
+      ],
+      chamfer,
+    )
     routed++
     return true
   }
+  // The corridor shift moves the VERTICAL RUNS the allocator separated —
+  // never the terminals, which stay pinned on their ports (emitRoute).
+  // The runs reconnect to the ports with 45° diagonals (the comb `bendY`
+  // grammar): a diagonal needs no track allocation — a horizontal jog row
+  // here would be an unallocated track and collide with its neighbours —
+  // and it collapses away entirely when the shift is zero.
   for (const route of straights) {
     if (emitGutter(route)) continue
     const edge = edges.get(route.id)
     if (!edge) continue
-    const points: Position[] = [
-      { x: route.x1 + route.shiftX, y: route.y1 },
-      { x: route.x2 + route.shiftX, y: route.y2 },
-    ]
-    edge.route = { kind: 'polyline', points }
-    edge.points = points
+    const mid = (route.y1 + route.y2) / 2
+    const xm = (route.x1 + route.x2) / 2 + route.shiftX
+    emitRoute(
+      edge,
+      route.start,
+      route.shiftX === 0
+        ? []
+        : [
+            { x: xm, y: Math.min(route.y1 + Math.abs(xm - route.x1), mid) },
+            { x: xm, y: Math.max(route.y2 - Math.abs(route.x2 - xm), mid) },
+          ],
+      chamfer,
+    )
     routed++
   }
   for (const route of orths) {
     if (emitGutter(route)) continue
     const edge = edges.get(route.id)
     if (!edge) continue
-    const corner: Position[] = [
-      { x: route.x1 + route.shiftX, y: route.y1 },
-      { x: route.x1 + route.shiftX, y: route.trackY },
-      { x: route.x2 + route.shiftX, y: route.trackY },
-      { x: route.x2 + route.shiftX, y: route.y2 },
-    ]
-    edge.route = { kind: 'polyline', points: chamferCorners(corner, chamfer) }
-    edge.points = corner
+    const s = route.shiftX
+    emitRoute(
+      edge,
+      route.start,
+      [
+        { x: route.x1 + s, y: Math.min(route.y1 + Math.abs(s), route.trackY) },
+        { x: route.x1 + s, y: route.trackY },
+        { x: route.x2 + s, y: route.trackY },
+        { x: route.x2 + s, y: Math.max(route.y2 - Math.abs(s), route.trackY) },
+      ],
+      chamfer,
+    )
     routed++
   }
   for (const comb of combRoutes) {
@@ -1178,31 +1271,25 @@ export function applyOctilinearRoutes(
       const busLaneY = comb.busY + lane
       const dx = Math.abs(m.px - trunkLaneX)
       const bendY = busLaneY > gatherY ? Math.min(gatherY + dx, busLaneY) : busLaneY
-      const raw: Position[] = [
-        { x: m.px, y: m.py },
-        { x: m.px, y: gatherY },
-        { x: trunkLaneX, y: bendY },
-        { x: trunkLaneX, y: busLaneY },
-        { x: m.cx, y: busLaneY },
-        { x: m.cx, y: m.cy },
-      ]
-      // drop zero-length segments (member sitting exactly on the trunk)
-      const corner = raw.filter(
-        (p, idx) =>
-          idx === 0 ||
-          Math.hypot(p.x - (raw[idx - 1]?.x ?? p.x), p.y - (raw[idx - 1]?.y ?? p.y)) > 0.5,
+      emitRoute(
+        edge,
+        m.start,
+        [
+          { x: m.px, y: gatherY },
+          { x: trunkLaneX, y: bendY },
+          { x: trunkLaneX, y: busLaneY },
+          { x: m.cx, y: busLaneY },
+        ],
+        chamfer,
+        {
+          // row groups split the allocator id with "~k" but remain ONE
+          // harness — share the root busId so same-comb strand pairs stay
+          // exempt from collinear scoring
+          busId: comb.id.split('~')[0] ?? comb.id,
+          branchIndex: i,
+          branchCount: n,
+        },
       )
-      edge.route = {
-        kind: 'bus',
-        // row groups split the allocator id with "~k" but remain ONE
-        // harness — share the root busId so same-comb strand pairs stay
-        // exempt from collinear scoring
-        points: chamferCorners(corner, chamfer),
-        busId: comb.id.split('~')[0] ?? comb.id,
-        branchIndex: i,
-        branchCount: n,
-      }
-      edge.points = corner
       routed++
     }
   }

--- a/libs/@shumoku/core/src/layout/constraints.test.ts
+++ b/libs/@shumoku/core/src/layout/constraints.test.ts
@@ -136,6 +136,52 @@ describe('constraint registry', () => {
     expect(siblings.blockingViolations).toContain('container-overlap')
     expect(siblings.ok).toBe(false)
   })
+
+  test('a wire detached from its port is a blocking port-attachment violation', () => {
+    const port = (id: string, x: number, y: number) =>
+      ({ id, absolutePosition: { x, y }, side: 'top', size: { width: 8, height: 8 } }) as never
+    const fromPort = port('a:p', 130, 120)
+    const toPort = port('b:p', 330, 80)
+    const layout = layoutOf({
+      nodes: [
+        { id: 'a', x: 100, y: 100 },
+        { id: 'b', x: 300, y: 100 },
+      ],
+    })
+    const edge = {
+      id: 'e1',
+      fromPortId: 'a:p',
+      toPortId: 'b:p',
+      fromPort,
+      toPort,
+      fromNodeId: 'a',
+      toNodeId: 'b',
+      fromEndpoint: { node: 'a', port: 'p' },
+      toEndpoint: { node: 'b', port: 'p' },
+      // the historical bug shape: a corridor shift displaced the terminal
+      // 12u sideways off the port
+      points: [
+        { x: 142, y: 120 },
+        { x: 342, y: 80 },
+      ],
+      width: 2,
+      link: { from: { node: 'a', port: 'p' }, to: { node: 'b', port: 'p' } },
+    } as never
+    layout.edges = new Map([['e1', edge]])
+    const report = verifyLayoutConstraints(layout)
+    expect(report.counts['port-attachment']).toBe(2)
+    expect(report.blockingViolations).toContain('port-attachment')
+    expect(report.ok).toBe(false)
+
+    // pinned back on the ports → clean
+    const pinned = { ...(edge as object) } as { points: { x: number; y: number }[] }
+    pinned.points = [
+      { x: 130, y: 120 },
+      { x: 330, y: 80 },
+    ]
+    layout.edges = new Map([['e1', pinned as never]])
+    expect(verifyLayoutConstraints(layout).counts['port-attachment']).toBe(0)
+  })
 })
 
 describe('findEdgeNodePiercing equals the O(n²) reference', () => {

--- a/libs/@shumoku/core/src/layout/constraints.ts
+++ b/libs/@shumoku/core/src/layout/constraints.ts
@@ -27,6 +27,7 @@
 
 import { resolveNodeSize } from './engine/index.js'
 import {
+  type AttachedLineSpec,
   type BoxBounds,
   type BoxSpec,
   type CollinearOverlap,
@@ -37,13 +38,16 @@ import {
   findCollinearOverlaps,
   findContainerOverlaps,
   findContainmentViolations,
+  findDetachedTerminals,
   findEdgeNodePiercing,
   findNodeOverlaps,
   findPortClutter,
+  type LayoutInvariantReport,
   type NodeOverlap,
   type PierceLineSpec,
   type PolylineSpec,
   type PortClutter,
+  type TerminalDetachment,
 } from './invariants.js'
 import type { ResolvedLayout } from './resolved-types.js'
 
@@ -56,6 +60,7 @@ export type ConstraintId =
   | 'collinear-track'
   | 'port-clutter'
   | 'edge-pierce'
+  | 'port-attachment'
 
 export interface ConstraintSpec {
   id: ConstraintId
@@ -117,6 +122,17 @@ export const LAYOUT_CONSTRAINTS: readonly ConstraintSpec[] = [
     enforcedBy: 'search cost penalty (×20) only — preventive routing is #485',
     params: { inflate: 2 },
   },
+  {
+    id: 'port-attachment',
+    title: 'A wire terminates ON its ports, in from→to order',
+    // The only INCIDENCE constraint in the registry (the rest are
+    // separation). Blocking from day one: routes exist only through the
+    // router's emitRoute(), which pins both terminals by construction —
+    // this check is the tripwire for any future emitter that bypasses it.
+    level: 'blocking',
+    enforcedBy: 'emitRoute() terminal pinning + alignPortsToPeers final points refresh',
+    params: { epsilon: 0.5 },
+  },
 ]
 
 export interface ConstraintViolations {
@@ -126,6 +142,7 @@ export interface ConstraintViolations {
   collinearOverlaps: CollinearOverlap[]
   portClutter: PortClutter[]
   edgePierces: EdgeNodePierce[]
+  terminalDetachments: TerminalDetachment[]
 }
 
 export interface ConstraintReport {
@@ -179,6 +196,7 @@ export function verifyLayoutConstraints(layout: ResolvedLayout): ConstraintRepor
 
   const trackLines: PolylineSpec[] = []
   const pierceLines: PierceLineSpec[] = []
+  const attachedLines: AttachedLineSpec[] = []
   const busOf = new Map<string, string>()
   for (const [id, edge] of layout.edges) {
     // Couplings (HA glasses bridges) are not wires — same exclusion the
@@ -189,6 +207,12 @@ export function verifyLayoutConstraints(layout: ResolvedLayout): ConstraintRepor
     if (points.length < 2) continue
     trackLines.push({ id, points, halfWidth: Math.max(0.5, edge.width / 2) })
     pierceLines.push({ id, points, fromNodeId: edge.fromNodeId, toNodeId: edge.toNodeId })
+    attachedLines.push({
+      id,
+      points,
+      from: edge.fromPort.absolutePosition,
+      to: edge.toPort.absolutePosition,
+    })
     if (edge.route?.kind === 'bus') busOf.set(id, edge.route.busId)
   }
 
@@ -217,6 +241,10 @@ export function verifyLayoutConstraints(layout: ResolvedLayout): ConstraintRepor
       nodeBoxes,
       specOf('edge-pierce').params['inflate'] ?? 2,
     ),
+    terminalDetachments: findDetachedTerminals(
+      attachedLines,
+      specOf('port-attachment').params['epsilon'] ?? 0.5,
+    ),
   }
 
   const counts: Record<ConstraintId, number> = {
@@ -226,6 +254,7 @@ export function verifyLayoutConstraints(layout: ResolvedLayout): ConstraintRepor
     'collinear-track': violations.collinearOverlaps.length,
     'port-clutter': violations.portClutter.length,
     'edge-pierce': violations.edgePierces.length,
+    'port-attachment': violations.terminalDetachments.length,
   }
 
   const blockingViolations = LAYOUT_CONSTRAINTS.filter(
@@ -237,6 +266,28 @@ export function verifyLayoutConstraints(layout: ResolvedLayout): ConstraintRepor
     counts,
     blockingViolations,
     ok: blockingViolations.length === 0,
+  }
+}
+
+/**
+ * @deprecated Use `verifyLayoutConstraints` — the registry-driven aggregate
+ * that covers ALL constraints (this older shape misses container-overlap,
+ * edge-pierce and port-attachment). Kept as a thin adapter so existing
+ * imports keep working; the per-check option knobs are gone on purpose —
+ * parameters live in `LAYOUT_CONSTRAINTS`, the single source of truth.
+ */
+export function checkLayoutInvariants(layout: ResolvedLayout): LayoutInvariantReport {
+  const { violations } = verifyLayoutConstraints(layout)
+  return {
+    nodeOverlaps: violations.nodeOverlaps,
+    containmentViolations: violations.containmentViolations,
+    collinearOverlaps: violations.collinearOverlaps,
+    portClutter: violations.portClutter,
+    ok:
+      violations.nodeOverlaps.length === 0 &&
+      violations.containmentViolations.length === 0 &&
+      violations.collinearOverlaps.length === 0 &&
+      violations.portClutter.length === 0,
   }
 }
 

--- a/libs/@shumoku/core/src/layout/index.ts
+++ b/libs/@shumoku/core/src/layout/index.ts
@@ -57,6 +57,8 @@ export {
   type ConstraintLevel,
   type ConstraintReport,
   type ConstraintSpec,
+  type ConstraintViolations,
+  checkLayoutInvariants,
   LAYOUT_CONSTRAINTS,
   verifyLayoutConstraints,
 } from './constraints.js'
@@ -112,27 +114,28 @@ export {
 // Layout invariant checks (containment / overlap / collinear tracks) —
 // standing verification fixture for every placement/routing pass.
 export {
+  type AttachedLineSpec,
   type BoxBounds,
   type BoxSpec,
   type CollinearOverlap,
   type ContainerOverlap,
   type ContainerSpec,
   type ContainmentViolation,
-  checkLayoutInvariants,
   type EdgeNodePierce,
   findCollinearOverlaps,
   findContainerOverlaps,
   findContainmentViolations,
+  findDetachedTerminals,
   findEdgeNodePiercing,
   findNodeOverlaps,
   findPortClutter,
-  type LayoutInvariantOptions,
   type LayoutInvariantReport,
   type NodeOverlap,
   type PierceLineSpec,
   type PolylineSpec,
   type PortClutter,
   segmentsIntersect,
+  type TerminalDetachment,
 } from './invariants.js'
 export {
   bpsToLinkWidth,
@@ -180,7 +183,7 @@ export {
 // Conversion utilities (for backward compatibility with legacy LayoutResult)
 export { resolveLayout, unresolveLayout } from './resolve.js'
 // Resolved layout model (Port/Edge as computed objects, Node/Subgraph used directly)
-export type { ResolvedEdge, ResolvedLayout, ResolvedPort } from './resolved-types.js'
+export type { EdgeRoute, ResolvedEdge, ResolvedLayout, ResolvedPort } from './resolved-types.js'
 export { routeEdges } from './route-edges.js'
 // Top-level convenience entry that runs autoLayoutFlatTree +
 // edge routing in one call. Used by the editor / server / CLI.

--- a/libs/@shumoku/core/src/layout/invariants.test.ts
+++ b/libs/@shumoku/core/src/layout/invariants.test.ts
@@ -7,6 +7,7 @@ import {
   type BoxSpec,
   findCollinearOverlaps,
   findContainmentViolations,
+  findDetachedTerminals,
   findNodeOverlaps,
 } from './invariants.js'
 
@@ -57,6 +58,43 @@ describe('findContainmentViolations', () => {
 
   it('ignores members that are not laid out', () => {
     expect(findContainmentViolations([box('a', 150, 50)], [container])).toHaveLength(0)
+  })
+})
+
+describe('findDetachedTerminals', () => {
+  const from = { x: 0, y: 0 }
+  const to = { x: 100, y: 200 }
+
+  it('accepts a polyline sitting exactly on its ports', () => {
+    const line = { id: 'e1', points: [from, { x: 100, y: 0 }, to], from, to }
+    expect(findDetachedTerminals([line])).toHaveLength(0)
+  })
+
+  it('reports a terminal displaced beyond epsilon, with the distance', () => {
+    // The historical bug shape: a corridor shift moved the endpoint 12u
+    // sideways off the port.
+    const line = { id: 'e1', points: [{ x: 12, y: 0 }, to], from, to }
+    const out = findDetachedTerminals([line])
+    expect(out).toEqual([{ edgeId: 'e1', end: 'from', distance: 12 }])
+  })
+
+  it('tolerates sub-epsilon jitter', () => {
+    const line = { id: 'e1', points: [{ x: 0.4, y: 0 }, to], from, to }
+    expect(findDetachedTerminals([line])).toHaveLength(0)
+  })
+
+  it('reports a reversed polyline as detached at BOTH ends', () => {
+    // Touching-but-backwards breaks the direction contract (points[0] must
+    // be the FROM port) — consumers like endpoint labels and weathermap
+    // lane direction depend on it.
+    const line = { id: 'e1', points: [to, from], from, to }
+    const out = findDetachedTerminals([line])
+    expect(out.map((v) => v.end).sort()).toEqual(['from', 'to'])
+  })
+
+  it('skips degenerate lines with fewer than two points', () => {
+    expect(findDetachedTerminals([{ id: 'e1', points: [from], from, to }])).toHaveLength(0)
+    expect(findDetachedTerminals([{ id: 'e1', points: [], from, to }])).toHaveLength(0)
   })
 })
 

--- a/libs/@shumoku/core/src/layout/invariants.ts
+++ b/libs/@shumoku/core/src/layout/invariants.ts
@@ -21,14 +21,14 @@
  *      strands/lanes are separated by design, so any near-zero-gap pair is
  *      a routing bug, not a style.
  *
- * `checkLayoutInvariants` adapts a ResolvedLayout; the `find*` functions
- * are pure and unit-testable without an engine.
+ * The `find*` functions are pure and unit-testable without an engine.
+ * `verifyLayoutConstraints` (constraints.ts) is the ResolvedLayout adapter —
+ * it derives every parameter from the LAYOUT_CONSTRAINTS registry.
  */
 
 import type { Bounds, Position } from '../models/types.js'
-import { resolveNodeSize } from './engine/index.js'
 import { portBox, portLabelBox } from './port-geometry.js'
-import type { ResolvedLayout, ResolvedPort } from './resolved-types.js'
+import type { ResolvedPort } from './resolved-types.js'
 import { BBoxGrid } from './spatial-grid.js'
 
 // ============================================================================
@@ -371,6 +371,48 @@ export function segmentsIntersect(a1: Position, a2: Position, b1: Position, b2: 
   return d1 > 0 !== d2 > 0 && d3 > 0 !== d4 > 0
 }
 
+/** Edge polyline with the port anchors its terminals MUST sit on. */
+export interface AttachedLineSpec {
+  id: string
+  points: readonly Position[]
+  /** The source port's absolute position — where `points[0]` must be. */
+  from: Position
+  /** The destination port's absolute position — where the last point must be. */
+  to: Position
+}
+
+export interface TerminalDetachment {
+  edgeId: string
+  end: 'from' | 'to'
+  /** Distance between the polyline terminal and the port anchor. */
+  distance: number
+}
+
+/**
+ * Find wires whose polyline does not terminate ON its ports in from→to
+ * order (port-attachment constraint). Checks both the position (each
+ * terminal within `epsilon` of its port) and the direction contract
+ * (`points[0]` is the FROM port specifically — a reversed but touching
+ * polyline is reported as detached at both ends). Lines with fewer than
+ * two points are skipped: there is no path to check.
+ */
+export function findDetachedTerminals(
+  lines: readonly AttachedLineSpec[],
+  epsilon = 0.5,
+): TerminalDetachment[] {
+  const out: TerminalDetachment[] = []
+  for (const line of lines) {
+    const first = line.points[0]
+    const last = line.points[line.points.length - 1]
+    if (line.points.length < 2 || !first || !last) continue
+    const dFrom = Math.hypot(first.x - line.from.x, first.y - line.from.y)
+    if (dFrom > epsilon) out.push({ edgeId: line.id, end: 'from', distance: dFrom })
+    const dTo = Math.hypot(last.x - line.to.x, last.y - line.to.y)
+    if (dTo > epsilon) out.push({ edgeId: line.id, end: 'to', distance: dTo })
+  }
+  return out
+}
+
 /** Edge polyline with its endpoint nodes (which it may legally touch). */
 export interface PierceLineSpec {
   id: string
@@ -496,79 +538,11 @@ export function findContainerOverlaps(boxes: readonly BoxBounds[]): ContainerOve
 // ResolvedLayout adapter
 // ============================================================================
 
+/** @deprecated Superseded by `ConstraintReport` — see `verifyLayoutConstraints`. */
 export interface LayoutInvariantReport {
   nodeOverlaps: NodeOverlap[]
   containmentViolations: ContainmentViolation[]
   collinearOverlaps: CollinearOverlap[]
   portClutter: PortClutter[]
   ok: boolean
-}
-
-export interface LayoutInvariantOptions {
-  /** Required clear space between node boxes. Default 0 (touching is ok). */
-  nodeMargin?: number
-  /** Containment padding inside subgraph bounds. Default 0. */
-  containmentPad?: number
-  collinear?: CollinearOptions
-}
-
-/**
- * Run all invariant checks against a ResolvedLayout. Containment uses
- * `node.parent` → subgraph bounds (subgraphs without bounds are skipped).
- * Edge tracks use `route.points` when present, else `points`.
- */
-export function checkLayoutInvariants(
-  layout: ResolvedLayout,
-  options: LayoutInvariantOptions = {},
-): LayoutInvariantReport {
-  const boxes: BoxSpec[] = []
-  for (const [id, node] of layout.nodes) {
-    const pos = node.position
-    if (!pos) continue
-    const size = resolveNodeSize(node)
-    boxes.push({ id, x: pos.x, y: pos.y, width: size.width, height: size.height })
-  }
-
-  const members = new Map<string, string[]>()
-  for (const [id, node] of layout.nodes) {
-    const parent = node.parent
-    if (!parent) continue
-    const list = members.get(parent)
-    if (list) list.push(id)
-    else members.set(parent, [id])
-  }
-  const containers: ContainerSpec[] = []
-  for (const [id, sg] of layout.subgraphs) {
-    const bounds = sg.bounds
-    const memberIds = members.get(id)
-    if (!bounds || !memberIds || memberIds.length === 0) continue
-    containers.push({ id, bounds, memberIds })
-  }
-
-  const lines: PolylineSpec[] = []
-  for (const [id, edge] of layout.edges) {
-    const points = edge.route?.points ?? edge.points
-    if (points.length < 2) continue
-    lines.push({ id, points, halfWidth: Math.max(0.5, edge.width / 2) })
-  }
-
-  const nodeOverlaps = findNodeOverlaps(boxes, options.nodeMargin ?? 0)
-  const containmentViolations = findContainmentViolations(
-    boxes,
-    containers,
-    options.containmentPad ?? 0,
-  )
-  const collinearOverlaps = findCollinearOverlaps(lines, options.collinear)
-  const portClutter = findPortClutter([...layout.ports.values()], boxes)
-  return {
-    nodeOverlaps,
-    containmentViolations,
-    collinearOverlaps,
-    portClutter,
-    ok:
-      nodeOverlaps.length === 0 &&
-      containmentViolations.length === 0 &&
-      collinearOverlaps.length === 0 &&
-      portClutter.length === 0,
-  }
 }

--- a/libs/@shumoku/core/src/layout/resolved-types.ts
+++ b/libs/@shumoku/core/src/layout/resolved-types.ts
@@ -61,6 +61,28 @@ export interface ResolvedPort {
 // ============================================================================
 
 /**
+ * Routed drawing geometry for an edge.
+ *
+ * Variants:
+ *   - `bus`      — orthogonal T / Christmas-tree polyline sharing a
+ *                 horizontal backbone with siblings of the same fan-out
+ *                 group. `busId` ties this edge to the sibling set so
+ *                 renderers can draw the backbone once and the branches
+ *                 as stubs.
+ *   - `polyline` — orthogonal multi-segment path, no shared backbone.
+ *
+ * INVARIANT (port-attachment, see `LAYOUT_CONSTRAINTS`): `points[0]` is the
+ * source port's absolute position and `points[points.length - 1]` the
+ * destination port's — a route terminates ON its ports, in from→to order.
+ * Routes are produced only through the router's `emitRoute()`, which pins
+ * the terminals by construction; emitters can shape the middle but can
+ * never detach the ends.
+ */
+export type EdgeRoute =
+  | { kind: 'bus'; points: Position[]; busId: string; branchIndex: number; branchCount: number }
+  | { kind: 'polyline'; points: Position[] }
+
+/**
  * A routed edge connecting two existing ports. Points are absolute coordinates;
  * the first point is at the source port, and the last point at the destination
  * port. Both endpoints always have a port — the model invariant guarantees it.
@@ -100,29 +122,14 @@ export interface ResolvedEdge {
   /** Same for the destination endpoint. */
   toLateralOffset?: number
   /**
-   * How the renderer should draw this edge. When absent, the renderer
-   * falls back to the standard port-anchored Bezier (today's default).
-   *
-   * Variants:
-   *   - `bus`      — orthogonal T / Christmas-tree polyline sharing
-   *                 a horizontal backbone with siblings of the same
-   *                 fan-out group. `points` carries the polyline
-   *                 (source endpoint → trunk-attach → backbone-leave →
-   *                 target endpoint). `busId` ties this edge to the
-   *                 sibling set so renderers can draw the backbone
-   *                 once and the branches as stubs.
-   *   - `polyline` — orthogonal multi-segment path, no shared backbone.
-   *                 Used for edges that the router preferred to draw
-   *                 with right angles for clarity but didn't qualify
-   *                 as a bus.
+   * How the renderer should draw this edge (see {@link EdgeRoute}). When
+   * absent, the renderer falls back to the standard port-anchored Bezier.
    *
    * The hit-test geometry continues to live on `points`; `route` is
    * purely a drawing hint and never invalidates the existing 2-point
    * fallback used by labels / hit testing / cable-length / BOM.
    */
-  route?:
-    | { kind: 'bus'; points: Position[]; busId: string; branchIndex: number; branchCount: number }
-    | { kind: 'polyline'; points: Position[] }
+  route?: EdgeRoute
   /**
    * Semantic weight for renderers (v3 grammar): `primary` = the edge
    * belongs to the primary dependency tree (each node's strongest


### PR DESCRIPTION
## The symptom class

"線とポートが一致しない / 1ポートに複数線 / 線が支離滅裂な場所を走る" — recurring geometry bugs that have each been fixed ad-hoc before. Measured on a live campus topology: 6/64 rendered link endpoints sat 4–12u off their ports, always horizontally, always a multiple of 4.

## Root cause

The invariant *"a routed edge's `points[0]`/`points[last]` are its port positions, in from→to order"* existed only as a doc comment on `ResolvedEdge` (resolved-types.ts). Nothing enforced it:

- `LAYOUT_CONSTRAINTS` holds six constraints — **all separation** (overlap / containment / collinear / pierce). No **incidence** constraint exists, and the checker's `PolylineSpec` doesn't even receive port references, so the check couldn't be written.
- The router's straights/orths emitters added the corridor-collision shift `shiftX` to the **terminal** points (`router.ts`) — the direct cause of the measured detachments.
- Emitted point order was **upper-port-first**, not from→to — silently breaking direction-sensitive consumers (weathermap in/out lane direction, renderer-svg endpoint labels).
- `alignPortsToPeers` re-seats port anchors but refreshed only *coupling* edges' 2-point geometry — every bezier-fallback edge fed **stale coordinates** to bounds, label placement, scoring, and the constraint checks.
- straights aliased `route.points`/`edge.points` to one array; the comb zero-length filter could drop the terminal point.

## The fix — make illegal states unrepresentable

**`emitRoute()` is now the only way a route reaches an edge.** It takes *interior* waypoints only; terminals come from the edge's own ports, so an emitter can shape the middle but can never detach the ends. It also normalizes direction to from→to, dedupes (terminals always survive — fixes the comb terminus drop), removes pass-through collinear points, and never aliases the two point arrays. All four emitters (straights / orths / gutter / comb) go through it.

Shifted corridors reconnect to the pinned terminals with **45° diagonals** (the existing comb `bendY` grammar) rather than horizontal jog rows — a jog row would be an unallocated track and collide with neighbours (caught by the existing collinear test while developing this).

**Registry:** `port-attachment` joins `LAYOUT_CONSTRAINTS` as its first incidence constraint, **blocking** from day one (`findDetachedTerminals`, ε=0.5, direction-checked). The existing `assertLayoutConstraints` gate and the composite E2E `blockingViolations` assertion pick it up automatically.

**Aggregate unification:** `checkLayoutInvariants` (zero callers — dead public API) is deprecated into a thin adapter over `verifyLayoutConstraints`; parameters live in the registry only. `EdgeRoute` gets a named exported type.

**Server:** `RESOLVER_VERSION` 21→22 so persisted layout artifacts with detached endpoints rebake (documented protocol in topology.ts).

## Verified

- Live topology, DOM-measured: **64/64 endpoints Δ=0** (was 58/64, worst 12u), after artifact rebake.
- New tests: `findDetachedTerminals` unit (5), registry blocking wiring (1), composite E2E "pins every routed polyline ON its ports, in from→to order" (also asserts no aliasing). 413 core tests green.
- Full turbo run: only pre-existing flake `entity-lifecycle > last_seen_at advances…` (strict `>` on two `Date.now()` reads; fails on origin/main too, unrelated).

## Out of scope (follow-up issues to be filed)

- `route` is dropped at every `LayoutLink` boundary (resolve.ts / unified-engine.ts / renderer-svg draws bezier only).
- Editor drag (`moveNode`/`moveSubgraph`) rebuilds edges via `routeEdges` only, destroying routed geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014batWzWC9HSikr4UTRnUsq