### PR TITLE
chore: ignore generated Next.js types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,9 @@ build
 
 # Environment variables
 .env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*
+!.env.example
+!.env.*.example
 
 # Logs
 logs

--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,3 +1,4 @@
 .open-next
 .source
+next-env.d.ts
 public/renderer/

--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- stop tracking the Next.js-generated apps/docs/next-env.d.ts file
- ignore it locally so next dev and next typegen no longer create noisy path-only diffs
- cover all .env.* variants while preserving .env.example and .env.*.example templates

## Audit

Reviewed tracked and ignored generated files across the monorepo. Existing ignores cover the active Next.js, SvelteKit, Vite/Turbo, build, coverage, SQLite, editor, and OS artifacts. No other tracked generated artifacts or clear missing patterns were found, so this PR stays intentionally small.

## Validation

- apps/docs: bun run typecheck
- repository pre-commit lint/typecheck: 40 tasks passed
- verified next typegen recreates next-env.d.ts without dirtying the worktree
- verified environment templates remain trackable
- git diff --check