### PR TITLE
fix(server): resolve All Metrics from source-qualified bindings

### DIFF
--- a/apps/server/api/src/api/source-mapping-view.test.ts
+++ b/apps/server/api/src/api/source-mapping-view.test.ts
@@ -1,0 +1,47 @@
+import type { MetricsMapping } from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import type { TopologyDataSource } from '../types.js'
+import { buildSourceMetricsMappingView } from './source-mapping-view.js'
+
+function source(dataSourceId: string, priority: number): TopologyDataSource {
+  return {
+    id: `attachment-${dataSourceId}`,
+    topologyId: 'topology-1',
+    dataSourceId,
+    purpose: 'metrics',
+    syncMode: 'manual',
+    priority,
+    nodeContribution: 'scoop',
+    linkContribution: 'add',
+    createdAt: 1,
+    updatedAt: 1,
+  }
+}
+
+describe('buildSourceMetricsMappingView', () => {
+  it('preserves attached-source order and provenance', () => {
+    const mapping: MetricsMapping = {
+      nodes: { router: { hostId: 'host-1' } },
+      links: {},
+    }
+    const result = buildSourceMetricsMappingView(
+      [source('primary', 0), source('secondary', 1)],
+      new Map([['primary', mapping]]),
+    )
+
+    expect(result).toEqual([
+      {
+        sourceId: 'primary',
+        sourceName: 'primary',
+        priority: 0,
+        mapping,
+      },
+      {
+        sourceId: 'secondary',
+        sourceName: 'secondary',
+        priority: 1,
+        mapping: { nodes: {}, links: {} },
+      },
+    ])
+  })
+})

--- a/apps/server/api/src/api/source-mapping-view.ts
+++ b/apps/server/api/src/api/source-mapping-view.ts
@@ -1,0 +1,27 @@
+import type { MetricsMapping } from '@shumoku/core'
+import type { TopologyDataSource } from '../types.js'
+
+export interface SourceMetricsMappingView {
+  sourceId: string
+  sourceName: string
+  priority: number
+  mapping: MetricsMapping
+}
+
+/**
+ * Preserve metrics-source provenance for UI consumers. `MetricsMapping` remains
+ * the source-local plugin contract; this web read model wraps it instead of
+ * widening the core type or asking clients to reconstruct provenance from host
+ * inventories.
+ */
+export function buildSourceMetricsMappingView(
+  sources: TopologyDataSource[],
+  mappings: ReadonlyMap<string, MetricsMapping>,
+): SourceMetricsMappingView[] {
+  return sources.map((source) => ({
+    sourceId: source.dataSourceId,
+    sourceName: source.dataSource?.name ?? source.dataSourceId,
+    priority: source.priority,
+    mapping: mappings.get(source.dataSourceId) ?? { nodes: {}, links: {} },
+  }))
+}

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -25,6 +25,7 @@ import type {
   Topology,
   TopologyInput,
 } from '../types.js'
+import { buildSourceMetricsMappingView } from './source-mapping-view.js'
 
 /**
  * Overlay per-link bandwidth from the metrics mapping onto the graph.
@@ -492,6 +493,23 @@ export function createTopologiesApi(): Hono {
         return c.json(mapping ?? { nodes: {}, links: {} })
       }
       return c.json(parsed.mapping ?? { nodes: {}, links: {} })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 400)
+    }
+  })
+
+  // Source-qualified read model for UI features that must address the exact
+  // plugin owning a binding. The compatibility GET /mapping union deliberately
+  // omits provenance and remains unchanged for existing consumers.
+  app.get('/:id/mapping/sources', async (c) => {
+    const id = c.req.param('id')
+    try {
+      const parsed = await service.getParsed(id)
+      if (!parsed) return c.json({ error: 'Topology not found' }, 404)
+      const sources = getTopologySourcesService().listByPurpose(id, 'metrics')
+      const mappings = service.buildMappingsBySource(id, parsed.graph)
+      return c.json(buildSourceMetricsMappingView(sources, mappings))
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 400)

--- a/apps/server/web/src/lib/api.ts
+++ b/apps/server/web/src/lib/api.ts
@@ -19,6 +19,7 @@ import type {
   NodeContribution,
   ScopeFilter,
   ScopeMode,
+  SourceMetricsMapping,
   SyncJob,
   SyncMode,
   SystemInfo,
@@ -249,6 +250,9 @@ export const topologies = {
     const qs = opts?.sourceId ? `?sourceId=${encodeURIComponent(opts.sourceId)}` : ''
     return request<MetricsMapping>(`/topologies/${id}/mapping${qs}`)
   },
+
+  getSourceMappings: (id: string) =>
+    request<SourceMetricsMapping[]>(`/topologies/${id}/mapping/sources`),
 
   // Orphaned mapping rows (Phase 4): entities no longer present in the current
   // resolved graph (a mapping pointing at a retired / disappeared element).

--- a/apps/server/web/src/lib/components/NodeMappingModal.svelte
+++ b/apps/server/web/src/lib/components/NodeMappingModal.svelte
@@ -16,12 +16,14 @@
   import { api } from '$lib/api'
   import { Button } from '$lib/components/ui/button'
   import * as Dialog from '$lib/components/ui/dialog'
+  import { resolveNodeMetricsTarget } from '$lib/metrics-discovery'
   import {
     type EdgeMetrics,
     mappingHosts,
     mappingStore,
     metricsData,
     metricsSources,
+    sourceMappings,
   } from '$lib/stores'
   import type { DiscoveredMetric, MetricsMapping } from '$lib/types'
   import { formatTraffic } from '$lib/utils/format'
@@ -59,7 +61,8 @@
 
   // State for metrics discovery
   let discoveredMetrics = $state<DiscoveredMetric[]>([])
-  let loadingMetrics = $state(false)
+  let metricsLoadStatus = $state<'idle' | 'loading' | 'loaded' | 'error'>('idle')
+  let metricsLoadKey = $state('')
   let metricsError = $state('')
   let metricsExpanded = $state(false)
   let metricsSearchQuery = $state('')
@@ -91,13 +94,14 @@
 
   let currentNodeMapping = $derived(nodeData && currentMapping?.nodes?.[nodeData.node.id])
   let hasMetricsSource = $derived($metricsSources.length > 0)
-  // Resolve the source for the currently selected binding so metric discovery
-  // calls the matching plugin. Other sources may bind the same node too; their
-  // live observations are shown independently below.
-  let mappedHostSourceId = $derived(
-    currentNodeMapping?.hostId
-      ? hosts.find((h) => h.id === currentNodeMapping.hostId)?.sourceId
-      : undefined,
+  // Resolve provenance from the authoritative source-qualified mappings. Host
+  // inventories are live plugin data loaded only by the Mapping picker; metric
+  // discovery must not depend on that unrelated lazy request (#651).
+  let metricsTarget = $derived(
+    resolveNodeMetricsTarget($sourceMappings, nodeData?.node.id, currentNodeMapping?.hostId),
+  )
+  let metricsTargetKey = $derived(
+    `${nodeData?.node.id ?? ''}\t${currentNodeMapping?.hostId ?? ''}\t${metricsTarget?.sourceId ?? ''}`,
   )
 
   // Filter discovered metrics by search query
@@ -160,7 +164,30 @@
       mode = 'status'
       metricsExpanded = false
       discoveredMetrics = []
+      metricsLoadStatus = 'idle'
+      metricsLoadKey = ''
+      metricsError = ''
       metricsSearchQuery = ''
+    }
+  })
+
+  // A node, binding, or owning source change invalidates the previous result.
+  // Keep an explicit request state so a successful empty response stays loaded
+  // instead of retriggering forever.
+  $effect(() => {
+    const key = metricsTargetKey
+    if (metricsLoadKey === key) return
+    metricsLoadKey = key
+    metricsLoadStatus = 'idle'
+    discoveredMetrics = []
+    metricsError = ''
+  })
+
+  // Expanding before the mapping view resolves is safe: once source-qualified
+  // provenance arrives, this effect starts exactly one request for that target.
+  $effect(() => {
+    if (metricsExpanded && metricsTarget && metricsLoadStatus === 'idle') {
+      void loadDiscoveredMetrics()
     }
   })
 
@@ -177,27 +204,26 @@
   // Hosts are loaded via shared store
 
   async function loadDiscoveredMetrics() {
-    if (!mappedHostSourceId || !currentNodeMapping?.hostId) return
+    const target = metricsTarget
+    const requestKey = metricsTargetKey
+    if (!target) return
 
-    loadingMetrics = true
+    metricsLoadStatus = 'loading'
     metricsError = ''
     try {
-      discoveredMetrics = await api.dataSources.discoverMetrics(
-        mappedHostSourceId,
-        currentNodeMapping.hostId,
-      )
+      const metrics = await api.dataSources.discoverMetrics(target.sourceId, target.hostId)
+      if (metricsTargetKey !== requestKey) return
+      discoveredMetrics = metrics
+      metricsLoadStatus = 'loaded'
     } catch (e) {
+      if (metricsTargetKey !== requestKey) return
       metricsError = e instanceof Error ? e.message : 'Failed to load metrics'
-    } finally {
-      loadingMetrics = false
+      metricsLoadStatus = 'error'
     }
   }
 
   function handleMetricsToggle() {
     metricsExpanded = !metricsExpanded
-    if (metricsExpanded && discoveredMetrics.length === 0 && !loadingMetrics) {
-      loadDiscoveredMetrics()
-    }
   }
 
   function formatMetricValue(value: number | string | boolean): string {
@@ -661,14 +687,14 @@
 
                 {#if metricsExpanded}
                   <div class="border rounded-lg">
-                    {#if loadingMetrics}
+                    {#if metricsLoadStatus === 'loading'}
                       <div class="flex items-center justify-center py-8">
                         <div
                           class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin"
                         ></div>
                         <span class="ml-2 text-sm text-muted-foreground">Loading metrics...</span>
                       </div>
-                    {:else if metricsError}
+                    {:else if metricsLoadStatus === 'error'}
                       <div class="p-3 text-sm">
                         <p class="text-destructive">{metricsError}</p>
                         <button
@@ -678,11 +704,21 @@
                           Retry
                         </button>
                       </div>
-                    {:else if discoveredMetrics.length === 0}
+                    {:else if metricsLoadStatus === 'loaded' && discoveredMetrics.length === 0}
                       <div class="p-3 text-sm text-muted-foreground text-center">
                         No metrics found
                       </div>
-                    {:else}
+                    {:else if metricsLoadStatus === 'idle'}
+                      <div class="p-3 text-sm text-muted-foreground text-center">
+                        {#if $mappingStore.loading}
+                          Resolving metrics source...
+                        {:else if !metricsTarget}
+                          Metrics source for this mapping is unavailable
+                        {:else}
+                          Preparing metrics...
+                        {/if}
+                      </div>
+                    {:else if discoveredMetrics.length > 0}
                       <!-- Search -->
                       <div class="p-2 border-b">
                         <div class="relative">

--- a/apps/server/web/src/lib/metrics-discovery.test.ts
+++ b/apps/server/web/src/lib/metrics-discovery.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import type { SourceMetricsMapping } from '$lib/types'
+import { resolveNodeMetricsTarget } from './metrics-discovery'
+
+function source(
+  sourceId: string,
+  priority: number,
+  nodes: SourceMetricsMapping['mapping']['nodes'],
+): SourceMetricsMapping {
+  return {
+    sourceId,
+    sourceName: sourceId,
+    priority,
+    mapping: { nodes, links: {} },
+  }
+}
+
+describe('resolveNodeMetricsTarget', () => {
+  it('uses the source-qualified binding without a host inventory', () => {
+    const result = resolveNodeMetricsTarget(
+      [source('zabbix', 0, { router: { hostId: '42' } })],
+      'router',
+      '42',
+    )
+
+    expect(result).toEqual({ sourceId: 'zabbix', sourceName: 'zabbix', hostId: '42' })
+  })
+
+  it('respects source priority when host-id namespaces collide', () => {
+    const result = resolveNodeMetricsTarget(
+      [
+        source('primary', 0, { ap: { hostId: 'shared-id' } }),
+        source('secondary', 1, { ap: { hostId: 'shared-id' } }),
+      ],
+      'ap',
+      'shared-id',
+    )
+
+    expect(result?.sourceId).toBe('primary')
+  })
+
+  it('does not guess a source from a different binding', () => {
+    const result = resolveNodeMetricsTarget(
+      [source('prometheus', 0, { router: { hostId: 'prom-router' } })],
+      'router',
+      'zabbix-router',
+    )
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/apps/server/web/src/lib/metrics-discovery.ts
+++ b/apps/server/web/src/lib/metrics-discovery.ts
@@ -1,0 +1,32 @@
+import type { SourceMetricsMapping } from '$lib/types'
+
+export interface NodeMetricsTarget {
+  sourceId: string
+  sourceName: string
+  hostId: string
+}
+
+/**
+ * Resolve the exact plugin + host pair behind the compatibility mapping shown
+ * by the UI. Source mappings arrive in priority order; matching the merged
+ * host id keeps this aligned with the server's highest-priority-wins view while
+ * preserving source provenance (including colliding plugin host-id namespaces).
+ */
+export function resolveNodeMetricsTarget(
+  sourceMappings: SourceMetricsMapping[],
+  nodeId: string | undefined,
+  mergedHostId: string | undefined,
+): NodeMetricsTarget | undefined {
+  if (!nodeId || !mergedHostId) return undefined
+
+  for (const source of sourceMappings) {
+    if (source.mapping.nodes[nodeId]?.hostId === mergedHostId) {
+      return {
+        sourceId: source.sourceId,
+        sourceName: source.sourceName,
+        hostId: mergedHostId,
+      }
+    }
+  }
+  return undefined
+}

--- a/apps/server/web/src/lib/stores/index.ts
+++ b/apps/server/web/src/lib/stores/index.ts
@@ -28,6 +28,7 @@ export {
   mappingStore,
   metricsSources,
   nodeMapping,
+  sourceMappings,
 } from './mapping'
 export {
   type EdgeMetrics,

--- a/apps/server/web/src/lib/stores/mapping.ts
+++ b/apps/server/web/src/lib/stores/mapping.ts
@@ -26,6 +26,7 @@ import type {
   HostItem,
   InterfaceNeighbor,
   MetricsMapping,
+  SourceMetricsMapping,
   Topology,
   TopologyDataSource,
 } from '$lib/types'
@@ -55,6 +56,8 @@ interface MappingState {
   hosts: MappingHost[]
   /** Metrics sources for this topology (id + display name). Empty when none configured. */
   metricsSources: MetricsSourceInfo[]
+  /** Authoritative per-source mappings, kept in source priority order. */
+  sourceMappings: SourceMetricsMapping[]
   /**
    * The source whose rows "Auto-map links" writes under.
    * Wave B-3 (#569): when >1 metrics sources are attached the mapping page shows
@@ -76,6 +79,7 @@ const initialState: MappingState = {
   mapping: { nodes: {}, links: {} },
   hosts: [],
   metricsSources: [],
+  sourceMappings: [],
   hostInterfaces: {},
   hostInterfacesLoading: {},
   hostNeighbors: {},
@@ -114,6 +118,23 @@ async function loadHostsForSources(sources: MetricsSourceInfo[]): Promise<Mappin
   return out
 }
 
+async function loadMappingViews(
+  topologyId: string,
+): Promise<{ mapping: MetricsMapping; sourceMappings: SourceMetricsMapping[] }> {
+  const [mapping, sourceMappings] = await Promise.all([
+    api.topologies.getMapping(topologyId),
+    api.topologies.getSourceMappings(topologyId),
+  ])
+  return { mapping, sourceMappings }
+}
+
+function sameMetricsSources(state: MappingState, sources: MetricsSourceInfo[]): boolean {
+  return (
+    state.metricsSources.length === sources.length &&
+    state.metricsSources.every((source, i) => source.id === sources[i]?.id)
+  )
+}
+
 /** Extract the `metrics`-purpose sources, resolved + priority-sorted. */
 function metricsSourcesOf(sources: TopologyDataSource[]): MetricsSourceInfo[] {
   return (
@@ -137,32 +158,56 @@ function createMappingStore() {
     subscribe,
 
     /**
-     * Hydrate from already-fetched topology + sources. Use this when the
-     * caller has already fetched the data (avoids duplicate API calls).
-     * Triggers host loading in the background.
+     * Hydrate from already-fetched topology + sources. Mapping reads are local
+     * DB projections; live host inventories remain lazy and are loaded only by
+     * the Mapping picker.
      */
     hydrate: (topologyId: string, _topo: Topology, sources: TopologyDataSource[]) => {
       const metricsSources = metricsSourcesOf(sources)
 
-      update((s) => ({
-        ...s,
-        topologyId,
-        mapping: { nodes: {}, links: {} },
-        metricsSources,
-        loading: false,
-        error: null,
-      }))
+      update((s) => {
+        const sourceContextChanged =
+          s.topologyId !== topologyId || !sameMetricsSources(s, metricsSources)
+        return {
+          ...s,
+          topologyId,
+          mapping: { nodes: {}, links: {} },
+          metricsSources,
+          sourceMappings: [],
+          loading: true,
+          error: null,
+          ...(sourceContextChanged
+            ? {
+                hosts: [],
+                hostsLoading: false,
+                hostInterfaces: {},
+                hostInterfacesLoading: {},
+                hostNeighbors: {},
+              }
+            : {}),
+        }
+      })
 
-      // Fetch the RESOLVED mapping (bindings ∪ residual), not topo.mappingJson —
-      // node bindings live as attachments and would be missed (and stripped on
-      // save) if we parsed the blob. Guard against a topology switch mid-flight:
-      // only apply if the store is still on this topology.
-      api.topologies
-        .getMapping(topologyId)
-        .then((mapping) => update((s) => (s.topologyId === topologyId ? { ...s, mapping } : s)))
-        .catch(() => {
-          /* leave the empty mapping; a transient resolve failure isn't fatal */
-        })
+      // Fetch the compatibility union and authoritative source-qualified views
+      // together. A topology switch while either request is in flight makes the
+      // response stale, so only apply it to the topology that requested it.
+      loadMappingViews(topologyId)
+        .then(({ mapping, sourceMappings }) =>
+          update((s) =>
+            s.topologyId === topologyId ? { ...s, mapping, sourceMappings, loading: false } : s,
+          ),
+        )
+        .catch((e) =>
+          update((s) =>
+            s.topologyId === topologyId
+              ? {
+                  ...s,
+                  loading: false,
+                  error: e instanceof Error ? e.message : 'Failed to load mapping',
+                }
+              : s,
+          ),
+        )
 
       // NOTE: do NOT fetch host lists here. `hydrate` runs on every diagram open
       // (the canvas only needs the node→host mapping, above, for status). Host
@@ -186,25 +231,50 @@ function createMappingStore() {
       // hydrated left hosts empty → auto-map matched nothing).
       const alreadyOnTopology = current.topologyId === topologyId && !current.loading
       if (forceReload || !alreadyOnTopology) {
-        update((s) => ({ ...s, loading: true, error: null, topologyId }))
+        update((s) => ({
+          ...s,
+          topologyId,
+          loading: true,
+          error: null,
+          ...(s.topologyId !== topologyId
+            ? {
+                mapping: { nodes: {}, links: {} },
+                sourceMappings: [],
+                metricsSources: [],
+                hosts: [],
+                hostsLoading: false,
+                hostInterfaces: {},
+                hostInterfacesLoading: {},
+                hostNeighbors: {},
+              }
+            : {}),
+        }))
         try {
-          // The RESOLVED mapping (bindings ∪ residual), not topo.mappingJson.
-          const [mapping, sources] = await Promise.all([
-            api.topologies.getMapping(topologyId),
+          const [{ mapping, sourceMappings }, sources] = await Promise.all([
+            loadMappingViews(topologyId),
             api.topologies.sources.list(topologyId),
           ])
-          update((s) => ({
-            ...s,
-            mapping,
-            metricsSources: metricsSourcesOf(sources),
-            loading: false,
-          }))
+          update((s) =>
+            s.topologyId === topologyId
+              ? {
+                  ...s,
+                  mapping,
+                  sourceMappings,
+                  metricsSources: metricsSourcesOf(sources),
+                  loading: false,
+                }
+              : s,
+          )
         } catch (e) {
-          update((s) => ({
-            ...s,
-            loading: false,
-            error: e instanceof Error ? e.message : 'Failed to load mapping',
-          }))
+          update((s) =>
+            s.topologyId === topologyId
+              ? {
+                  ...s,
+                  loading: false,
+                  error: e instanceof Error ? e.message : 'Failed to load mapping',
+                }
+              : s,
+          )
           return
         }
       }
@@ -216,9 +286,17 @@ function createMappingStore() {
         update((s) => ({ ...s, hostsLoading: true }))
         try {
           const hosts = await loadHostsForSources(st.metricsSources)
-          update((s) => ({ ...s, hosts, hostsLoading: false }))
+          update((s) =>
+            s.topologyId === topologyId && sameMetricsSources(s, st.metricsSources)
+              ? { ...s, hosts, hostsLoading: false }
+              : s,
+          )
         } catch {
-          update((s) => ({ ...s, hostsLoading: false }))
+          update((s) =>
+            s.topologyId === topologyId && sameMetricsSources(s, st.metricsSources)
+              ? { ...s, hostsLoading: false }
+              : s,
+          )
         }
       }
     },
@@ -229,9 +307,12 @@ function createMappingStore() {
     updateNode: async (nodeId: string, hostMapping: { hostId?: string; hostName?: string }) => {
       const current = get({ subscribe })
       if (!current.topologyId) return
+      const existingSourceId = current.sourceMappings.find(
+        (source) => source.mapping.nodes[nodeId]?.hostId,
+      )?.sourceId
       const sourceId = hostMapping.hostId
         ? sourceIdForHost(current.hosts, hostMapping.hostId)
-        : undefined
+        : existingSourceId
 
       // Optimistic update
       update((s) => {
@@ -241,7 +322,14 @@ function createMappingStore() {
         } else {
           delete nodes[nodeId]
         }
-        return { ...s, mapping: { ...s.mapping, nodes } }
+        const sourceMappings = s.sourceMappings.map((source) => {
+          if (source.sourceId !== sourceId) return source
+          const sourceNodes = { ...source.mapping.nodes }
+          if (hostMapping.hostId) sourceNodes[nodeId] = hostMapping
+          else delete sourceNodes[nodeId]
+          return { ...source, mapping: { ...source.mapping, nodes: sourceNodes } }
+        })
+        return { ...s, mapping: { ...s.mapping, nodes }, sourceMappings }
       })
 
       // Save to backend
@@ -460,8 +548,8 @@ function createMappingStore() {
 
       // Rehydrate the compatibility union used by the canvas and coverage
       // counters after all source-qualified writes have landed.
-      const mapping = await api.topologies.getMapping(topologyId)
-      update((s) => (s.topologyId === topologyId ? { ...s, mapping } : s))
+      const { mapping, sourceMappings } = await loadMappingViews(topologyId)
+      update((s) => (s.topologyId === topologyId ? { ...s, mapping, sourceMappings } : s))
       for (const nodeId of identityNodes) nameNodes.delete(nodeId)
       return {
         matched: matchedNodes.size,
@@ -479,7 +567,14 @@ function createMappingStore() {
       if (!current.topologyId) return
 
       // Optimistic local clear
-      update((s) => ({ ...s, mapping: { ...s.mapping, nodes: {} } }))
+      update((s) => ({
+        ...s,
+        mapping: { ...s.mapping, nodes: {} },
+        sourceMappings: s.sourceMappings.map((source) => ({
+          ...source,
+          mapping: { ...source.mapping, nodes: {} },
+        })),
+      }))
 
       try {
         // No sourceId: clear EVERY source's rows — "Clear" means clear.
@@ -500,7 +595,14 @@ function createMappingStore() {
       if (!current.topologyId) return
 
       // Optimistic local clear
-      update((s) => ({ ...s, mapping: { ...s.mapping, links: {} } }))
+      update((s) => ({
+        ...s,
+        mapping: { ...s.mapping, links: {} },
+        sourceMappings: s.sourceMappings.map((source) => ({
+          ...source,
+          mapping: { ...source.mapping, links: {} },
+        })),
+      }))
 
       try {
         // No sourceId: clear EVERY source's rows — "Clear" means clear.
@@ -539,6 +641,7 @@ export const linkMapping = derived(mappingStore, ($s) => $s.mapping.links)
 /** Wave B-3 (#569): the source id currently selected for writes (undefined = first source). */
 export const mappingHosts = derived(mappingStore, ($s) => $s.hosts)
 export const metricsSources = derived(mappingStore, ($s) => $s.metricsSources)
+export const sourceMappings = derived(mappingStore, ($s) => $s.sourceMappings)
 export const hostInterfaces = derived(mappingStore, ($s) => $s.hostInterfaces)
 export const hostInterfacesLoading = derived(mappingStore, ($s) => $s.hostInterfacesLoading)
 export const hostNeighbors = derived(mappingStore, ($s) => $s.hostNeighbors)

--- a/apps/server/web/src/lib/types.ts
+++ b/apps/server/web/src/lib/types.ts
@@ -190,6 +190,14 @@ export interface TopologyDataSourceInput {
   linkContribution?: LinkContribution
 }
 
+/** Source-qualified metrics mapping read model used by the web UI. */
+export interface SourceMetricsMapping {
+  sourceId: string
+  sourceName: string
+  priority: number
+  mapping: MetricsMapping
+}
+
 export interface ApiError {
   error: string
 }


### PR DESCRIPTION
## Summary

- add a source-qualified metrics mapping read model without widening the core plugin contract
- resolve All Metrics directly from persisted source bindings instead of the lazy live host inventory
- model idle, loading, loaded-empty, and error states explicitly and ignore stale responses
- clear source-dependent caches on topology changes and guard late host results

## Root cause

The compatibility mapping intentionally merges all metrics sources and drops source provenance. The modal reconstructed that source by searching a host inventory that is loaded lazily only for the Mapping picker. Opening All Metrics before that inventory resolved therefore had no source ID, performed no request, and remained on No metrics found.

## Verification

- bun test apps/server/api/src/api/source-mapping-view.test.ts apps/server/web/src/lib/metrics-discovery.test.ts
- bun x biome check on all changed files
- bun run typecheck
- pre-commit lint and typecheck hooks

Fixes #651