### PR TITLE
fix(web): make copy actions work outside secure contexts

### DIFF
--- a/apps/server/web/src/lib/clipboard.test.ts
+++ b/apps/server/web/src/lib/clipboard.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+import { copyTextToClipboard } from './clipboard'
+
+describe('copyTextToClipboard', () => {
+  it('prefers the Async Clipboard API', async () => {
+    const writeText = vi.fn(async () => {})
+    const fallback = vi.fn(() => true)
+
+    await copyTextToClipboard('share-url', { writeText, fallback })
+
+    expect(writeText).toHaveBeenCalledWith('share-url')
+    expect(fallback).not.toHaveBeenCalled()
+  })
+
+  it('falls back when the Async Clipboard API is unavailable', async () => {
+    const fallback = vi.fn(() => true)
+
+    await copyTextToClipboard('webhook-url', { fallback })
+
+    expect(fallback).toHaveBeenCalledWith('webhook-url')
+  })
+
+  it('falls back when clipboard permission is denied', async () => {
+    const writeText = vi.fn(async () => {
+      throw new Error('NotAllowedError')
+    })
+    const fallback = vi.fn(() => true)
+
+    await copyTextToClipboard('resolved-json', { writeText, fallback })
+
+    expect(fallback).toHaveBeenCalledWith('resolved-json')
+  })
+
+  it('reports failure when neither copy mechanism works', async () => {
+    await expect(copyTextToClipboard('share-url', { fallback: () => false })).rejects.toThrow(
+      'Clipboard access is unavailable',
+    )
+  })
+})

--- a/apps/server/web/src/lib/clipboard.ts
+++ b/apps/server/web/src/lib/clipboard.ts
@@ -1,0 +1,57 @@
+interface ClipboardEnvironment {
+  writeText?: (text: string) => Promise<void>
+  fallback: (text: string) => boolean
+}
+
+function fallbackCopyText(text: string): boolean {
+  if (typeof document === 'undefined' || !document.body) return false
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  textarea.style.pointerEvents = 'none'
+  document.body.appendChild(textarea)
+  textarea.select()
+
+  try {
+    return document.execCommand('copy')
+  } catch {
+    return false
+  } finally {
+    textarea.remove()
+  }
+}
+
+function browserClipboardEnvironment(): ClipboardEnvironment {
+  const writeText =
+    typeof navigator !== 'undefined' && navigator.clipboard?.writeText
+      ? (text: string) => navigator.clipboard.writeText(text)
+      : undefined
+
+  return { writeText, fallback: fallbackCopyText }
+}
+
+/**
+ * Copy text using the modern Async Clipboard API when available. Browsers only
+ * expose that API in a secure context and may still reject it based on
+ * permissions, so retain a user-gesture-compatible fallback for HTTP/LAN and
+ * embedded deployments.
+ */
+export async function copyTextToClipboard(
+  text: string,
+  environment: ClipboardEnvironment = browserClipboardEnvironment(),
+): Promise<void> {
+  if (environment.writeText) {
+    try {
+      await environment.writeText(text)
+      return
+    } catch {
+      // Permission and secure-context failures can still use the fallback.
+    }
+  }
+
+  if (environment.fallback(text)) return
+  throw new Error('Clipboard access is unavailable')
+}

--- a/apps/server/web/src/lib/components/ShareButton.svelte
+++ b/apps/server/web/src/lib/components/ShareButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { CheckIcon, LinkSimpleIcon, ShareNetworkIcon, XIcon } from 'phosphor-svelte'
+  import { copyTextToClipboard } from '$lib/clipboard'
 
   export let shareToken: string | undefined = undefined
   export let shareType: 'topologies' | 'dashboards' = 'topologies'
@@ -8,6 +9,7 @@
 
   let showPopover = false
   let copied = false
+  let copyError = ''
   let loading = false
 
   function getShareUrl(): string {
@@ -35,25 +37,28 @@
 
   async function copyLink() {
     if (!shareToken) return
+    copyError = ''
     try {
-      await navigator.clipboard.writeText(getShareUrl())
+      await copyTextToClipboard(getShareUrl())
       copied = true
       setTimeout(() => {
         copied = false
       }, 2000)
     } catch {
-      // Fallback
+      copyError = 'Could not copy the link. Select and copy it manually.'
     }
   }
 
   function togglePopover() {
     showPopover = !showPopover
     copied = false
+    copyError = ''
   }
 </script>
 
 <div class="relative">
   <button
+    type="button"
     onclick={togglePopover}
     class="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border transition-colors {shareToken
       ? 'bg-primary/10 border-primary/30 text-primary hover:bg-primary/20'
@@ -67,6 +72,7 @@
   {#if showPopover}
     <!-- Backdrop -->
     <button
+      type="button"
       class="fixed inset-0 z-20"
       onclick={() => (showPopover = false)}
       aria-label="Close"
@@ -79,6 +85,7 @@
       <div class="flex items-center justify-between mb-3">
         <h3 class="text-sm font-semibold text-theme-text-emphasis">Share Link</h3>
         <button
+          type="button"
           onclick={() => (showPopover = false)}
           class="w-6 h-6 flex items-center justify-center rounded hover:bg-theme-bg text-theme-text-muted hover:text-theme-text"
         >
@@ -96,11 +103,13 @@
             class="flex-1 text-xs bg-theme-bg border border-theme-border rounded-lg px-3 py-2 text-theme-text font-mono truncate"
           >
           <button
+            type="button"
             onclick={copyLink}
             class="flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-lg border border-theme-border hover:bg-theme-bg transition-colors {copied
               ? 'text-success'
               : 'text-theme-text-muted hover:text-theme-text'}"
             title="Copy link"
+            aria-label="Copy link"
           >
             {#if copied}
               <CheckIcon size={16} />
@@ -109,10 +118,14 @@
             {/if}
           </button>
         </div>
+        {#if copyError}
+          <p class="text-xs text-danger mb-3" role="status">{copyError}</p>
+        {/if}
         <p class="text-xs text-theme-text-muted mb-3">
           Anyone with this link can view this page without logging in.
         </p>
         <button
+          type="button"
           onclick={handleUnshare}
           disabled={loading}
           class="w-full text-xs px-3 py-2 rounded-lg border border-danger/30 text-danger hover:bg-danger/10 transition-colors disabled:opacity-50"
@@ -125,6 +138,7 @@
           Create a public link that anyone can use to view this page without logging in.
         </p>
         <button
+          type="button"
           onclick={handleShare}
           disabled={loading}
           class="w-full text-sm px-3 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary-dark transition-colors disabled:opacity-50"

--- a/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/[id]/+page.svelte
@@ -11,6 +11,7 @@
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
   import { api } from '$lib/api'
+  import { copyTextToClipboard } from '$lib/clipboard'
   import SchemaForm from '$lib/components/SchemaForm.svelte'
   import { dataSources } from '$lib/stores'
   import type {
@@ -55,6 +56,7 @@
   // generically from the plugin's getConnectionInfo — no per-plugin branch.
   let connectionItems = $state<{ label: string; value: string; copyable?: boolean }[]>([])
   let copiedValue = $state<string | null>(null)
+  let copyErrorValue = $state<string | null>(null)
   let copiedTimer: ReturnType<typeof setTimeout> | null = null
 
   async function loadConnectionInfo() {
@@ -66,14 +68,20 @@
     }
   }
 
-  function copyValue(value: string) {
-    navigator.clipboard.writeText(value)
-    copiedValue = value
-    if (copiedTimer) clearTimeout(copiedTimer)
-    copiedTimer = setTimeout(() => {
+  async function copyValue(value: string) {
+    copyErrorValue = null
+    try {
+      await copyTextToClipboard(value)
+      copiedValue = value
+      if (copiedTimer) clearTimeout(copiedTimer)
+      copiedTimer = setTimeout(() => {
+        copiedValue = null
+        copiedTimer = null
+      }, 2000)
+    } catch {
       copiedValue = null
-      copiedTimer = null
-    }, 2000)
+      copyErrorValue = value
+    }
   }
 
   $effect(() => {
@@ -493,6 +501,11 @@
                     </button>
                   {/if}
                 </div>
+                {#if copyErrorValue === item.value}
+                  <p class="mt-1 text-xs text-danger" role="status">
+                    Could not copy this value. Select and copy it manually.
+                  </p>
+                {/if}
               </div>
             {/each}
 

--- a/apps/server/web/src/routes/(app)/topologies/[id]/resolved/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/resolved/+page.svelte
@@ -9,6 +9,7 @@
    * to see "what is the resolver actually producing right now".
    */
   import { api } from '$lib/api'
+  import { copyTextToClipboard } from '$lib/clipboard'
   import { Button } from '$lib/components/ui/button'
   import { useTopologyCtx } from '../_context.svelte'
 
@@ -19,6 +20,7 @@
   let loading = $state(false)
   let error = $state('')
   let copied = $state(false)
+  let copyError = $state('')
 
   // Load when the id is ready, and whenever a committed mutation bumps the shell
   // revision (reflect Save/Sync without a reload). No separate onMount — it would
@@ -44,14 +46,15 @@
   }
 
   async function copy() {
+    copyError = ''
     try {
-      await navigator.clipboard.writeText(resolvedJson)
+      await copyTextToClipboard(resolvedJson)
       copied = true
       setTimeout(() => {
         copied = false
       }, 1500)
-    } catch (e) {
-      console.error('[Resolved] Copy failed:', e)
+    } catch {
+      copyError = 'Could not copy the graph. Select and copy it manually.'
     }
   }
 </script>
@@ -76,6 +79,15 @@
       {copied ? 'Copied ✓' : 'Copy'}
     </Button>
   </div>
+
+  {#if copyError}
+    <div
+      class="p-3 bg-danger/10 border border-danger/20 rounded-lg text-danger text-sm"
+      role="status"
+    >
+      {copyError}
+    </div>
+  {/if}
 
   {#if error}
     <div class="p-3 bg-danger/10 border border-danger/20 rounded-lg text-danger text-sm">

--- a/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/sources/+page.svelte
@@ -25,6 +25,7 @@
     TrashIcon,
   } from 'phosphor-svelte'
   import { api } from '$lib/api'
+  import { copyTextToClipboard } from '$lib/clipboard'
   import SchemaForm from '$lib/components/SchemaForm.svelte'
   import { Button } from '$lib/components/ui/button'
   import * as Dialog from '$lib/components/ui/dialog'
@@ -607,13 +608,19 @@
   }
 
   async function copyWebhookUrl(source: TopologyDataSource) {
-    await navigator.clipboard.writeText(getWebhookUrl(source))
-    copiedSecret = source.id
-    if (copiedTimer) clearTimeout(copiedTimer)
-    copiedTimer = setTimeout(() => {
+    localError = ''
+    try {
+      await copyTextToClipboard(getWebhookUrl(source))
+      copiedSecret = source.id
+      if (copiedTimer) clearTimeout(copiedTimer)
+      copiedTimer = setTimeout(() => {
+        copiedSecret = null
+        copiedTimer = null
+      }, 2000)
+    } catch {
       copiedSecret = null
-      copiedTimer = null
-    }, 2000)
+      localError = 'Could not copy the webhook URL. Select and copy it manually.'
+    }
   }
 </script>
 


### PR DESCRIPTION
## Summary

- centralize all Server Web copy actions behind one clipboard utility
- prefer the modern Async Clipboard API and fall back for HTTP, LAN, embedded, or permission-restricted deployments
- show success only after a copy actually succeeds
- surface actionable errors instead of swallowing clipboard failures
- add explicit button types and an accessible label to the share copy action

## Root cause

Four UI surfaces called navigator.clipboard.writeText directly. That API is normally available only in secure contexts and can also reject based on browser permissions. The share button swallowed every error, while the data-source connection screen showed a successful copy before the Promise had resolved. This made failures look like an unclickable button and duplicated the same fragile behavior across the app.

## Affected surfaces

- topology and dashboard share links
- data-source connection values
- topology webhook URLs
- resolved topology JSON

## Verification

- 4 clipboard utility regression tests
- Server Web full test suite
- monorepo build and full test suite
- Server Web svelte-check: 0 errors, 0 warnings
- Biome on all changed files
- pre-commit lint and typecheck hooks