### PR TITLE
feat(server): add secure dev API automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ lerna-debug.log*
 .research/
 .wrangler/
 apps/server/data/plugins.yaml
+apps/server/.shumoku/
 
 # scratch files for ad-hoc API inspection
 obs*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,22 @@ Shumoku is a modern network topology visualization library for Markdown. It enab
 bun install           # Install all dependencies
 bun run build         # Build all packages (respects dependency order)
 bun run dev           # Run all packages in dev mode
+bun run dev:server    # Run the Server API + Web UI with a loopback dev credential
+bun run dev:server:request -- GET /api/topologies  # Authenticated dev API request
 bun run typecheck     # Type check all packages
 bun run lint          # Lint all packages
 bun run format        # Format with Biome
 bun run test          # Run tests across packages
 ```
+
+### Dev Server API Automation
+
+`bun run dev:server` generates a fresh 256-bit Bearer credential for the API
+process and stores it in the gitignored `apps/server/.shumoku/` directory with
+owner-only permissions. Agents and scripts must use
+`bun run dev:server:request -- <METHOD> /api/...` instead of reading or printing
+the credential. The wrapper refuses non-API paths and plaintext non-loopback
+destinations. Do not pass the token in a URL, command argument, log, or chat.
 
 ### Package-specific
 ```bash

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -106,6 +106,27 @@ bun install
 bun run dev:server     # turbo: API (:8080) + web UI (:5173, HMR)
 ```
 
+The development command binds the API to `127.0.0.1`, generates a fresh 256-bit
+Bearer credential for that API process, and stores it locally with owner-only
+permissions. It is ignored by production builds and never printed. Use the
+credential-aware request wrapper when debugging or automating the development
+server:
+
+```bash
+bun run dev:server:request -- GET /api/topologies
+bun run dev:server:request -- POST /api/topologies/example/rebuild
+bun run dev:server:request -- PATCH /api/topologies/example/discovery-policy \
+  --json '{"nodes":[]}'
+```
+
+The wrapper accepts only `/api/*` paths and sends the credential with the
+standard `Authorization: Bearer` scheme. The generated credential is restricted
+to the IPv4 or IPv6 loopback address and cannot be sent to a remote origin.
+Browser authentication continues to use the existing session cookie. See the
+[Hono Bearer Auth middleware](https://hono.dev/docs/middleware/builtin/bearer-auth)
+and [RFC 6750](https://datatracker.ietf.org/doc/html/rfc6750.html) for the
+underlying standard.
+
 ### From apps/server (Bun)
 
 ```bash

--- a/apps/server/api/README.md
+++ b/apps/server/api/README.md
@@ -14,20 +14,39 @@ Or just the API, from here:
 
 ```bash
 cd apps/server/api
-bun run dev      # NODE_ENV=development bun --watch src/index.ts  → :8080
+bun run dev      # API only, session authentication, → :8080
 bun run start    # production
 bun run build
 ```
+
+For development automation, use the server-level launcher instead. It binds the
+API to loopback, creates an ephemeral Bearer credential, and removes it when the
+API exits:
+
+```bash
+# From the repo root
+bun run dev:server
+bun run dev:server:request -- GET /api/topologies
+```
+
+The direct API command does not create an automation credential. See the
+[API reference](../docs/api.en.mdx#development-automation) for the authentication
+and security boundaries.
 
 Scripts: `dev`, `start`, `build`, `typecheck`, `lint`, `format`, and tests (`test`, `test:unit`, `test:db`).
 
 ## Layout
 
 - `src/index.ts` — entry point
-- `src/server.ts` — Hono app: static serving, health checker, WebSocket
-- `src/api/*` — route modules: `auth`, `share`, `datasources` (+ `scan`), `plugins`, `topologies` (+ `sources`, `observations`, `resolved`, `discovery-policy`), `dashboards`, `settings`, `webhooks`, and `runtime.js`
+- `src/server.ts` — composition root: Hono app, static serving, schedulers, and WebSocket
+- `src/api/*` — HTTP route modules mounted below `/api`
+- `src/middleware/*` — cross-cutting HTTP middleware, including session and dev Bearer auth
+- `src/services/*` — application and domain services used by routes and background jobs
+- `src/db/*` — SQLite access, schema, and ordered migrations
+- `src/discovery/*` — SNMP/LLDP deep-read infrastructure
 - `src/plugins/loader.ts` — discovers bundled plugins and calls each one's `register(pluginRegistry)`
 - `src/config.ts` — reads `PORT` / `HOST` / `DATA_DIR`; SQLite lives at `$DATA_DIR/shumoku.db` (default `/data`)
+- `test/*` — Bun-powered SQLite integration tests; colocated `*.test.ts` files use Vitest
 
 See the [server README](../README.md) for the full endpoint list, environment variables, and deployment.
 

--- a/apps/server/api/src/index.ts
+++ b/apps/server/api/src/index.ts
@@ -4,10 +4,13 @@
  */
 
 import { loadConfig } from './config.js'
+import { validateDevApiAuthConfiguration } from './middleware/auth.js'
 import { Server } from './server.js'
 
 async function main() {
   console.log('Starting Shumoku Server...')
+
+  validateDevApiAuthConfiguration()
 
   // Load configuration
   const config = loadConfig()

--- a/apps/server/api/src/middleware/auth.test.ts
+++ b/apps/server/api/src/middleware/auth.test.ts
@@ -1,0 +1,126 @@
+import { Hono } from 'hono'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { authMiddleware, getDevApiToken, validateDevApiAuthConfiguration } from './auth.js'
+
+const TOKEN = 'a'.repeat(64)
+
+const authService = vi.hoisted(() => ({
+  isSetupComplete: vi.fn(() => true),
+  validateSession: vi.fn(() => false),
+}))
+
+vi.mock('../services/auth.js', () => ({
+  isSetupComplete: authService.isSetupComplete,
+  SESSION_COOKIE: 'shumoku_session',
+  validateSession: authService.validateSession,
+}))
+
+describe('development API bearer authentication', () => {
+  afterEach(() => {
+    delete process.env['SHUMOKU_DEV_API_TOKEN']
+    delete process.env['HOST']
+    delete process.env['NODE_ENV']
+    authService.isSetupComplete.mockReturnValue(true)
+    authService.validateSession.mockReturnValue(false)
+  })
+
+  it('is disabled outside development even when a token is present', () => {
+    expect(
+      getDevApiToken({
+        NODE_ENV: 'production',
+        HOST: '0.0.0.0',
+        SHUMOKU_DEV_API_TOKEN: TOKEN,
+      }),
+    ).toBeNull()
+  })
+
+  it('accepts a 256-bit hexadecimal token on loopback', () => {
+    expect(
+      getDevApiToken({
+        NODE_ENV: 'development',
+        HOST: '127.0.0.1',
+        SHUMOKU_DEV_API_TOKEN: TOKEN,
+      }),
+    ).toBe(TOKEN)
+  })
+
+  it('rejects malformed credentials', () => {
+    expect(() =>
+      validateDevApiAuthConfiguration({
+        NODE_ENV: 'development',
+        HOST: '127.0.0.1',
+        SHUMOKU_DEV_API_TOKEN: 'too-short',
+      }),
+    ).toThrow('64-character hexadecimal token')
+  })
+
+  it('rejects plaintext bearer authentication on non-loopback hosts', () => {
+    expect(() =>
+      validateDevApiAuthConfiguration({
+        NODE_ENV: 'development',
+        HOST: '0.0.0.0',
+        SHUMOKU_DEV_API_TOKEN: TOKEN,
+      }),
+    ).toThrow('requires HOST=127.0.0.1 or HOST=::1')
+  })
+
+  it('authenticates the real management middleware with Hono bearer semantics', async () => {
+    process.env['NODE_ENV'] = 'development'
+    process.env['HOST'] = '127.0.0.1'
+    process.env['SHUMOKU_DEV_API_TOKEN'] = TOKEN
+
+    const app = new Hono()
+    app.use('/protected', authMiddleware)
+    app.get('/protected', (c) => c.json({ ok: true }))
+
+    const accepted = await app.request('/protected', {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })
+    expect(accepted.status).toBe(200)
+
+    const rejected = await app.request('/protected', {
+      headers: { Authorization: `Bearer ${'b'.repeat(64)}` },
+    })
+    expect(rejected.status).toBe(401)
+    expect(rejected.headers.get('www-authenticate')).toContain('Bearer')
+  })
+
+  it('does not accept the development token in production', async () => {
+    process.env['NODE_ENV'] = 'production'
+    process.env['HOST'] = '0.0.0.0'
+    process.env['SHUMOKU_DEV_API_TOKEN'] = TOKEN
+
+    const app = new Hono()
+    app.use('/protected', authMiddleware)
+    app.get('/protected', (c) => c.json({ ok: true }))
+
+    const response = await app.request('/protected', {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    })
+    expect(response.status).toBe(401)
+  })
+
+  it('preserves the existing authenticated session-cookie flow', async () => {
+    authService.validateSession.mockReturnValue(true)
+
+    const app = new Hono()
+    app.use('/protected', authMiddleware)
+    app.get('/protected', (c) => c.json({ ok: true }))
+
+    const response = await app.request('/protected', {
+      headers: { Cookie: 'shumoku_session=browser-session' },
+    })
+    expect(response.status).toBe(200)
+    expect(authService.validateSession).toHaveBeenCalledWith('browser-session')
+  })
+
+  it('preserves access before initial password setup', async () => {
+    authService.isSetupComplete.mockReturnValue(false)
+
+    const app = new Hono()
+    app.use('/protected', authMiddleware)
+    app.get('/protected', (c) => c.json({ ok: true }))
+
+    expect((await app.request('/protected')).status).toBe(200)
+  })
+})

--- a/apps/server/api/src/middleware/auth.ts
+++ b/apps/server/api/src/middleware/auth.ts
@@ -7,8 +7,44 @@
  */
 
 import type { Context, Next } from 'hono'
+import { bearerAuth } from 'hono/bearer-auth'
 import { getCookie } from 'hono/cookie'
 import { isSetupComplete, SESSION_COOKIE, validateSession } from '../services/auth.js'
+
+const DEV_API_TOKEN_PATTERN = /^[a-f0-9]{64}$/i
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', '[::1]'])
+
+type AuthEnvironment = Record<string, string | undefined>
+
+/**
+ * Resolve the opt-in development API credential.
+ *
+ * The credential is deliberately ignored outside development. When enabled,
+ * it is accepted only on a loopback-bound server so a bearer token is never
+ * sent over plaintext LAN traffic.
+ */
+export function getDevApiToken(env: AuthEnvironment = process.env): string | null {
+  if (env['NODE_ENV'] !== 'development') return null
+
+  const token = env['SHUMOKU_DEV_API_TOKEN']?.trim()
+  if (!token) return null
+
+  if (!DEV_API_TOKEN_PATTERN.test(token)) {
+    throw new Error('SHUMOKU_DEV_API_TOKEN must be a 64-character hexadecimal token')
+  }
+
+  const host = env['HOST'] ?? '0.0.0.0'
+  if (!LOOPBACK_HOSTS.has(host)) {
+    throw new Error('SHUMOKU_DEV_API_TOKEN requires HOST=127.0.0.1 or HOST=::1')
+  }
+
+  return token
+}
+
+/** Fail fast during startup instead of discovering a bad dev credential on the first request. */
+export function validateDevApiAuthConfiguration(env: AuthEnvironment = process.env): void {
+  getDevApiToken(env)
+}
 
 /**
  * Check if a request path + method is public (no auth needed)
@@ -57,11 +93,19 @@ export async function authMiddleware(c: Context, next: Next) {
   }
 
   // Check session cookie
-  const token = getCookie(c, SESSION_COOKIE)
-  if (!token || !validateSession(token)) {
-    return c.json({ error: 'Authentication required' }, 401)
+  const sessionToken = getCookie(c, SESSION_COOKIE)
+  if (sessionToken && validateSession(sessionToken)) {
+    await next()
+    return
   }
 
-  await next()
-  return
+  // Development automation uses the standard Authorization: Bearer scheme.
+  // Invoke Hono's official middleware only after the browser session check so
+  // the existing UI authentication flow remains unchanged.
+  const devApiToken = getDevApiToken()
+  if (devApiToken) {
+    return bearerAuth({ token: devApiToken, realm: 'shumoku-dev-api' })(c, next)
+  }
+
+  return c.json({ error: 'Authentication required' }, 401)
 }

--- a/apps/server/docs/api.en.mdx
+++ b/apps/server/docs/api.en.mdx
@@ -6,7 +6,8 @@ description: HTTP endpoints and WebSocket protocol
 
 ## Authentication
 
-All API endpoints (except health check and shared views) require session authentication. Login via:
+All API endpoints (except health check and shared views) require authentication.
+Browsers use the session cookie obtained by logging in:
 
 ```
 POST /api/auth/login
@@ -14,6 +15,30 @@ Content-Type: application/json
 
 { "password": "your-password" }
 ```
+
+### Development automation
+
+When the Server is started from the repository with `bun run dev:server`, the
+launcher binds the API to loopback and creates an ephemeral 256-bit development
+credential. Agents and local scripts should use the request wrapper; they do not
+need to handle or print the credential:
+
+```bash
+bun run dev:server:request -- GET /api/topologies
+bun run dev:server:request -- POST /api/topologies/example/rebuild
+bun run dev:server:request -- PATCH /api/topologies/example/discovery-policy \
+  --json '{"nodes":[]}'
+```
+
+The wrapper uses the standard `Authorization: Bearer` scheme. This path is
+available only when `NODE_ENV=development`, requires the API to be bound to
+`127.0.0.1` or `::1`, accepts only normalized `/api/*` paths, and refuses to
+send the generated credential to any remote HTTP or HTTPS origin. Production
+continues to accept session authentication only. The credential is stored in a
+gitignored owner-only file while the API is running and is removed on shutdown.
+
+Starting `apps/server/api` directly with `bun run dev` does not create this
+credential; use the server-level command above when automating API access.
 
 ## Shared views (public, token-scoped)
 

--- a/apps/server/docs/api.ja.mdx
+++ b/apps/server/docs/api.ja.mdx
@@ -6,7 +6,8 @@ description: HTTP エンドポイントと WebSocket プロトコル
 
 ## 認証
 
-ヘルスチェックと共有ビューを除くすべての API エンドポイントはセッション認証が必要です。
+ヘルスチェックと共有ビューを除くすべての API エンドポイントは認証が必要です。
+ブラウザーでは、ログインで取得したセッションCookieを使用します。
 
 ```
 POST /api/auth/login
@@ -14,6 +15,30 @@ Content-Type: application/json
 
 { "password": "your-password" }
 ```
+
+### 開発時の自動操作
+
+リポジトリから`bun run dev:server`でServerを起動すると、ランチャーはAPIを
+loopbackへバインドし、一時的な256-bit開発credentialを生成します。AIエージェントや
+ローカルスクリプトはrequest wrapperを使用するため、credentialを直接読み取ったり
+表示したりする必要はありません。
+
+```bash
+bun run dev:server:request -- GET /api/topologies
+bun run dev:server:request -- POST /api/topologies/example/rebuild
+bun run dev:server:request -- PATCH /api/topologies/example/discovery-policy \
+  --json '{"nodes":[]}'
+```
+
+wrapperは標準の`Authorization: Bearer`方式を使用します。この認証経路は
+`NODE_ENV=development`でのみ有効で、APIのバインド先を`127.0.0.1`または`::1`に
+限定します。正規化後も`/api/*`内に留まるパスだけを受け付け、生成したcredentialを
+リモートのHTTP/HTTPS originへ送信しません。本番環境では従来どおりセッション認証
+だけが有効です。credentialはAPI実行中のみgitignore済み・所有者限定のファイルへ
+保存され、終了時に削除されます。
+
+`apps/server/api`内で`bun run dev`を直接実行しても、このcredentialは生成されません。
+APIを自動操作する場合は上記のServer全体のコマンドを使用してください。
 
 ## 共有ビュー（公開・トークンスコープ）
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -20,6 +20,7 @@
     "@shumoku/server-web": "workspace:*"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.6",
     "concurrently": "^9.1.2",
     "wait-on": "^9.0.3"
   }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,11 +5,13 @@
   "description": "Real-time network topology visualization server with Zabbix integration",
   "scripts": {
     "dev": "concurrently -k -n api,web -c blue,green \"bun run dev:api\" \"bun run dev:web\"",
-    "dev:api": "cd api && NODE_ENV=development bun --watch src/index.ts",
+    "dev:api": "bun scripts/dev-api-server.ts",
+    "dev:request": "bun scripts/dev-api-request.ts",
     "dev:web": "wait-on http://127.0.0.1:8080/api/health && cd web && bun run dev",
     "build": "cd api && bun run build && cd ../web && bun run build",
     "start": "cd api && bun run start",
-    "typecheck": "cd api && bun run typecheck && cd ../web && bun run check",
+    "test": "vitest run scripts",
+    "typecheck": "bun x tsc -p tsconfig.scripts.json && cd api && bun run typecheck && cd ../web && bun run check",
     "lint": "cd api && bun run lint",
     "format": "biome check --write ."
   },

--- a/apps/server/scripts/dev-api-request.test.ts
+++ b/apps/server/scripts/dev-api-request.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { parseArgs } from './dev-api-request.js'
+
+describe('development API request CLI', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('parses a loopback JSON request', () => {
+    vi.stubEnv('SHUMOKU_DEV_API_URL', 'http://127.0.0.1:8080')
+    expect(parseArgs(['post', '/api/topologies', '--json', '{"name":"lab"}'])).toEqual({
+      method: 'POST',
+      pathname: '/api/topologies',
+      body: '{"name":"lab"}',
+      baseUrl: 'http://127.0.0.1:8080',
+    })
+  })
+
+  it('rejects paths outside the management API', () => {
+    vi.stubEnv('SHUMOKU_DEV_API_URL', 'http://127.0.0.1:8080')
+    expect(() => parseArgs(['GET', '/topology/example'])).toThrow('must start with /api/')
+  })
+
+  it('rejects paths that normalize outside the management API', () => {
+    expect(() => parseArgs(['GET', '/api/../health'])).toThrow(
+      'normalized request path must stay within /api/',
+    )
+  })
+
+  it('rejects non-loopback destinations to prevent token disclosure', () => {
+    expect(() =>
+      parseArgs(['GET', '/api/topologies', '--base-url', 'http://192.0.2.10:8080']),
+    ).toThrow('restricted to 127.0.0.1 or ::1')
+  })
+
+  it('does not send the generated credential to a remote HTTPS origin', () => {
+    expect(() =>
+      parseArgs(['GET', '/api/topologies', '--base-url', 'https://dev.example.test']),
+    ).toThrow('restricted to 127.0.0.1 or ::1')
+  })
+})

--- a/apps/server/scripts/dev-api-request.ts
+++ b/apps/server/scripts/dev-api-request.ts
@@ -1,0 +1,121 @@
+import { readFile, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])
+const serverDir = fileURLToPath(new URL('..', import.meta.url))
+const credentialPath = path.join(serverDir, '.shumoku', 'dev-api-token')
+
+interface CliOptions {
+  method: string
+  pathname: string
+  body?: string
+  baseUrl: string
+}
+
+export function parseArgs(args: string[]): CliOptions {
+  const [rawMethod, pathname, ...rest] = args
+  const method = rawMethod?.toUpperCase()
+  if (!method || !ALLOWED_METHODS.has(method) || !pathname) {
+    throw new Error(
+      'Usage: bun run dev:request -- <GET|POST|PUT|PATCH|DELETE> /api/path [--json JSON] [--base-url URL]',
+    )
+  }
+  if (!pathname.startsWith('/api/')) {
+    throw new Error('The request path must start with /api/')
+  }
+
+  let body: string | undefined
+  let baseUrl = process.env['SHUMOKU_DEV_API_URL'] ?? 'http://127.0.0.1:8080'
+  const remaining = [...rest]
+  while (remaining.length > 0) {
+    const value = remaining.shift()
+    if (value === '--json') {
+      const argument = remaining.shift()
+      if (!argument) throw new Error('--json requires a JSON value')
+      body = JSON.stringify(JSON.parse(argument))
+      continue
+    }
+    if (value === '--base-url') {
+      const argument = remaining.shift()
+      if (!argument) throw new Error('--base-url requires a URL')
+      baseUrl = argument
+      continue
+    }
+    throw new Error(`Unknown option: ${value}`)
+  }
+
+  const url = new URL(baseUrl)
+  const loopback = url.hostname === '127.0.0.1' || url.hostname === '[::1]'
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('The development API URL must use HTTP or HTTPS')
+  }
+  if (!loopback) {
+    throw new Error('The generated development credential is restricted to 127.0.0.1 or ::1')
+  }
+
+  const requestUrl = new URL(pathname, `${url.origin}/`)
+  if (!requestUrl.pathname.startsWith('/api/')) {
+    throw new Error('The normalized request path must stay within /api/')
+  }
+
+  return {
+    method,
+    pathname: `${requestUrl.pathname}${requestUrl.search}`,
+    body,
+    baseUrl: url.origin,
+  }
+}
+
+async function readCredential(): Promise<string> {
+  const fromEnvironment = process.env['SHUMOKU_DEV_API_TOKEN']?.trim()
+  if (fromEnvironment) return fromEnvironment
+
+  try {
+    const metadata = await stat(credentialPath)
+    if (process.platform !== 'win32' && (metadata.mode & 0o077) !== 0) {
+      throw new Error(`Credential permissions are too broad: ${credentialPath}`)
+    }
+    return (await readFile(credentialPath, 'utf8')).trim()
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('Credential permissions')) throw error
+    throw new Error(
+      'Development API credential not found; start the server with bun run dev:server',
+    )
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2))
+  const token = await readCredential()
+  const response = await fetch(`${options.baseUrl}${options.pathname}`, {
+    method: options.method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: options.body,
+  })
+
+  const text = await response.text()
+  let output = text
+  try {
+    output = JSON.stringify(JSON.parse(text), null, 2)
+  } catch {
+    // Preserve non-JSON responses as-is.
+  }
+
+  if (output) console.log(output)
+  if (!response.ok) {
+    console.error(`[Dev API] HTTP ${response.status} ${response.statusText}`)
+    process.exit(1)
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`[Dev API] ${message}`)
+    process.exit(1)
+  })
+}

--- a/apps/server/scripts/dev-api-request.ts
+++ b/apps/server/scripts/dev-api-request.ts
@@ -1,8 +1,9 @@
-import { readFile, stat } from 'node:fs/promises'
+import { open } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])
+const TOKEN_PATTERN = /^[a-f0-9]{64}$/i
 const serverDir = fileURLToPath(new URL('..', import.meta.url))
 const credentialPath = path.join(serverDir, '.shumoku', 'dev-api-token')
 
@@ -67,18 +68,36 @@ export function parseArgs(args: string[]): CliOptions {
   }
 }
 
+function validateCredential(token: string): string {
+  if (!TOKEN_PATTERN.test(token)) {
+    throw new Error('Development API credential must be a 64-character hexadecimal token')
+  }
+  return token
+}
+
 async function readCredential(): Promise<string> {
   const fromEnvironment = process.env['SHUMOKU_DEV_API_TOKEN']?.trim()
-  if (fromEnvironment) return fromEnvironment
+  if (fromEnvironment) return validateCredential(fromEnvironment)
 
   try {
-    const metadata = await stat(credentialPath)
-    if (process.platform !== 'win32' && (metadata.mode & 0o077) !== 0) {
-      throw new Error(`Credential permissions are too broad: ${credentialPath}`)
+    const credential = await open(credentialPath, 'r')
+    try {
+      const metadata = await credential.stat()
+      if (process.platform !== 'win32' && (metadata.mode & 0o077) !== 0) {
+        throw new Error(`Credential permissions are too broad: ${credentialPath}`)
+      }
+      return validateCredential((await credential.readFile('utf8')).trim())
+    } finally {
+      await credential.close()
     }
-    return (await readFile(credentialPath, 'utf8')).trim()
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('Credential permissions')) throw error
+    if (
+      error instanceof Error &&
+      (error.message.startsWith('Credential permissions') ||
+        error.message.startsWith('Development API credential'))
+    ) {
+      throw error
+    }
     throw new Error(
       'Development API credential not found; start the server with bun run dev:server',
     )
@@ -88,6 +107,8 @@ async function readCredential(): Promise<string> {
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2))
   const token = await readCredential()
+  // The only permitted origins are the normalized IPv4/IPv6 loopback addresses validated above.
+  // codeql[js/file-access-to-http]
   const response = await fetch(`${options.baseUrl}${options.pathname}`, {
     method: options.method,
     headers: {

--- a/apps/server/scripts/dev-api-server.ts
+++ b/apps/server/scripts/dev-api-server.ts
@@ -1,0 +1,74 @@
+import { randomBytes } from 'node:crypto'
+import { chmod, mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const serverDir = fileURLToPath(new URL('..', import.meta.url))
+const apiDir = path.join(serverDir, 'api')
+const credentialDir = path.join(serverDir, '.shumoku')
+const credentialPath = path.join(credentialDir, 'dev-api-token')
+
+async function createCredential(): Promise<string> {
+  const token = randomBytes(32).toString('hex')
+  await mkdir(credentialDir, { recursive: true, mode: 0o700 })
+  await writeFile(credentialPath, `${token}\n`, { mode: 0o600 })
+  await chmod(credentialDir, 0o700)
+  await chmod(credentialPath, 0o600)
+  return token
+}
+
+async function removeCredential(token: string): Promise<void> {
+  try {
+    const current = (await readFile(credentialPath, 'utf8')).trim()
+    if (current === token) await unlink(credentialPath)
+  } catch {
+    // The credential may already have been replaced or removed by another dev process.
+  }
+}
+
+async function main(): Promise<void> {
+  const host = process.env['HOST'] ?? '127.0.0.1'
+
+  if (host !== '127.0.0.1' && host !== '::1' && host !== '[::1]') {
+    throw new Error('The development API token requires a loopback HOST')
+  }
+
+  const token = await createCredential()
+
+  console.log(`[Dev API] Bearer credential ready at ${credentialPath}`)
+  console.log(`[Dev API] Listening on loopback (${host}); the token will not be printed`)
+
+  let exitCode = 1
+  try {
+    const child = Bun.spawn(['bun', '--watch', 'src/index.ts'], {
+      cwd: apiDir,
+      env: {
+        ...process.env,
+        HOST: host,
+        NODE_ENV: 'development',
+        SHUMOKU_DEV_API_TOKEN: token,
+      },
+      stdin: 'inherit',
+      stdout: 'inherit',
+      stderr: 'inherit',
+    })
+
+    const forward = (signal: NodeJS.Signals) => {
+      child.kill(signal)
+    }
+    process.on('SIGINT', () => forward('SIGINT'))
+    process.on('SIGTERM', () => forward('SIGTERM'))
+
+    exitCode = await child.exited
+  } finally {
+    await removeCredential(token)
+  }
+
+  process.exit(exitCode)
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`[Dev API] ${message}`)
+  process.exit(1)
+})

--- a/apps/server/tsconfig.scripts.json
+++ b/apps/server/tsconfig.scripts.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "incremental": false,
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["scripts/**/*.ts"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "@shumoku/server-web": "workspace:*",
       },
       "devDependencies": {
+        "@types/bun": "^1.3.6",
         "concurrently": "^9.1.2",
         "wait-on": "^9.0.3",
       },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "dev": "turbo run dev",
     "dev:server": "turbo run dev --filter=@shumoku/server",
+    "dev:server:request": "bun apps/server/scripts/dev-api-request.ts",
     "build": "turbo run build --filter='!@shumoku/server'",
     "build:all": "turbo run build",
     "test": "turbo run test",


### PR DESCRIPTION
## Summary

- add an opt-in development-only Bearer credential using Hono's official bearer auth middleware
- generate a fresh 256-bit token for each dev API process, bind it to loopback, and keep it in a gitignored owner-only file
- add a credential-aware request wrapper for agents and scripts, restricted to normalized `/api/*` loopback requests
- preserve the existing browser session-cookie and initial-setup flows
- document the supported workflow in the Server README and AGENTS.md

## Security boundaries

- ignored unless `NODE_ENV=development`
- startup fails if a token is configured on a non-loopback host
- generated credentials cannot be sent to remote HTTP or HTTPS origins by the wrapper
- tokens are never printed or accepted in URLs
- production authentication behavior is unchanged

## Usage

```bash
bun run dev:server
bun run dev:server:request -- GET /api/topologies
bun run dev:server:request -- PATCH /api/topologies/example/discovery-policy --json '{"nodes":[]}'
```

## Verification

- `bun run test` (40/40 tasks)
- `bun run typecheck` (40/40 tasks)
- `bun run lint` (40/40 tasks)
- `bun run version:products:check`
- focused auth middleware tests (8)
- focused request wrapper tests (5)
- isolated end-to-end check: unauthenticated request returns 401, wrapper succeeds, credential mode is 0600, credential is removed on shutdown
