### PR TITLE
fix(server): protect legacy topology routes

### DIFF
--- a/apps/server/api/src/api/legacy-topology.test.ts
+++ b/apps/server/api/src/api/legacy-topology.test.ts
@@ -1,0 +1,58 @@
+import { Hono } from 'hono'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { registerLegacyTopologyRoutes } from './legacy-topology.js'
+
+const authService = vi.hoisted(() => ({
+  isSetupComplete: vi.fn(() => true),
+  validateSession: vi.fn(() => false),
+}))
+
+vi.mock('../services/auth.js', () => ({
+  isSetupComplete: authService.isSetupComplete,
+  SESSION_COOKIE: 'shumoku_session',
+  validateSession: authService.validateSession,
+}))
+
+function createApp() {
+  const app = new Hono()
+  const getTopology = vi.fn(() => undefined)
+  registerLegacyTopologyRoutes(app, { getTopology }, { thresholds: [] })
+  return { app, getTopology }
+}
+
+describe('legacy topology route authentication', () => {
+  afterEach(() => {
+    authService.isSetupComplete.mockReturnValue(true)
+    authService.validateSession.mockReturnValue(false)
+  })
+
+  it.each([
+    '/api/topology/example',
+    '/topology/example',
+  ])('rejects an anonymous request to %s before topology lookup', async (pathname) => {
+    const { app, getTopology } = createApp()
+
+    expect((await app.request(pathname)).status).toBe(401)
+    expect(getTopology).not.toHaveBeenCalled()
+  })
+
+  it('preserves session access to the legacy routes', async () => {
+    authService.validateSession.mockReturnValue(true)
+    const { app, getTopology } = createApp()
+
+    const response = await app.request('/api/topology/example', {
+      headers: { Cookie: 'shumoku_session=browser-session' },
+    })
+
+    expect(response.status).toBe(404)
+    expect(getTopology).toHaveBeenCalledWith('example')
+  })
+
+  it('preserves access before initial password setup', async () => {
+    authService.isSetupComplete.mockReturnValue(false)
+    const { app, getTopology } = createApp()
+
+    expect((await app.request('/api/topology/example')).status).toBe(404)
+    expect(getTopology).toHaveBeenCalledWith('example')
+  })
+})

--- a/apps/server/api/src/api/legacy-topology.ts
+++ b/apps/server/api/src/api/legacy-topology.ts
@@ -1,0 +1,46 @@
+import type { Hono } from 'hono'
+import { generateMetricsHtml } from '../html-generator.js'
+import { authMiddleware } from '../middleware/auth.js'
+import type { TopologyManager } from '../topology.js'
+import type { WeathermapConfig } from '../types.js'
+
+type LegacyTopologyLookup = Pick<TopologyManager, 'getTopology'>
+
+/**
+ * Register the file-backed topology endpoints retained for compatibility.
+ *
+ * These routes live outside the `/api` router, so they must install the same
+ * authentication boundary explicitly. Keeping registration in one function
+ * prevents a legacy endpoint from being added without its auth middleware.
+ */
+export function registerLegacyTopologyRoutes(
+  app: Hono,
+  topologyManager: LegacyTopologyLookup,
+  weathermap: WeathermapConfig,
+): void {
+  app.use('/api/topology/*', authMiddleware)
+  app.use('/topology/*', authMiddleware)
+
+  app.get('/api/topology/:name', (c) => {
+    const name = c.req.param('name')
+    const instance = topologyManager.getTopology(name)
+    if (!instance) {
+      return c.json({ error: 'Topology not found' }, 404)
+    }
+    return c.json({
+      name: instance.name,
+      graph: instance.graph,
+      metrics: instance.metrics,
+    })
+  })
+
+  app.get('/topology/:name', (c) => {
+    const name = c.req.param('name')
+    const instance = topologyManager.getTopology(name)
+    if (!instance) {
+      return c.html('<h1>Topology not found</h1>', 404)
+    }
+
+    return c.html(generateMetricsHtml(instance, { weathermap }))
+  })
+}

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -10,9 +10,9 @@ import { Hono } from 'hono'
 import { serveStatic } from 'hono/bun'
 import { cors } from 'hono/cors'
 import { createApiRouter } from './api/index.js'
+import { registerLegacyTopologyRoutes } from './api/legacy-topology.js'
 import { applyMappingBandwidth, getTopologyService } from './api/topologies.js'
 import { closeDatabase, initDatabase } from './db/index.js'
-import { generateMetricsHtml } from './html-generator.js'
 import { MockMetricsProvider } from './mock-metrics.js'
 import {
   hasMetricsCapability,
@@ -86,34 +86,7 @@ export class Server {
 
   private setupBaseRoutes(): void {
     this.app.use('*', cors())
-
-    // Legacy API: Get topology details with current metrics (by name)
-    this.app.get('/api/topology/:name', (c) => {
-      const name = c.req.param('name')
-      const instance = this.topologyManager.getTopology(name)
-      if (!instance) {
-        return c.json({ error: 'Topology not found' }, 404)
-      }
-      return c.json({
-        name: instance.name,
-        graph: instance.graph,
-        metrics: instance.metrics,
-      })
-    })
-
-    // Legacy: Topology view (HTML page with real-time updates)
-    this.app.get('/topology/:name', (c) => {
-      const name = c.req.param('name')
-      const instance = this.topologyManager.getTopology(name)
-      if (!instance) {
-        return c.html('<h1>Topology not found</h1>', 404)
-      }
-
-      const html = generateMetricsHtml(instance, {
-        weathermap: this.config.weathermap,
-      })
-      return c.html(html)
-    })
+    registerLegacyTopologyRoutes(this.app, this.topologyManager, this.config.weathermap)
   }
 
   private setupStaticFileServing(): void {


### PR DESCRIPTION
## Summary

- apply the standard authentication middleware to the legacy topology JSON and HTML routes
- centralize registration so legacy routes outside the `/api` router cannot silently miss the auth boundary
- preserve session access and the initial pre-setup behavior

## Root cause

`/api/topology/:name` and `/topology/:name` were registered directly on the root Hono app. Unlike routes mounted through `createApiRouter()`, they never passed through `authMiddleware`, so an anonymous client could read topology data after setup.

## Verification

- `bun x vitest run src/api/legacy-topology.test.ts src/middleware/auth.test.ts` (12 tests)
- `bun run test` (40/40 tasks)
- `bun run typecheck` (40/40 tasks)
- `bun run lint` (40/40 tasks)
- `bun run version:products:check`
- isolated dev-server smoke test: both anonymous legacy endpoints return 401; authenticated dev request passes auth and reaches the expected topology lookup

No changeset is required because this only changes the private server application.