### PR TITLE
refactor(server): migrate topology CRUD to OpenAPI

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -191,7 +191,8 @@ Base path `/api`. (`/api/auth` and `/api/share` are public; everything else requ
 | `/ws` | WebSocket — real-time metrics stream |
 
 The OpenAPI document is generated from the same Zod schemas that validate
-migrated routes at runtime. Coverage is being expanded resource by resource;
+migrated routes at runtime. It currently includes system/admin diagnostics and
+topology CRUD. Coverage is being expanded resource by resource;
 the endpoint table remains the reference for routes not yet present in the
 generated contract.
 

--- a/apps/server/api/README.md
+++ b/apps/server/api/README.md
@@ -59,6 +59,10 @@ bun run dev:server:request -- GET /api/openapi.json
 bun run dev:server:request -- GET /api/admin/status
 ```
 
+The generated contract currently covers health, system/admin diagnostics, and
+topology CRUD. Rendering, mapping, source attachment, and sync routes remain in
+`src/api/topologies.ts` while they are migrated feature by feature.
+
 See the [server README](../README.md) for the full endpoint list, environment variables, and deployment.
 
 ## License

--- a/apps/server/api/src/api/index.ts
+++ b/apps/server/api/src/api/index.ts
@@ -3,12 +3,14 @@
  * Combines all API endpoints
  */
 
-import { OpenAPIHono } from '@hono/zod-openapi'
+import type { OpenAPIHono } from '@hono/zod-openapi'
 import { INTERACTIVE_IIFE } from '@shumoku/renderer-html/iife-string'
 import type { AppServices } from '../app/services.js'
 import { authMiddleware } from '../middleware/auth.js'
 import { createAdminApi } from '../modules/admin/routes.js'
 import { createHealthApi, createSystemApi } from '../modules/system/routes.js'
+import { createTopologyCrudApi } from '../modules/topologies/routes.js'
+import { createOpenAPIApp } from '../openapi/common.js'
 import { createAuthApi } from './auth.js'
 import { createDashboardsApi } from './dashboards.js'
 import { createDataSourcesApi } from './datasources.js'
@@ -22,12 +24,7 @@ import { topologySourcesApi } from './topology-sources.js'
 import { webhooksApi } from './webhooks.js'
 
 export function createApiRouter(services: AppServices): OpenAPIHono {
-  const api = new OpenAPIHono({
-    defaultHook: (result, c) => {
-      if (!result.success) return c.json({ error: 'Invalid request' }, 400)
-      return undefined
-    },
-  })
+  const api = createOpenAPIApp()
 
   api.openAPIRegistry.registerComponent('securitySchemes', 'sessionCookie', {
     type: 'apiKey',
@@ -60,6 +57,7 @@ export function createApiRouter(services: AppServices): OpenAPIHono {
   api.route('/datasources', createDataSourcesApi())
   api.route('/datasources', createScanRoute()) // POST /datasources/:id/scan
   api.route('/plugins', createPluginsApi())
+  api.route('/topologies', createTopologyCrudApi(services))
   api.route('/topologies', createTopologiesApi())
   api.route('/topologies', topologySourcesApi) // Nested: /topologies/:id/sources
   api.route('/topologies', createObservationsRoute()) // /topologies/:id/observations + /resolved

--- a/apps/server/api/src/api/topologies.ts
+++ b/apps/server/api/src/api/topologies.ts
@@ -19,13 +19,7 @@ import { ObservationsService } from '../services/observations.js'
 import { cancelSyncJob, getSyncJob, startSyncJob, syncJobView } from '../services/sync-job.js'
 import { type ParsedTopology, TopologyService } from '../services/topology.js'
 import { TopologySourcesService } from '../services/topology-sources.js'
-import type {
-  CompositionMode,
-  MetricsMapping,
-  ScopeMode,
-  Topology,
-  TopologyInput,
-} from '../types.js'
+import type { CompositionMode, MetricsMapping, ScopeMode, Topology } from '../types.js'
 import { buildSourceMetricsMappingView } from './source-mapping-view.js'
 
 /**
@@ -216,12 +210,6 @@ export function createTopologiesApi(): Hono {
   const service = getTopologyService()
   const dataSourceService = getDataSourceService()
 
-  // List all topologies
-  app.get('/', (c) => {
-    const topologies = service.list()
-    return c.json(topologies)
-  })
-
   // Get parsed topology with graph and layout
   // NOTE: More specific routes must be defined before /:id
   app.get('/:id/parsed', async (c) => {
@@ -378,51 +366,6 @@ export function createTopologiesApi(): Hono {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return c.json({ error: message }, 500)
-    }
-  })
-
-  // Get single topology (must be after all /:id/* routes)
-  app.get('/:id', (c) => {
-    const id = c.req.param('id')
-    const topology = service.get(id)
-    if (!topology) {
-      return c.json({ error: 'Topology not found' }, 404)
-    }
-    return c.json(topology)
-  })
-
-  // Create new topology
-  app.post('/', async (c) => {
-    try {
-      const body = (await c.req.json()) as TopologyInput
-      if (!body.name) {
-        return c.json({ error: 'name is required' }, 400)
-      }
-      // contentJson is optional — when present, create() attaches a
-      // Manual source and records the first observation. See
-      // TopologyService.create().
-
-      const topology = await service.create(body)
-      return c.json(topology, 201)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      return c.json({ error: message }, 400)
-    }
-  })
-
-  // Update topology
-  app.put('/:id', async (c) => {
-    const id = c.req.param('id')
-    try {
-      const body = (await c.req.json()) as Partial<TopologyInput>
-      const topology = await service.update(id, body)
-      if (!topology) {
-        return c.json({ error: 'Topology not found' }, 404)
-      }
-      return c.json(topology)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      return c.json({ error: message }, 400)
     }
   })
 
@@ -984,16 +927,6 @@ export function createTopologiesApi(): Hono {
     const id = c.req.param('id')
     const success = service.unshare(id)
     if (!success) {
-      return c.json({ error: 'Topology not found' }, 404)
-    }
-    return c.json({ success: true })
-  })
-
-  // Delete topology
-  app.delete('/:id', (c) => {
-    const id = c.req.param('id')
-    const deleted = service.delete(id)
-    if (!deleted) {
       return c.json({ error: 'Topology not found' }, 404)
     }
     return c.json({ success: true })

--- a/apps/server/api/src/app/services.ts
+++ b/apps/server/api/src/app/services.ts
@@ -1,4 +1,13 @@
 import type { BuildInfo, SystemInfo } from '../services/system-info.js'
+import type { Topology, TopologyInput } from '../types.js'
+
+export interface TopologyCrudService {
+  list(): Topology[]
+  get(id: string): Topology | null
+  create(input: TopologyInput): Promise<Topology>
+  update(id: string, input: Partial<TopologyInput>): Promise<Topology | null>
+  delete(id: string): boolean
+}
 
 export interface PollSchedulerStatusView {
   running: boolean
@@ -57,4 +66,5 @@ export interface AppServices {
   admin: {
     getStatus(): AdminStatus
   }
+  topologies: TopologyCrudService
 }

--- a/apps/server/api/src/modules/admin/routes.test.ts
+++ b/apps/server/api/src/modules/admin/routes.test.ts
@@ -33,19 +33,8 @@ const status = {
   },
 }
 
-function createServices(): AppServices {
+function createServices(): Pick<AppServices, 'admin'> {
   return {
-    system: {
-      getBuildInfo: () => ({
-        version: 'test',
-        channel: 'development',
-        deployment: 'source',
-      }),
-      getSystemInfo: async () => ({
-        build: { version: 'test', channel: 'development', deployment: 'source' },
-        update: { status: 'disabled', currentVersion: 'test' },
-      }),
-    },
     admin: { getStatus: () => status },
   }
 }

--- a/apps/server/api/src/modules/admin/routes.ts
+++ b/apps/server/api/src/modules/admin/routes.ts
@@ -1,6 +1,10 @@
-import { createRoute, OpenAPIHono } from '@hono/zod-openapi'
+import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
-import { protectedRouteSecurity, unauthorizedResponse } from '../../openapi/common.js'
+import {
+  createOpenAPIApp,
+  protectedRouteSecurity,
+  unauthorizedResponse,
+} from '../../openapi/common.js'
 import { AdminStatusSchema } from './schemas.js'
 
 const statusRoute = createRoute({
@@ -19,8 +23,8 @@ const statusRoute = createRoute({
   },
 })
 
-export function createAdminApi(services: AppServices): OpenAPIHono {
-  const app = new OpenAPIHono()
+export function createAdminApi(services: Pick<AppServices, 'admin'>): OpenAPIHono {
+  const app = createOpenAPIApp()
   app.openapi(statusRoute, (c) => c.json(services.admin.getStatus(), 200))
   return app
 }

--- a/apps/server/api/src/modules/system/routes.test.ts
+++ b/apps/server/api/src/modules/system/routes.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { AppServices } from '../../app/services.js'
 import { createHealthApi, createSystemApi } from './routes.js'
 
-function createServices(): AppServices {
+function createServices(): Pick<AppServices, 'system'> {
   return {
     system: {
       getBuildInfo: () => ({
@@ -20,7 +20,6 @@ function createServices(): AppServices {
         update: { status: 'disabled', currentVersion: '0.1.0' },
       })),
     },
-    admin: { getStatus: vi.fn() },
   }
 }
 

--- a/apps/server/api/src/modules/system/routes.ts
+++ b/apps/server/api/src/modules/system/routes.ts
@@ -1,7 +1,8 @@
-import { createRoute, OpenAPIHono } from '@hono/zod-openapi'
+import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
 import {
   badRequestResponse,
+  createOpenAPIApp,
   protectedRouteSecurity,
   unauthorizedResponse,
 } from '../../openapi/common.js'
@@ -37,8 +38,8 @@ const systemRoute = createRoute({
   },
 })
 
-export function createHealthApi(services: AppServices): OpenAPIHono {
-  const app = new OpenAPIHono()
+export function createHealthApi(services: Pick<AppServices, 'system'>): OpenAPIHono {
+  const app = createOpenAPIApp()
   app.openapi(healthRoute, (c) =>
     c.json(
       {
@@ -52,8 +53,8 @@ export function createHealthApi(services: AppServices): OpenAPIHono {
   return app
 }
 
-export function createSystemApi(services: AppServices): OpenAPIHono {
-  const app = new OpenAPIHono()
+export function createSystemApi(services: Pick<AppServices, 'system'>): OpenAPIHono {
+  const app = createOpenAPIApp()
   app.openapi(systemRoute, async (c) => {
     const { refresh } = c.req.valid('query')
     return c.json(await services.system.getSystemInfo(refresh === 'true'), 200)

--- a/apps/server/api/src/modules/topologies/routes.test.ts
+++ b/apps/server/api/src/modules/topologies/routes.test.ts
@@ -1,0 +1,104 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { describe, expect, it, vi } from 'vitest'
+import type { TopologyCrudService } from '../../app/services.js'
+import type { Topology } from '../../types.js'
+import { createTopologyCrudApi } from './routes.js'
+
+function topology(overrides: Partial<Topology> = {}): Topology {
+  return {
+    id: 'topology-1',
+    name: 'Core Network',
+    compositionMode: 'additive',
+    scopeMode: 'auto',
+    scope: { include: [], exclude: [] },
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+function createService(): TopologyCrudService {
+  const items = new Map<string, Topology>([['topology-1', topology()]])
+  return {
+    list: vi.fn(() => [...items.values()]),
+    get: vi.fn((id) => items.get(id) ?? null),
+    create: vi.fn(async (input) => {
+      const created = topology({ id: 'topology-2', name: input.name })
+      items.set(created.id, created)
+      return created
+    }),
+    update: vi.fn(async (id, input) => {
+      const current = items.get(id)
+      if (!current) return null
+      const updated = topology({ ...current, ...input, updatedAt: 2 })
+      items.set(id, updated)
+      return updated
+    }),
+    delete: vi.fn((id) => items.delete(id)),
+  }
+}
+
+function createApp(service: TopologyCrudService): OpenAPIHono {
+  return new OpenAPIHono().route('/topologies', createTopologyCrudApi({ topologies: service }))
+}
+
+describe('OpenAPI topology CRUD routes', () => {
+  it('preserves list, get, create, update, and delete behavior', async () => {
+    const app = createApp(createService())
+
+    expect((await app.request('/topologies')).status).toBe(200)
+    expect((await app.request('/topologies/topology-1')).status).toBe(200)
+
+    const createResponse = await app.request('/topologies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Branch Network' }),
+    })
+    expect(createResponse.status).toBe(201)
+    expect(await createResponse.json()).toMatchObject({
+      id: 'topology-2',
+      name: 'Branch Network',
+    })
+
+    const updateResponse = await app.request('/topologies/topology-2', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Updated Branch' }),
+    })
+    expect(updateResponse.status).toBe(200)
+    expect(await updateResponse.json()).toMatchObject({ name: 'Updated Branch' })
+
+    expect((await app.request('/topologies/topology-2', { method: 'DELETE' })).status).toBe(200)
+    expect((await app.request('/topologies/topology-2')).status).toBe(404)
+  })
+
+  it('rejects an invalid create request before calling the service', async () => {
+    const service = createService()
+    const response = await createApp(service).request('/topologies', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '' }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid request' })
+    expect(service.create).not.toHaveBeenCalled()
+  })
+
+  it('publishes all CRUD operations with protected security', () => {
+    const app = createApp(createService())
+    const document = app.getOpenAPI31Document({
+      openapi: '3.1.0',
+      info: { title: 'test', version: 'test' },
+    })
+
+    expect(document.paths['/topologies']?.get?.security).toEqual([
+      { sessionCookie: [] },
+      { bearerAuth: [] },
+    ])
+    expect(document.paths['/topologies']?.post).toBeDefined()
+    expect(document.paths['/topologies/{id}']?.get).toBeDefined()
+    expect(document.paths['/topologies/{id}']?.put).toBeDefined()
+    expect(document.paths['/topologies/{id}']?.delete).toBeDefined()
+  })
+})

--- a/apps/server/api/src/modules/topologies/routes.ts
+++ b/apps/server/api/src/modules/topologies/routes.ts
@@ -1,0 +1,159 @@
+import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
+import type { AppServices } from '../../app/services.js'
+import {
+  badRequestResponse,
+  createOpenAPIApp,
+  ErrorSchema,
+  protectedRouteSecurity,
+  unauthorizedResponse,
+} from '../../openapi/common.js'
+import {
+  CreateTopologySchema,
+  DeleteTopologyResultSchema,
+  TopologyIdParamsSchema,
+  TopologyListSchema,
+  TopologySchema,
+  UpdateTopologySchema,
+} from './schemas.js'
+
+const notFoundResponse = {
+  description: 'The topology does not exist',
+  content: { 'application/json': { schema: ErrorSchema } },
+} as const
+
+const listRoute = createRoute({
+  method: 'get',
+  path: '/',
+  tags: ['Topologies'],
+  summary: 'List topologies',
+  security: protectedRouteSecurity,
+  responses: {
+    200: {
+      description: 'Topology shells ordered by name',
+      content: { 'application/json': { schema: TopologyListSchema } },
+    },
+    401: unauthorizedResponse,
+  },
+})
+
+const getRoute = createRoute({
+  method: 'get',
+  path: '/{id}',
+  tags: ['Topologies'],
+  summary: 'Get a topology',
+  security: protectedRouteSecurity,
+  request: { params: TopologyIdParamsSchema },
+  responses: {
+    200: {
+      description: 'Topology shell',
+      content: { 'application/json': { schema: TopologySchema } },
+    },
+    401: unauthorizedResponse,
+    404: notFoundResponse,
+  },
+})
+
+const createTopologyRoute = createRoute({
+  method: 'post',
+  path: '/',
+  tags: ['Topologies'],
+  summary: 'Create a topology',
+  security: protectedRouteSecurity,
+  request: {
+    body: {
+      required: true,
+      content: { 'application/json': { schema: CreateTopologySchema } },
+    },
+  },
+  responses: {
+    201: {
+      description: 'Created topology shell',
+      content: { 'application/json': { schema: TopologySchema } },
+    },
+    400: badRequestResponse,
+    401: unauthorizedResponse,
+  },
+})
+
+const updateRoute = createRoute({
+  method: 'put',
+  path: '/{id}',
+  tags: ['Topologies'],
+  summary: 'Update a topology',
+  security: protectedRouteSecurity,
+  request: {
+    params: TopologyIdParamsSchema,
+    body: {
+      required: true,
+      content: { 'application/json': { schema: UpdateTopologySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Updated topology shell',
+      content: { 'application/json': { schema: TopologySchema } },
+    },
+    400: badRequestResponse,
+    401: unauthorizedResponse,
+    404: notFoundResponse,
+  },
+})
+
+const deleteRoute = createRoute({
+  method: 'delete',
+  path: '/{id}',
+  tags: ['Topologies'],
+  summary: 'Delete a topology',
+  security: protectedRouteSecurity,
+  request: { params: TopologyIdParamsSchema },
+  responses: {
+    200: {
+      description: 'Topology deleted',
+      content: { 'application/json': { schema: DeleteTopologyResultSchema } },
+    },
+    401: unauthorizedResponse,
+    404: notFoundResponse,
+  },
+})
+
+export function createTopologyCrudApi(services: Pick<AppServices, 'topologies'>): OpenAPIHono {
+  const app = createOpenAPIApp()
+  const service = services.topologies
+
+  app.openapi(listRoute, (c) => c.json(service.list(), 200))
+
+  app.openapi(getRoute, (c) => {
+    const topology = service.get(c.req.valid('param').id)
+    if (!topology) return c.json({ error: 'Topology not found' }, 404)
+    return c.json(topology, 200)
+  })
+
+  app.openapi(createTopologyRoute, async (c) => {
+    try {
+      return c.json(await service.create(c.req.valid('json')), 201)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 400)
+    }
+  })
+
+  app.openapi(updateRoute, async (c) => {
+    try {
+      const topology = await service.update(c.req.valid('param').id, c.req.valid('json'))
+      if (!topology) return c.json({ error: 'Topology not found' }, 404)
+      return c.json(topology, 200)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return c.json({ error: message }, 400)
+    }
+  })
+
+  app.openapi(deleteRoute, (c) => {
+    if (!service.delete(c.req.valid('param').id)) {
+      return c.json({ error: 'Topology not found' }, 404)
+    }
+    return c.json({ success: true as const }, 200)
+  })
+
+  return app
+}

--- a/apps/server/api/src/modules/topologies/schemas.ts
+++ b/apps/server/api/src/modules/topologies/schemas.ts
@@ -1,0 +1,53 @@
+import { z } from '@hono/zod-openapi'
+
+const MembershipCriterionSchema = z.object({
+  attr: z.enum(['name', 'subnet', 'metadata']),
+  value: z.string(),
+  key: z.string().optional(),
+})
+
+const ScopeFilterSchema = z.object({
+  include: z.array(MembershipCriterionSchema).optional(),
+  exclude: z.array(MembershipCriterionSchema).optional(),
+})
+
+export const TopologySchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    compositionMode: z.enum(['additive', 'enrichment']),
+    scopeMode: z.enum(['auto', 'open', 'closed']),
+    scopeSourceId: z.string().optional(),
+    scope: ScopeFilterSchema,
+    metricsSourceId: z.string().optional(),
+    mappingJson: z.string().optional(),
+    shareToken: z.string().optional(),
+    createdAt: z.number().int(),
+    updatedAt: z.number().int(),
+  })
+  .openapi('Topology')
+
+export const TopologyListSchema = z.array(TopologySchema).openapi('TopologyList')
+
+export const TopologyIdParamsSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .openapi({ param: { name: 'id', in: 'path' } }),
+})
+
+export const CreateTopologySchema = z
+  .object({
+    name: z.string().min(1),
+  })
+  .openapi('CreateTopology')
+
+export const UpdateTopologySchema = z
+  .object({
+    name: z.string().min(1).optional(),
+  })
+  .openapi('UpdateTopology')
+
+export const DeleteTopologyResultSchema = z
+  .object({ success: z.literal(true) })
+  .openapi('DeleteTopologyResult')

--- a/apps/server/api/src/openapi/common.ts
+++ b/apps/server/api/src/openapi/common.ts
@@ -1,4 +1,13 @@
-import { z } from '@hono/zod-openapi'
+import { OpenAPIHono, z } from '@hono/zod-openapi'
+
+export function createOpenAPIApp(): OpenAPIHono {
+  return new OpenAPIHono({
+    defaultHook: (result, c) => {
+      if (!result.success) return c.json({ error: 'Invalid request' }, 400)
+      return undefined
+    },
+  })
+}
 
 export const ErrorSchema = z
   .object({

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -585,6 +585,7 @@ export class Server {
     return {
       system: { getBuildInfo, getSystemInfo },
       admin: { getStatus: () => this.getAdminStatus() },
+      topologies: getTopologyService(),
     }
   }
 

--- a/apps/server/api/test/api/openapi.test.ts
+++ b/apps/server/api/test/api/openapi.test.ts
@@ -6,6 +6,7 @@ import { Hono } from 'hono'
 import { createApiRouter } from '../../src/api/index.js'
 import type { AppServices } from '../../src/app/services.js'
 import { getDatabase } from '../../src/db/index.js'
+import { TopologyService } from '../../src/services/topology.js'
 import { setupTempDb, type TempDb } from '../db/helper.js'
 
 const DEV_TOKEN = 'a'.repeat(64)
@@ -13,6 +14,7 @@ let database: TempDb
 let originalNodeEnv: string | undefined
 let originalHost: string | undefined
 let originalDevToken: string | undefined
+let topologyService: TopologyService
 
 const services: AppServices = {
   system: {
@@ -56,6 +58,13 @@ const services: AppServices = {
       },
     }),
   },
+  topologies: {
+    list: () => topologyService.list(),
+    get: (id) => topologyService.get(id),
+    create: (input) => topologyService.create(input),
+    update: (id, input) => topologyService.update(id, input),
+    delete: (id) => topologyService.delete(id),
+  },
 }
 
 beforeAll(() => {
@@ -69,6 +78,7 @@ beforeAll(() => {
   process.env['NODE_ENV'] = 'development'
   process.env['HOST'] = '127.0.0.1'
   process.env['SHUMOKU_DEV_API_TOKEN'] = DEV_TOKEN
+  topologyService = new TopologyService()
 })
 
 afterAll(() => {
@@ -109,5 +119,52 @@ describe('OpenAPI root integration', () => {
     expect(document.paths['/health']?.get).toBeDefined()
     expect(document.paths['/system']?.get).toBeDefined()
     expect(document.paths['/admin/status']?.get).toBeDefined()
+    expect(document.paths['/topologies']?.get).toBeDefined()
+    expect(document.paths['/topologies']?.post).toBeDefined()
+    expect(document.paths['/topologies/{id}']?.get).toBeDefined()
+    expect(document.paths['/topologies/{id}']?.put).toBeDefined()
+    expect(document.paths['/topologies/{id}']?.delete).toBeDefined()
+  })
+
+  test('supports authenticated topology CRUD through the generated contract', async () => {
+    const app = createApp()
+    const headers = {
+      Authorization: `Bearer ${DEV_TOKEN}`,
+      'Content-Type': 'application/json',
+    }
+
+    const createResponse = await app.request('/api/topologies', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ name: 'Automation Lab' }),
+    })
+    const created = (await createResponse.json()) as { id: string; name: string }
+    expect(createResponse.status).toBe(201)
+    expect(created.name).toBe('Automation Lab')
+
+    const updateResponse = await app.request(`/api/topologies/${created.id}`, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify({ name: 'Automation Lab Updated' }),
+    })
+    expect(updateResponse.status).toBe(200)
+    expect(await updateResponse.json()).toMatchObject({ name: 'Automation Lab Updated' })
+
+    const listResponse = await app.request('/api/topologies', { headers })
+    expect(listResponse.status).toBe(200)
+    expect(await listResponse.json()).toEqual([
+      expect.objectContaining({ id: created.id, name: 'Automation Lab Updated' }),
+    ])
+
+    expect((await app.request(`/api/topologies/${created.id}`, { headers })).status).toBe(200)
+    expect(
+      (
+        await app.request(`/api/topologies/${created.id}`, {
+          method: 'DELETE',
+          headers,
+        })
+      ).status,
+    ).toBe(200)
+    expect((await app.request(`/api/topologies/${created.id}`, { headers })).status).toBe(404)
   })
 })

--- a/apps/server/docs/api.en.mdx
+++ b/apps/server/docs/api.en.mdx
@@ -51,7 +51,7 @@ bun run dev:server:request -- GET /api/openapi.json
 
 Request and response schemas are the source of truth for migrated routes, and
 request schemas also perform runtime validation. Migration is incremental: the document
-currently covers health, system information, and the admin runtime status;
+currently covers health, system information, the admin runtime status, and topology CRUD;
 the manually documented endpoints below remain available while their contracts
 move to the generated document.
 

--- a/apps/server/docs/api.ja.mdx
+++ b/apps/server/docs/api.ja.mdx
@@ -51,8 +51,9 @@ bun run dev:server:request -- GET /api/openapi.json
 
 移行済みルートではrequest/response schemaが唯一の定義となり、request schemaは
 実行時検証にも使われます。
-移行は段階的です。現在の生成ドキュメントはhealth、system情報、admin runtime statusを
-収録し、以下の手動記載エンドポイントは契約を移行する間も引き続き利用できます。
+移行は段階的です。現在の生成ドキュメントはhealth、system情報、admin runtime status、
+トポロジーCRUDを収録し、以下の手動記載エンドポイントは契約を移行する間も引き続き
+利用できます。
 
 ## 共有ビュー（公開・トークンスコープ）
 


### PR DESCRIPTION
## Summary
- move topology list/get/create/update/delete into a feature-local OpenAPI module
- validate create/update requests with Zod and publish response/security schemas
- inject the topology CRUD service at the application boundary
- centralize migrated-route validation errors and update API documentation

## Compatibility
- preserves existing API URLs, response shapes, status codes, and authentication
- leaves render, mapping, source, composition, and sync routes in the legacy module for later incremental migration

## Verification
- API tests: 21 Vitest files / 123 tests and 21 Bun files / 159 tests
- monorepo test: 40/40 tasks
- monorepo typecheck: 40/40 tasks
- monorepo lint: 40/40 tasks
- knip and product version consistency checks pass

No changeset: this changes the private Server application only.