### PR TITLE
docs: link the homepage demo button to the live demo share view

### DIFF
--- a/apps/docs/components/home/HeroSection.tsx
+++ b/apps/docs/components/home/HeroSection.tsx
@@ -34,7 +34,18 @@ export function HeroSection({ locale }: { locale: string }) {
                 {t.deploy}
                 <ArrowRightIcon className="w-4 h-4" />
               </Link>
-              <a href="mailto:contact@shumoku.dev" className={cn(...buttonStyles.secondary)}>
+              <a
+                href="https://demo.shumoku.dev/share/topologies/R71ZG1gEigiVY82YKpgDT03I"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(...buttonStyles.secondary)}
+              >
+                {t.liveDemo}
+              </a>
+              <a
+                href="mailto:contact@shumoku.dev"
+                className="inline-flex items-center gap-1.5 text-sm text-neutral-500 dark:text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-300 transition-colors"
+              >
                 {t.demo}
               </a>
               <a

--- a/apps/docs/components/home/translations.ts
+++ b/apps/docs/components/home/translations.ts
@@ -5,6 +5,7 @@ export type HeroTranslations = {
   description1: string
   description2: string
   deploy: string
+  liveDemo: string
   demo: string
   githubLabel: string
 }
@@ -106,6 +107,7 @@ export const homeTranslations = {
       description1: 'Automatically derived from real infrastructure.',
       description2: 'Built for operations teams and enterprise environments.',
       deploy: 'Deploy Server',
+      liveDemo: 'Live Demo',
       demo: 'Request Demo',
       githubLabel: 'GitHub',
     },
@@ -386,7 +388,8 @@ export const homeTranslations = {
       description1: '現実のインフラから自動生成される構造基盤。',
       description2: '運用チームとエンタープライズ環境のために。',
       deploy: 'サーバーを導入',
-      demo: 'デモを見る',
+      liveDemo: 'デモを見る',
+      demo: 'デモを依頼',
       githubLabel: 'GitHub',
     },
     why: {


### PR DESCRIPTION
## Summary
- The hero's demo button was a `mailto:contact@shumoku.dev` link, so visitors clicking **Request Demo / デモを見る** never reached demo.shumoku.dev.
- Point the button at the public read-only share view of the demo topology (https://demo.shumoku.dev/share/topologies/R71ZG1gEigiVY82YKpgDT03I), opening in a new tab.
- Keep the sales contact as a plain text link (**Request Demo** / **デモを依頼**) next to the GitHub link.

## Notes
- The share view is the quick win; a proper public demo mode (anonymous read-only session on the server) remains a follow-up.
- Docs app only — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sfsReNLJA7HRc4ZZDrXiz