### PR TITLE
feat(server): harden the OpenAPI contract

### DIFF
--- a/.github/workflows/openapi-compatibility.yml
+++ b/.github/workflows/openapi-compatibility.yml
@@ -1,0 +1,29 @@
+name: OpenAPI Compatibility
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - apps/server/api/openapi.json
+      - .github/workflows/openapi-compatibility.yml
+
+permissions:
+  contents: read
+
+jobs:
+  breaking-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+
+      - name: Reject breaking OpenAPI changes
+        uses: oasdiff/oasdiff-action/breaking@2649ebe137aeb72a95707671204e829f86e091fc # v0.1.13
+        with:
+          base: origin/${{ github.base_ref }}:apps/server/api/openapi.json
+          revision: HEAD:apps/server/api/openapi.json
+          fail-on: WARN

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -195,7 +195,21 @@ HTTP route at runtime. It is the source of truth for management, sharing,
 discovery, rendering, mapping, sync, plugin, and webhook operations.
 `bun run openapi:generate` (from the repository root) writes the committed
 OpenAPI snapshot and typed web client definitions. CI rejects stale artifacts
-and any runtime route missing from the contract.
+and any runtime route missing from the contract. Every operation receives a
+deterministic, unique `operationId`, and CI uses `oasdiff` to reject breaking
+contract changes against the PR base branch.
+
+JSON errors have one machine-readable envelope. `error` remains as a deprecated
+compatibility alias for `message`:
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "Topology not found",
+  "requestId": "00000000-0000-4000-8000-000000000000",
+  "error": "Topology not found"
+}
+```
 
 ### WebSocket
 

--- a/apps/server/api/openapi.json
+++ b/apps/server/api/openapi.json
@@ -71,11 +71,29 @@
       "Error": {
         "type": "object",
         "properties": {
+          "code": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Z0-9_]*$",
+            "example": "NOT_FOUND"
+          },
+          "message": {
+            "type": "string",
+            "example": "Topology not found"
+          },
+          "requestId": {
+            "type": "string",
+            "format": "uuid"
+          },
           "error": {
-            "type": "string"
+            "type": "string",
+            "deprecated": true,
+            "description": "Deprecated alias of message, retained for compatibility"
           }
         },
         "required": [
+          "code",
+          "message",
+          "requestId",
           "error"
         ]
       },
@@ -3467,7 +3485,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getAuthStatus"
       }
     },
     "/auth/setup": {
@@ -3507,7 +3526,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postAuthSetup"
       }
     },
     "/auth/login": {
@@ -3567,7 +3587,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postAuthLogin"
       }
     },
     "/auth/change-password": {
@@ -3622,7 +3643,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postAuthChangePassword"
       }
     },
     "/auth/logout": {
@@ -3642,7 +3664,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postAuthLogout"
       }
     },
     "/health": {
@@ -3662,7 +3685,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getHealth"
       }
     },
     "/share/topologies/{token}": {
@@ -3733,7 +3757,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareTopologiesByToken"
       }
     },
     "/share/topologies/{token}/graph": {
@@ -3804,7 +3829,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareTopologiesByTokenGraph"
       }
     },
     "/share/topologies/{token}/view": {
@@ -3875,7 +3901,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareTopologiesByTokenView"
       }
     },
     "/share/topologies/{token}/render": {
@@ -3946,7 +3973,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareTopologiesByTokenRender"
       }
     },
     "/share/topologies/{token}/metrics/stream": {
@@ -3998,7 +4026,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareTopologiesByTokenMetricsStream"
       }
     },
     "/share/dashboards/{token}": {
@@ -4069,7 +4098,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareDashboardsByToken"
       }
     },
     "/share/dashboards/{token}/topologies/{id}": {
@@ -4149,7 +4179,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareDashboardsByTokenTopologiesById"
       }
     },
     "/share/dashboards/{token}/topologies/{id}/graph": {
@@ -4229,7 +4260,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareDashboardsByTokenTopologiesByIdGraph"
       }
     },
     "/share/dashboards/{token}/topologies/{id}/context": {
@@ -4309,7 +4341,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareDashboardsByTokenTopologiesByIdContext"
       }
     },
     "/share/dashboards/{token}/topologies/{id}/metrics/stream": {
@@ -4370,7 +4403,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareDashboardsByTokenTopologiesByIdMetricsStream"
       }
     },
     "/share/dashboards/{token}/datasources/{id}/alerts": {
@@ -4488,7 +4522,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getShareDashboardsByTokenDatasourcesByIdAlerts"
       }
     },
     "/datasources/types": {
@@ -4526,7 +4561,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesTypes"
       }
     },
     "/datasources/by-capability/{capability}": {
@@ -4589,7 +4625,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByCapabilityByCapability"
       }
     },
     "/datasources/{id}/config-options/{key}": {
@@ -4657,7 +4694,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByIdConfigOptionsByKey"
       }
     },
     "/datasources/{id}/connection-info": {
@@ -4714,7 +4752,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByIdConnectionInfo"
       }
     },
     "/datasources/{id}/topologies": {
@@ -4773,7 +4812,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByIdTopologies"
       }
     },
     "/datasources/{id}/test": {
@@ -4822,7 +4862,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postDatasourcesByIdTest"
       }
     },
     "/datasources/{id}/hosts": {
@@ -4881,7 +4922,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByIdHosts"
       }
     },
     "/datasources/{id}/hosts/{hostId}/items": {
@@ -4949,7 +4991,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByIdHostsByHostIdItems"
       }
     },
     "/datasources/{id}/hosts/{hostId}/neighbors": {
@@ -5017,7 +5060,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByIdHostsByHostIdNeighbors"
       }
     },
     "/datasources/{id}/hosts/{hostId}/metrics": {
@@ -5085,7 +5129,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByIdHostsByHostIdMetrics"
       }
     },
     "/datasources/{id}/filter-options": {
@@ -5155,7 +5200,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByIdFilterOptions"
       }
     },
     "/datasources/{id}/alerts": {
@@ -5259,7 +5305,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesByIdAlerts"
       }
     },
     "/datasources/{id}/_native": {
@@ -5349,7 +5396,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postDatasourcesByIdNative"
       }
     },
     "/datasources/{id}/scan": {
@@ -5438,7 +5486,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postDatasourcesByIdScan"
       }
     },
     "/dashboards": {
@@ -5476,7 +5525,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDashboards"
       },
       "post": {
         "tags": [
@@ -5532,7 +5582,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postDashboards"
       }
     },
     "/dashboards/{id}": {
@@ -5591,7 +5642,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDashboardsById"
       },
       "put": {
         "tags": [
@@ -5668,7 +5720,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putDashboardsById"
       },
       "delete": {
         "tags": [
@@ -5725,7 +5778,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteDashboardsById"
       }
     },
     "/dashboards/{id}/share": {
@@ -5784,7 +5838,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postDashboardsByIdShare"
       },
       "delete": {
         "tags": [
@@ -5841,7 +5896,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteDashboardsByIdShare"
       }
     },
     "/settings": {
@@ -5879,7 +5935,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getSettings"
       },
       "put": {
         "tags": [
@@ -5935,7 +5992,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putSettings"
       }
     },
     "/settings/{key}": {
@@ -5994,7 +6052,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getSettingsByKey"
       },
       "put": {
         "tags": [
@@ -6061,7 +6120,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putSettingsByKey"
       },
       "delete": {
         "tags": [
@@ -6118,7 +6178,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteSettingsByKey"
       }
     },
     "/plugins": {
@@ -6146,7 +6207,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getPlugins"
       },
       "post": {
         "tags": [
@@ -6212,7 +6274,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPlugins"
       }
     },
     "/plugins/{id}/manifest": {
@@ -6281,7 +6344,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getPluginsByIdManifest"
       }
     },
     "/plugins/upload": {
@@ -6362,7 +6426,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPluginsUpload"
       }
     },
     "/plugins/{id}": {
@@ -6441,7 +6506,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "patchPluginsById"
       },
       "delete": {
         "tags": [
@@ -6517,7 +6583,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deletePluginsById"
       }
     },
     "/plugins/reload": {
@@ -6575,7 +6642,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postPluginsReload"
       }
     },
     "/datasources": {
@@ -6613,7 +6681,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasources"
       },
       "post": {
         "tags": [
@@ -6669,7 +6738,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postDatasources"
       }
     },
     "/datasources/{id}": {
@@ -6728,7 +6798,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getDatasourcesById"
       },
       "put": {
         "tags": [
@@ -6805,7 +6876,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putDatasourcesById"
       },
       "delete": {
         "tags": [
@@ -6862,7 +6934,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteDatasourcesById"
       }
     },
     "/topologies": {
@@ -6900,7 +6973,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologies"
       },
       "post": {
         "tags": [
@@ -6956,7 +7030,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologies"
       }
     },
     "/topologies/{id}": {
@@ -7015,7 +7090,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesById"
       },
       "put": {
         "tags": [
@@ -7092,7 +7168,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putTopologiesById"
       },
       "delete": {
         "tags": [
@@ -7149,7 +7226,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteTopologiesById"
       }
     },
     "/topologies/{id}/observations": {
@@ -7251,7 +7329,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdObservations"
       }
     },
     "/topologies/{id}/observations/{obsId}": {
@@ -7309,7 +7388,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdObservationsByObsId"
       }
     },
     "/topologies/{topologyId}/sources/{sourceId}/latest-snapshot": {
@@ -7357,7 +7437,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByTopologyIdSourcesBySourceIdLatestSnapshot"
       }
     },
     "/topologies/{topologyId}/sources/{sourceId}/observation": {
@@ -7461,7 +7542,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByTopologyIdSourcesBySourceIdObservation"
       }
     },
     "/topologies/{id}/resolved": {
@@ -7520,7 +7602,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdResolved"
       }
     },
     "/topologies/{id}/display-settings": {
@@ -7559,7 +7642,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdDisplaySettings"
       },
       "put": {
         "tags": [
@@ -7626,7 +7710,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putTopologiesByIdDisplaySettings"
       }
     },
     "/topologies/{id}/mapping": {
@@ -7724,7 +7809,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdMapping"
       },
       "put": {
         "tags": [
@@ -7860,7 +7946,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putTopologiesByIdMapping"
       }
     },
     "/topologies/{id}/mapping/sources": {
@@ -7972,7 +8059,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdMappingSources"
       }
     },
     "/topologies/{id}/mapping/orphans": {
@@ -8089,7 +8177,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdMappingOrphans"
       }
     },
     "/topologies/{id}/mapping/orphans/{entityId}/reassign": {
@@ -8206,7 +8295,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByIdMappingOrphansByEntityIdReassign"
       }
     },
     "/topologies/{id}/mapping/orphans/{entityId}": {
@@ -8304,7 +8394,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteTopologiesByIdMappingOrphansByEntityId"
       }
     },
     "/topologies/{id}/registry/reset": {
@@ -8393,7 +8484,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByIdRegistryReset"
       }
     },
     "/topologies/{id}/mapping/nodes/{nodeId}": {
@@ -8542,7 +8634,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "patchTopologiesByIdMappingNodesByNodeId"
       }
     },
     "/topologies/{id}/mapping/links/{linkId}": {
@@ -8699,7 +8792,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "patchTopologiesByIdMappingLinksByLinkId"
       }
     },
     "/topologies/{id}/mapping/nodes": {
@@ -8805,7 +8899,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteTopologiesByIdMappingNodes"
       }
     },
     "/topologies/{id}/mapping/links": {
@@ -8911,7 +9006,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteTopologiesByIdMappingLinks"
       }
     },
     "/topologies/{id}/mapping/auto-map-links": {
@@ -9034,7 +9130,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByIdMappingAutoMapLinks"
       }
     },
     "/topologies/{id}/parsed": {
@@ -9123,7 +9220,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdParsed"
       }
     },
     "/topologies/{id}/graph": {
@@ -9212,7 +9310,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdGraph"
       }
     },
     "/topologies/{id}/view": {
@@ -9301,7 +9400,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdView"
       }
     },
     "/topologies/{id}/render": {
@@ -9390,7 +9490,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdRender"
       }
     },
     "/topologies/{id}/context": {
@@ -9479,7 +9580,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdContext"
       }
     },
     "/topologies/{id}/composition": {
@@ -9538,7 +9640,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdComposition"
       },
       "put": {
         "tags": [
@@ -9705,7 +9808,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putTopologiesByIdComposition"
       }
     },
     "/topologies/{topologyId}/sources": {
@@ -9787,7 +9891,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByTopologyIdSources"
       },
       "post": {
         "tags": [
@@ -9889,7 +9994,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByTopologyIdSources"
       },
       "put": {
         "tags": [
@@ -10035,7 +10141,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putTopologiesByTopologyIdSources"
       }
     },
     "/topologies/{topologyId}/sources/{sourceId}": {
@@ -10133,7 +10240,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "putTopologiesByTopologyIdSourcesBySourceId"
       },
       "delete": {
         "tags": [
@@ -10219,7 +10327,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteTopologiesByTopologyIdSourcesBySourceId"
       }
     },
     "/topologies/{topologyId}/sources/{sourceId}/clear": {
@@ -10322,7 +10431,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByTopologyIdSourcesBySourceIdClear"
       }
     },
     "/topologies/{topologyId}/sources/{sourceId}/probe": {
@@ -10441,7 +10551,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByTopologyIdSourcesBySourceIdProbe"
       }
     },
     "/topologies/{topologyId}/sources/{sourceId}/sync": {
@@ -10529,7 +10640,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByTopologyIdSourcesBySourceIdSync"
       }
     },
     "/topologies/{id}/sync-from-source": {
@@ -10608,7 +10720,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByIdSyncFromSource"
       }
     },
     "/topologies/{id}/rebuild": {
@@ -10687,7 +10800,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByIdRebuild"
       }
     },
     "/topologies/{id}/sync-job": {
@@ -10756,7 +10870,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdSyncJob"
       }
     },
     "/topologies/{id}/sync-job/cancel": {
@@ -10825,7 +10940,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByIdSyncJobCancel"
       }
     },
     "/topologies/{id}/share": {
@@ -10894,7 +11010,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByIdShare"
       },
       "delete": {
         "tags": [
@@ -10961,7 +11078,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteTopologiesByIdShare"
       }
     },
     "/topologies/{id}/discovery-policy": {
@@ -11010,7 +11128,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getTopologiesByIdDiscoveryPolicy"
       },
       "patch": {
         "tags": [
@@ -11255,7 +11374,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "patchTopologiesByIdDiscoveryPolicy"
       }
     },
     "/topologies/{id}/discovery-policy/exclusions": {
@@ -11363,7 +11483,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postTopologiesByIdDiscoveryPolicyExclusions"
       },
       "delete": {
         "tags": [
@@ -11469,7 +11590,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "deleteTopologiesByIdDiscoveryPolicyExclusions"
       }
     },
     "/webhooks/{type}/{id}": {
@@ -11576,7 +11698,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "postWebhooksByTypeById"
       }
     },
     "/webhooks/health": {
@@ -11604,7 +11727,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getWebhooksHealth"
       }
     },
     "/system": {
@@ -11668,7 +11792,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getSystem"
       }
     },
     "/admin/status": {
@@ -11707,7 +11832,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "getAdminStatus"
       }
     }
   },

--- a/apps/server/api/src/middleware/auth.ts
+++ b/apps/server/api/src/middleware/auth.ts
@@ -10,6 +10,7 @@ import type { Context, Next } from 'hono'
 import { bearerAuth } from 'hono/bearer-auth'
 import { getCookie } from 'hono/cookie'
 import { SESSION_COOKIE } from '../app/auth-session.js'
+import { apiError, apiErrorPayload } from '../openapi/common.js'
 import { isSetupComplete, validateSession } from '../services/auth.js'
 
 const DEV_API_TOKEN_PATTERN = /^[a-f0-9]{64}$/i
@@ -105,8 +106,20 @@ export async function authMiddleware(c: Context, next: Next) {
   // the existing UI authentication flow remains unchanged.
   const devApiToken = getDevApiToken()
   if (devApiToken) {
-    return bearerAuth({ token: devApiToken, realm: 'shumoku-dev-api' })(c, next)
+    return bearerAuth({
+      token: devApiToken,
+      realm: 'shumoku-dev-api',
+      noAuthenticationHeader: {
+        message: (context) => apiErrorPayload(context, 'Authentication required', 401),
+      },
+      invalidAuthenticationHeader: {
+        message: (context) => apiErrorPayload(context, 'Invalid authorization header', 400),
+      },
+      invalidToken: {
+        message: (context) => apiErrorPayload(context, 'Invalid bearer token', 401),
+      },
+    })(c, next)
   }
 
-  return c.json({ error: 'Authentication required' }, 401)
+  return apiError(c, 'Authentication required', 401)
 }

--- a/apps/server/api/src/modules/data-sources/routes.test.ts
+++ b/apps/server/api/src/modules/data-sources/routes.test.ts
@@ -85,7 +85,12 @@ describe('OpenAPI data source CRUD routes', () => {
     })
 
     expect(response.status).toBe(400)
-    expect(await response.json()).toEqual({ error: 'Invalid request' })
+    expect(await response.json()).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Invalid request',
+      error: 'Invalid request',
+      requestId: expect.any(String),
+    })
     expect(service.create).not.toHaveBeenCalled()
   })
 

--- a/apps/server/api/src/modules/topologies/routes.test.ts
+++ b/apps/server/api/src/modules/topologies/routes.test.ts
@@ -81,7 +81,12 @@ describe('OpenAPI topology CRUD routes', () => {
     })
 
     expect(response.status).toBe(400)
-    expect(await response.json()).toEqual({ error: 'Invalid request' })
+    expect(await response.json()).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Invalid request',
+      error: 'Invalid request',
+      requestId: expect.any(String),
+    })
     expect(service.create).not.toHaveBeenCalled()
   })
 

--- a/apps/server/api/src/openapi/common.ts
+++ b/apps/server/api/src/openapi/common.ts
@@ -1,12 +1,79 @@
 import { OpenAPIHono, z } from '@hono/zod-openapi'
+import type { Context } from 'hono'
+
+type ErrorStatus = 400 | 401 | 403 | 404 | 409 | 422 | 429 | 500 | 503
+
+const ERROR_CODE_BY_STATUS: Readonly<Record<number, string>> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  422: 'UNPROCESSABLE_CONTENT',
+  429: 'RATE_LIMITED',
+  500: 'INTERNAL_ERROR',
+  503: 'SERVICE_UNAVAILABLE',
+}
+
+function errorCode(status: number): string {
+  return ERROR_CODE_BY_STATUS[status] ?? 'HTTP_ERROR'
+}
+
+function errorBody(message: string, status: number, requestId: string) {
+  return {
+    code: errorCode(status),
+    message,
+    requestId,
+    error: message,
+  }
+}
+
+export function apiErrorPayload(c: Context, message: string, status: ErrorStatus) {
+  const requestId = crypto.randomUUID()
+  c.header('X-Request-ID', requestId)
+  return errorBody(message, status, requestId)
+}
+
+export function apiError(c: Context, message: string, status: ErrorStatus) {
+  return c.json(apiErrorPayload(c, message, status), status)
+}
 
 export function createOpenAPIApp(): OpenAPIHono {
-  return new OpenAPIHono({
+  const app = new OpenAPIHono({
     defaultHook: (result, c) => {
-      if (!result.success) return c.json({ error: 'Invalid request' }, 400)
+      if (!result.success) return apiError(c, 'Invalid request', 400)
       return undefined
     },
   })
+  app.use('*', async (c, next) => {
+    await next()
+    if (c.res.status < 400 || !c.res.headers.get('Content-Type')?.includes('application/json')) {
+      return
+    }
+    const body: unknown = await c.res
+      .clone()
+      .json()
+      .catch(() => null)
+    if (
+      !body ||
+      typeof body !== 'object' ||
+      !('error' in body) ||
+      typeof body.error !== 'string' ||
+      'code' in body
+    ) {
+      return
+    }
+
+    const requestId = crypto.randomUUID()
+    const headers = new Headers(c.res.headers)
+    headers.delete('Content-Length')
+    headers.set('X-Request-ID', requestId)
+    c.res = new Response(
+      JSON.stringify({ ...body, ...errorBody(body.error, c.res.status, requestId) }),
+      { status: c.res.status, statusText: c.res.statusText, headers },
+    )
+  })
+  return app
 }
 
 export function registerSecuritySchemes(app: OpenAPIHono): void {
@@ -38,7 +105,16 @@ export function registerSecuritySchemes(app: OpenAPIHono): void {
 
 export const ErrorSchema = z
   .object({
-    error: z.string(),
+    code: z
+      .string()
+      .regex(/^[A-Z][A-Z0-9_]*$/)
+      .openapi({ example: 'NOT_FOUND' }),
+    message: z.string().openapi({ example: 'Topology not found' }),
+    requestId: z.string().uuid(),
+    error: z.string().openapi({
+      deprecated: true,
+      description: 'Deprecated alias of message, retained for compatibility',
+    }),
   })
   .openapi('Error')
 

--- a/apps/server/api/src/openapi/document.ts
+++ b/apps/server/api/src/openapi/document.ts
@@ -27,6 +27,39 @@ interface OpenApiDocumentOptions {
   serverDescription?: string
 }
 
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'])
+
+function operationId(method: string, path: string): string {
+  const suffix = path
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => {
+      const parameter = /^\{(.+)\}$/.exec(segment)?.[1]
+      const words = (parameter ? `by-${parameter}` : segment).split(/[^a-zA-Z0-9]+/).filter(Boolean)
+      return words.map((word) => `${word[0]?.toUpperCase() ?? ''}${word.slice(1)}`).join('')
+    })
+    .join('')
+  return `${method.toLowerCase()}${suffix || 'Root'}`
+}
+
+function addOperationIds<T>(document: T): T {
+  const result = structuredClone(document)
+  if (!result || typeof result !== 'object' || !('paths' in result)) return result
+  const paths = result.paths
+  if (!paths || typeof paths !== 'object') return result
+
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (!HTTP_METHODS.has(method) || !operation || typeof operation !== 'object') continue
+      if (!('operationId' in operation) || typeof operation.operationId !== 'string') {
+        Object.assign(operation, { operationId: operationId(method, path) })
+      }
+    }
+  }
+  return result
+}
+
 export function registerPublicContractRoutes(app: OpenAPIHono, services: AppServices): void {
   app.route('/auth', createAuthApi(services))
   app.route('/health', createHealthApi(services))
@@ -62,19 +95,21 @@ export function createOpenApiDocument(
   registerPublicContractRoutes(contract, services)
   registerProtectedContractRoutes(contract, services)
 
-  return contract.getOpenAPI31Document({
-    openapi: '3.1.0',
-    info: {
-      title: 'Shumoku Server API',
-      version: options.version,
-      description:
-        'Authoritative machine-readable contract for Shumoku management, automation, and diagnostics.',
-    },
-    servers: [
-      {
-        url: options.serverUrl,
-        description: options.serverDescription ?? 'Shumoku Server API',
+  return addOperationIds(
+    contract.getOpenAPI31Document({
+      openapi: '3.1.0',
+      info: {
+        title: 'Shumoku Server API',
+        version: options.version,
+        description:
+          'Authoritative machine-readable contract for Shumoku management, automation, and diagnostics.',
       },
-    ],
-  })
+      servers: [
+        {
+          url: options.serverUrl,
+          description: options.serverDescription ?? 'Shumoku Server API',
+        },
+      ],
+    }),
+  )
 }

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -28,6 +28,7 @@ import { createTopologySyncApplicationService } from './app/topology-sync.js'
 import { createWebhookApplicationService } from './app/webhooks.js'
 import { closeDatabase, initDatabase } from './db/index.js'
 import { MockMetricsProvider } from './mock-metrics.js'
+import { apiError } from './openapi/common.js'
 import { createApiRouter } from './openapi/router.js'
 import {
   hasMetricsCapability,
@@ -107,9 +108,9 @@ export class Server {
     // default text/plain 500.
     this.app.onError((err, c) => {
       console.error(`[Server] Unhandled error on ${c.req.method} ${c.req.path}:`, err)
-      return c.json({ error: 'Internal server error' }, 500)
+      return apiError(c, 'Internal server error', 500)
     })
-    this.app.notFound((c) => c.json({ error: 'Not found' }, 404))
+    this.app.notFound((c) => apiError(c, 'Not found', 404))
     this.app.use('*', cors())
   }
 

--- a/apps/server/api/test/api/openapi.test.ts
+++ b/apps/server/api/test/api/openapi.test.ts
@@ -317,9 +317,14 @@ describe('OpenAPI root integration', () => {
       serverUrl: '/api',
     })
     const contractOperations = new Set<string>()
+    const operationIds: string[] = []
     for (const [path, pathItem] of Object.entries(document.paths ?? {})) {
       for (const method of openApiMethods) {
-        if (pathItem && method in pathItem) contractOperations.add(operationKey(method, path))
+        if (!pathItem || !(method in pathItem)) continue
+        contractOperations.add(operationKey(method, path))
+        const operation = pathItem[method]
+        expect(operation?.operationId).toEqual(expect.any(String))
+        if (operation?.operationId) operationIds.push(operation.operationId)
       }
     }
 
@@ -332,13 +337,23 @@ describe('OpenAPI root integration', () => {
 
     expect(missingAtRuntime).toEqual([])
     expect(undocumented).toEqual([])
+    expect(new Set(operationIds).size).toBe(operationIds.length)
+    expect(document.paths['/topologies/{id}']?.get?.operationId).toBe('getTopologiesById')
   })
 
   test('keeps health public and protects diagnostics after setup', async () => {
     const app = createApp()
 
     expect((await app.request('/api/health')).status).toBe(200)
-    expect((await app.request('/api/admin/status')).status).toBe(401)
+    const unauthorized = await app.request('/api/admin/status')
+    expect(unauthorized.status).toBe(401)
+    expect(unauthorized.headers.get('X-Request-ID')).toEqual(expect.any(String))
+    expect(await unauthorized.json()).toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: 'Authentication required',
+      error: 'Authentication required',
+      requestId: expect.any(String),
+    })
     expect((await app.request('/api/openapi.json')).status).toBe(401)
   })
 

--- a/apps/server/docs/api.en.mdx
+++ b/apps/server/docs/api.en.mdx
@@ -58,7 +58,30 @@ For repository development, `bun run openapi:generate` writes the deterministic
 `apps/server/api/openapi.json` snapshot and the web client's generated TypeScript
 definitions. The web client consumes those definitions with `openapi-fetch`;
 raw fetch is reserved for multipart upload and the tagged-Map view payload.
-CI checks artifact drift and requires every runtime HTTP route to exist in OpenAPI.
+Every operation has a deterministic, unique `operationId` derived from its HTTP
+method and path, so generated SDK names remain stable while the route remains
+stable. CI checks artifact drift, requires every runtime HTTP route to exist in
+OpenAPI, and runs `oasdiff` against the PR base branch. Definite and potential
+breaking changes fail the compatibility check and must be redesigned or handled
+as an intentional versioned change.
+
+### Error responses
+
+JSON error responses use one envelope across validation, authentication, and
+feature routes:
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "Topology not found",
+  "requestId": "00000000-0000-4000-8000-000000000000",
+  "error": "Topology not found"
+}
+```
+
+Clients should branch on `code`, display `message`, and include `requestId` when
+reporting a failure. `error` is a deprecated alias of `message` retained for
+compatibility with older clients.
 
 ## Shared views (public, token-scoped)
 

--- a/apps/server/docs/api.ja.mdx
+++ b/apps/server/docs/api.ja.mdx
@@ -58,7 +58,27 @@ Webhook入口まで生成ドキュメントに収録されます。
 `apps/server/api/openapi.json`スナップショットとWebクライアント用TypeScript型を
 生成します。Webクライアントはその型を`openapi-fetch`経由で利用し、生のfetchは
 multipart uploadとMapタグ付きview payloadに限定します。CIは生成物の差分を検査し、
-すべてのruntime HTTPルートがOpenAPIに存在することを強制します。
+すべてのruntime HTTPルートがOpenAPIに存在することを強制します。各操作にはHTTP
+methodとpathから決定的に生成される一意な`operationId`が付くため、routeが変わらない
+限り生成SDKの名前も安定します。またCIはPRのbase branchに対して`oasdiff`を実行し、
+確実または潜在的な破壊的変更を拒否します。破壊的変更が必要な場合は、設計を見直すか
+意図的なversioned changeとして扱います。
+
+### エラーレスポンス
+
+validation、認証、各機能のJSONエラーは共通のenvelopeを返します。
+
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "Topology not found",
+  "requestId": "00000000-0000-4000-8000-000000000000",
+  "error": "Topology not found"
+}
+```
+
+クライアントは`code`で分岐し、`message`を表示し、障害報告には`requestId`を含めます。
+`error`は既存クライアントとの互換性のため残した、非推奨の`message`別名です。
 
 ## 共有ビュー（公開・トークンスコープ）
 

--- a/apps/server/web/src/lib/api.generated.ts
+++ b/apps/server/web/src/lib/api.generated.ts
@@ -10,26 +10,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get authentication status */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Authentication state */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AuthStatus"];
-                    };
-                };
-            };
-        };
+        get: operations["getAuthStatus"];
         put?: never;
         post?: never;
         delete?: never;
@@ -48,39 +29,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Configure the initial administrator password */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["PasswordRequest"];
-                };
-            };
-            responses: {
-                /** @description Operation completed */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AuthSuccess"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postAuthSetup"];
         delete?: never;
         options?: never;
         head?: never;
@@ -97,57 +46,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Create an administrator session */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["PasswordRequest"];
-                };
-            };
-            responses: {
-                /** @description Operation completed */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AuthSuccess"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The password is invalid */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Too many login attempts */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postAuthLogin"];
         delete?: never;
         options?: never;
         head?: never;
@@ -164,48 +63,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Change the administrator password */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["ChangePasswordRequest"];
-                };
-            };
-            responses: {
-                /** @description Operation completed */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AuthSuccess"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication or current password is invalid */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postAuthChangePassword"];
         delete?: never;
         options?: never;
         head?: never;
@@ -222,26 +80,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** End the current administrator session */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Operation completed */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AuthSuccess"];
-                    };
-                };
-            };
-        };
+        post: operations["postAuthLogout"];
         delete?: never;
         options?: never;
         head?: never;
@@ -256,26 +95,7 @@ export interface paths {
             cookie?: never;
         };
         /** Check server liveness */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description The server process is running */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Health"];
-                    };
-                };
-            };
-        };
+        get: operations["getHealth"];
         put?: never;
         post?: never;
         delete?: never;
@@ -292,64 +112,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get shared topology context */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Shared topology context */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyContext"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareTopologiesByToken"];
         put?: never;
         post?: never;
         delete?: never;
@@ -366,64 +129,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get shared topology graph */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Shared topology graph */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyGraph"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareTopologiesByTokenGraph"];
         put?: never;
         post?: never;
         delete?: never;
@@ -440,64 +146,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get shared topology graph and layout */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Shared topology view */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyView"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareTopologiesByTokenView"];
         put?: never;
         post?: never;
         delete?: never;
@@ -514,64 +163,7 @@ export interface paths {
             cookie?: never;
         };
         /** Render a shared topology */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Shared topology render */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyRender"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareTopologiesByTokenRender"];
         put?: never;
         post?: never;
         delete?: never;
@@ -588,46 +180,7 @@ export interface paths {
             cookie?: never;
         };
         /** Stream shared topology metrics */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Metrics event stream */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/event-stream": string;
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                503: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareTopologiesByTokenMetricsStream"];
         put?: never;
         post?: never;
         delete?: never;
@@ -644,64 +197,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get a shared dashboard */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Shared dashboard */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PublicDashboard"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareDashboardsByToken"];
         put?: never;
         post?: never;
         delete?: never;
@@ -718,65 +214,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get shared dashboard topology metadata */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Topology metadata */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PublicTopologyMetadata"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareDashboardsByTokenTopologiesById"];
         put?: never;
         post?: never;
         delete?: never;
@@ -793,65 +231,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get a shared dashboard topology graph */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Topology graph */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyGraph"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareDashboardsByTokenTopologiesByIdGraph"];
         put?: never;
         post?: never;
         delete?: never;
@@ -868,65 +248,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get shared dashboard topology context */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Topology context */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyContext"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareDashboardsByTokenTopologiesByIdContext"];
         put?: never;
         post?: never;
         delete?: never;
@@ -943,47 +265,7 @@ export interface paths {
             cookie?: never;
         };
         /** Stream shared dashboard topology metrics */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    token: string;
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Metrics event stream */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/event-stream": string;
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                503: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareDashboardsByTokenTopologiesByIdMetricsStream"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1000,69 +282,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get alerts for a shared dashboard widget */
-        get: {
-            parameters: {
-                query?: {
-                    timeRange?: number | null;
-                    activeOnly?: string;
-                    minSeverity?: "critical" | "high" | "medium" | "low" | "info" | "ok";
-                };
-                header?: never;
-                path: {
-                    token: string;
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Projected alerts */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PublicAlert"][];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Shared resource unavailable */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getShareDashboardsByTokenDatasourcesByIdAlerts"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1079,35 +299,7 @@ export interface paths {
             cookie?: never;
         };
         /** List available data source plugin types */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Registered plugin types and their form schemas */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DataSourcePluginList"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesTypes"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1124,46 +316,7 @@ export interface paths {
             cookie?: never;
         };
         /** List data sources by capability */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    capability: "topology" | "metrics" | "alerts";
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Configured data sources supporting the capability */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DataSourceList"];
-                    };
-                };
-                /** @description The capability is not supported */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByCapabilityByCapability"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1180,47 +333,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get dynamic configuration options */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                    key: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Available values for the requested plugin schema field */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ConfigOptionsResult"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The data source does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByIdConfigOptionsByKey"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1237,39 +350,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get derived connection information */
-        get: {
-            parameters: {
-                query?: {
-                    origin?: string;
-                };
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Display-only connection information supplied by the plugin */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ConnectionInfoResult"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByIdConnectionInfo"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1286,46 +367,7 @@ export interface paths {
             cookie?: never;
         };
         /** List attached topologies */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Topologies currently using the data source */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AttachedTopologyList"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The data source does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByIdTopologies"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1344,37 +386,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Test a data source connection */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Connection test result */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ConnectionResult"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postDatasourcesByIdTest"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1389,46 +401,7 @@ export interface paths {
             cookie?: never;
         };
         /** List hosts from a data source */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Hosts exposed by the plugin */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["HostList"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The upstream data source request failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByIdHosts"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1445,47 +418,7 @@ export interface paths {
             cookie?: never;
         };
         /** List metric items for a host */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                    hostId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Host metric items */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["HostItemList"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The upstream data source request failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByIdHostsByHostIdItems"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1502,47 +435,7 @@ export interface paths {
             cookie?: never;
         };
         /** List interface neighbors for a host */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                    hostId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description LLDP or CDP interface neighbors */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["InterfaceNeighborList"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The upstream data source request failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByIdHostsByHostIdNeighbors"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1559,47 +452,7 @@ export interface paths {
             cookie?: never;
         };
         /** Discover metrics for a host */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                    hostId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Metrics currently exposed for the host */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DiscoveredMetricList"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The upstream data source request failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByIdHostsByHostIdMetrics"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1619,55 +472,7 @@ export interface paths {
          * Get legacy topology filter options
          * @description Compatibility endpoint for NetBox site and tag selectors. Prefer config-options for new plugins.
          */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Available sites and tags */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["FilterOptions"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The upstream data source request failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByIdFilterOptions"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1684,59 +489,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get alerts from a data source */
-        get: {
-            parameters: {
-                query?: {
-                    timeRange?: number | null;
-                    activeOnly?: string;
-                    minSeverity?: "critical" | "high" | "medium" | "low" | "info" | "ok";
-                };
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Alerts returned by the plugin */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AlertList"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The upstream data source request failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesByIdAlerts"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1758,68 +511,7 @@ export interface paths {
          * Call a plugin native API method
          * @description Development-only escape hatch for loopback API automation.
          */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["NativeApiRequest"];
-                };
-            };
-            responses: {
-                /** @description Raw upstream result */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["NativeApiResult"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Unavailable outside development or data source not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The upstream data source request failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postDatasourcesByIdNative"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1836,68 +528,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Run an ad-hoc topology scan */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": components["schemas"]["DataSourceScanRequest"];
-                };
-            };
-            responses: {
-                /** @description Scan snapshot and optional persisted observation */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DataSourceScanResult"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The data source does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The scan failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postDatasourcesByIdScan"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1912,79 +543,10 @@ export interface paths {
             cookie?: never;
         };
         /** List dashboards */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Configured dashboards */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DashboardList"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDashboards"];
         put?: never;
         /** Create a dashboard */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["CreateDashboard"];
-                };
-            };
-            responses: {
-                /** @description Created dashboard */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Dashboard"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postDashboards"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1999,142 +561,12 @@ export interface paths {
             cookie?: never;
         };
         /** Get a dashboard */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Dashboard */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Dashboard"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The dashboard does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDashboardsById"];
         /** Update a dashboard */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["UpdateDashboard"];
-                };
-            };
-            responses: {
-                /** @description Updated dashboard */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Dashboard"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The dashboard does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putDashboardsById"];
         post?: never;
         /** Delete a dashboard */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Dashboard deleted */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Success"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The dashboard does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteDashboardsById"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2150,87 +582,9 @@ export interface paths {
         get?: never;
         put?: never;
         /** Enable dashboard sharing */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Generated share token */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DashboardShareResult"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The dashboard does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postDashboardsByIdShare"];
         /** Disable dashboard sharing */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Sharing disabled */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Success"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The dashboard does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteDashboardsByIdShare"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2244,78 +598,9 @@ export interface paths {
             cookie?: never;
         };
         /** List settings */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description All settings */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Settings"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getSettings"];
         /** Update settings */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["Settings"];
-                };
-            };
-            responses: {
-                /** @description Settings updated */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SettingsSuccess"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putSettings"];
         post?: never;
         delete?: never;
         options?: never;
@@ -2331,133 +616,12 @@ export interface paths {
             cookie?: never;
         };
         /** Get a setting */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    key: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Setting */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Setting"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The setting does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getSettingsByKey"];
         /** Update a setting */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    key: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["SettingValue"];
-                };
-            };
-            responses: {
-                /** @description Updated setting */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Setting"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putSettingsByKey"];
         post?: never;
         /** Delete a setting */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    key: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Setting deleted */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SettingsSuccess"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The setting does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteSettingsByKey"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2471,79 +635,10 @@ export interface paths {
             cookie?: never;
         };
         /** List installed plugins */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Installed plugins */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PluginList"];
-                    };
-                };
-            };
-        };
+        get: operations["getPlugins"];
         put?: never;
         /** Install an external plugin */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["InstallPlugin"];
-                };
-            };
-            responses: {
-                /** @description Installed plugin */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PluginInfo"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postPlugins"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2558,55 +653,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get an external plugin manifest */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Plugin manifest */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PluginManifest"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getPluginsByIdManifest"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2625,61 +672,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Install an external plugin from a ZIP archive */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "multipart/form-data": {
-                        /** Format: binary */
-                        file: string;
-                        subdirectory?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Installed plugin */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PluginInfo"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postPluginsUpload"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2697,113 +690,11 @@ export interface paths {
         put?: never;
         post?: never;
         /** Remove an external plugin */
-        delete: {
-            parameters: {
-                query?: {
-                    deleteFiles?: string;
-                };
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Plugin removed */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PluginSuccess"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deletePluginsById"];
         options?: never;
         head?: never;
         /** Enable or disable an external plugin */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["SetPluginEnabled"];
-                };
-            };
-            responses: {
-                /** @description Plugin state updated */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["PluginSuccess"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        patch: operations["patchPluginsById"];
         trace?: never;
     };
     "/plugins/reload": {
@@ -2816,53 +707,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Reload external plugins */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Reload result */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ReloadPluginsResult"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Plugin operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postPluginsReload"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2877,79 +722,10 @@ export interface paths {
             cookie?: never;
         };
         /** List data sources */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Configured data sources ordered by creation time */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DataSourceList"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasources"];
         put?: never;
         /** Create a data source */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["CreateDataSource"];
-                };
-            };
-            responses: {
-                /** @description Created data source */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DataSource"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postDatasources"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2964,142 +740,12 @@ export interface paths {
             cookie?: never;
         };
         /** Get a data source */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Configured data source */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DataSource"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The data source does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getDatasourcesById"];
         /** Update a data source */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["UpdateDataSource"];
-                };
-            };
-            responses: {
-                /** @description Updated data source */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DataSource"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The data source does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putDatasourcesById"];
         post?: never;
         /** Delete a data source */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Data source deleted */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DeleteDataSourceResult"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The data source does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteDatasourcesById"];
         options?: never;
         head?: never;
         patch?: never;
@@ -3113,79 +759,10 @@ export interface paths {
             cookie?: never;
         };
         /** List topologies */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Topology shells ordered by name */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyList"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologies"];
         put?: never;
         /** Create a topology */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["CreateTopology"];
-                };
-            };
-            responses: {
-                /** @description Created topology shell */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Topology"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologies"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3200,142 +777,12 @@ export interface paths {
             cookie?: never;
         };
         /** Get a topology */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Topology shell */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Topology"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The topology does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesById"];
         /** Update a topology */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["UpdateTopology"];
-                };
-            };
-            responses: {
-                /** @description Updated topology shell */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Topology"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The topology does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putTopologiesById"];
         post?: never;
         /** Delete a topology */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Topology deleted */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DeleteTopologyResult"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The topology does not exist */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteTopologiesById"];
         options?: never;
         head?: never;
         patch?: never;
@@ -3349,42 +796,7 @@ export interface paths {
             cookie?: never;
         };
         /** List recent topology observations */
-        get: {
-            parameters: {
-                query?: {
-                    limit?: number;
-                };
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Observation summaries */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            id: string;
-                            topologyId: string;
-                            sourceId: string;
-                            capturedAt: number;
-                            /** @enum {string} */
-                            status: "ok" | "partial" | "failed" | "empty";
-                            statusMessage?: string;
-                            nodeCount: number;
-                            linkCount: number;
-                            portCount: number;
-                            createdAt: number;
-                        }[];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdObservations"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3401,38 +813,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get a topology observation */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                    obsId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Observation */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyObservation"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdObservationsByObsId"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3449,29 +830,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get the latest snapshot from a topology source */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                    sourceId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Latest snapshot */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["LatestTopologySnapshot"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByTopologyIdSourcesBySourceIdLatestSnapshot"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3490,60 +849,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Record a pushed topology observation */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                    sourceId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        graph: components["schemas"]["NetworkGraph"];
-                        /**
-                         * @default ok
-                         * @enum {string}
-                         */
-                        status?: "ok" | "partial" | "failed" | "empty";
-                    };
-                };
-            };
-            responses: {
-                /** @description Recorded observation */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            observation: components["schemas"]["TopologyObservation"];
-                        };
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByTopologyIdSourcesBySourceIdObservation"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3558,46 +864,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get the resolved topology graph */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Resolved graph */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ResolvedTopology"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdResolved"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3614,73 +881,9 @@ export interface paths {
             cookie?: never;
         };
         /** Get topology display settings */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Display settings */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDisplaySettings"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdDisplaySettings"];
         /** Update topology display settings */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["UpdateTopologyDisplaySettings"];
-                };
-            };
-            responses: {
-                /** @description Settings updated */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["OkResult"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putTopologiesByIdDisplaySettings"];
         post?: never;
         delete?: never;
         options?: never;
@@ -3696,155 +899,9 @@ export interface paths {
             cookie?: never;
         };
         /** Get a topology metrics mapping */
-        get: {
-            parameters: {
-                query?: {
-                    sourceId?: string;
-                };
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Metrics mapping */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["MetricsMapping"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdMapping"];
         /** Replace a topology metrics mapping */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        mapping: components["schemas"]["MetricsMapping"];
-                        sourceId?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Updated mapping */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Topology"] & {
-                            skipped: {
-                                nodes: number;
-                                links: number;
-                            };
-                        };
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putTopologiesByIdMapping"];
         post?: never;
         delete?: never;
         options?: never;
@@ -3860,78 +917,7 @@ export interface paths {
             cookie?: never;
         };
         /** List source-qualified metrics mappings */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Source mappings */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            sourceId: string;
-                            sourceName: string;
-                            priority: number;
-                            mapping: components["schemas"]["MetricsMapping"];
-                        }[];
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdMappingSources"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3948,80 +934,7 @@ export interface paths {
             cookie?: never;
         };
         /** List orphaned metrics mappings */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Mapping orphans */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            orphans: {
-                                entityId: string;
-                                kind: string;
-                                sourceId: string;
-                                payload?: unknown;
-                            }[];
-                        };
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdMappingOrphans"];
         put?: never;
         post?: never;
         delete?: never;
@@ -4040,80 +953,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Reassign an orphaned mapping */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                    entityId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        toEntityId: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Mapping reassigned */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["MappingSuccess"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByIdMappingOrphansByEntityIdReassign"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4131,74 +971,7 @@ export interface paths {
         put?: never;
         post?: never;
         /** Discard an orphaned mapping */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                    entityId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Mapping discarded */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["MappingSuccess"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteTopologiesByIdMappingOrphansByEntityId"];
         options?: never;
         head?: never;
         patch?: never;
@@ -4214,73 +987,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Reset the topology entity registry and mappings */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Registry reset */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["MappingSuccess"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByIdRegistryReset"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4301,90 +1008,7 @@ export interface paths {
         options?: never;
         head?: never;
         /** Replace one node mapping */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                    nodeId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        hostId?: string;
-                        hostName?: string;
-                        sourceId?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Updated node mapping */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: true;
-                            topology: components["schemas"]["Topology"];
-                            nodeMapping: {
-                                hostId?: string;
-                                hostName?: string;
-                            } | null;
-                        };
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        patch: operations["patchTopologiesByIdMappingNodesByNodeId"];
         trace?: never;
     };
     "/topologies/{id}/mapping/links/{linkId}": {
@@ -4401,92 +1025,7 @@ export interface paths {
         options?: never;
         head?: never;
         /** Replace one link mapping */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                    linkId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        monitoredNodeId?: string;
-                        interface?: string;
-                        bandwidth?: number;
-                        sourceId?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Updated link mapping */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            /** @enum {boolean} */
-                            success: true;
-                            topology: components["schemas"]["Topology"];
-                            linkMapping: {
-                                monitoredNodeId?: string;
-                                interface?: string;
-                                bandwidth?: number;
-                            } | null;
-                        };
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        patch: operations["patchTopologiesByIdMappingLinksByLinkId"];
         trace?: never;
     };
     "/topologies/{id}/mapping/nodes": {
@@ -4500,77 +1039,7 @@ export interface paths {
         put?: never;
         post?: never;
         /** Delete node mappings */
-        delete: {
-            parameters: {
-                query?: {
-                    sourceId?: string;
-                };
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Deleted mapping count */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            deleted: number;
-                        };
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteTopologiesByIdMappingNodes"];
         options?: never;
         head?: never;
         patch?: never;
@@ -4587,77 +1056,7 @@ export interface paths {
         put?: never;
         post?: never;
         /** Delete link mappings */
-        delete: {
-            parameters: {
-                query?: {
-                    sourceId?: string;
-                };
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Deleted mapping count */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            deleted: number;
-                        };
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteTopologiesByIdMappingLinks"];
         options?: never;
         head?: never;
         patch?: never;
@@ -4673,84 +1072,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Automatically map topology links */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": {
-                        overwrite?: boolean;
-                        sourceId?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Auto-map result */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            matched: number;
-                            total: number;
-                            skipped: number;
-                        };
-                    };
-                };
-                /** @description Mapping operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Mapping operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByIdMappingAutoMapLinks"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4765,73 +1087,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get parsed topology and layout */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get parsed topology and layout */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ParsedTopology"];
-                    };
-                };
-                /** @description The initial topology derivation is still running */
-                202: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDeriving"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdParsed"];
         put?: never;
         post?: never;
         delete?: never;
@@ -4848,73 +1104,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get the resolved topology graph */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get the resolved topology graph */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyGraph"];
-                    };
-                };
-                /** @description The initial topology derivation is still running */
-                202: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDeriving"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdGraph"];
         put?: never;
         post?: never;
         delete?: never;
@@ -4931,73 +1121,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get graph and server-baked layout */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get graph and server-baked layout */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyView"];
-                    };
-                };
-                /** @description The initial topology derivation is still running */
-                202: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDeriving"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdView"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5014,73 +1138,7 @@ export interface paths {
             cookie?: never;
         };
         /** Render a topology for embedding */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Render a topology for embedding */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyRender"];
-                    };
-                };
-                /** @description The initial topology derivation is still running */
-                202: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDeriving"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdRender"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5097,73 +1155,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get simplified topology context */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Get simplified topology context */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyContext"];
-                    };
-                };
-                /** @description The initial topology derivation is still running */
-                202: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDeriving"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdContext"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5180,129 +1172,9 @@ export interface paths {
             cookie?: never;
         };
         /** Get topology composition policy */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Topology composition policy */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyComposition"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdComposition"];
         /** Update topology composition policy */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        /** @enum {string} */
-                        scopeMode?: "auto" | "open" | "closed";
-                        scopeSourceId?: string | null;
-                        scope?: {
-                            include?: {
-                                /** @enum {string} */
-                                attr: "name" | "subnet" | "metadata";
-                                value: string;
-                                key?: string;
-                            }[];
-                            exclude?: {
-                                /** @enum {string} */
-                                attr: "name" | "subnet" | "metadata";
-                                value: string;
-                                key?: string;
-                            }[];
-                        };
-                        /** @enum {string} */
-                        compositionMode?: "additive" | "enrichment";
-                    };
-                };
-            };
-            responses: {
-                /** @description Updated composition policy */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyComposition"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putTopologiesByIdComposition"];
         post?: never;
         delete?: never;
         options?: never;
@@ -5318,206 +1190,11 @@ export interface paths {
             cookie?: never;
         };
         /** List attached topology data sources */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Attached sources */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDataSource"][];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Source already attached */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByTopologyIdSources"];
         /** Replace all attached sources */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        sources: {
-                            dataSourceId: string;
-                            /** @enum {string} */
-                            purpose: "topology" | "metrics";
-                            /** @enum {string} */
-                            syncMode?: "manual" | "on_view" | "webhook";
-                            priority?: number;
-                            optionsJson?: string;
-                            /** @enum {string} */
-                            nodeContribution?: "scoop" | "anchor";
-                            /** @enum {string} */
-                            linkContribution?: "add" | "update";
-                        }[];
-                    };
-                };
-            };
-            responses: {
-                /** @description Attached sources */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDataSource"][];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Source already attached */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putTopologiesByTopologyIdSources"];
         /** Attach a data source to a topology */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["AddTopologySource"];
-                };
-            };
-            responses: {
-                /** @description Attached source */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDataSource"] | {
-                            dataSourceId: string;
-                        };
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Source already attached */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByTopologyIdSources"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5533,130 +1210,10 @@ export interface paths {
         };
         get?: never;
         /** Update a topology source attachment */
-        put: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                    sourceId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": components["schemas"]["UpdateTopologySource"];
-                };
-            };
-            responses: {
-                /** @description Updated source */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologyDataSource"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Source already attached */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        put: operations["putTopologiesByTopologyIdSourcesBySourceId"];
         post?: never;
         /** Detach a topology source */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                    sourceId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Source detached */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologySourceSuccess"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Source already attached */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteTopologiesByTopologyIdSourcesBySourceId"];
         options?: never;
         head?: never;
         patch?: never;
@@ -5672,67 +1229,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Clear a source contribution without detaching it */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                    sourceId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Contribution cleared */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologySourceSuccess"] & {
-                            deleted: number;
-                        };
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Source already attached */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByTopologyIdSourcesBySourceIdClear"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5749,73 +1246,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Deep-read selected source targets */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                    sourceId: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        seeds: string[];
-                    };
-                };
-            };
-            responses: {
-                /** @description Probe observation */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            observation: components["schemas"]["TopologyObservation"];
-                        };
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Source already attached */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByTopologyIdSourcesBySourceIdProbe"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5832,65 +1263,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Synchronize one attached topology source */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    topologyId: string;
-                    sourceId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Source snapshot and observation */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SyncTopologySourceResult"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Resource not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Source already attached */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByTopologyIdSourcesBySourceIdSync"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5907,64 +1280,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Synchronize all topology sources */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Sync job started */
-                202: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["StartedTopologySyncJobResult"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description A sync job is already running */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["StartedTopologySyncJobResult"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByIdSyncFromSource"];
         delete?: never;
         options?: never;
         head?: never;
@@ -5981,64 +1297,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Clear pull-source observations and rebuild */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Sync job started */
-                202: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["StartedTopologySyncJobResult"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description A sync job is already running */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["StartedTopologySyncJobResult"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByIdRebuild"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6053,55 +1312,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get the current or last sync job */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Sync job state */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologySyncJobResult"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdSyncJob"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6120,55 +1331,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Cancel the current sync job */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Sync job state */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["TopologySyncJobResult"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByIdSyncJobCancel"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6185,105 +1348,9 @@ export interface paths {
         get?: never;
         put?: never;
         /** Enable topology sharing */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Share token */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["ShareTopologyResult"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByIdShare"];
         /** Disable topology sharing */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Sharing disabled */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["UnshareTopologyResult"];
-                    };
-                };
-                /** @description Topology operation failed */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteTopologiesByIdShare"];
         options?: never;
         head?: never;
         patch?: never;
@@ -6297,139 +1364,14 @@ export interface paths {
             cookie?: never;
         };
         /** Get effective per-node discovery policy */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Discovery policy */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["DiscoveryPolicy"];
-                    };
-                };
-                /** @description Topology or node not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getTopologiesByIdDiscoveryPolicy"];
         put?: never;
         post?: never;
         delete?: never;
         options?: never;
         head?: never;
         /** Update topology or node discovery policy */
-        patch: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        /** @enum {string} */
-                        scope: "topology" | "node";
-                        id?: string;
-                        attachments?: ({
-                            /** @enum {string} */
-                            kind: "access";
-                            /** @enum {string} */
-                            protocol: "snmp";
-                            community?: string;
-                        } | {
-                            /** @enum {string} */
-                            kind: "policy";
-                            /** @enum {string} */
-                            mode?: "auto" | "observe" | "disabled";
-                            intervalMs?: number;
-                        })[] | null;
-                        label?: string | null;
-                        suppressedAttachments?: string[] | null;
-                    };
-                };
-            };
-            responses: {
-                /** @description Effective policy after update */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            effective: {
-                                /** @enum {string} */
-                                mode: "auto" | "observe" | "disabled";
-                                intervalMs: number;
-                                community?: string;
-                                source: {
-                                    /** @enum {string} */
-                                    mode: "node" | "subgraph" | "topology" | "default";
-                                    /** @enum {string} */
-                                    intervalMs: "node" | "subgraph" | "topology" | "default";
-                                    /** @enum {string} */
-                                    community: "node" | "subgraph" | "topology" | "default";
-                                };
-                            };
-                        };
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology or node not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description The node cannot be safely updated */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Discovery policy operation failed */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        patch: operations["patchTopologiesByIdDiscoveryPolicy"];
         trace?: never;
     };
     "/topologies/{id}/discovery-policy/exclusions": {
@@ -6442,115 +1384,9 @@ export interface paths {
         get?: never;
         put?: never;
         /** Exclude a node identity from discovery */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        mgmtIp?: string;
-                        chassisId?: string;
-                        sysName?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Current exclusions */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            exclusions: {
-                                mgmtIp?: string;
-                                chassisId?: string;
-                                sysName?: string;
-                            }[];
-                        };
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology or node not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postTopologiesByIdDiscoveryPolicyExclusions"];
         /** Remove a node identity exclusion */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        mgmtIp?: string;
-                        chassisId?: string;
-                        sysName?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Current exclusions */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            exclusions: {
-                                mgmtIp?: string;
-                                chassisId?: string;
-                                sysName?: string;
-                            }[];
-                        };
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Topology or node not found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        delete: operations["deleteTopologiesByIdDiscoveryPolicyExclusions"];
         options?: never;
         head?: never;
         patch?: never;
@@ -6566,73 +1402,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Receive a data source webhook */
-        post: {
-            parameters: {
-                query?: {
-                    secret?: string;
-                };
-                header?: never;
-                path: {
-                    type: string;
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: {
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            responses: {
-                /** @description Webhook processed */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["WebhookResult"];
-                    };
-                };
-                /** @description Webhook rejected */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Webhook rejected */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Webhook rejected */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Webhook rejected */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        post: operations["postWebhooksByTypeById"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6647,26 +1417,7 @@ export interface paths {
             cookie?: never;
         };
         /** Check webhook ingress health */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Webhook ingress is healthy */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["WebhookHealth"];
-                    };
-                };
-            };
-        };
+        get: operations["getWebhooksHealth"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6683,47 +1434,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get build and update information */
-        get: {
-            parameters: {
-                query?: {
-                    /** @description Refresh cached release information when true */
-                    refresh?: "true" | "false";
-                };
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Build and release information */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["SystemInfo"];
-                    };
-                };
-                /** @description The request did not match the API contract */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getSystem"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6743,35 +1454,7 @@ export interface paths {
          * Inspect server runtime status
          * @description Returns redacted operational state for diagnostics and automation.
          */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description Current runtime status */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["AdminStatus"];
-                    };
-                };
-                /** @description Authentication is required */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["Error"];
-                    };
-                };
-            };
-        };
+        get: operations["getAdminStatus"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6793,6 +1476,16 @@ export interface components {
             success: true;
         };
         Error: {
+            /** @example NOT_FOUND */
+            code: string;
+            /** @example Topology not found */
+            message: string;
+            /** Format: uuid */
+            requestId: string;
+            /**
+             * @deprecated
+             * @description Deprecated alias of message, retained for compatibility
+             */
             error: string;
         };
         PasswordRequest: {
@@ -7699,4 +2392,5430 @@ export interface components {
     pathItems: never;
 }
 export type $defs = Record<string, never>;
-export type operations = Record<string, never>;
+export interface operations {
+    getAuthStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Authentication state */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthStatus"];
+                };
+            };
+        };
+    };
+    postAuthSetup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PasswordRequest"];
+            };
+        };
+        responses: {
+            /** @description Operation completed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthSuccess"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postAuthLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PasswordRequest"];
+            };
+        };
+        responses: {
+            /** @description Operation completed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthSuccess"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The password is invalid */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Too many login attempts */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postAuthChangePassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangePasswordRequest"];
+            };
+        };
+        responses: {
+            /** @description Operation completed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthSuccess"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication or current password is invalid */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postAuthLogout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Operation completed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthSuccess"];
+                };
+            };
+        };
+    };
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The server process is running */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Health"];
+                };
+            };
+        };
+    };
+    getShareTopologiesByToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Shared topology context */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyContext"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareTopologiesByTokenGraph: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Shared topology graph */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyGraph"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareTopologiesByTokenView: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Shared topology view */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyView"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareTopologiesByTokenRender: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Shared topology render */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyRender"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareTopologiesByTokenMetricsStream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Metrics event stream */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": string;
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareDashboardsByToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Shared dashboard */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicDashboard"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareDashboardsByTokenTopologiesById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topology metadata */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicTopologyMetadata"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareDashboardsByTokenTopologiesByIdGraph: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topology graph */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyGraph"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareDashboardsByTokenTopologiesByIdContext: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topology context */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyContext"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareDashboardsByTokenTopologiesByIdMetricsStream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                token: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Metrics event stream */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/event-stream": string;
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getShareDashboardsByTokenDatasourcesByIdAlerts: {
+        parameters: {
+            query?: {
+                timeRange?: number | null;
+                activeOnly?: string;
+                minSeverity?: "critical" | "high" | "medium" | "low" | "info" | "ok";
+            };
+            header?: never;
+            path: {
+                token: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Projected alerts */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicAlert"][];
+                };
+            };
+            /** @description Shared resource unavailable */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Shared resource unavailable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesTypes: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Registered plugin types and their form schemas */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataSourcePluginList"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByCapabilityByCapability: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                capability: "topology" | "metrics" | "alerts";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Configured data sources supporting the capability */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataSourceList"];
+                };
+            };
+            /** @description The capability is not supported */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByIdConfigOptionsByKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Available values for the requested plugin schema field */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConfigOptionsResult"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The data source does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByIdConnectionInfo: {
+        parameters: {
+            query?: {
+                origin?: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Display-only connection information supplied by the plugin */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectionInfoResult"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByIdTopologies: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topologies currently using the data source */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttachedTopologyList"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The data source does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postDatasourcesByIdTest: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Connection test result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConnectionResult"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByIdHosts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Hosts exposed by the plugin */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HostList"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The upstream data source request failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByIdHostsByHostIdItems: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                hostId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Host metric items */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HostItemList"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The upstream data source request failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByIdHostsByHostIdNeighbors: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                hostId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description LLDP or CDP interface neighbors */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InterfaceNeighborList"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The upstream data source request failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByIdHostsByHostIdMetrics: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                hostId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Metrics currently exposed for the host */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DiscoveredMetricList"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The upstream data source request failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByIdFilterOptions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Available sites and tags */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FilterOptions"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The upstream data source request failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesByIdAlerts: {
+        parameters: {
+            query?: {
+                timeRange?: number | null;
+                activeOnly?: string;
+                minSeverity?: "critical" | "high" | "medium" | "low" | "info" | "ok";
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Alerts returned by the plugin */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlertList"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The upstream data source request failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postDatasourcesByIdNative: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NativeApiRequest"];
+            };
+        };
+        responses: {
+            /** @description Raw upstream result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NativeApiResult"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Unavailable outside development or data source not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The upstream data source request failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postDatasourcesByIdScan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["DataSourceScanRequest"];
+            };
+        };
+        responses: {
+            /** @description Scan snapshot and optional persisted observation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataSourceScanResult"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The data source does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The scan failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDashboards: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Configured dashboards */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardList"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postDashboards: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDashboard"];
+            };
+        };
+        responses: {
+            /** @description Created dashboard */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Dashboard"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDashboardsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Dashboard */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Dashboard"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The dashboard does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    putDashboardsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDashboard"];
+            };
+        };
+        responses: {
+            /** @description Updated dashboard */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Dashboard"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The dashboard does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteDashboardsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Dashboard deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Success"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The dashboard does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postDashboardsByIdShare: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Generated share token */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardShareResult"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The dashboard does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteDashboardsByIdShare: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sharing disabled */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Success"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The dashboard does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All settings */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Settings"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    putSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Settings"];
+            };
+        };
+        responses: {
+            /** @description Settings updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SettingsSuccess"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getSettingsByKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Setting */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Setting"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The setting does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    putSettingsByKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SettingValue"];
+            };
+        };
+        responses: {
+            /** @description Updated setting */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Setting"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteSettingsByKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Setting deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SettingsSuccess"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The setting does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getPlugins: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Installed plugins */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PluginList"];
+                };
+            };
+        };
+    };
+    postPlugins: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InstallPlugin"];
+            };
+        };
+        responses: {
+            /** @description Installed plugin */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PluginInfo"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getPluginsByIdManifest: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Plugin manifest */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PluginManifest"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postPluginsUpload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /** Format: binary */
+                    file: string;
+                    subdirectory?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Installed plugin */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PluginInfo"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deletePluginsById: {
+        parameters: {
+            query?: {
+                deleteFiles?: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Plugin removed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PluginSuccess"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    patchPluginsById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetPluginEnabled"];
+            };
+        };
+        responses: {
+            /** @description Plugin state updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PluginSuccess"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postPluginsReload: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Reload result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReloadPluginsResult"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Plugin operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Configured data sources ordered by creation time */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataSourceList"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postDatasources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDataSource"];
+            };
+        };
+        responses: {
+            /** @description Created data source */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataSource"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getDatasourcesById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Configured data source */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataSource"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The data source does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    putDatasourcesById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDataSource"];
+            };
+        };
+        responses: {
+            /** @description Updated data source */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DataSource"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The data source does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteDatasourcesById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Data source deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteDataSourceResult"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The data source does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologies: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topology shells ordered by name */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyList"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologies: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTopology"];
+            };
+        };
+        responses: {
+            /** @description Created topology shell */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Topology"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topology shell */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Topology"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The topology does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    putTopologiesById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateTopology"];
+            };
+        };
+        responses: {
+            /** @description Updated topology shell */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Topology"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The topology does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteTopologiesById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topology deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeleteTopologyResult"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The topology does not exist */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdObservations: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Observation summaries */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        topologyId: string;
+                        sourceId: string;
+                        capturedAt: number;
+                        /** @enum {string} */
+                        status: "ok" | "partial" | "failed" | "empty";
+                        statusMessage?: string;
+                        nodeCount: number;
+                        linkCount: number;
+                        portCount: number;
+                        createdAt: number;
+                    }[];
+                };
+            };
+        };
+    };
+    getTopologiesByIdObservationsByObsId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                obsId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Observation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyObservation"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByTopologyIdSourcesBySourceIdLatestSnapshot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+                sourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Latest snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LatestTopologySnapshot"];
+                };
+            };
+        };
+    };
+    postTopologiesByTopologyIdSourcesBySourceIdObservation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+                sourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    graph: components["schemas"]["NetworkGraph"];
+                    /**
+                     * @default ok
+                     * @enum {string}
+                     */
+                    status?: "ok" | "partial" | "failed" | "empty";
+                };
+            };
+        };
+        responses: {
+            /** @description Recorded observation */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        observation: components["schemas"]["TopologyObservation"];
+                    };
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdResolved: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Resolved graph */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResolvedTopology"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdDisplaySettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Display settings */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDisplaySettings"];
+                };
+            };
+        };
+    };
+    putTopologiesByIdDisplaySettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateTopologyDisplaySettings"];
+            };
+        };
+        responses: {
+            /** @description Settings updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OkResult"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdMapping: {
+        parameters: {
+            query?: {
+                sourceId?: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Metrics mapping */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MetricsMapping"];
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    putTopologiesByIdMapping: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    mapping: components["schemas"]["MetricsMapping"];
+                    sourceId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Updated mapping */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Topology"] & {
+                        skipped: {
+                            nodes: number;
+                            links: number;
+                        };
+                    };
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdMappingSources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Source mappings */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        sourceId: string;
+                        sourceName: string;
+                        priority: number;
+                        mapping: components["schemas"]["MetricsMapping"];
+                    }[];
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdMappingOrphans: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Mapping orphans */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        orphans: {
+                            entityId: string;
+                            kind: string;
+                            sourceId: string;
+                            payload?: unknown;
+                        }[];
+                    };
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByIdMappingOrphansByEntityIdReassign: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                entityId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    toEntityId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Mapping reassigned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MappingSuccess"];
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteTopologiesByIdMappingOrphansByEntityId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                entityId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Mapping discarded */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MappingSuccess"];
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByIdRegistryReset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Registry reset */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MappingSuccess"];
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    patchTopologiesByIdMappingNodesByNodeId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                nodeId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    hostId?: string;
+                    hostName?: string;
+                    sourceId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Updated node mapping */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        topology: components["schemas"]["Topology"];
+                        nodeMapping: {
+                            hostId?: string;
+                            hostName?: string;
+                        } | null;
+                    };
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    patchTopologiesByIdMappingLinksByLinkId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                linkId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    monitoredNodeId?: string;
+                    interface?: string;
+                    bandwidth?: number;
+                    sourceId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Updated link mapping */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {boolean} */
+                        success: true;
+                        topology: components["schemas"]["Topology"];
+                        linkMapping: {
+                            monitoredNodeId?: string;
+                            interface?: string;
+                            bandwidth?: number;
+                        } | null;
+                    };
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteTopologiesByIdMappingNodes: {
+        parameters: {
+            query?: {
+                sourceId?: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted mapping count */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        deleted: number;
+                    };
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteTopologiesByIdMappingLinks: {
+        parameters: {
+            query?: {
+                sourceId?: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted mapping count */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        deleted: number;
+                    };
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByIdMappingAutoMapLinks: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    overwrite?: boolean;
+                    sourceId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Auto-map result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        matched: number;
+                        total: number;
+                        skipped: number;
+                    };
+                };
+            };
+            /** @description Mapping operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Mapping operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdParsed: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get parsed topology and layout */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ParsedTopology"];
+                };
+            };
+            /** @description The initial topology derivation is still running */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDeriving"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdGraph: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get the resolved topology graph */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyGraph"];
+                };
+            };
+            /** @description The initial topology derivation is still running */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDeriving"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdView: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get graph and server-baked layout */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyView"];
+                };
+            };
+            /** @description The initial topology derivation is still running */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDeriving"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdRender: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Render a topology for embedding */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyRender"];
+                };
+            };
+            /** @description The initial topology derivation is still running */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDeriving"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdContext: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Get simplified topology context */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyContext"];
+                };
+            };
+            /** @description The initial topology derivation is still running */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDeriving"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdComposition: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topology composition policy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyComposition"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    putTopologiesByIdComposition: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    scopeMode?: "auto" | "open" | "closed";
+                    scopeSourceId?: string | null;
+                    scope?: {
+                        include?: {
+                            /** @enum {string} */
+                            attr: "name" | "subnet" | "metadata";
+                            value: string;
+                            key?: string;
+                        }[];
+                        exclude?: {
+                            /** @enum {string} */
+                            attr: "name" | "subnet" | "metadata";
+                            value: string;
+                            key?: string;
+                        }[];
+                    };
+                    /** @enum {string} */
+                    compositionMode?: "additive" | "enrichment";
+                };
+            };
+        };
+        responses: {
+            /** @description Updated composition policy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyComposition"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByTopologyIdSources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Attached sources */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDataSource"][];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Source already attached */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    putTopologiesByTopologyIdSources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    sources: {
+                        dataSourceId: string;
+                        /** @enum {string} */
+                        purpose: "topology" | "metrics";
+                        /** @enum {string} */
+                        syncMode?: "manual" | "on_view" | "webhook";
+                        priority?: number;
+                        optionsJson?: string;
+                        /** @enum {string} */
+                        nodeContribution?: "scoop" | "anchor";
+                        /** @enum {string} */
+                        linkContribution?: "add" | "update";
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description Attached sources */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDataSource"][];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Source already attached */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByTopologyIdSources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AddTopologySource"];
+            };
+        };
+        responses: {
+            /** @description Attached source */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDataSource"] | {
+                        dataSourceId: string;
+                    };
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Source already attached */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    putTopologiesByTopologyIdSourcesBySourceId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+                sourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateTopologySource"];
+            };
+        };
+        responses: {
+            /** @description Updated source */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyDataSource"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Source already attached */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteTopologiesByTopologyIdSourcesBySourceId: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+                sourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Source detached */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologySourceSuccess"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Source already attached */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByTopologyIdSourcesBySourceIdClear: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+                sourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Contribution cleared */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologySourceSuccess"] & {
+                        deleted: number;
+                    };
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Source already attached */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByTopologyIdSourcesBySourceIdProbe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+                sourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    seeds: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Probe observation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        observation: components["schemas"]["TopologyObservation"];
+                    };
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Source already attached */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByTopologyIdSourcesBySourceIdSync: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                topologyId: string;
+                sourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Source snapshot and observation */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncTopologySourceResult"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Source already attached */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByIdSyncFromSource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sync job started */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StartedTopologySyncJobResult"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description A sync job is already running */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StartedTopologySyncJobResult"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByIdRebuild: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sync job started */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StartedTopologySyncJobResult"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description A sync job is already running */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StartedTopologySyncJobResult"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdSyncJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sync job state */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologySyncJobResult"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByIdSyncJobCancel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sync job state */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologySyncJobResult"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByIdShare: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Share token */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShareTopologyResult"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteTopologiesByIdShare: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sharing disabled */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnshareTopologyResult"];
+                };
+            };
+            /** @description Topology operation failed */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getTopologiesByIdDiscoveryPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Discovery policy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DiscoveryPolicy"];
+                };
+            };
+            /** @description Topology or node not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    patchTopologiesByIdDiscoveryPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    scope: "topology" | "node";
+                    id?: string;
+                    attachments?: ({
+                        /** @enum {string} */
+                        kind: "access";
+                        /** @enum {string} */
+                        protocol: "snmp";
+                        community?: string;
+                    } | {
+                        /** @enum {string} */
+                        kind: "policy";
+                        /** @enum {string} */
+                        mode?: "auto" | "observe" | "disabled";
+                        intervalMs?: number;
+                    })[] | null;
+                    label?: string | null;
+                    suppressedAttachments?: string[] | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Effective policy after update */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        effective: {
+                            /** @enum {string} */
+                            mode: "auto" | "observe" | "disabled";
+                            intervalMs: number;
+                            community?: string;
+                            source: {
+                                /** @enum {string} */
+                                mode: "node" | "subgraph" | "topology" | "default";
+                                /** @enum {string} */
+                                intervalMs: "node" | "subgraph" | "topology" | "default";
+                                /** @enum {string} */
+                                community: "node" | "subgraph" | "topology" | "default";
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology or node not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The node cannot be safely updated */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Discovery policy operation failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postTopologiesByIdDiscoveryPolicyExclusions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    mgmtIp?: string;
+                    chassisId?: string;
+                    sysName?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Current exclusions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        exclusions: {
+                            mgmtIp?: string;
+                            chassisId?: string;
+                            sysName?: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology or node not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteTopologiesByIdDiscoveryPolicyExclusions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    mgmtIp?: string;
+                    chassisId?: string;
+                    sysName?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Current exclusions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        exclusions: {
+                            mgmtIp?: string;
+                            chassisId?: string;
+                            sysName?: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Topology or node not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    postWebhooksByTypeById: {
+        parameters: {
+            query?: {
+                secret?: string;
+            };
+            header?: never;
+            path: {
+                type: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    [key: string]: unknown;
+                };
+            };
+        };
+        responses: {
+            /** @description Webhook processed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebhookResult"];
+                };
+            };
+            /** @description Webhook rejected */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Webhook rejected */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Webhook rejected */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Webhook rejected */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getWebhooksHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Webhook ingress is healthy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebhookHealth"];
+                };
+            };
+        };
+    };
+    getSystem: {
+        parameters: {
+            query?: {
+                /** @description Refresh cached release information when true */
+                refresh?: "true" | "false";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Build and release information */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemInfo"];
+                };
+            };
+            /** @description The request did not match the API contract */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getAdminStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current runtime status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminStatus"];
+                };
+            };
+            /** @description Authentication is required */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+}


### PR DESCRIPTION
## Summary

- assign deterministic, unique `operationId` values to all OpenAPI operations
- normalize JSON failures into a machine-readable `{ code, message, requestId, error }` envelope while retaining the legacy `error` field
- add an oasdiff compatibility check that rejects definite and potential breaking changes against the PR base
- regenerate the OpenAPI snapshot and typed web client, and document the compatibility policy in English and Japanese

## Validation

- `cd apps/server/api && bun run test` (27 Vitest files / 114 tests, 161 Bun integration tests)
- `cd apps/server && bun run test`
- `cd apps/server && bun run typecheck`
- `cd apps/server && bun run build`
- `bun x knip --workspace apps/server/api`
- repository pre-commit lint and typecheck (40/40 tasks)

No changeset is required because the Server workspaces are private products.