### PR TITLE
feat(server): add secure public demo authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,13 @@ See the **[Server Setup Guide](apps/server/README.md)** for Docker, Kubernetes (
 
 ```bash
 # Published Docker image (quickest)
-docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/konoe-akitoshi/shumoku:latest
+install -d -m 700 .shumoku
+openssl rand -base64 32 > .shumoku/admin-password
+chmod 600 .shumoku/admin-password
+docker run -d -p 8080:8080 -v shumoku-data:/data \
+  -v "$PWD/.shumoku/admin-password:/run/secrets/shumoku_admin_password:ro" \
+  -e SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=/run/secrets/shumoku_admin_password \
+  ghcr.io/konoe-akitoshi/shumoku:latest
 # → http://localhost:8080   (add `-e DEMO_MODE=true` to preload a sample network)
 
 # Docker Compose with an exact production version

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -18,3 +18,18 @@ SHUMOKU_PORT=8080
 # Seed the sample-network topology and stream mock metrics on first start
 # (no Prometheus/Zabbix needed). Keep false for real deployments.
 DEMO_MODE=false
+
+# Expose the full application to unauthenticated visitors as a read-only demo.
+# This is independent from DEMO_MODE, which only seeds sample data.
+PUBLIC_DEMO=false
+
+# Compose mounts this file as a Docker secret. Create it before the first start:
+#   install -d -m 700 .shumoku
+#   openssl rand -base64 32 > .shumoku/admin-password
+#   chmod 600 .shumoku/admin-password
+SHUMOKU_ADMIN_PASSWORD_FILE=./.shumoku/admin-password
+
+# Enable these when TLS terminates at a trusted reverse proxy. The proxy must
+# replace (not append untrusted client values to) X-Forwarded-For.
+SHUMOKU_SECURE_COOKIES=false
+SHUMOKU_TRUST_PROXY=false

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -43,14 +43,24 @@ before you pipe? The script is [`scripts/install.sh`](scripts/install.sh).
 
 ### Docker image (quickest — no clone)
 
-Pull the published image from GitHub Container Registry:
+Create an owner-readable bootstrap secret, then mount it into the container. It
+is consumed only when the database has no administrator password; later starts
+never overwrite the stored password hash.
 
 ```bash
+install -d -m 700 .shumoku
+openssl rand -base64 32 > .shumoku/admin-password
+chmod 600 .shumoku/admin-password
 docker run -d -p 8080:8080 -v shumoku-data:/data \
+  -v "$PWD/.shumoku/admin-password:/run/secrets/shumoku_admin_password:ro" \
+  -e SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=/run/secrets/shumoku_admin_password \
   ghcr.io/konoe-akitoshi/shumoku:latest          # http://localhost:8080
 
 # preload a sample network:
-docker run -d -p 8080:8080 -e DEMO_MODE=true ghcr.io/konoe-akitoshi/shumoku:latest
+docker run -d -p 8080:8080 -e DEMO_MODE=true \
+  -v "$PWD/.shumoku/admin-password:/run/secrets/shumoku_admin_password:ro" \
+  -e SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=/run/secrets/shumoku_admin_password \
+  ghcr.io/konoe-akitoshi/shumoku:latest
 ```
 
 Tags: `X.Y.Z` is the immutable production release and `latest` follows the
@@ -63,6 +73,8 @@ For production, pin an exact version rather than `latest`:
 
 ```bash
 docker run -d -p 8080:8080 -v shumoku-data:/data \
+  -v "$PWD/.shumoku/admin-password:/run/secrets/shumoku_admin_password:ro" \
+  -e SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=/run/secrets/shumoku_admin_password \
   ghcr.io/konoe-akitoshi/shumoku:0.1.6-beta.3
 ```
 
@@ -70,6 +82,8 @@ Test the newest beta without changing `latest`:
 
 ```bash
 docker run -d -p 8080:8080 -v shumoku-beta-data:/data \
+  -v "$PWD/.shumoku/admin-password:/run/secrets/shumoku_admin_password:ro" \
+  -e SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=/run/secrets/shumoku_admin_password \
   ghcr.io/konoe-akitoshi/shumoku:beta
 ```
 
@@ -81,6 +95,9 @@ docker run -d -p 8080:8080 -v shumoku-beta-data:/data \
 ```bash
 cd apps/server
 cp .env.example .env     # SHUMOKU_VERSION / SHUMOKU_PORT / DEMO_MODE
+install -d -m 700 .shumoku
+openssl rand -base64 32 > .shumoku/admin-password
+chmod 600 .shumoku/admin-password
 docker compose up -d
 ```
 
@@ -263,10 +280,45 @@ See the [YAML Reference](https://www.shumoku.dev/docs/npm/yaml-reference) for th
 | `DATA_DIR` | SQLite data directory | `/data` |
 | `SHUMOKU_PORT` | External port (Docker Compose) | `8080` |
 | `DEMO_MODE` | Load the sample network on an empty DB (`true`/`false`) | `false` |
+| `PUBLIC_DEMO` | Map unauthenticated visitors to a projected read-only viewer (`true`/`false`) | `false` |
+| `SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE` | Initial administrator password file; used only when auth is unconfigured | — |
+| `SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD` | Initial administrator password value for platforms without secret files | — |
+| `SHUMOKU_ALLOW_WEB_SETUP` | Enable browser-driven first-run setup for local development only | `false` |
+| `SHUMOKU_SECURE_COOKIES` | Always mark administrator session cookies `Secure` | `false` |
+| `SHUMOKU_TRUST_PROXY` | Trust proxy-supplied client IP headers for login throttling | `false` |
 | `SHUMOKU_UPDATE_CHECK` | Set to `off` to disable GitHub release checks | enabled |
 | `SHUMOKU_GITHUB_TOKEN` | Optional token for a higher GitHub API rate limit | — |
 
 Configuration is otherwise stored in SQLite (`$DATA_DIR/shumoku.db`) and managed from the web UI.
+
+## Authentication and public demo mode
+
+A fresh production server bound beyond loopback fails to start until an
+administrator password is supplied through one of the bootstrap variables.
+The file variant is preferred for Docker and Kubernetes; do not place the
+password in `config.yaml`, a Helm ConfigMap, the image, or source control. The
+server hashes it with Argon2id and stores only the hash in SQLite. Existing
+authentication is never replaced on restart.
+
+The browser setup endpoint is disabled by default. `bun run dev` enables it
+while binding the API to loopback; do not set `SHUMOKU_ALLOW_WEB_SETUP=true` on
+an externally reachable server.
+
+`DEMO_MODE=true` seeds sample topology data and mock metrics. It does not change
+access control. `PUBLIC_DEMO=true` separately enables the full application shell
+for unauthenticated viewers: only an explicit set of GET endpoints is reachable,
+known credential and device-identity carriers are projected out, mutations return
+`403`, and live metrics are sanitized. Administrator login remains available at
+`/login`.
+
+When TLS terminates at a reverse proxy, set `SHUMOKU_SECURE_COOKIES=true`. Set
+`SHUMOKU_TRUST_PROXY=true` only when the trusted proxy replaces untrusted
+`X-Forwarded-For` input.
+
+Internally, sessions resolve to a provider-neutral principal and routes authorize
+permissions rather than cookie presence. The `user` role and session claims are
+already reserved for future multi-user/OIDC support; see the
+[authentication and authorization model](docs/design/authentication-authorization.md).
 
 ## Deployment
 

--- a/apps/server/api/openapi.json
+++ b/apps/server/api/openapi.json
@@ -47,11 +47,51 @@
           },
           "authenticated": {
             "type": "boolean"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "anonymous",
+              "viewer",
+              "user",
+              "admin"
+            ]
+          },
+          "authMethod": {
+            "type": "string",
+            "enum": [
+              "anonymous",
+              "password",
+              "bearer"
+            ]
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "public:read",
+                "workspace:read",
+                "workspace:write",
+                "admin:manage"
+              ]
+            }
+          },
+          "publicDemo": {
+            "type": "boolean"
           }
         },
         "required": [
           "setupComplete",
-          "authenticated"
+          "authenticated",
+          "subject",
+          "role",
+          "authMethod",
+          "permissions",
+          "publicDemo"
         ]
       },
       "AuthSuccess": {
@@ -3518,6 +3558,16 @@
           },
           "400": {
             "description": "The request did not match the API contract",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Browser-driven setup is disabled",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/api/src/index.js",
   "scripts": {
     "build": "tsc && bun -e \"import{cpSync}from'fs';cpSync('src/db/migrations','dist/api/src/db/migrations',{recursive:true})\"",
-    "dev": "NODE_ENV=development bun --watch src/index.ts",
+    "dev": "HOST=127.0.0.1 SHUMOKU_ALLOW_WEB_SETUP=true NODE_ENV=development bun --watch src/index.ts",
     "start": "bun dist/api/src/index.js",
     "test": "vitest run && bun test ./test",
     "test:unit": "vitest run",

--- a/apps/server/api/src/app/auth.ts
+++ b/apps/server/api/src/app/auth.ts
@@ -2,11 +2,13 @@ import {
   checkRateLimit,
   clearAttempts,
   createSession,
+  deleteAllSessions,
   deleteSession,
+  getSessionPrincipal,
   isSetupComplete,
   recordFailedAttempt,
+  setInitialPassword,
   setPassword,
-  validateSession,
   verifyPassword,
 } from '../services/auth.js'
 import type { AuthApplicationService } from './services.js'
@@ -14,11 +16,13 @@ import type { AuthApplicationService } from './services.js'
 export function createAuthApplicationService(): AuthApplicationService {
   return {
     isSetupComplete,
-    validateSession,
+    getSessionPrincipal,
     setPassword,
+    setInitialPassword,
     verifyPassword,
     createSession,
     deleteSession,
+    deleteAllSessions,
     checkRateLimit,
     recordFailedAttempt,
     clearAttempts,

--- a/apps/server/api/src/app/services.ts
+++ b/apps/server/api/src/app/services.ts
@@ -18,6 +18,7 @@ import type {
   Snapshot,
   SplineMode,
 } from '@shumoku/core'
+import type { AuthPrincipal } from '../auth/principal.js'
 import type { Alert, AlertQueryOptions } from '../plugins/types.js'
 import type { BuildInfo, SystemInfo } from '../services/system-info.js'
 import type {
@@ -136,11 +137,13 @@ export interface SettingsApplicationService {
 
 export interface AuthApplicationService {
   isSetupComplete(): boolean
-  validateSession(token: string): boolean
+  getSessionPrincipal(token: string): AuthPrincipal | null
   setPassword(password: string): Promise<void>
+  setInitialPassword(password: string): Promise<boolean>
   verifyPassword(password: string): Promise<boolean>
-  createSession(): string
+  createSession(principal?: AuthPrincipal): string
   deleteSession(token: string): void
+  deleteAllSessions(): void
   checkRateLimit(clientId: string): number
   recordFailedAttempt(clientId: string): void
   clearAttempts(clientId: string): void

--- a/apps/server/api/src/auth-config.ts
+++ b/apps/server/api/src/auth-config.ts
@@ -1,0 +1,13 @@
+type AuthEnvironment = Record<string, string | undefined>
+
+export function isPublicDemoEnabled(env: AuthEnvironment = process.env): boolean {
+  return env['PUBLIC_DEMO'] === 'true'
+}
+
+/** Browser-driven first-run setup is an explicit local-development capability. */
+export function isWebSetupEnabled(env: AuthEnvironment = process.env): boolean {
+  if (env['SHUMOKU_ALLOW_WEB_SETUP'] === 'true') return true
+  if (env['NODE_ENV'] !== 'development') return false
+  const host = env['HOST'] ?? '0.0.0.0'
+  return host === '127.0.0.1' || host === '::1' || host === '[::1]' || host === 'localhost'
+}

--- a/apps/server/api/src/auth/access-policy.test.ts
+++ b/apps/server/api/src/auth/access-policy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { authorizeRequest } from './access-policy.js'
+import type { AuthPrincipal } from './principal.js'
+
+const user: AuthPrincipal = { subject: 'user-1', role: 'user', authMethod: 'password' }
+const viewer: AuthPrincipal = {
+  subject: 'public-demo',
+  role: 'viewer',
+  authMethod: 'anonymous',
+}
+
+describe('principal authorization policy', () => {
+  it('lets a normal user read and write workspace resources but not administration', () => {
+    expect(authorizeRequest(user, 'GET', '/api/topologies').allowed).toBe(true)
+    expect(authorizeRequest(user, 'POST', '/api/topologies').allowed).toBe(true)
+    expect(authorizeRequest(user, 'GET', '/api/datasources').allowed).toBe(false)
+    expect(authorizeRequest(user, 'GET', '/api/settings').allowed).toBe(false)
+    expect(authorizeRequest(user, 'POST', '/api/plugins/reload').allowed).toBe(false)
+  })
+
+  it('keeps a viewer on the projected public allow-list', () => {
+    expect(authorizeRequest(viewer, 'GET', '/api/topologies/topology-1/view')).toMatchObject({
+      allowed: true,
+      projectPublicResponse: true,
+    })
+    expect(authorizeRequest(viewer, 'GET', '/api/topologies/topology-1/sources').allowed).toBe(
+      false,
+    )
+    expect(authorizeRequest(viewer, 'POST', '/api/topologies').allowed).toBe(false)
+  })
+})

--- a/apps/server/api/src/auth/access-policy.ts
+++ b/apps/server/api/src/auth/access-policy.ts
@@ -1,0 +1,59 @@
+import type { AuthPermission, AuthPrincipal } from './principal.js'
+import { hasPermission } from './principal.js'
+
+const PUBLIC_DEMO_READS = [
+  /^\/api\/topologies$/,
+  /^\/api\/topologies\/[^/]+$/,
+  /^\/api\/topologies\/[^/]+\/(?:graph|view|render|context)$/,
+  /^\/api\/dashboards$/,
+  /^\/api\/dashboards\/[^/]+$/,
+  /^\/api\/datasources$/,
+  /^\/api\/datasources\/by-capability\/alerts$/,
+  /^\/api\/datasources\/[^/]+\/alerts$/,
+  /^\/api\/system$/,
+] as const
+
+const ADMIN_SURFACES = [
+  /^\/api\/admin(?:\/|$)/,
+  /^\/api\/datasources(?:\/|$)/,
+  /^\/api\/plugins(?:\/|$)/,
+  /^\/api\/settings(?:\/|$)/,
+  /^\/api\/topologies\/[^/]+\/sources(?:\/|$)/,
+]
+
+export interface AuthorizationDecision {
+  allowed: boolean
+  projectPublicResponse: boolean
+  requiredPermission: AuthPermission
+}
+
+export function isPublicDemoRead(method: string, pathname: string): boolean {
+  return method === 'GET' && PUBLIC_DEMO_READS.some((pattern) => pattern.test(pathname))
+}
+
+export function requiredPermission(method: string, pathname: string): AuthPermission {
+  if (ADMIN_SURFACES.some((pattern) => pattern.test(pathname))) return 'admin:manage'
+  return method === 'GET' || method === 'HEAD' ? 'workspace:read' : 'workspace:write'
+}
+
+/** One policy for HTTP and future user-backed sessions. */
+export function authorizeRequest(
+  principal: AuthPrincipal,
+  method: string,
+  pathname: string,
+): AuthorizationDecision {
+  if (principal.role === 'viewer') {
+    return {
+      allowed: hasPermission(principal, 'public:read') && isPublicDemoRead(method, pathname),
+      projectPublicResponse: true,
+      requiredPermission: 'public:read',
+    }
+  }
+
+  const permission = requiredPermission(method, pathname)
+  return {
+    allowed: hasPermission(principal, permission),
+    projectPublicResponse: false,
+    requiredPermission: permission,
+  }
+}

--- a/apps/server/api/src/auth/principal.ts
+++ b/apps/server/api/src/auth/principal.ts
@@ -1,0 +1,66 @@
+export const AUTH_ROLES = ['anonymous', 'viewer', 'user', 'admin'] as const
+export type AuthRole = (typeof AUTH_ROLES)[number]
+
+export const AUTH_METHODS = ['anonymous', 'password', 'bearer'] as const
+export type AuthMethod = (typeof AUTH_METHODS)[number]
+
+export const AUTH_PERMISSIONS = [
+  'public:read',
+  'workspace:read',
+  'workspace:write',
+  'admin:manage',
+] as const
+export type AuthPermission = (typeof AUTH_PERMISSIONS)[number]
+
+export interface AuthPrincipal {
+  subject: string
+  role: AuthRole
+  authMethod: AuthMethod
+}
+
+const ROLE_PERMISSIONS: Record<AuthRole, readonly AuthPermission[]> = {
+  anonymous: [],
+  viewer: ['public:read'],
+  user: ['public:read', 'workspace:read', 'workspace:write'],
+  admin: AUTH_PERMISSIONS,
+}
+
+export const ANONYMOUS_PRINCIPAL: AuthPrincipal = {
+  subject: 'anonymous',
+  role: 'anonymous',
+  authMethod: 'anonymous',
+}
+
+export const PUBLIC_DEMO_PRINCIPAL: AuthPrincipal = {
+  subject: 'public-demo',
+  role: 'viewer',
+  authMethod: 'anonymous',
+}
+
+export const LOCAL_ADMIN_PRINCIPAL: AuthPrincipal = {
+  subject: 'local-admin',
+  role: 'admin',
+  authMethod: 'password',
+}
+
+export const DEV_AUTOMATION_PRINCIPAL: AuthPrincipal = {
+  subject: 'dev-automation',
+  role: 'admin',
+  authMethod: 'bearer',
+}
+
+export function permissionsForRole(role: AuthRole): readonly AuthPermission[] {
+  return ROLE_PERMISSIONS[role]
+}
+
+export function hasPermission(principal: AuthPrincipal, permission: AuthPermission): boolean {
+  return ROLE_PERMISSIONS[principal.role].includes(permission)
+}
+
+export function isAuthRole(value: string): value is AuthRole {
+  return (AUTH_ROLES as readonly string[]).includes(value)
+}
+
+export function isAuthMethod(value: string): value is AuthMethod {
+  return (AUTH_METHODS as readonly string[]).includes(value)
+}

--- a/apps/server/api/src/auth/request-principal.ts
+++ b/apps/server/api/src/auth/request-principal.ts
@@ -1,0 +1,11 @@
+import type { AuthPrincipal } from './principal.js'
+
+const requestPrincipals = new WeakMap<Request, AuthPrincipal>()
+
+export function setRequestPrincipal(request: Request, principal: AuthPrincipal): void {
+  requestPrincipals.set(request, principal)
+}
+
+export function getRequestPrincipal(request: Request): AuthPrincipal | null {
+  return requestPrincipals.get(request) ?? null
+}

--- a/apps/server/api/src/db/migrations/033_auth_principals.sql
+++ b/apps/server/api/src/db/migrations/033_auth_principals.sql
@@ -1,0 +1,9 @@
+-- Attach an authenticated subject and claims to every session. Existing
+-- single-administrator sessions become local-admin sessions automatically.
+ALTER TABLE sessions ADD COLUMN subject TEXT NOT NULL DEFAULT 'local-admin';
+ALTER TABLE sessions ADD COLUMN role TEXT NOT NULL DEFAULT 'admin'
+  CHECK (role IN ('viewer', 'user', 'admin'));
+ALTER TABLE sessions ADD COLUMN auth_method TEXT NOT NULL DEFAULT 'password'
+  CHECK (auth_method IN ('password', 'bearer'));
+
+CREATE INDEX IF NOT EXISTS idx_sessions_subject ON sessions(subject);

--- a/apps/server/api/src/db/schema.ts
+++ b/apps/server/api/src/db/schema.ts
@@ -37,6 +37,7 @@ import migration029 from './migrations/029_entity_identity_key_source.sql'
 import migration030 from './migrations/030_entity_element.sql'
 import migration031 from './migrations/031_discovery_config.sql'
 import migration032 from './migrations/032_deep_read_rename.sql'
+import migration033 from './migrations/033_auth_principals.sql'
 
 /** Ordered list of all migrations */
 const MIGRATIONS: { name: string; sql: string }[] = [
@@ -70,6 +71,7 @@ const MIGRATIONS: { name: string; sql: string }[] = [
   { name: '030_entity_element.sql', sql: migration030 },
   { name: '031_discovery_config.sql', sql: migration031 },
   { name: '032_deep_read_rename.sql', sql: migration032 },
+  { name: '033_auth_principals.sql', sql: migration033 },
 ]
 
 interface MigrationRecord {

--- a/apps/server/api/src/middleware/auth.test.ts
+++ b/apps/server/api/src/middleware/auth.test.ts
@@ -1,18 +1,19 @@
 import { Hono } from 'hono'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getRequestPrincipal } from '../auth/request-principal.js'
 import { authMiddleware, getDevApiToken, validateDevApiAuthConfiguration } from './auth.js'
 
 const TOKEN = 'a'.repeat(64)
 
 const authService = vi.hoisted(() => ({
   isSetupComplete: vi.fn(() => true),
-  validateSession: vi.fn(() => false),
+  getSessionPrincipal: vi.fn((): import('../auth/principal.js').AuthPrincipal | null => null),
 }))
 
 vi.mock('../services/auth.js', () => ({
   isSetupComplete: authService.isSetupComplete,
+  getSessionPrincipal: authService.getSessionPrincipal,
   SESSION_COOKIE: 'shumoku_session',
-  validateSession: authService.validateSession,
 }))
 
 describe('development API bearer authentication', () => {
@@ -20,8 +21,9 @@ describe('development API bearer authentication', () => {
     delete process.env['SHUMOKU_DEV_API_TOKEN']
     delete process.env['HOST']
     delete process.env['NODE_ENV']
+    delete process.env['PUBLIC_DEMO']
     authService.isSetupComplete.mockReturnValue(true)
-    authService.validateSession.mockReturnValue(false)
+    authService.getSessionPrincipal.mockReturnValue(null)
   })
 
   it('is disabled outside development even when a token is present', () => {
@@ -101,7 +103,11 @@ describe('development API bearer authentication', () => {
   })
 
   it('preserves the existing authenticated session-cookie flow', async () => {
-    authService.validateSession.mockReturnValue(true)
+    authService.getSessionPrincipal.mockReturnValue({
+      subject: 'local-admin',
+      role: 'admin',
+      authMethod: 'password',
+    })
 
     const app = new Hono()
     app.use('/protected', authMiddleware)
@@ -111,16 +117,66 @@ describe('development API bearer authentication', () => {
       headers: { Cookie: 'shumoku_session=browser-session' },
     })
     expect(response.status).toBe(200)
-    expect(authService.validateSession).toHaveBeenCalledWith('browser-session')
+    expect(authService.getSessionPrincipal).toHaveBeenCalledWith('browser-session')
   })
 
-  it('preserves access before initial password setup', async () => {
+  it('propagates a normal-user principal and enforces admin permissions', async () => {
+    authService.getSessionPrincipal.mockReturnValue({
+      subject: 'user-1',
+      role: 'user',
+      authMethod: 'password',
+    })
+
+    const app = new Hono()
+    app.use('/api/*', authMiddleware)
+    app.post('/api/topologies', (c) => c.json(getRequestPrincipal(c.req.raw)))
+    app.get('/api/settings', (c) => c.json({ sensitive: true }))
+
+    const workspaceResponse = await app.request('/api/topologies', {
+      method: 'POST',
+      headers: { Cookie: 'shumoku_session=user-session' },
+    })
+    expect(workspaceResponse.status).toBe(200)
+    expect(await workspaceResponse.json()).toMatchObject({ subject: 'user-1', role: 'user' })
+
+    const adminResponse = await app.request('/api/settings', {
+      headers: { Cookie: 'shumoku_session=user-session' },
+    })
+    expect(adminResponse.status).toBe(403)
+  })
+
+  it('fails closed before initial password setup', async () => {
     authService.isSetupComplete.mockReturnValue(false)
 
     const app = new Hono()
     app.use('/protected', authMiddleware)
     app.get('/protected', (c) => c.json({ ok: true }))
 
-    expect((await app.request('/protected')).status).toBe(200)
+    expect((await app.request('/protected')).status).toBe(503)
+  })
+
+  it('allows and projects explicit public-demo reads', async () => {
+    process.env['PUBLIC_DEMO'] = 'true'
+    const app = new Hono()
+    app.use('/api/*', authMiddleware)
+    app.get('/api/datasources', (c) =>
+      c.json([{ id: 'source-1', configJson: '{"password":"secret"}', statusMessage: 'internal' }]),
+    )
+
+    const response = await app.request('/api/datasources')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([{ id: 'source-1', configJson: '{}' }])
+    expect(response.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('denies public-demo mutations and sensitive read surfaces', async () => {
+    process.env['PUBLIC_DEMO'] = 'true'
+    const app = new Hono()
+    app.use('/api/*', authMiddleware)
+    app.post('/api/topologies', (c) => c.json({ ok: true }))
+    app.get('/api/settings', (c) => c.json({ auth_password_hash: 'secret' }))
+
+    expect((await app.request('/api/topologies', { method: 'POST' })).status).toBe(403)
+    expect((await app.request('/api/settings')).status).toBe(403)
   })
 })

--- a/apps/server/api/src/middleware/auth.ts
+++ b/apps/server/api/src/middleware/auth.ts
@@ -10,8 +10,17 @@ import type { Context, Next } from 'hono'
 import { bearerAuth } from 'hono/bearer-auth'
 import { getCookie } from 'hono/cookie'
 import { SESSION_COOKIE } from '../app/auth-session.js'
+import { authorizeRequest } from '../auth/access-policy.js'
+import {
+  type AuthPrincipal,
+  DEV_AUTOMATION_PRINCIPAL,
+  PUBLIC_DEMO_PRINCIPAL,
+} from '../auth/principal.js'
+import { setRequestPrincipal } from '../auth/request-principal.js'
+import { isPublicDemoEnabled } from '../auth-config.js'
 import { apiError, apiErrorPayload } from '../openapi/common.js'
-import { isSetupComplete, validateSession } from '../services/auth.js'
+import { getSessionPrincipal, isSetupComplete } from '../services/auth.js'
+import { projectPublicDemoResponse } from './public-demo.js'
 
 const DEV_API_TOKEN_PATTERN = /^[a-f0-9]{64}$/i
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', '[::1]'])
@@ -48,6 +57,32 @@ export function validateDevApiAuthConfiguration(env: AuthEnvironment = process.e
   getDevApiToken(env)
 }
 
+async function continueAsPrincipal(
+  c: Context,
+  next: Next,
+  principal: AuthPrincipal,
+  projectPublicResponse: boolean,
+): Promise<void> {
+  setRequestPrincipal(c.req.raw, principal)
+  await next()
+  if (projectPublicResponse) await projectPublicDemoResponse(c)
+}
+
+async function authorizeAndContinue(
+  c: Context,
+  next: Next,
+  principal: AuthPrincipal,
+): Promise<Response | undefined> {
+  const pathname = new URL(c.req.url).pathname
+  const decision = authorizeRequest(principal, c.req.method, pathname)
+  if (!decision.allowed) {
+    return apiError(c, `Permission required: ${decision.requiredPermission}`, 403)
+  }
+
+  await continueAsPrincipal(c, next, principal, decision.projectPublicResponse)
+  return undefined
+}
+
 /**
  * Check if a request path + method is public (no auth needed)
  */
@@ -79,10 +114,10 @@ function isPublicRequest(method: string, pathname: string): boolean {
  * Hono middleware that enforces authentication on protected routes
  */
 export async function authMiddleware(c: Context, next: Next) {
-  // If password not set yet, allow everything (setup not complete)
+  // Initial setup is handled by the public /api/auth routes. Management APIs
+  // stay closed until an administrator password exists.
   if (!isSetupComplete()) {
-    await next()
-    return
+    return apiError(c, 'Administrator setup required', 503)
   }
 
   const pathname = new URL(c.req.url).pathname
@@ -96,15 +131,39 @@ export async function authMiddleware(c: Context, next: Next) {
 
   // Check session cookie
   const sessionToken = getCookie(c, SESSION_COOKIE)
-  if (sessionToken && validateSession(sessionToken)) {
-    await next()
-    return
+  const sessionPrincipal = sessionToken ? getSessionPrincipal(sessionToken) : null
+  if (sessionPrincipal) {
+    return authorizeAndContinue(c, next, sessionPrincipal)
   }
 
   // Development automation uses the standard Authorization: Bearer scheme.
   // Invoke Hono's official middleware only after the browser session check so
   // the existing UI authentication flow remains unchanged.
   const devApiToken = getDevApiToken()
+  const authorization = c.req.header('authorization')
+  if (devApiToken && authorization) {
+    return bearerAuth({
+      token: devApiToken,
+      realm: 'shumoku-dev-api',
+      noAuthenticationHeader: {
+        message: (context) => apiErrorPayload(context, 'Authentication required', 401),
+      },
+      invalidAuthenticationHeader: {
+        message: (context) => apiErrorPayload(context, 'Invalid authorization header', 400),
+      },
+      invalidToken: {
+        message: (context) => apiErrorPayload(context, 'Invalid bearer token', 401),
+      },
+    })(c, () => continueAsPrincipal(c, next, DEV_AUTOMATION_PRINCIPAL, false))
+  }
+
+  // PUBLIC_DEMO maps an unauthenticated request to an implicit viewer. The
+  // request must pass a narrow route allow-list and its response is projected
+  // before leaving the process.
+  if (isPublicDemoEnabled()) {
+    return authorizeAndContinue(c, next, PUBLIC_DEMO_PRINCIPAL)
+  }
+
   if (devApiToken) {
     return bearerAuth({
       token: devApiToken,

--- a/apps/server/api/src/middleware/public-demo.test.ts
+++ b/apps/server/api/src/middleware/public-demo.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { isViewerRequestAllowed, publicDemoValue } from './public-demo.js'
+
+describe('public demo authorization', () => {
+  it('uses an explicit read allow-list', () => {
+    expect(isViewerRequestAllowed('GET', '/api/topologies')).toBe(true)
+    expect(isViewerRequestAllowed('GET', '/api/dashboards/dashboard-1')).toBe(true)
+    expect(isViewerRequestAllowed('GET', '/api/topologies/topology-1/view')).toBe(true)
+    expect(isViewerRequestAllowed('GET', '/api/datasources/source-1/alerts')).toBe(true)
+    expect(isViewerRequestAllowed('POST', '/api/topologies')).toBe(false)
+    expect(isViewerRequestAllowed('HEAD', '/api/topologies')).toBe(false)
+    expect(isViewerRequestAllowed('GET', '/api/settings')).toBe(false)
+    expect(isViewerRequestAllowed('GET', '/api/topologies/topology-1/mapping')).toBe(false)
+    expect(isViewerRequestAllowed('GET', '/api/topologies/topology-1/sources')).toBe(false)
+    expect(isViewerRequestAllowed('GET', '/api/datasources/source-1/hosts')).toBe(false)
+    expect(isViewerRequestAllowed('GET', '/api/datasources/source-1/config-options/site')).toBe(
+      false,
+    )
+  })
+
+  it('removes credentials and internal identities recursively', () => {
+    expect(
+      publicDemoValue({
+        id: 'source-1',
+        configJson: '{"password":"secret"}',
+        webhookSecret: 'secret',
+        dataSource: {
+          statusMessage: 'failed to connect to 10.0.0.1 with token=secret',
+          path: '/private/plugin/path',
+        },
+      }),
+    ).toEqual({ id: 'source-1', configJson: '{}', dataSource: {} })
+  })
+
+  it('uses the narrow metrics and alert projections', () => {
+    expect(
+      publicDemoValue({
+        nodes: {
+          router: { status: 'up', monitoringError: 'secret internal address', cpu: 42 },
+        },
+        links: { uplink: { status: 'up', inBps: 12, outBps: 34 } },
+        timestamp: 123,
+        warnings: ['internal parser error'],
+      }),
+    ).toEqual({
+      nodes: { router: { status: 'up' } },
+      links: { uplink: { status: 'up', inBps: 12, outBps: 34 } },
+      timestamp: 123,
+    })
+
+    expect(
+      publicDemoValue({
+        id: 'alert-1',
+        severity: 'high',
+        status: 'firing',
+        title: 'Router down',
+        startTime: 123,
+        description: 'query with secret',
+        hostId: 'internal-host-id',
+        url: 'http://internal.example',
+      }),
+    ).toEqual({
+      id: 'alert-1',
+      severity: 'high',
+      status: 'firing',
+      title: 'Router down',
+      startTime: 123,
+    })
+  })
+})

--- a/apps/server/api/src/middleware/public-demo.ts
+++ b/apps/server/api/src/middleware/public-demo.ts
@@ -1,0 +1,104 @@
+import type { Alert, MetricsData, NetworkGraph } from '@shumoku/core'
+import type { Context } from 'hono'
+
+export { isPublicDemoRead as isViewerRequestAllowed } from '../auth/access-policy.js'
+
+import {
+  publicAlert,
+  publicDashboardLayout,
+  publicGraph,
+  publicMetrics,
+} from '../modules/share/projections.js'
+
+const DROPPED_KEYS = new Set([
+  'attachments',
+  'exclusions',
+  'description',
+  'hostId',
+  'identity',
+  'ip',
+  'mapping',
+  'mappingJson',
+  'metadata',
+  'monitoringError',
+  'optionsJson',
+  'password',
+  'path',
+  'secret',
+  'shareToken',
+  'source',
+  'statusMessage',
+  'token',
+  'url',
+  'warnings',
+  'webhookSecret',
+])
+
+function looksLikeAlert(value: Record<string, unknown>): boolean {
+  return (
+    typeof value['id'] === 'string' &&
+    typeof value['severity'] === 'string' &&
+    typeof value['status'] === 'string' &&
+    typeof value['title'] === 'string' &&
+    typeof value['startTime'] === 'number'
+  )
+}
+
+function looksLikeGraph(value: Record<string, unknown>): boolean {
+  return Array.isArray(value['nodes']) && Array.isArray(value['links'])
+}
+
+function looksLikeMetrics(value: Record<string, unknown>): boolean {
+  return (
+    typeof value['nodes'] === 'object' &&
+    !Array.isArray(value['nodes']) &&
+    typeof value['links'] === 'object' &&
+    !Array.isArray(value['links']) &&
+    typeof value['timestamp'] === 'number'
+  )
+}
+
+/**
+ * Defense-in-depth projection for the management-shaped demo reads. Dedicated
+ * share projections remain stricter; this removes every known credential and
+ * internal-identity carrier before a viewer response leaves the server.
+ */
+export function publicDemoValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(publicDemoValue)
+  if (!value || typeof value !== 'object') return value
+
+  const object = value as Record<string, unknown>
+  if (looksLikeAlert(object)) return publicAlert(object as unknown as Alert)
+  if (looksLikeGraph(object)) return publicGraph(object as unknown as NetworkGraph)
+  if (looksLikeMetrics(object)) return publicMetrics(object as unknown as MetricsData)
+
+  const projected: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(object)) {
+    if (key === 'configJson') {
+      projected[key] = '{}'
+      continue
+    }
+    if (key === 'layoutJson' && typeof child === 'string') {
+      projected[key] = publicDashboardLayout(child)
+      continue
+    }
+    if (DROPPED_KEYS.has(key)) continue
+    projected[key] = publicDemoValue(child)
+  }
+  return projected
+}
+
+export async function projectPublicDemoResponse(c: Context): Promise<void> {
+  const contentType = c.res.headers.get('content-type')
+  if (!contentType?.includes('application/json') || c.res.status < 200 || c.res.status >= 300)
+    return
+
+  const value: unknown = await c.res.clone().json()
+  const headers = new Headers(c.res.headers)
+  headers.set('Cache-Control', 'no-store')
+  c.res = new Response(JSON.stringify(publicDemoValue(value)), {
+    status: c.res.status,
+    statusText: c.res.statusText,
+    headers,
+  })
+}

--- a/apps/server/api/src/modules/auth/routes.test.ts
+++ b/apps/server/api/src/modules/auth/routes.test.ts
@@ -1,16 +1,22 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AuthApplicationService } from '../../app/services.js'
 import { createAuthApi } from './routes.js'
 
 function createService(overrides: Partial<AuthApplicationService> = {}): AuthApplicationService {
   return {
     isSetupComplete: vi.fn(() => true),
-    validateSession: vi.fn(() => true),
+    getSessionPrincipal: vi.fn(() => ({
+      subject: 'local-admin',
+      role: 'admin' as const,
+      authMethod: 'password' as const,
+    })),
     setPassword: vi.fn(async () => undefined),
+    setInitialPassword: vi.fn(async () => true),
     verifyPassword: vi.fn(async () => true),
     createSession: vi.fn(() => 'session-token'),
     deleteSession: vi.fn(),
+    deleteAllSessions: vi.fn(),
     checkRateLimit: vi.fn(() => 0),
     recordFailedAttempt: vi.fn(),
     clearAttempts: vi.fn(),
@@ -23,12 +29,22 @@ function createApp(service = createService()): OpenAPIHono {
 }
 
 describe('OpenAPI authentication routes', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
   it('reports setup and session status', async () => {
     const response = await createApp().request('/auth/status', {
       headers: { Cookie: 'shumoku_session=session-token' },
     })
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ setupComplete: true, authenticated: true })
+    expect(await response.json()).toEqual({
+      setupComplete: true,
+      authenticated: true,
+      subject: 'local-admin',
+      role: 'admin',
+      authMethod: 'password',
+      permissions: ['public:read', 'workspace:read', 'workspace:write', 'admin:manage'],
+      publicDemo: false,
+    })
   })
 
   it('creates a session for a valid login', async () => {
@@ -39,6 +55,38 @@ describe('OpenAPI authentication routes', () => {
     })
     expect(response.status).toBe(200)
     expect(response.headers.get('set-cookie')).toContain('shumoku_session=session-token')
+  })
+
+  it('requires an explicit local-development opt-in for browser setup', async () => {
+    const disabled = await createApp().request('/auth/setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'initial-password' }),
+    })
+    expect(disabled.status).toBe(403)
+
+    vi.stubEnv('SHUMOKU_ALLOW_WEB_SETUP', 'true')
+    const enabled = await createApp().request('/auth/setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'initial-password' }),
+    })
+    expect(enabled.status).toBe(200)
+  })
+
+  it('invalidates older sessions when the password changes', async () => {
+    const service = createService()
+    const response = await createApp(service).request('/auth/change-password', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'shumoku_session=session-token',
+      },
+      body: JSON.stringify({ currentPassword: 'old-password', newPassword: 'new-password' }),
+    })
+    expect(response.status).toBe(200)
+    expect(service.deleteAllSessions).toHaveBeenCalledOnce()
+    expect(service.createSession).toHaveBeenCalledOnce()
   })
 
   it('rejects an invalid login and records the attempt', async () => {

--- a/apps/server/api/src/modules/auth/routes.ts
+++ b/apps/server/api/src/modules/auth/routes.ts
@@ -3,6 +3,13 @@ import type { Context } from 'hono'
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie'
 import { SESSION_COOKIE } from '../../app/auth-session.js'
 import type { AppServices } from '../../app/services.js'
+import {
+  ANONYMOUS_PRINCIPAL,
+  hasPermission,
+  PUBLIC_DEMO_PRINCIPAL,
+  permissionsForRole,
+} from '../../auth/principal.js'
+import { isPublicDemoEnabled, isWebSetupEnabled } from '../../auth-config.js'
 import { badRequestResponse, createOpenAPIApp, ErrorSchema } from '../../openapi/common.js'
 import {
   AuthStatusSchema,
@@ -37,7 +44,14 @@ const setupRoute = createRoute({
   request: {
     body: { required: true, content: { 'application/json': { schema: PasswordSchema } } },
   },
-  responses: { 200: successResponse, 400: badRequestResponse },
+  responses: {
+    200: successResponse,
+    400: badRequestResponse,
+    403: {
+      description: 'Browser-driven setup is disabled',
+      content: { 'application/json': { schema: ErrorSchema } },
+    },
+  },
 })
 const loginRoute = createRoute({
   method: 'post',
@@ -87,6 +101,7 @@ const logoutRoute = createRoute({
 })
 
 function clientIp(c: Context): string {
+  if (process.env['SHUMOKU_TRUST_PROXY'] !== 'true') return 'global'
   return (
     c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ?? c.req.header('x-real-ip') ?? '0.0.0.0'
   )
@@ -98,7 +113,7 @@ function setSessionCookie(c: Context, token: string): void {
     sameSite: 'Lax',
     path: '/',
     maxAge: COOKIE_MAX_AGE,
-    secure: c.req.url.startsWith('https'),
+    secure: process.env['SHUMOKU_SECURE_COOKIES'] === 'true' || c.req.url.startsWith('https'),
   })
 }
 
@@ -108,17 +123,35 @@ export function createAuthApi(services: Pick<AppServices, 'auth'>): OpenAPIHono 
 
   app.openapi(statusRoute, (c) => {
     const token = getCookie(c, SESSION_COOKIE)
+    const setupComplete = service.isSetupComplete()
+    const publicDemo = isPublicDemoEnabled()
+    const sessionPrincipal = token === undefined ? null : service.getSessionPrincipal(token)
+    const principal =
+      sessionPrincipal ??
+      (setupComplete && publicDemo ? PUBLIC_DEMO_PRINCIPAL : ANONYMOUS_PRINCIPAL)
     return c.json(
       {
-        setupComplete: service.isSetupComplete(),
-        authenticated: token !== undefined && service.validateSession(token),
+        setupComplete,
+        authenticated: sessionPrincipal !== null,
+        subject: principal.subject,
+        role: principal.role,
+        authMethod: principal.authMethod,
+        permissions: [...permissionsForRole(principal.role)],
+        publicDemo,
       },
       200,
     )
   })
   app.openapi(setupRoute, async (c) => {
-    if (service.isSetupComplete()) return c.json({ error: 'Setup already completed' }, 400)
-    await service.setPassword(c.req.valid('json').password)
+    if (!isWebSetupEnabled()) {
+      return c.json(
+        { error: 'Browser-driven setup is disabled; configure an administrator Secret' },
+        403,
+      )
+    }
+    if (!(await service.setInitialPassword(c.req.valid('json').password))) {
+      return c.json({ error: 'Setup already completed' }, 400)
+    }
     setSessionCookie(c, service.createSession())
     return c.json({ success: true as const }, 200)
   })
@@ -140,7 +173,8 @@ export function createAuthApi(services: Pick<AppServices, 'auth'>): OpenAPIHono 
   app.openapi(changePasswordRoute, async (c) => {
     if (!service.isSetupComplete()) return c.json({ error: 'Setup not completed' }, 400)
     const token = getCookie(c, SESSION_COOKIE)
-    if (!token || !service.validateSession(token)) {
+    const principal = token ? service.getSessionPrincipal(token) : null
+    if (!principal || !hasPermission(principal, 'admin:manage')) {
       return c.json({ error: 'Authentication required' }, 401)
     }
     const body = c.req.valid('json')
@@ -148,6 +182,8 @@ export function createAuthApi(services: Pick<AppServices, 'auth'>): OpenAPIHono 
       return c.json({ error: 'Current password is incorrect' }, 401)
     }
     await service.setPassword(body.newPassword)
+    service.deleteAllSessions()
+    setSessionCookie(c, service.createSession())
     return c.json({ success: true as const }, 200)
   })
   app.openapi(logoutRoute, (c) => {

--- a/apps/server/api/src/modules/auth/schemas.ts
+++ b/apps/server/api/src/modules/auth/schemas.ts
@@ -1,7 +1,16 @@
 import { z } from '@hono/zod-openapi'
+import { AUTH_METHODS, AUTH_PERMISSIONS, AUTH_ROLES } from '../../auth/principal.js'
 
 export const AuthStatusSchema = z
-  .object({ setupComplete: z.boolean(), authenticated: z.boolean() })
+  .object({
+    setupComplete: z.boolean(),
+    authenticated: z.boolean(),
+    subject: z.string(),
+    role: z.enum(AUTH_ROLES),
+    authMethod: z.enum(AUTH_METHODS),
+    permissions: z.array(z.enum(AUTH_PERMISSIONS)),
+    publicDemo: z.boolean(),
+  })
   .openapi('AuthStatus')
 export const PasswordSchema = z.object({ password: z.string().min(8) }).openapi('PasswordRequest')
 export const ChangePasswordSchema = z

--- a/apps/server/api/src/modules/share/projections.ts
+++ b/apps/server/api/src/modules/share/projections.ts
@@ -88,7 +88,7 @@ export function publicTopologyContext(parsed: ShareParsedTopology) {
  * P0: strip the known sensitive carriers (a strict improvement). P1 promotes this
  * to an allow-list render DTO (see #412) so a future field can't leak by default.
  */
-function shareSafeGraph(graph: NetworkGraph): NetworkGraph {
+export function publicGraph(graph: NetworkGraph): NetworkGraph {
   const { attachments: _ga, exclusions: _gx, ...rest } = graph
   return {
     ...rest,
@@ -129,7 +129,7 @@ export function publicTopologyGraph(parsed: ShareParsedTopology) {
   return {
     id: parsed.id,
     name: parsed.name,
-    graph: shareSafeGraph(applyMappingBandwidth(parsed.graph, parsed.mapping)),
+    graph: publicGraph(applyMappingBandwidth(parsed.graph, parsed.mapping)),
   }
 }
 

--- a/apps/server/api/src/server.ts
+++ b/apps/server/api/src/server.ts
@@ -26,8 +26,11 @@ import { createTopologyQueryApplicationService } from './app/topology-queries.js
 import { createTopologySourceApplicationService } from './app/topology-sources.js'
 import { createTopologySyncApplicationService } from './app/topology-sync.js'
 import { createWebhookApplicationService } from './app/webhooks.js'
+import { type AuthPrincipal, hasPermission, PUBLIC_DEMO_PRINCIPAL } from './auth/principal.js'
+import { isPublicDemoEnabled } from './auth-config.js'
 import { closeDatabase, initDatabase } from './db/index.js'
 import { MockMetricsProvider } from './mock-metrics.js'
+import { publicMetrics } from './modules/share/projections.js'
 import { apiError } from './openapi/common.js'
 import { createApiRouter } from './openapi/router.js'
 import {
@@ -36,7 +39,12 @@ import {
   pluginRegistry,
   registerBundledPlugins,
 } from './plugins/index.js'
-import { isSetupComplete, validateSession } from './services/auth.js'
+import {
+  assertAuthenticationReady,
+  bootstrapAdminAuthentication,
+  getSessionPrincipal,
+  isSetupComplete,
+} from './services/auth.js'
 import { getDashboardService } from './services/dashboard.js'
 import { DataSourceService } from './services/datasource.js'
 import { GrafanaAlertService } from './services/grafana-alerts.js'
@@ -63,21 +71,44 @@ import { TopologySourcesService } from './services/topology-sources.js'
 import type { ClientMessage, ClientState, Config, MetricsData, MetricsMapping } from './types.js'
 
 /**
- * Validate the admin session straight off a raw `Request` (the WebSocket upgrade
+ * Resolve the session straight off a raw `Request` (the WebSocket upgrade
  * runs in Bun's `fetch`, before Hono, so we parse the Cookie header ourselves
- * rather than via hono/cookie). Returns true only for a live session.
+ * rather than via hono/cookie).
  */
-function hasValidSession(req: Request): boolean {
+function sessionPrincipal(req: Request): AuthPrincipal | null {
   const cookie = req.headers.get('cookie')
-  if (!cookie) return false
+  if (!cookie) return null
   for (const part of cookie.split(';')) {
     const eq = part.indexOf('=')
     if (eq === -1) continue
     if (part.slice(0, eq).trim() !== SESSION_COOKIE) continue
-    const value = decodeURIComponent(part.slice(eq + 1).trim())
-    return validateSession(value)
+    try {
+      const value = decodeURIComponent(part.slice(eq + 1).trim())
+      return getSessionPrincipal(value)
+    } catch {
+      return null
+    }
   }
-  return false
+  return null
+}
+
+function webSocketPrincipal(req: Request): AuthPrincipal | null {
+  if (!isSetupComplete()) return null
+  const principal = sessionPrincipal(req)
+  if (principal && hasPermission(principal, 'workspace:read')) return principal
+  return isPublicDemoEnabled() ? PUBLIC_DEMO_PRINCIPAL : null
+}
+
+function hasAllowedWebSocketOrigin(req: Request): boolean {
+  const origin = req.headers.get('origin')
+  if (!origin) return true
+  const host = req.headers.get('host')
+  if (!host) return false
+  try {
+    return new URL(origin).host === host
+  } catch {
+    return false
+  }
 }
 
 export class Server {
@@ -169,6 +200,7 @@ export class Server {
 
   private handleWebSocketOpen(ws: ServerWebSocket<ClientState>): void {
     const state: ClientState = {
+      principal: ws.data.principal,
       subscribedTopology: null,
       filter: { nodes: [], links: [] },
     }
@@ -179,12 +211,20 @@ export class Server {
 
   private handleClientMessage(ws: ServerWebSocket<ClientState>, data: string): void {
     try {
+      if (data.length > 16_384) {
+        ws.close(1009, 'Message too large')
+        return
+      }
       const message: ClientMessage = JSON.parse(data)
       const state = this.clients.get(ws)
       if (!state) return
 
       switch (message.type) {
         case 'subscribe': {
+          if (message.topology && !this.topologyService?.get(message.topology)) {
+            ws.send(JSON.stringify({ type: 'error', error: 'Topology not found' }))
+            return
+          }
           const prevTopology = state.subscribedTopology
           state.subscribedTopology = message.topology || null
           console.log(`[WebSocket] Client subscribed to: ${state.subscribedTopology}`)
@@ -232,7 +272,8 @@ export class Server {
     // Check DB topology first
     const dbMetrics = this.dbTopologyMetrics.get(state.subscribedTopology)
     if (dbMetrics) {
-      ws.send(JSON.stringify({ type: 'metrics', data: dbMetrics }))
+      const data = state.principal.role === 'viewer' ? publicMetrics(dbMetrics) : dbMetrics
+      ws.send(JSON.stringify({ type: 'metrics', data }))
       return
     }
   }
@@ -245,6 +286,10 @@ export class Server {
         // Check DB topology first
         const dbMetrics = this.dbTopologyMetrics.get(state.subscribedTopology)
         if (dbMetrics) {
+          if (state.principal.role === 'viewer') {
+            ws.send(JSON.stringify({ type: 'metrics', data: publicMetrics(dbMetrics) }))
+            continue
+          }
           // Inject parse error warnings if any
           const parseError = this.topologyService?.getParseError(state.subscribedTopology)
           if (parseError) {
@@ -626,6 +671,8 @@ export class Server {
     await loadPluginsFromConfig(pluginsConfigPath)
 
     initDatabase(this.config.server.dataDir)
+    await bootstrapAdminAuthentication()
+    assertAuthenticationReady(this.config.server.host)
     this.topologyService = new TopologyService()
     this.setupApiRoutes()
     this.setupStaticFileServing()
@@ -674,18 +721,27 @@ export class Server {
       fetch(req, server) {
         // Handle WebSocket upgrade
         if (new URL(req.url).pathname === '/ws') {
-          // AUTH GATE: the live-metrics socket requires a valid admin session.
+          // AUTH GATE: the live-metrics socket requires a principal with read
+          // permission, or the explicitly enabled projected public viewer.
           // It bypasses Hono (and thus authMiddleware), so without this check ANY
-          // anonymous client could subscribe to ANY topology id and receive its
-          // live metrics + internal warnings — a data leak. Public/shared live
-          // metrics will be served separately via a token-scoped channel, NOT here.
-          // (When setup isn't complete there's no password yet — mirror
-          // authMiddleware and allow through.)
-          if (isSetupComplete() && !hasValidSession(req)) {
+          // anonymous client could otherwise subscribe to ANY topology id and
+          // receive its live metrics + internal warnings — a data leak.
+          if (!hasAllowedWebSocketOrigin(req)) {
+            return new Response('Forbidden origin', { status: 403 })
+          }
+          const principal = webSocketPrincipal(req)
+          if (!principal) {
             return new Response('Unauthorized', { status: 401 })
           }
+          if (
+            principal.role === 'viewer' &&
+            [...self.clients.values()].filter((client) => client.principal.role === 'viewer')
+              .length >= 100
+          ) {
+            return new Response('Too many public demo connections', { status: 503 })
+          }
           const upgraded = server.upgrade(req, {
-            data: { subscribedTopology: null, filter: { nodes: [], links: [] } },
+            data: { principal, subscribedTopology: null, filter: { nodes: [], links: [] } },
           })
           if (upgraded) return undefined
           return new Response('WebSocket upgrade failed', { status: 400 })

--- a/apps/server/api/src/services/auth.ts
+++ b/apps/server/api/src/services/auth.ts
@@ -65,9 +65,14 @@ export async function setInitialPassword(password: string): Promise<boolean> {
 type AuthEnvironment = Record<string, string | undefined>
 
 function secretFileValue(path: string): string {
-  const stat = fs.statSync(path)
-  if (!stat.isFile()) throw new Error('SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE must name a file')
-  return fs.readFileSync(path, 'utf8').replace(/\r?\n$/, '')
+  const descriptor = fs.openSync(path, fs.constants.O_RDONLY)
+  try {
+    const stat = fs.fstatSync(descriptor)
+    if (!stat.isFile()) throw new Error('SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE must name a file')
+    return fs.readFileSync(descriptor, 'utf8').replace(/\r?\n$/, '')
+  } finally {
+    fs.closeSync(descriptor)
+  }
 }
 
 /** Resolve the one-time bootstrap password without logging its value. */

--- a/apps/server/api/src/services/auth.ts
+++ b/apps/server/api/src/services/auth.ts
@@ -3,6 +3,13 @@
  * Handles password management, session creation/validation, rate limiting
  */
 
+import * as fs from 'node:fs'
+import {
+  type AuthPrincipal,
+  isAuthMethod,
+  isAuthRole,
+  LOCAL_ADMIN_PRINCIPAL,
+} from '../auth/principal.js'
 import { getDatabase } from '../db/index.js'
 
 const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
@@ -11,6 +18,7 @@ const MAX_LOGIN_ATTEMPTS = 5
 const LOCKOUT_DURATION_MS = 15 * 60 * 1000 // 15 minutes
 
 let lastCleanup = 0
+let initialPasswordInProgress = false
 
 /** In-memory rate limiting for login attempts */
 const loginAttempts: Map<string, { count: number; firstAttempt: number }> = new Map()
@@ -35,6 +43,73 @@ export async function setPassword(password: string): Promise<void> {
   const db = getDatabase()
   db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('auth_password_hash', ?)").run(
     hash,
+  )
+}
+
+/**
+ * Claim the one-time initial password setup. The in-process guard closes the
+ * async hash race where two setup requests could both pass isSetupComplete().
+ */
+export async function setInitialPassword(password: string): Promise<boolean> {
+  if (initialPasswordInProgress || isSetupComplete()) return false
+  initialPasswordInProgress = true
+  try {
+    if (isSetupComplete()) return false
+    await setPassword(password)
+    return true
+  } finally {
+    initialPasswordInProgress = false
+  }
+}
+
+type AuthEnvironment = Record<string, string | undefined>
+
+function secretFileValue(path: string): string {
+  const stat = fs.statSync(path)
+  if (!stat.isFile()) throw new Error('SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE must name a file')
+  return fs.readFileSync(path, 'utf8').replace(/\r?\n$/, '')
+}
+
+/** Resolve the one-time bootstrap password without logging its value. */
+export function getBootstrapAdminPassword(env: AuthEnvironment = process.env): string | null {
+  const passwordFile = env['SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE']?.trim()
+  const passwordValue = env['SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD']
+  if (passwordFile && passwordValue !== undefined) {
+    throw new Error(
+      'Set only one of SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE or SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD',
+    )
+  }
+
+  const password = passwordFile ? secretFileValue(passwordFile) : passwordValue
+  if (password === undefined || password === '') return null
+  if (password.length < 8) {
+    throw new Error('The bootstrap administrator password must be at least 8 characters')
+  }
+  return password
+}
+
+/** Initialize authentication exactly once from an orchestrator-provided secret. */
+export async function bootstrapAdminAuthentication(
+  env: AuthEnvironment = process.env,
+): Promise<boolean> {
+  if (isSetupComplete()) return false
+  const password = getBootstrapAdminPassword(env)
+  if (!password) return false
+  const created = await setInitialPassword(password)
+  if (created) console.log('[Auth] Administrator authentication bootstrapped from a secret')
+  return created
+}
+
+/**
+ * Instances exposed beyond loopback must not start in the historic fail-open
+ * setup state. Local development keeps the web setup flow by binding to
+ * loopback explicitly.
+ */
+export function assertAuthenticationReady(host: string): void {
+  if (isSetupComplete()) return
+  if (host === '127.0.0.1' || host === '::1' || host === '[::1]' || host === 'localhost') return
+  throw new Error(
+    'Administrator authentication is not configured. Provide SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE (recommended) or SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD for the first start.',
   )
 }
 
@@ -98,16 +173,17 @@ export async function verifyPassword(password: string): Promise<boolean> {
 /**
  * Create a new session and return the token
  */
-export function createSession(): string {
-  const token = crypto.randomUUID()
+export function createSession(principal: AuthPrincipal = LOCAL_ADMIN_PRINCIPAL): string {
+  if (principal.role === 'anonymous' || principal.authMethod === 'anonymous') {
+    throw new Error('Anonymous principals cannot create sessions')
+  }
+  const token = crypto.getRandomValues(new Uint8Array(32)).toBase64({ alphabet: 'base64url' })
   const now = Date.now()
   const expiresAt = now + SESSION_TTL_MS
   const db = getDatabase()
-  db.prepare('INSERT INTO sessions (token, expires_at, created_at) VALUES (?, ?, ?)').run(
-    token,
-    expiresAt,
-    now,
-  )
+  db.prepare(
+    'INSERT INTO sessions (token, subject, role, auth_method, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+  ).run(token, principal.subject, principal.role, principal.authMethod, expiresAt, now)
   return token
 }
 
@@ -123,18 +199,20 @@ function cleanupExpiredSessions(): void {
 }
 
 /**
- * Validate a session token
- * Returns true if valid and not expired
+ * Resolve a session into the authenticated principal it represents.
  */
-export function validateSession(token: string): boolean {
+export function getSessionPrincipal(token: string): AuthPrincipal | null {
   cleanupExpiredSessions()
 
   const db = getDatabase()
   const now = Date.now()
   const row = db
-    .prepare('SELECT id FROM sessions WHERE token = ? AND expires_at > ?')
-    .get(token, now) as { id: number } | undefined
-  return !!row
+    .prepare(
+      'SELECT subject, role, auth_method AS authMethod FROM sessions WHERE token = ? AND expires_at > ?',
+    )
+    .get(token, now) as { subject: string; role: string; authMethod: string } | undefined
+  if (!row || !isAuthRole(row.role) || !isAuthMethod(row.authMethod)) return null
+  return { subject: row.subject, role: row.role, authMethod: row.authMethod }
 }
 
 /**
@@ -143,4 +221,9 @@ export function validateSession(token: string): boolean {
 export function deleteSession(token: string): void {
   const db = getDatabase()
   db.prepare('DELETE FROM sessions WHERE token = ?').run(token)
+}
+
+/** Invalidate every administrator session after a password change. */
+export function deleteAllSessions(): void {
+  getDatabase().prepare('DELETE FROM sessions').run()
 }

--- a/apps/server/api/src/types.ts
+++ b/apps/server/api/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { MetricsData, ScopeFilter } from '@shumoku/core'
+import type { AuthPrincipal } from './auth/principal.js'
 
 export type {
   LinkMetricObservation,
@@ -225,6 +226,7 @@ export type ClientMessage = SubscribeMessage | SetIntervalMessage | FilterMessag
 // ============================================
 
 export interface ClientState {
+  principal: AuthPrincipal
   subscribedTopology: string | null
   filter: {
     nodes: string[]

--- a/apps/server/api/test/api/openapi.test.ts
+++ b/apps/server/api/test/api/openapi.test.ts
@@ -24,11 +24,13 @@ const settings = new Map<string, string>()
 const services: AppServices = {
   auth: {
     isSetupComplete: () => true,
-    validateSession: () => false,
+    getSessionPrincipal: () => null,
     setPassword: async () => undefined,
+    setInitialPassword: async () => false,
     verifyPassword: async () => false,
     createSession: () => 'test-session',
     deleteSession: () => undefined,
+    deleteAllSessions: () => undefined,
     checkRateLimit: () => 0,
     recordFailedAttempt: () => undefined,
     clearAttempts: () => undefined,

--- a/apps/server/api/test/auth-bootstrap.test.ts
+++ b/apps/server/api/test/auth-bootstrap.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getBootstrapAdminPassword } from '../src/services/auth.js'
+
+let directory: string | null = null
+
+afterEach(() => {
+  if (directory) rmSync(directory, { recursive: true, force: true })
+  directory = null
+})
+
+describe('administrator bootstrap secret', () => {
+  test('prefers an explicit secret file and removes one trailing newline', () => {
+    directory = mkdtempSync(join(tmpdir(), 'shumoku-auth-'))
+    const passwordFile = join(directory, 'password')
+    writeFileSync(passwordFile, 'generated-password\n', { mode: 0o600 })
+
+    expect(getBootstrapAdminPassword({ SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE: passwordFile })).toBe(
+      'generated-password',
+    )
+  })
+
+  test('rejects ambiguous and short bootstrap configuration', () => {
+    expect(() =>
+      getBootstrapAdminPassword({
+        SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE: '/unused',
+        SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD: 'another-password',
+      }),
+    ).toThrow('Set only one')
+    expect(() => getBootstrapAdminPassword({ SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD: 'short' })).toThrow(
+      'at least 8 characters',
+    )
+  })
+})

--- a/apps/server/api/test/auth-bootstrap.test.ts
+++ b/apps/server/api/test/auth-bootstrap.test.ts
@@ -33,4 +33,12 @@ describe('administrator bootstrap secret', () => {
       'at least 8 characters',
     )
   })
+
+  test('rejects a secret path that is not a regular file', () => {
+    directory = mkdtempSync(join(tmpdir(), 'shumoku-auth-'))
+
+    expect(() =>
+      getBootstrapAdminPassword({ SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE: directory ?? undefined }),
+    ).toThrow('must name a file')
+  })
 })

--- a/apps/server/api/test/auth-principal-session.test.ts
+++ b/apps/server/api/test/auth-principal-session.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import type { AuthPrincipal } from '../src/auth/principal.js'
+import { createSession, deleteAllSessions, getSessionPrincipal } from '../src/services/auth.js'
+import { setupTempDb, type TempDb } from './db/helper.js'
+
+let database: TempDb
+
+beforeAll(() => {
+  database = setupTempDb()
+})
+
+afterAll(() => database.teardown())
+
+describe('principal-backed sessions', () => {
+  test('defaults new password sessions to the local administrator', () => {
+    const token = createSession()
+    expect(getSessionPrincipal(token)).toEqual({
+      subject: 'local-admin',
+      role: 'admin',
+      authMethod: 'password',
+    })
+  })
+
+  test('round-trips a future normal-user principal', () => {
+    const principal: AuthPrincipal = {
+      subject: 'user-1',
+      role: 'user',
+      authMethod: 'password',
+    }
+    const token = createSession(principal)
+    expect(getSessionPrincipal(token)).toEqual(principal)
+  })
+
+  test('does not persist anonymous principals', () => {
+    expect(() =>
+      createSession({ subject: 'anonymous', role: 'anonymous', authMethod: 'anonymous' }),
+    ).toThrow('Anonymous principals')
+    deleteAllSessions()
+  })
+})

--- a/apps/server/api/test/db/schema.test.ts
+++ b/apps/server/api/test/db/schema.test.ts
@@ -80,4 +80,9 @@ describe('migration chain (001-014)', () => {
     }[]
     expect(info.find((c) => c.name === 'local_id')?.notnull).toBe(0)
   })
+
+  test('sessions carry a subject and authentication claims (033)', () => {
+    const cols = columns('sessions')
+    for (const column of ['subject', 'role', 'auth_method']) expect(cols).toContain(column)
+  })
 })

--- a/apps/server/chart/shumoku/templates/deployment.yaml
+++ b/apps/server/chart/shumoku/templates/deployment.yaml
@@ -47,6 +47,18 @@ spec:
               value: /data
             - name: SHUMOKU_DEPLOYMENT
               value: kubernetes
+            - name: DEMO_MODE
+              value: {{ .Values.demoMode | quote }}
+            - name: PUBLIC_DEMO
+              value: {{ .Values.publicDemo | quote }}
+            - name: SHUMOKU_SECURE_COOKIES
+              value: {{ .Values.auth.secureCookies | quote }}
+            - name: SHUMOKU_TRUST_PROXY
+              value: {{ .Values.auth.trustProxy | quote }}
+            {{- if .Values.auth.existingSecret }}
+            - name: SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /run/secrets/shumoku-admin/password
+            {{- end }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -79,6 +91,11 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.auth.existingSecret }}
+            - name: bootstrap-admin
+              mountPath: /run/secrets/shumoku-admin
+              readOnly: true
+            {{- end }}
       volumes:
         - name: data
           {{- if .Values.persistence.enabled }}
@@ -94,6 +111,14 @@ spec:
         {{- end }}
         - name: tmp
           emptyDir: {}
+        {{- if .Values.auth.existingSecret }}
+        - name: bootstrap-admin
+          secret:
+            secretName: {{ .Values.auth.existingSecret }}
+            items:
+              - key: {{ .Values.auth.passwordKey }}
+                path: password
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/apps/server/chart/shumoku/values.yaml
+++ b/apps/server/chart/shumoku/values.yaml
@@ -45,6 +45,17 @@ ingress:
           pathType: Prefix
   tls: []
 
+demoMode: false
+publicDemo: false
+
+auth:
+  # Existing Kubernetes Secret containing the one-time bootstrap administrator
+  # password. Required for a fresh non-loopback deployment.
+  existingSecret: ""
+  passwordKey: admin-password
+  secureCookies: false
+  trustProxy: false
+
 resources: {}
 
 persistence:

--- a/apps/server/compose.yaml
+++ b/apps/server/compose.yaml
@@ -18,6 +18,12 @@ services:
       # mock metrics on first start (no Prometheus/Zabbix needed).
       # Defaults to "false" so production deployments stay clean.
       - DEMO_MODE=${DEMO_MODE:-false}
+      - PUBLIC_DEMO=${PUBLIC_DEMO:-false}
+      - SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=/run/secrets/shumoku_admin_password
+      - SHUMOKU_SECURE_COOKIES=${SHUMOKU_SECURE_COOKIES:-false}
+      - SHUMOKU_TRUST_PROXY=${SHUMOKU_TRUST_PROXY:-false}
+    secrets:
+      - shumoku_admin_password
     restart: unless-stopped
 
     # Process management
@@ -48,3 +54,7 @@ services:
 volumes:
   shumoku-data:
     name: shumoku-data
+
+secrets:
+  shumoku_admin_password:
+    file: ${SHUMOKU_ADMIN_PASSWORD_FILE:-./.shumoku/admin-password}

--- a/apps/server/docs/api.en.mdx
+++ b/apps/server/docs/api.en.mdx
@@ -191,9 +191,31 @@ to the matching data-source plugin — currently only `grafana` handles webhooks
 | POST | `/api/auth/setup` | Initial password setup |
 | POST | `/api/auth/logout` | Logout |
 
+### Public-demo authorization
+
+`GET /api/auth/status` returns the resolved `subject`, `role` (`anonymous`,
+`viewer`, `user`, or `admin`), `authMethod`, `permissions`, and `publicDemo` in
+addition to the compatibility `authenticated` flag. When
+`PUBLIC_DEMO=true`, a request without an administrator session becomes an
+implicit viewer: only the diagram/dashboard reads, projected alert reads, data
+source status list, and system build information needed by the viewer are
+accepted. Host inventory, source configuration, settings, plugins, admin
+diagnostics, mappings, and every mutation return `403`. Successful JSON responses are projected server-side to
+remove stored configuration, credentials, management identities, internal
+errors, and unreviewed dashboard widget configuration.
+
+`POST /api/auth/setup` is disabled by default. The repository development
+command explicitly enables it while binding to loopback. A fresh non-loopback
+server must instead bootstrap authentication from a Secret and fails to start
+if none is configured.
+
 ## WebSocket
 
-Connect to `ws://<host>/ws` for real-time metrics streaming.
+Connect to `ws://<host>/ws` for real-time metrics streaming. Administrator
+sessions receive management metrics; public-demo viewers receive the narrower
+public metrics projection. The server validates browser Origin, authorizes the
+topology subscription, limits public connections, and rejects oversized
+messages.
 
 ### Client Messages
 

--- a/apps/server/docs/api.ja.mdx
+++ b/apps/server/docs/api.ja.mdx
@@ -186,9 +186,27 @@ Webhook シークレットを `X-Webhook-Secret` ヘッダー（推奨）また�
 | POST | `/api/auth/setup` | 初期パスワード設定 |
 | POST | `/api/auth/logout` | ログアウト |
 
+### 公開デモの認可
+
+`GET /api/auth/status`は従来の`authenticated`に加え、解決済みの`subject`、
+`role`（`anonymous`、`viewer`、`user`、`admin`）、`authMethod`、`permissions`、
+`publicDemo`を返します。`PUBLIC_DEMO=true`では、管理者
+セッションを持たないリクエストを暗黙のviewerとして扱います。viewerが利用できるのは
+diagram・dashboard表示、projection済みalert、データソース状態一覧、system build情報に
+必要なallowlist済みGETだけです。host inventory、source設定、Settings、Plugins、管理診断、
+mapping、すべての変更操作は`403`に
+なります。成功したJSONレスポンスはサーバー側でprojectionされ、保存済み設定、認証情報、
+管理identity、内部エラー、未レビューのwidget設定が除去されます。
+
+`POST /api/auth/setup`はデフォルトで無効です。リポジトリの開発コマンドだけがloopbackへ
+bindした上で明示的に有効化します。loopback以外へ公開する新規サーバーはSecretから認証を
+bootstrapする必要があり、未設定なら起動しません。
+
 ## WebSocket
 
-`ws://<host>/ws` に接続してリアルタイムメトリクスをストリーミングします。
+`ws://<host>/ws`に接続してリアルタイムメトリクスをストリーミングします。管理者には
+管理用metrics、公開デモviewerには限定されたpublic projectionを送ります。サーバーは
+browser Originと購読対象を検証し、公開接続数を制限し、過大なmessageを拒否します。
 
 ### クライアントメッセージ
 

--- a/apps/server/docs/design/authentication-authorization.md
+++ b/apps/server/docs/design/authentication-authorization.md
@@ -1,0 +1,60 @@
+# Authentication and authorization model
+
+Shumoku separates authentication (who made the request) from authorization
+(what that identity may do). Every authenticated path resolves to one
+`AuthPrincipal` before policy is evaluated:
+
+```ts
+interface AuthPrincipal {
+  subject: string
+  role: 'anonymous' | 'viewer' | 'user' | 'admin'
+  authMethod: 'anonymous' | 'password' | 'bearer'
+}
+```
+
+Current subjects are `local-admin`, `public-demo`, and `dev-automation`. The
+`user` role is part of the contract even though user management is not yet
+exposed. This lets a future local-user or OIDC provider issue the same principal
+without changing route authorization.
+
+## Permissions
+
+Routes authorize permissions, not cookie presence or authentication method.
+
+| Role | Permissions |
+|------|-------------|
+| `anonymous` | none |
+| `viewer` | `public:read` |
+| `user` | `public:read`, `workspace:read`, `workspace:write` |
+| `admin` | all user permissions plus `admin:manage` |
+
+Data-source and topology-source configuration, Settings, plugin management, and
+administrator diagnostics require `admin:manage`. Other workspace reads require
+`workspace:read`; mutations require `workspace:write`. A public-demo viewer
+additionally passes a strict route allow-list and receives only server-projected
+responses. Future user-facing data-source consumption should receive its own
+narrow permission and response DTO rather than exposing stored configuration.
+
+HTTP and WebSocket authentication share the same principal types and permission
+definitions. Middleware attaches the resolved principal to the raw request via
+`getRequestPrincipal(request)`, so future handlers and audit logging can obtain
+the subject without parsing cookies again.
+
+## Sessions and future providers
+
+Sessions store `subject`, `role`, and `auth_method`. Migration 033 upgrades
+existing sessions to `local-admin` / `admin` / `password`. The initial
+administrator Secret remains a credential bootstrap mechanism; it does not
+define route permissions.
+
+When adding multiple users, introduce the user/identity store behind principal
+resolution and keep these invariants:
+
+- Routes never inspect password hashes, cookies, or provider-specific claims.
+- Providers translate their identity into `AuthPrincipal` at the boundary.
+- Authorization uses permissions, not provider names or scattered role checks.
+- Role changes invalidate or refresh affected sessions.
+- Audit records use `principal.subject` as the actor identifier.
+
+This keeps local passwords, OIDC, LDAP, and service credentials interchangeable
+from the API's point of view.

--- a/apps/server/docs/helm-chart.md
+++ b/apps/server/docs/helm-chart.md
@@ -84,6 +84,10 @@ config:
 
 | Parameter | Description | Default |
 |---|---|---|
+| `auth.existingSecret` | 初回管理者パスワードを持つ既存Secret名（新規環境では必須） | `""` |
+| `auth.passwordKey` | Secret内のパスワードkey | `admin-password` |
+| `auth.secureCookies` | 管理者Cookieへ常に`Secure`を付与 | `false` |
+| `auth.trustProxy` | proxyのクライアントIPヘッダーをログイン制限に利用 | `false` |
 | `podSecurityContext.runAsUser` | Pod の実行ユーザー | `1000` |
 | `podSecurityContext.runAsGroup` | Pod の実行グループ | `1000` |
 | `podSecurityContext.fsGroup` | ファイルシステムのグループ | `1000` |
@@ -94,6 +98,8 @@ config:
 | Parameter | Description | Default |
 |---|---|---|
 | `replicaCount` | レプリカ数 | `1` |
+| `demoMode` | サンプルデータとmock metricsを投入 | `false` |
+| `publicDemo` | 匿名read-only viewerを有効化 | `false` |
 | `resources` | CPU/メモリの requests/limits | `{}` |
 | `env` | 追加の環境変数 | `[]` |
 | `nodeSelector` | Node selector | `{}` |
@@ -102,6 +108,36 @@ config:
 | `serviceAccount.create` | ServiceAccount を作成するか | `true` |
 
 ## Examples
+
+### 初回管理者Secret
+
+新しい環境では、Chartをインストールする前に管理者パスワードをSecretとして作成します。
+SecretはConfigMapやvaluesファイルへ平文で書かず、既存Secretの名前だけをChartへ渡します。
+
+```bash
+kubectl create namespace shumoku
+kubectl -n shumoku create secret generic shumoku-admin \
+  --from-literal=admin-password="$(openssl rand -base64 32)"
+
+helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku \
+  --namespace shumoku \
+  --set auth.existingSecret=shumoku-admin
+```
+
+初回起動後、DBにはArgon2idハッシュだけが保存されます。Secretを変更してPodを再起動しても
+既存の管理者パスワードは上書きされません。変更はWeb UIの管理者設定から行います。
+
+公開デモでは、管理者Secretとは別にviewerモードを有効にします。IngressでTLS終端する場合は
+Secure Cookieも有効にしてください。
+
+```yaml
+publicDemo: true
+demoMode: true
+auth:
+  existingSecret: shumoku-admin
+  secureCookies: true
+  trustProxy: true
+```
 
 ### Ingress を有効にして TLS 設定
 

--- a/apps/server/docs/installation.en.mdx
+++ b/apps/server/docs/installation.en.mdx
@@ -29,7 +29,13 @@ before you pipe? See `apps/server/scripts/install.sh`.
 The quickest way — pull the published image, no clone required:
 
 ```bash
-docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/konoe-akitoshi/shumoku:latest
+install -d -m 700 .shumoku
+openssl rand -base64 32 > .shumoku/admin-password
+chmod 600 .shumoku/admin-password
+docker run -d -p 8080:8080 -v shumoku-data:/data \
+  -v "$PWD/.shumoku/admin-password:/run/secrets/shumoku_admin_password:ro" \
+  -e SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=/run/secrets/shumoku_admin_password \
+  ghcr.io/konoe-akitoshi/shumoku:latest
 # → http://localhost:8080   (add `-e DEMO_MODE=true` to preload a sample network)
 ```
 
@@ -43,7 +49,8 @@ cd shumoku/apps/server
 docker compose up -d
 ```
 
-Open `http://localhost:8080`, set an admin password, and you're ready to go.
+Open `http://localhost:8080/login` and sign in with the administrator password
+stored in `.shumoku/admin-password`.
 
 ### Docker Compose Options
 
@@ -52,6 +59,9 @@ Open `http://localhost:8080`, set an admin password, and you're ready to go.
 
 ```bash
 cp .env.example .env     # SHUMOKU_VERSION / SHUMOKU_PORT / DEMO_MODE
+install -d -m 700 .shumoku
+openssl rand -base64 32 > .shumoku/admin-password
+chmod 600 .shumoku/admin-password
 docker compose up -d
 ```
 
@@ -149,12 +159,22 @@ make setup
 sudo cp "$(command -v bun)" /usr/local/bin/bun
 
 sudo cp scripts/shumoku.service /etc/systemd/system/
+sudo install -d -m 700 /etc/shumoku /etc/systemd/system/shumoku.service.d
+openssl rand -base64 32 | sudo tee /etc/shumoku/admin-password >/dev/null
+sudo chmod 600 /etc/shumoku/admin-password
+sudo tee /etc/systemd/system/shumoku.service.d/credential.conf >/dev/null <<'EOF'
+[Service]
+LoadCredential=shumoku-admin-password:/etc/shumoku/admin-password
+Environment=SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=%d/shumoku-admin-password
+EOF
 sudo systemctl daemon-reload
 sudo systemctl enable --now shumoku
 ```
 
 No user or data-directory preparation is needed — the unit manages a dedicated
-user and `/var/lib/shumoku` itself via `DynamicUser=` and `StateDirectory=`.
+user and `/var/lib/shumoku` itself via `DynamicUser=` and `StateDirectory=`. The
+administrator secret is exposed read-only through a systemd credential, not the
+process environment or unit file.
 
 ### Configuration
 
@@ -249,6 +269,8 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
         # Syncs that run SNMP scans stay quiet for minutes (default 60s cuts them off)
         proxy_read_timeout 300s;
     }
@@ -269,6 +291,39 @@ server sends `X-Accel-Buffering: no`.
 | `DATA_DIR` | Data directory (SQLite) | Docker: `/data`, systemd: `/var/lib/shumoku`, from source: `apps/server/data` |
 | `SHUMOKU_PORT` | External port (Docker Compose) | `8080` |
 | `DEMO_MODE` | Load sample network on empty DB | `false` |
+| `PUBLIC_DEMO` | Treat unauthenticated access as a read-only viewer | `false` |
+| `SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE` | Secret file containing the initial administrator password | — |
+| `SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD` | Initial password fallback for platforms without secret files | — |
+| `SHUMOKU_ALLOW_WEB_SETUP` | Enable browser-driven first-run setup for local development only | `false` |
+| `SHUMOKU_SECURE_COOKIES` | Always mark administrator cookies `Secure` | `false` |
+| `SHUMOKU_TRUST_PROXY` | Trust proxy client-IP headers for login throttling | `false` |
+
+## Authentication and public demos
+
+A fresh server bound beyond loopback refuses to start without an initial
+administrator secret. Keep the password out of `config.yaml`, ConfigMaps,
+container images, and Git. Supply it through Docker Secrets, a Kubernetes Secret
+volume, or an owner-readable file. The server hashes it with Argon2id on first
+start and never overwrites existing authentication on restart.
+
+Browser-driven setup is disabled by default. The repository development command
+enables it while binding the API to loopback. Never enable
+`SHUMOKU_ALLOW_WEB_SETUP` on an externally reachable server.
+
+`DEMO_MODE` only seeds sample data. Set `PUBLIC_DEMO=true` separately to map
+unauthenticated visitors to an implicit viewer. Viewers can call only explicitly
+allowed GET APIs; credential, management-address, and internal-error carriers
+are projected from responses, and mutations return `403`. Administrators can
+still sign in at `/login`.
+
+Behind a TLS-terminating proxy, set `SHUMOKU_SECURE_COOKIES=true`. Enable
+`SHUMOKU_TRUST_PROXY=true` only when the proxy replaces untrusted
+`X-Forwarded-For` input.
+
+The internal contract already distinguishes `viewer`, `user`, and `admin` and
+authorizes permissions on a provider-neutral principal. See
+[Authentication and authorization model](./design/authentication-authorization.md)
+for the multi-user and external-provider extension rules.
 
 ## Backup & Restore
 

--- a/apps/server/docs/installation.ja.mdx
+++ b/apps/server/docs/installation.ja.mdx
@@ -29,7 +29,13 @@ curl -fsSL https://raw.githubusercontent.com/konoe-akitoshi/shumoku/main/apps/se
 最も簡単な方法 — 公開イメージを取得するだけ（clone 不要）:
 
 ```bash
-docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/konoe-akitoshi/shumoku:latest
+install -d -m 700 .shumoku
+openssl rand -base64 32 > .shumoku/admin-password
+chmod 600 .shumoku/admin-password
+docker run -d -p 8080:8080 -v shumoku-data:/data \
+  -v "$PWD/.shumoku/admin-password:/run/secrets/shumoku_admin_password:ro" \
+  -e SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=/run/secrets/shumoku_admin_password \
+  ghcr.io/konoe-akitoshi/shumoku:latest
 # → http://localhost:8080   （`-e DEMO_MODE=true` でサンプルネットワークを投入）
 ```
 
@@ -40,10 +46,13 @@ docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/konoe-akitoshi/shumoku:
 ```bash
 git clone https://github.com/konoe-akitoshi/shumoku.git
 cd shumoku/apps/server
+install -d -m 700 .shumoku
+openssl rand -base64 32 > .shumoku/admin-password
+chmod 600 .shumoku/admin-password
 docker compose up -d
 ```
 
-`http://localhost:8080` を開き、管理者パスワードを設定すれば準備完了です。
+`http://localhost:8080/login` を開き、Secretに生成した管理者パスワードでログインします。
 
 ### Docker Compose オプション
 
@@ -51,6 +60,9 @@ docker compose up -d
 
 ```bash
 cp .env.example .env     # SHUMOKU_VERSION / SHUMOKU_PORT / DEMO_MODE
+install -d -m 700 .shumoku
+openssl rand -base64 32 > .shumoku/admin-password
+chmod 600 .shumoku/admin-password
 docker compose up -d
 ```
 
@@ -141,12 +153,21 @@ make setup
 sudo cp "$(command -v bun)" /usr/local/bin/bun
 
 sudo cp scripts/shumoku.service /etc/systemd/system/
+sudo install -d -m 700 /etc/shumoku /etc/systemd/system/shumoku.service.d
+openssl rand -base64 32 | sudo tee /etc/shumoku/admin-password >/dev/null
+sudo chmod 600 /etc/shumoku/admin-password
+sudo tee /etc/systemd/system/shumoku.service.d/credential.conf >/dev/null <<'EOF'
+[Service]
+LoadCredential=shumoku-admin-password:/etc/shumoku/admin-password
+Environment=SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=%d/shumoku-admin-password
+EOF
 sudo systemctl daemon-reload
 sudo systemctl enable --now shumoku
 ```
 
-ユーザー作成やデータディレクトリの準備は不要です — unit が `DynamicUser=` と
-`StateDirectory=` で専用ユーザーと `/var/lib/shumoku` を自動管理します。
+ユーザー作成やデータディレクトリの準備は不要です — unit が`DynamicUser=`と
+`StateDirectory=`で専用ユーザーと`/var/lib/shumoku`を自動管理します。管理者Secretは
+systemd credentialとしてread-onlyで渡され、プロセス環境やunitファイルには入りません。
 
 ### 設定の変更
 
@@ -240,6 +261,8 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
         # SNMP スキャンを伴う同期は数分無応答で流れる（デフォルト 60s では切れる）
         proxy_read_timeout 300s;
     }
@@ -259,6 +282,38 @@ WebSocket（`/ws`）には上記の `Upgrade` / `Connection` ヘッダーが、S
 | `DATA_DIR` | データディレクトリ（SQLite） | Docker: `/data`、systemd: `/var/lib/shumoku`、ソース実行: `apps/server/data` |
 | `SHUMOKU_PORT` | 外部ポート（Docker Compose） | `8080` |
 | `DEMO_MODE` | 空の DB にサンプルネットワークを読み込む | `false` |
+| `PUBLIC_DEMO` | 未認証アクセスをread-only viewerとして扱う | `false` |
+| `SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE` | 初回管理者パスワードを読むSecretファイル | — |
+| `SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD` | Secretファイル非対応環境向けの初回管理者パスワード | — |
+| `SHUMOKU_ALLOW_WEB_SETUP` | ローカル開発でのみブラウザ初期設定を有効化 | `false` |
+| `SHUMOKU_SECURE_COOKIES` | 管理者Cookieに常に`Secure`を付与 | `false` |
+| `SHUMOKU_TRUST_PROXY` | ログイン制限でproxyのクライアントIPヘッダーを信頼する | `false` |
+
+## 認証と公開デモ
+
+loopback以外へbindする新規環境は、初回管理者Secretがない状態では起動しません。
+パスワードは`config.yaml`、ConfigMap、コンテナイメージ、Gitには保存せず、Docker
+Secrets、Kubernetes Secret volume、または所有者だけが読めるファイルから渡します。
+初回起動時にArgon2idでハッシュ化され、DBに認証が存在する場合は再起動しても上書き
+されません。
+
+ブラウザからの初期設定はデフォルトで無効です。リポジトリの開発コマンドはAPIを
+loopbackへbindした上で有効化します。外部到達可能なサーバーでは
+`SHUMOKU_ALLOW_WEB_SETUP=true`を指定しないでください。
+
+`DEMO_MODE`はサンプルデータ投入だけを行い、アクセス制御は変更しません。
+`PUBLIC_DEMO=true`を別途指定すると、未認証訪問者は暗黙のviewerになります。viewerは
+明示的に許可されたGET APIのみ利用でき、レスポンスから認証情報・管理IP・内部エラー
+などが除去され、変更操作は`403`になります。管理者は`/login`から通常どおりログイン
+できます。
+
+TLS終端proxy配下では`SHUMOKU_SECURE_COOKIES=true`を指定してください。
+`SHUMOKU_TRUST_PROXY=true`は、proxyが外部入力の`X-Forwarded-For`を置換する場合だけ
+有効にします。
+
+内部契約では`viewer`、`user`、`admin`を区別し、認証方式に依存しないprincipalへ
+permissionを適用します。複数ユーザーや外部IdPを追加するときの規約は
+[Authentication and authorization model](./design/authentication-authorization.md)を参照してください。
 
 ## バックアップとリストア
 

--- a/apps/server/scripts/install.sh
+++ b/apps/server/scripts/install.sh
@@ -12,6 +12,8 @@
 #   SHUMOKU_VERSION   image tag to run           (default: latest)
 #   SHUMOKU_PORT      host port to publish        (default: 8080)
 #   DEMO_MODE         seed sample network         (default: false)
+#   PUBLIC_DEMO       anonymous read-only UI       (default: false)
+#   SHUMOKU_ADMIN_PASSWORD initial administrator password (default: generated)
 #   INSTALL_DIR       where to place compose files (default: ./shumoku)
 #   SHUMOKU_REF       git ref to fetch compose.yaml from (default: main)
 #
@@ -23,9 +25,16 @@ set -eu
 SHUMOKU_VERSION="${SHUMOKU_VERSION:-latest}"
 SHUMOKU_PORT="${SHUMOKU_PORT:-8080}"
 DEMO_MODE="${DEMO_MODE:-false}"
+PUBLIC_DEMO="${PUBLIC_DEMO:-false}"
+SHUMOKU_ADMIN_PASSWORD="${SHUMOKU_ADMIN_PASSWORD:-}"
 INSTALL_DIR="${INSTALL_DIR:-./shumoku}"
 SHUMOKU_REF="${SHUMOKU_REF:-main}"
 COMPOSE_URL="https://raw.githubusercontent.com/konoe-akitoshi/shumoku/${SHUMOKU_REF}/apps/server/compose.yaml"
+
+if [ -n "$SHUMOKU_ADMIN_PASSWORD" ] && [ "${#SHUMOKU_ADMIN_PASSWORD}" -lt 8 ]; then
+  printf '%s\n' 'Error: SHUMOKU_ADMIN_PASSWORD must be at least 8 characters.' >&2
+  exit 1
+fi
 
 log() { printf '\033[1;34m==>\033[0m %s\n' "$1"; }
 warn() { printf '\033[1;33m!!\033[0m %s\n' "$1" >&2; }
@@ -82,10 +91,26 @@ log "Preparing install directory: $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 fetch "$COMPOSE_URL" "$INSTALL_DIR/compose.yaml"
 
+mkdir -p "$INSTALL_DIR/.shumoku"
+chmod 700 "$INSTALL_DIR/.shumoku"
+ADMIN_PASSWORD_FILE="$INSTALL_DIR/.shumoku/admin-password"
+if [ ! -f "$ADMIN_PASSWORD_FILE" ]; then
+  umask 077
+  if [ -n "$SHUMOKU_ADMIN_PASSWORD" ]; then
+    printf '%s' "$SHUMOKU_ADMIN_PASSWORD" > "$ADMIN_PASSWORD_FILE"
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl rand -base64 32 > "$ADMIN_PASSWORD_FILE"
+  else
+    die "openssl is required to generate the initial administrator password. Set SHUMOKU_ADMIN_PASSWORD and retry."
+  fi
+fi
+chmod 600 "$ADMIN_PASSWORD_FILE"
+
 cat > "$INSTALL_DIR/.env" <<EOF
 SHUMOKU_VERSION=$SHUMOKU_VERSION
 SHUMOKU_PORT=$SHUMOKU_PORT
 DEMO_MODE=$DEMO_MODE
+PUBLIC_DEMO=$PUBLIC_DEMO
 EOF
 
 # 3. Pull and start.
@@ -113,4 +138,5 @@ fi
 printf '\n'
 log "Web UI:  http://<this-host>:$SHUMOKU_PORT"
 log "Manage:  cd $INSTALL_DIR && $DOCKER compose {ps,logs -f,restart,down}"
+log "Initial administrator password: cat $ADMIN_PASSWORD_FILE"
 log "Upgrade: edit SHUMOKU_VERSION in $INSTALL_DIR/.env, then '$DOCKER compose pull && $DOCKER compose up -d'"

--- a/apps/server/scripts/openapi.ts
+++ b/apps/server/scripts/openapi.ts
@@ -15,11 +15,13 @@ const generatedHeader = `// Copyright (C) 2026-present Akitoshi Saeki
 const services: AppServices = {
   auth: {
     isSetupComplete: () => true,
-    validateSession: () => false,
+    getSessionPrincipal: () => null,
     setPassword: async () => undefined,
+    setInitialPassword: async () => false,
     verifyPassword: async () => false,
     createSession: () => 'not-executed',
     deleteSession: () => undefined,
+    deleteAllSessions: () => undefined,
     checkRateLimit: () => 0,
     recordFailedAttempt: () => undefined,
     clearAttempts: () => undefined,

--- a/apps/server/web/src/lib/api.generated.ts
+++ b/apps/server/web/src/lib/api.generated.ts
@@ -1470,6 +1470,13 @@ export interface components {
         AuthStatus: {
             setupComplete: boolean;
             authenticated: boolean;
+            subject: string;
+            /** @enum {string} */
+            role: "anonymous" | "viewer" | "user" | "admin";
+            /** @enum {string} */
+            authMethod: "anonymous" | "password" | "bearer";
+            permissions: ("public:read" | "workspace:read" | "workspace:write" | "admin:manage")[];
+            publicDemo: boolean;
         };
         AuthSuccess: {
             /** @enum {boolean} */
@@ -2437,6 +2444,15 @@ export interface operations {
             };
             /** @description The request did not match the API contract */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Browser-driven setup is disabled */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/apps/server/web/src/lib/stores/auth.ts
+++ b/apps/server/web/src/lib/stores/auth.ts
@@ -1,0 +1,23 @@
+import { derived, writable } from 'svelte/store'
+
+export type AuthRole = 'anonymous' | 'viewer' | 'user' | 'admin'
+export type AuthMethod = 'anonymous' | 'password' | 'bearer'
+export type AuthPermission = 'public:read' | 'workspace:read' | 'workspace:write' | 'admin:manage'
+
+export interface AuthAccessState {
+  subject: string
+  role: AuthRole
+  authMethod: AuthMethod
+  permissions: AuthPermission[]
+  publicDemo: boolean
+}
+
+export const authAccess = writable<AuthAccessState>({
+  subject: 'anonymous',
+  role: 'anonymous',
+  authMethod: 'anonymous',
+  permissions: [],
+  publicDemo: false,
+})
+export const authRole = derived(authAccess, ($access) => $access.role)
+export const readOnlyAccess = derived(authRole, ($role) => $role === 'viewer')

--- a/apps/server/web/src/routes/(app)/+layout.svelte
+++ b/apps/server/web/src/routes/(app)/+layout.svelte
@@ -17,20 +17,22 @@
   import { auth, system } from '$lib/api'
   import Header from '$lib/components/header.svelte'
   import Logo from '$lib/components/Logo.svelte'
+  import { type AuthPermission, type AuthRole, authAccess } from '$lib/stores/auth'
 
   interface NavItem {
     href: string
     label: string
     icon: 'home' | 'dashboard' | 'topology' | 'database' | 'plugins' | 'settings'
+    adminOnly?: boolean
   }
 
   const navItems: NavItem[] = [
     { href: '/', label: 'Home', icon: 'home' },
     { href: '/dashboards', label: 'Dashboards', icon: 'dashboard' },
     { href: '/topologies', label: 'Topologies', icon: 'topology' },
-    { href: '/datasources', label: 'Data Sources', icon: 'database' },
-    { href: '/plugins', label: 'Plugins', icon: 'plugins' },
-    { href: '/settings', label: 'Settings', icon: 'settings' },
+    { href: '/datasources', label: 'Data Sources', icon: 'database', adminOnly: true },
+    { href: '/plugins', label: 'Plugins', icon: 'plugins', adminOnly: true },
+    { href: '/settings', label: 'Settings', icon: 'settings', adminOnly: true },
   ]
 
   function isActive(href: string, pathname: string): boolean {
@@ -41,6 +43,8 @@
   // Sidebar collapsed state
   let sidebarCollapsed = false
   let authenticated = false
+  let role: AuthRole = 'anonymous'
+  let permissions: AuthPermission[] = []
   let version = 'development'
   let updateAvailable = false
   let releaseUrl: string | undefined
@@ -61,7 +65,16 @@
           return
         }
         authenticated = status.authenticated
-        if (!authenticated) {
+        role = status.role
+        permissions = status.permissions
+        authAccess.set({
+          subject: status.subject,
+          role,
+          authMethod: status.authMethod,
+          permissions: status.permissions,
+          publicDemo: status.publicDemo,
+        })
+        if (role === 'anonymous') {
           goto('/login')
           return
         }
@@ -133,7 +146,7 @@
     <!-- Navigation Items -->
     <div class="flex-1 py-3 px-2">
       <div class="space-y-1">
-        {#each navItems as item}
+        {#each navItems.filter((item) => !item.adminOnly || permissions.includes('admin:manage')) as item}
           <a
             href={item.href}
             class="flex items-center h-10 text-sm rounded-lg transition-colors {sidebarCollapsed
@@ -179,6 +192,19 @@
             <span class="whitespace-nowrap">Logout</span>
           {/if}
         </button>
+      {:else if role === 'viewer'}
+        <a
+          href="/login"
+          class="flex items-center h-10 text-sm rounded-lg transition-colors text-theme-text-muted hover:bg-theme-bg-elevated hover:text-theme-text {sidebarCollapsed
+            ? 'justify-center w-10 mx-auto'
+            : 'gap-3 px-3'}"
+          title={sidebarCollapsed ? 'Administrator login' : undefined}
+        >
+          <SignOutIcon size={20} />
+          {#if !sidebarCollapsed}
+            <span class="whitespace-nowrap">Administrator login</span>
+          {/if}
+        </a>
       {/if}
       {#if updateAvailable}
         <a
@@ -207,6 +233,12 @@
   <div class="flex-1 flex flex-col overflow-hidden">
     <!-- Header -->
     <Header />
+
+    {#if role === 'viewer'}
+      <div class="border-b border-info/25 bg-info/10 px-4 py-2 text-center text-xs text-theme-text">
+        Public demo · Read-only access
+      </div>
+    {/if}
 
     <!-- Main Content -->
     <main class="flex-1 overflow-auto"><slot /></main>

--- a/apps/server/web/src/routes/(app)/dashboards/+page.svelte
+++ b/apps/server/web/src/routes/(app)/dashboards/+page.svelte
@@ -8,6 +8,7 @@
   } from 'phosphor-svelte'
   import { onMount } from 'svelte'
   import { goto } from '$app/navigation'
+  import { readOnlyAccess } from '$lib/stores/auth'
   import {
     dashboardError,
     dashboardLoading,
@@ -59,13 +60,15 @@
       <h1 class="text-2xl font-bold text-theme-text-emphasis">Dashboards</h1>
       <p class="text-theme-text-muted mt-1">Create custom dashboard views with widgets</p>
     </div>
-    <button
-      onclick={() => (showCreateModal = true)}
-      class="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary-dark transition-colors"
-    >
-      <PlusIcon size={20} />
-      <span>New Dashboard</span>
-    </button>
+    {#if !$readOnlyAccess}
+      <button
+        onclick={() => (showCreateModal = true)}
+        class="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary-dark transition-colors"
+      >
+        <PlusIcon size={20} />
+        <span>New Dashboard</span>
+      </button>
+    {/if}
   </div>
 
   <!-- Error Message -->
@@ -86,16 +89,19 @@
       <SquaresFourIcon size={64} class="text-theme-text-muted mb-4" />
       <h2 class="text-xl font-semibold text-theme-text-emphasis mb-2">No dashboards yet</h2>
       <p class="text-theme-text-muted mb-6 max-w-md">
-        Create your first dashboard to get started. You can add widgets to visualize your network
-        topology and metrics.
+        {$readOnlyAccess
+          ? 'No demo dashboards are available.'
+          : 'Create your first dashboard to get started. You can add widgets to visualize your network topology and metrics.'}
       </p>
-      <button
-        onclick={() => (showCreateModal = true)}
-        class="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary-dark transition-colors"
-      >
-        <PlusIcon size={20} />
-        <span>Create Dashboard</span>
-      </button>
+      {#if !$readOnlyAccess}
+        <button
+          onclick={() => (showCreateModal = true)}
+          class="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary-dark transition-colors"
+        >
+          <PlusIcon size={20} />
+          <span>Create Dashboard</span>
+        </button>
+      {/if}
     </div>
   {:else}
     <!-- Dashboard Grid -->
@@ -125,17 +131,19 @@
           </a>
 
           <!-- Delete Button -->
-          <button
-            onclick={(e) => {
+          {#if !$readOnlyAccess}
+            <button
+              onclick={(e) => {
               e.preventDefault()
               e.stopPropagation()
               deleteConfirmId = dashboard.id
             }}
-            class="absolute top-3 right-3 w-7 h-7 flex items-center justify-center rounded-lg opacity-0 group-hover:opacity-100 hover:bg-danger/10 text-theme-text-muted hover:text-danger transition-all"
-            title="Delete dashboard"
-          >
-            <TrashIcon size={16} />
-          </button>
+              class="absolute top-3 right-3 w-7 h-7 flex items-center justify-center rounded-lg opacity-0 group-hover:opacity-100 hover:bg-danger/10 text-theme-text-muted hover:text-danger transition-all"
+              title="Delete dashboard"
+            >
+              <TrashIcon size={16} />
+            </button>
+          {/if}
         </div>
       {/each}
     </div>

--- a/apps/server/web/src/routes/(app)/dashboards/[id]/+page.svelte
+++ b/apps/server/web/src/routes/(app)/dashboards/[id]/+page.svelte
@@ -18,6 +18,7 @@
   import { goto } from '$app/navigation'
   import { api } from '$lib/api'
   import ShareButton from '$lib/components/ShareButton.svelte'
+  import { readOnlyAccess } from '$lib/stores/auth'
   import {
     currentDashboard,
     currentLayout,
@@ -58,6 +59,10 @@
   // Re-fetch the dashboard whenever the route id changes. SvelteKit reuses
   // this component for navigations within /dashboards/[id], so onMount alone
   // would leave the previous dashboard's grid on screen.
+  $effect(() => {
+    if ($readOnlyAccess && $dashboardEditMode) dashboardStore.setEditMode(false)
+  })
+
   $effect(() => {
     const currentId = id
     if (!currentId) return
@@ -328,52 +333,54 @@
       </h1>
     </div>
 
-    <div class="flex items-center gap-2">
-      {#if $dashboardEditMode}
-        <!-- Edit Mode Actions -->
-        <button
-          onclick={() => (showWidgetPanel = !showWidgetPanel)}
-          class="flex items-center gap-2 px-3 py-1.5 bg-theme-bg-canvas border border-theme-border rounded-lg hover:border-primary/50 transition-colors text-sm"
-        >
-          <PlusIcon size={16} />
-          <span>Add Widget</span>
-        </button>
-        <button
-          onclick={handleCancel}
-          class="flex items-center gap-2 px-3 py-1.5 text-theme-text-muted hover:text-theme-text transition-colors text-sm"
-        >
-          <XIcon size={16} />
-          <span>Cancel</span>
-        </button>
-        <button
-          onclick={handleSave}
-          disabled={saving}
-          class="flex items-center gap-2 px-3 py-1.5 bg-primary text-primary-foreground rounded-lg hover:bg-primary-dark transition-colors text-sm disabled:opacity-50"
-        >
-          {#if saving}
-            <SpinnerIcon size={16} class="animate-spin" />
-          {:else}
-            <FloppyDiskIcon size={16} />
-          {/if}
-          <span>Save</span>
-        </button>
-      {:else}
-        <!-- View Mode Actions -->
-        <ShareButton
-          shareToken={$currentDashboard?.shareToken}
-          shareType="dashboards"
-          onShare={handleShare}
-          onUnshare={handleUnshare}
-        />
-        <button
-          onclick={() => dashboardStore.setEditMode(true)}
-          class="flex items-center gap-2 px-3 py-1.5 bg-theme-bg-canvas border border-theme-border rounded-lg hover:border-primary/50 transition-colors text-sm"
-        >
-          <PencilSimpleIcon size={16} />
-          <span>Edit</span>
-        </button>
-      {/if}
-    </div>
+    {#if !$readOnlyAccess}
+      <div class="flex items-center gap-2">
+        {#if $dashboardEditMode}
+          <!-- Edit Mode Actions -->
+          <button
+            onclick={() => (showWidgetPanel = !showWidgetPanel)}
+            class="flex items-center gap-2 px-3 py-1.5 bg-theme-bg-canvas border border-theme-border rounded-lg hover:border-primary/50 transition-colors text-sm"
+          >
+            <PlusIcon size={16} />
+            <span>Add Widget</span>
+          </button>
+          <button
+            onclick={handleCancel}
+            class="flex items-center gap-2 px-3 py-1.5 text-theme-text-muted hover:text-theme-text transition-colors text-sm"
+          >
+            <XIcon size={16} />
+            <span>Cancel</span>
+          </button>
+          <button
+            onclick={handleSave}
+            disabled={saving}
+            class="flex items-center gap-2 px-3 py-1.5 bg-primary text-primary-foreground rounded-lg hover:bg-primary-dark transition-colors text-sm disabled:opacity-50"
+          >
+            {#if saving}
+              <SpinnerIcon size={16} class="animate-spin" />
+            {:else}
+              <FloppyDiskIcon size={16} />
+            {/if}
+            <span>Save</span>
+          </button>
+        {:else}
+          <!-- View Mode Actions -->
+          <ShareButton
+            shareToken={$currentDashboard?.shareToken}
+            shareType="dashboards"
+            onShare={handleShare}
+            onUnshare={handleUnshare}
+          />
+          <button
+            onclick={() => dashboardStore.setEditMode(true)}
+            class="flex items-center gap-2 px-3 py-1.5 bg-theme-bg-canvas border border-theme-border rounded-lg hover:border-primary/50 transition-colors text-sm"
+          >
+            <PencilSimpleIcon size={16} />
+            <span>Edit</span>
+          </button>
+        {/if}
+      </div>
+    {/if}
   </div>
 
   <!-- Main Content -->

--- a/apps/server/web/src/routes/(app)/datasources/+page.svelte
+++ b/apps/server/web/src/routes/(app)/datasources/+page.svelte
@@ -6,6 +6,7 @@
   import { Button } from '$lib/components/ui/button'
   import * as Dialog from '$lib/components/ui/dialog'
   import { dataSources, dataSourcesError, dataSourcesList, dataSourcesLoading } from '$lib/stores'
+  import { readOnlyAccess } from '$lib/stores/auth'
   import type {
     ConnectionResult,
     DataSource,
@@ -208,10 +209,12 @@
 <div class="p-6">
   <!-- Actions -->
   <div class="flex items-center justify-end mb-6">
-    <Button onclick={openCreateModal}>
-      <PlusIcon size={20} class="mr-1" />
-      Add Data Source
-    </Button>
+    {#if !$readOnlyAccess}
+      <Button onclick={openCreateModal}>
+        <PlusIcon size={20} class="mr-1" />
+        Add Data Source
+      </Button>
+    {/if}
   </div>
 
   {#if $dataSourcesLoading}
@@ -232,7 +235,9 @@
       <p class="text-theme-text-muted mb-4">
         Add a data source to start collecting metrics or topology
       </p>
-      <Button onclick={openCreateModal}>Add Data Source</Button>
+      {#if !$readOnlyAccess}
+        <Button onclick={openCreateModal}>Add Data Source</Button>
+      {/if}
     </div>
   {:else}
     <!-- Data Sources Table -->
@@ -260,12 +265,16 @@
               {@const dsConfig = parseConfig(ds.configJson)}
               <tr>
                 <td>
-                  <a
-                    href="/datasources/{ds.id}"
-                    class="font-medium text-theme-text-emphasis hover:text-primary"
-                  >
-                    {ds.name}
-                  </a>
+                  {#if $readOnlyAccess}
+                    <span class="font-medium text-theme-text-emphasis">{ds.name}</span>
+                  {:else}
+                    <a
+                      href="/datasources/{ds.id}"
+                      class="font-medium text-theme-text-emphasis hover:text-primary"
+                    >
+                      {ds.name}
+                    </a>
+                  {/if}
                 </td>
                 <td>
                   <div class="flex items-center gap-2">
@@ -323,31 +332,33 @@
                   </div>
                 </td>
                 <td class="text-right datasources-actions-cell">
-                  <div class="flex items-center justify-end gap-2 datasources-actions">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onclick={() => handleTest(ds.id)}
-                      disabled={testingId === ds.id}
-                    >
-                      {#if testingId === ds.id}
-                        <span
-                          class="w-3 h-3 border border-current border-t-transparent rounded-full animate-spin mr-1"
-                        ></span>
-                      {/if}
-                      Test
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onclick={() => (window.location.href = `/datasources/${ds.id}`)}
-                    >
-                      Edit
-                    </Button>
-                    <Button variant="destructive" size="sm" onclick={() => handleDelete(ds)}>
-                      Delete
-                    </Button>
-                  </div>
+                  {#if !$readOnlyAccess}
+                    <div class="flex items-center justify-end gap-2 datasources-actions">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onclick={() => handleTest(ds.id)}
+                        disabled={testingId === ds.id}
+                      >
+                        {#if testingId === ds.id}
+                          <span
+                            class="w-3 h-3 border border-current border-t-transparent rounded-full animate-spin mr-1"
+                          ></span>
+                        {/if}
+                        Test
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onclick={() => (window.location.href = `/datasources/${ds.id}`)}
+                      >
+                        Edit
+                      </Button>
+                      <Button variant="destructive" size="sm" onclick={() => handleDelete(ds)}>
+                        Delete
+                      </Button>
+                    </div>
+                  {/if}
                 </td>
               </tr>
             {/each}

--- a/apps/server/web/src/routes/(app)/topologies/+page.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/+page.svelte
@@ -7,6 +7,7 @@
   import { Input } from '$lib/components/ui/input'
   import { Label } from '$lib/components/ui/label'
   import { topologies, topologiesError, topologiesList, topologiesLoading } from '$lib/stores'
+  import { readOnlyAccess } from '$lib/stores/auth'
 
   let showCreateModal = $state(false)
   let formName = $state('')
@@ -52,10 +53,12 @@
 
 <div class="p-6">
   <div class="flex items-center justify-end mb-6">
-    <Button onclick={openCreateModal}>
-      <PlusIcon size={20} />
-      Add Topology
-    </Button>
+    {#if !$readOnlyAccess}
+      <Button onclick={openCreateModal}>
+        <PlusIcon size={20} />
+        Add Topology
+      </Button>
+    {/if}
   </div>
 
   {#if $topologiesLoading}
@@ -73,8 +76,14 @@
     <div class="card p-12 text-center">
       <TreeStructureIcon size={64} class="text-theme-text-muted mx-auto mb-4" />
       <h3 class="text-lg font-medium text-theme-text-emphasis mb-2">No topologies</h3>
-      <p class="text-theme-text-muted mb-4">Create your first network topology diagram</p>
-      <Button onclick={openCreateModal}>Add Topology</Button>
+      <p class="text-theme-text-muted mb-4">
+        {$readOnlyAccess
+          ? 'No demo topologies are available.'
+          : 'Create your first network topology diagram'}
+      </p>
+      {#if !$readOnlyAccess}
+        <Button onclick={openCreateModal}>Add Topology</Button>
+      {/if}
     </div>
   {:else}
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -85,13 +94,15 @@
               <div class="w-12 h-12 bg-primary/10 rounded-lg flex items-center justify-center">
                 <TreeStructureIcon size={24} class="text-primary" />
               </div>
-              <a
-                href="/topologies/{topo.id}/settings"
-                class="text-theme-text-muted hover:text-theme-text"
-                title="Settings"
-              >
-                <GearSixIcon size={20} />
-              </a>
+              {#if !$readOnlyAccess}
+                <a
+                  href="/topologies/{topo.id}/settings"
+                  class="text-theme-text-muted hover:text-theme-text"
+                  title="Settings"
+                >
+                  <GearSixIcon size={20} />
+                </a>
+              {/if}
             </div>
 
             <h3 class="font-medium text-theme-text-emphasis mb-1">{topo.name}</h3>

--- a/apps/server/web/src/routes/(app)/topologies/[id]/+layout.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/+layout.svelte
@@ -21,6 +21,7 @@
   import { api } from '$lib/api'
   import ShareButton from '$lib/components/ShareButton.svelte'
   import { topologies } from '$lib/stores'
+  import { readOnlyAccess } from '$lib/stores/auth'
   import { createTopologyCtx } from './_context.svelte'
   import TopologyCanvas from './TopologyCanvas.svelte'
 
@@ -109,6 +110,24 @@
     ctx.loading = true
     ctx.error = ''
     try {
+      if ($readOnlyAccess) {
+        const [topoData, renderResponse] = await Promise.all([
+          api.topologies.get(id),
+          api.topologies.getRender(id),
+        ])
+        ctx.topology = topoData
+        topologies.upsert(topoData)
+        if (!('deriving' in renderResponse)) {
+          ctx.renderData = {
+            nodeCount: renderResponse.nodeCount,
+            edgeCount: renderResponse.edgeCount,
+          }
+        }
+        ctx.currentSources = []
+        ctx.topologyDataSources = []
+        ctx.metricsDataSources = []
+        return
+      }
       const [topoData, renderResponse, sources, topoSources, metricsSrcs] = await Promise.all([
         api.topologies.get(id),
         api.topologies.getRender(id),
@@ -160,7 +179,7 @@
        when the drawer is open so it never stacks on the drawer's own header. -->
   {#if !drawerOpen}
     <div class="absolute top-4 right-4 z-20 flex items-center gap-2">
-      {#if ctx.topology}
+      {#if ctx.topology && !$readOnlyAccess}
         <ShareButton
           shareToken={ctx.topology.shareToken}
           shareType="topologies"
@@ -168,7 +187,7 @@
           onUnshare={handleUnshare}
         />
       {/if}
-      {#each ZONES as z (z.key)}
+      {#each $readOnlyAccess ? [] : ZONES as z (z.key)}
         <a
           href={`${base}/${z.href}`}
           class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-sm font-medium transition-colors bg-theme-bg-elevated/90 backdrop-blur border-theme-border text-theme-text hover:text-primary"
@@ -176,13 +195,15 @@
           {z.label}
         </a>
       {/each}
-      <a
-        href={`${base}/settings`}
-        class="inline-flex items-center justify-center w-8 h-8 rounded-lg border transition-colors bg-theme-bg-elevated/90 backdrop-blur border-theme-border text-theme-text-muted hover:text-theme-text"
-        aria-label="Topology settings"
-      >
-        <GearSixIcon size={16} />
-      </a>
+      {#if !$readOnlyAccess}
+        <a
+          href={`${base}/settings`}
+          class="inline-flex items-center justify-center w-8 h-8 rounded-lg border transition-colors bg-theme-bg-elevated/90 backdrop-blur border-theme-border text-theme-text-muted hover:text-theme-text"
+          aria-label="Topology settings"
+        >
+          <GearSixIcon size={16} />
+        </a>
+      {/if}
     </div>
   {/if}
 

--- a/apps/server/web/src/routes/(app)/topologies/[id]/TopologyCanvas.svelte
+++ b/apps/server/web/src/routes/(app)/topologies/[id]/TopologyCanvas.svelte
@@ -18,6 +18,7 @@
   import NodeSearchPalette from '$lib/components/NodeSearchPalette.svelte'
   import SubgraphInfoModal from '$lib/components/SubgraphInfoModal.svelte'
   import { mappingStore, metricsConnected } from '$lib/stores'
+  import { readOnlyAccess } from '$lib/stores/auth'
   import type { TopologyDataSource } from '$lib/types'
   import { useTopologyCtx } from './_context.svelte'
 
@@ -54,6 +55,7 @@
     const topo = ctx.topology
     const sources = ctx.currentSources
     if (!id || !topo) return
+    if ($readOnlyAccess) return
     mappingStore.hydrate(id, topo, sources)
     netboxBaseUrl = undefined
     const netboxSource = sources.find(
@@ -70,6 +72,7 @@
   })
 
   function handleNodeSelect(event: NodeSelectEvent) {
+    if ($readOnlyAccess) return
     selectedNodeData = event
     mappingModalOpen = true
   }
@@ -153,7 +156,7 @@
   onSelect={handleSearchSelect}
 />
 
-{#if ctx.topology}
+{#if ctx.topology && !$readOnlyAccess}
   <NodeMappingModal
     bind:open={mappingModalOpen}
     {topologyId}

--- a/docs/homepage-draft.ja.md
+++ b/docs/homepage-draft.ja.md
@@ -183,10 +183,16 @@ Shumoku を運用現場で使うためのセルフホスト型 Web アプリケ�
 公開 Docker image を使うのが最短（clone 不要）。
 
 ```bash
-docker run -d -p 8080:8080 -v shumoku-data:/data ghcr.io/konoe-akitoshi/shumoku:latest
+install -d -m 700 .shumoku
+openssl rand -base64 32 > .shumoku/admin-password
+chmod 600 .shumoku/admin-password
+docker run -d -p 8080:8080 -v shumoku-data:/data \
+  -v "$PWD/.shumoku/admin-password:/run/secrets/shumoku_admin_password:ro" \
+  -e SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE=/run/secrets/shumoku_admin_password \
+  ghcr.io/konoe-akitoshi/shumoku:latest
 ```
 
-起動後 `http://localhost:8080` を開き、管理者パスワードを設定する。サンプル投入は `-e DEMO_MODE=true`。本番では `latest` ではなく正確な `X.Y.Z` タグを pin する。
+初回管理者パスワードはコンテナへSecretファイルとして渡し、`http://localhost:8080/login`からログインする。サンプル投入は`DEMO_MODE=true`、匿名read-onlyデモは別途`PUBLIC_DEMO=true`。本番では`latest`ではなく正確な`X.Y.Z`タグをpinする。
 
 その他: Docker Compose / Kubernetes・Helm / systemd / 手動 / nginx 等のリバースプロキシ / SQLite ファイルのバックアップ・リストア。
 


### PR DESCRIPTION
## Summary

- bootstrap the local administrator from a container Secret, with an environment-variable fallback and fail-closed startup
- add an explicitly enabled `PUBLIC_DEMO` viewer with allow-listed routes, projected responses, protected WebSocket access, and a read-only UI
- introduce principal, role, authentication-method, and permission primitives so normal users and future auth providers can be added without rewriting route authorization
- document Docker Compose, Helm, systemd, and authentication/authorization deployment guidance

Closes #692

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Screenshots

N/A — the UI changes only hide mutation controls for read-only viewers.

## Breaking changes

None. Browser-based setup remains available for loopback development when `SHUMOKU_ALLOW_WEB_SETUP=true`; non-loopback deployments now fail closed until an administrator bootstrap secret is configured.

## Test plan

- API Vitest: 124 passed
- API Bun tests: 167 passed
- Web Svelte check: 0 errors, 0 warnings
- Biome check on staged snapshot: passed
- Repository pre-commit lint and typecheck: passed
- OpenAPI contract check: passed

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guidelines
- [x] My commits are signed off for the DCO (`git commit -s`)
- [x] My code follows the project's code style (`bun run lint`)
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`bun run test`)
- [x] A changeset is not required because only private Server packages and documentation changed
- [x] I have updated the documentation if needed
