### PR TITLE
refactor(renderer): unify static render pipelines

### DIFF
--- a/.changeset/calm-renderers-unify.md
+++ b/.changeset/calm-renderers-unify.md
@@ -1,0 +1,10 @@
+---
+'@shumoku/cli': patch
+'@shumoku/renderer': patch
+'@shumoku/renderer-html': patch
+'@shumoku/renderer-png': patch
+'@shumoku/renderer-svg': patch
+'shumoku': patch
+---
+
+Use the canonical ResolvedLayout-based static renderer for CLI SVG/PNG/HTML, server SSR output, Editor export, Playground, and the public SVG/PNG/HTML graph APIs. Preserve tooltip and hierarchical-navigation DOM metadata, add Svelte/static parity coverage for HA hulls, ports, edges, and themes, and isolate the old LayoutResult renderer behind deprecated compatibility exports and prepared-render fallbacks.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ const html = await renderGraphToHtml(graph, { title: 'My Network' })
 Need SVG or PNG instead? Use the dedicated renderers:
 
 ```typescript
-import { renderGraphToSvg } from '@shumoku/renderer-svg'
+import { renderGraphToSvg } from '@shumoku/renderer/static'
 import { renderGraphToPng } from '@shumoku/renderer-png' // Node.js only
 
 const svg = await renderGraphToSvg(graph)
@@ -231,10 +231,10 @@ npx @shumoku/cli render network.yaml -f png -o diagram.png --scale 3
 |---------|------|-------------|
 | [`shumoku`](libs/shumoku) | `libs/shumoku` | All-in-one — core + SVG/HTML renderers |
 | [`@shumoku/core`](libs/@shumoku/core) | `libs/@shumoku/core` | Models, parser, layout engine, themes, plugin kit |
-| [`@shumoku/renderer-svg`](libs/@shumoku/renderer-svg) | `libs/@shumoku/renderer-svg` | SVG render pipeline (`prepareRender` → `renderSvg`) |
+| [`@shumoku/renderer-svg`](libs/@shumoku/renderer-svg) | `libs/@shumoku/renderer-svg` | Canonical SVG pipeline + legacy LayoutResult compatibility |
 | [`@shumoku/renderer-html`](libs/@shumoku/renderer-html) | `libs/@shumoku/renderer-html` | Interactive HTML output |
 | [`@shumoku/renderer-png`](libs/@shumoku/renderer-png) | `libs/@shumoku/renderer-png` | PNG output (Node.js, via resvg) |
-| [`@shumoku/renderer`](libs/@shumoku/renderer) | `libs/@shumoku/renderer` | Svelte interactive renderer (pan/zoom components) |
+| [`@shumoku/renderer`](libs/@shumoku/renderer) | `libs/@shumoku/renderer` | Canonical Svelte + static SVG renderer |
 | [`@shumoku/catalog`](libs/@shumoku/catalog) | `libs/@shumoku/catalog` | Device / service catalog (vendor, model, sysObjectID) |
 | [`@shumoku/plugin-sdk`](libs/@shumoku/plugin-sdk) | `libs/@shumoku/plugin-sdk` | HTTP client + pagination for data-source plugins |
 | [`@shumoku/cli`](apps/cli) | `apps/cli` | `shumoku render` command-line tool |

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -2,6 +2,8 @@
 
 Command-line renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Turns a `NetworkGraph` YAML or JSON file into an **SVG**, interactive **HTML**, or **PNG** diagram.
 
+SVG, PNG, and standalone HTML use the canonical framework-free `@shumoku/renderer/static` path, so every CLI format follows the same drawing model as the server, Editor export, Playground, and Svelte renderer. HTML adds pan/zoom, tooltips, and sheet navigation around that shared SVG.
+
 ## Install
 
 Run it with `npx` (no install):

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@shumoku/core": "workspace:*",
-    "@shumoku/renderer-svg": "workspace:*",
+    "@shumoku/renderer": "workspace:*",
     "@shumoku/renderer-html": "workspace:*",
     "@shumoku/renderer-png": "workspace:*"
   },

--- a/apps/cli/src/shumoku.ts
+++ b/apps/cli/src/shumoku.ts
@@ -10,13 +10,18 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, extname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
-import type { NetworkGraph } from '@shumoku/core'
 import {
   buildHierarchicalSheets,
   computeNetworkLayout,
   createNetworkLayoutEngine,
+  darkTheme,
+  lightTheme,
+  type NetworkGraph,
   parser,
+  type Theme,
+  type ThemeType,
 } from '@shumoku/core'
+import { renderSvgString } from '@shumoku/renderer/static'
 import {
   render as renderHtml,
   renderHierarchical as renderHtmlHierarchical,
@@ -24,7 +29,6 @@ import {
 } from '@shumoku/renderer-html'
 import { INTERACTIVE_IIFE } from '@shumoku/renderer-html/iife-string'
 import { png } from '@shumoku/renderer-png'
-import { SVGRenderer } from '@shumoku/renderer-svg'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8'))
@@ -58,6 +62,14 @@ Examples:
 `
 
 type OutputFormat = 'svg' | 'html' | 'png'
+
+function resolveTheme(value: string | undefined): { name: ThemeType; theme: Theme } {
+  const name = value ?? 'light'
+  if (name !== 'light' && name !== 'dark') {
+    throw new Error(`Invalid theme "${name}". Expected light or dark.`)
+  }
+  return { name, theme: name === 'dark' ? darkTheme : lightTheme }
+}
 
 function cli() {
   const args = process.argv.slice(2)
@@ -160,6 +172,11 @@ async function main(): Promise<void> {
     // Build output path
     const hasExt = /\.(svg|html|htm|png)$/i.test(outputBase)
     const outputPath = resolve(process.cwd(), hasExt ? outputBase : `${outputBase}.${format}`)
+    const { name: themeName, theme } = resolveTheme(values.theme)
+    const renderGraph: NetworkGraph = {
+      ...graph,
+      settings: { ...graph.settings, theme: themeName },
+    }
 
     // Ensure output directory exists
     mkdirSync(dirname(outputPath), { recursive: true })
@@ -167,29 +184,34 @@ async function main(): Promise<void> {
     // Layout
     console.log('Generating layout...')
     const engine = createNetworkLayoutEngine()
-    const { resolved, layout: layoutResult } = await computeNetworkLayout(graph)
+    const { resolved, layout: layoutResult } = await computeNetworkLayout(renderGraph)
 
     // Render
     if (format === 'html') {
       console.log('Rendering HTML...')
       setIIFE(INTERACTIVE_IIFE)
 
-      const sheets = await buildHierarchicalSheets(graph, layoutResult, engine)
+      const sheets = await buildHierarchicalSheets(renderGraph, layoutResult, engine)
+      const rootSheet = sheets.get('root')
+      if (rootSheet) sheets.set('root', { ...rootSheet, resolved })
 
       if (sheets.size > 1) {
-        writeFileSync(outputPath, renderHtmlHierarchical(sheets), 'utf-8')
+        writeFileSync(outputPath, renderHtmlHierarchical(sheets, { theme: themeName }), 'utf-8')
       } else {
-        writeFileSync(outputPath, renderHtml(graph, layoutResult), 'utf-8')
+        writeFileSync(
+          outputPath,
+          renderHtml(renderGraph, layoutResult, { theme: themeName, resolved }),
+          'utf-8',
+        )
       }
     } else if (format === 'png') {
       console.log('Rendering PNG...')
       const scale = Number.parseFloat(values.scale) || 2
-      const pngBuffer = await png.render(graph, layoutResult, { scale })
+      const pngBuffer = await png.renderResolved(resolved, { scale, theme })
       writeFileSync(outputPath, pngBuffer)
     } else {
       console.log('Rendering SVG...')
-      const renderer = new SVGRenderer({})
-      writeFileSync(outputPath, renderer.renderResolved(graph, resolved), 'utf-8')
+      writeFileSync(outputPath, renderSvgString(resolved, { theme }), 'utf-8')
     }
 
     console.log(`Output written to: ${outputPath}`)

--- a/apps/docs/app/[lang]/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/[lang]/playground/PlaygroundClient.tsx
@@ -333,6 +333,7 @@ export default function PlaygroundClient() {
       sheetDataMap.set('root', {
         graph: preparedRef.current.graph,
         layout: preparedRef.current.layout,
+        resolved: preparedRef.current.resolved,
       })
 
       // Layout and add each child sheet
@@ -343,6 +344,7 @@ export default function PlaygroundClient() {
         sheetDataMap.set(sheetId, {
           graph: sheetPrepared.graph,
           layout: sheetPrepared.layout,
+          resolved: sheetPrepared.resolved,
         })
       }
 

--- a/apps/docs/content/docs/npm/api-reference.en.mdx
+++ b/apps/docs/content/docs/npm/api-reference.en.mdx
@@ -58,6 +58,12 @@ const prepared = await prepareRender(graph) // icon dimension resolution + layou
 const svg2 = await renderSvg(prepared)
 ```
 
+`renderGraphToSvg`, `renderSvg`, and `renderEmbeddable` use the canonical `ResolvedLayout` renderer. `SVGRenderer` (also exported as `LegacySVGRenderer`) and synchronous `svg.render(graph, layout)` are deprecated compatibility APIs for old `LayoutResult` consumers.
+
+`renderGraphToPng` computes `ResolvedLayout` and uses the canonical static renderer. For an already resolved layout, use `png.renderResolved(resolved, options)`; the older `renderPng(prepared)` entry point is deprecated but remains available for compatibility.
+
+`renderGraphToHtml` uses that same resolved SVG and adds the standalone pan/zoom, tooltip, and multi-sheet navigation shell. Legacy prepared values without `ResolvedLayout` continue to use the compatibility SVG renderer.
+
 `prepareRender` / `renderSvg` / `renderGraphToSvg` / `renderGraphToHtml` / `renderGraphToPng` are all `async` (`renderHtml(prepared)` is the only sync one).
 
 ## Themes

--- a/apps/docs/content/docs/npm/api-reference.ja.mdx
+++ b/apps/docs/content/docs/npm/api-reference.ja.mdx
@@ -58,6 +58,12 @@ const prepared = await prepareRender(graph) // アイコン寸法解決 + レイ
 const svg2 = await renderSvg(prepared)
 ```
 
+`renderGraphToSvg`、`renderSvg`、`renderEmbeddable` は標準の `ResolvedLayout` レンダラーを使用します。`SVGRenderer`（`LegacySVGRenderer` 名でも公開）と同期版 `svg.render(graph, layout)` は、旧 `LayoutResult` 利用者向けの非推奨互換 API です。
+
+`renderGraphToPng` は `ResolvedLayout` を計算し、標準の静的レンダラーを使用します。すでに解決済みのレイアウトには `png.renderResolved(resolved, options)` を使ってください。旧 `renderPng(prepared)` は非推奨ですが、互換性のために残されています。
+
+`renderGraphToHtml` も同じ解決済み SVG を使用し、スタンドアロンのパン／ズーム、ツールチップ、複数シートナビゲーションを追加します。`ResolvedLayout` を持たない旧 prepared 値は、引き続き互換 SVG レンダラーを使用します。
+
 `prepareRender` / `renderSvg` / `renderGraphToSvg` / `renderGraphToHtml` / `renderGraphToPng` はいずれも `async` です（`renderHtml(prepared)` のみ同期）。
 
 ## テーマ

--- a/apps/docs/content/docs/npm/custom-integration.en.mdx
+++ b/apps/docs/content/docs/npm/custom-integration.en.mdx
@@ -69,19 +69,18 @@ const svg = await renderGraphToSvg(networkGraph)
 const html = await renderGraphToHtml(networkGraph)
 const pngBuffer = await renderGraphToPng(networkGraph)  // Node.js only
 
-// Or use the pipeline API for more control
-import { prepareRender, renderSvg } from '@shumoku/renderer-svg'
-import { renderHtml } from '@shumoku/renderer-html'
-import { renderPng } from '@shumoku/renderer-png'  // Node.js only
+// Reuse the canonical layout for static SVG and PNG
+import { computeNetworkLayout } from '@shumoku/core'
+import { renderSvgString } from '@shumoku/renderer/static'
+import { png } from '@shumoku/renderer-png'  // Node.js only
 
-const prepared = await prepareRender(networkGraph)
-const svg = await renderSvg(prepared)
-const html = renderHtml(prepared)
-const png = await renderPng(prepared)  // Node.js only
+const { resolved } = await computeNetworkLayout(networkGraph)
+const svgFromLayout = renderSvgString(resolved)
+const pngFromLayout = await png.renderResolved(resolved)  // Node.js only
 ```
 
 <Callout type="info">
-The pipeline automatically resolves icon dimensions from CDN for proper aspect ratio rendering.
+The CLI, server, static SVG, and PNG paths share `ResolvedLayout` and the canonical static renderer. `renderPng(prepared)` remains available only as a compatibility API for the legacy prepared-render pipeline.
 </Callout>
 
 ## CLI Workflow

--- a/apps/docs/content/docs/npm/custom-integration.ja.mdx
+++ b/apps/docs/content/docs/npm/custom-integration.ja.mdx
@@ -69,19 +69,18 @@ const svg = await renderGraphToSvg(networkGraph)
 const html = await renderGraphToHtml(networkGraph)
 const pngBuffer = await renderGraphToPng(networkGraph)  // Node.js のみ
 
-// より細かい制御が必要な場合はパイプライン API を使用
-import { prepareRender, renderSvg } from '@shumoku/renderer-svg'
-import { renderHtml } from '@shumoku/renderer-html'
-import { renderPng } from '@shumoku/renderer-png'  // Node.js のみ
+// 静的 SVG と PNG で共通のレイアウトを再利用
+import { computeNetworkLayout } from '@shumoku/core'
+import { renderSvgString } from '@shumoku/renderer/static'
+import { png } from '@shumoku/renderer-png'  // Node.js のみ
 
-const prepared = await prepareRender(networkGraph)
-const svg = await renderSvg(prepared)
-const html = renderHtml(prepared)
-const png = await renderPng(prepared)  // Node.js のみ
+const { resolved } = await computeNetworkLayout(networkGraph)
+const svgFromLayout = renderSvgString(resolved)
+const pngFromLayout = await png.renderResolved(resolved)  // Node.js のみ
 ```
 
 <Callout type="info">
-パイプラインは CDN からアイコンの寸法を自動的に解決し、適切なアスペクト比でレンダリングします。
+CLI、サーバー、静的 SVG、PNG は `ResolvedLayout` と標準の静的レンダラーを共有します。`renderPng(prepared)` は旧 prepared-render パイプライン向けの互換 API としてのみ残されています。
 </Callout>
 
 ## CLI でのワークフロー

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -20,6 +20,7 @@
     "@hono/zod-openapi": "^1.5.2",
     "@shumoku/catalog": "workspace:*",
     "@shumoku/core": "workspace:*",
+    "@shumoku/renderer": "workspace:*",
     "@shumoku/renderer-html": "workspace:*",
     "@shumoku/renderer-svg": "workspace:*",
     "adm-zip": "^0.6.0",

--- a/apps/server/api/src/app/topology-queries.ts
+++ b/apps/server/api/src/app/topology-queries.ts
@@ -1,5 +1,14 @@
-import { buildHierarchicalSheets, specDeviceType, stringifyWithMaps } from '@shumoku/core'
-import { type EmbeddableRenderOutput, renderEmbeddable } from '@shumoku/renderer-svg'
+import {
+  buildHierarchicalSheets,
+  computeNetworkLayout,
+  darkTheme,
+  lightTheme,
+  type NetworkGraph,
+  type ResolvedLayout,
+  specDeviceType,
+  stringifyWithMaps,
+} from '@shumoku/core'
+import { renderSvgString } from '@shumoku/renderer/static'
 import { getLayoutEngine } from '../layout.js'
 import type { ParsedTopology, TopologyService } from '../services/topology.js'
 import type { Topology } from '../types.js'
@@ -12,20 +21,31 @@ import type {
 } from './services.js'
 import { applyMappingBandwidth } from './topology-graph.js'
 
+async function renderStaticOutput(graph: NetworkGraph, resolved?: ResolvedLayout) {
+  const padding = 50
+  const canonicalLayout = resolved ?? (await computeNetworkLayout(graph)).resolved
+  const { bounds } = canonicalLayout
+  return {
+    svg: renderSvgString(canonicalLayout, {
+      theme: graph.settings?.theme === 'dark' ? darkTheme : lightTheme,
+    }),
+    // Kept for API compatibility. The canonical static SVG contains its styles.
+    css: '',
+    viewBox: {
+      x: bounds.x - padding,
+      y: bounds.y - padding,
+      width: bounds.width + padding * 2,
+      height: bounds.height + padding * 2,
+    },
+  }
+}
+
 export async function buildRenderOutput(parsed: ParsedTopology): Promise<TopologyRenderView> {
   if (parsed.graph.subgraphs && parsed.graph.subgraphs.length > 0) {
     const sheets = await buildHierarchicalSheets(parsed.graph, parsed.layout, getLayoutEngine())
     const renderedSheets: Extract<TopologyRenderView, { hierarchical: true }>['sheets'] = {}
     for (const [sheetId, sheetData] of sheets) {
-      const output = renderEmbeddable(
-        {
-          graph: sheetData.graph,
-          layout: sheetData.layout,
-          resolved: sheetData.resolved,
-          iconDimensions: parsed.iconDimensions,
-        },
-        { hierarchical: true, toolbar: false },
-      )
+      const output = await renderStaticOutput(sheetData.graph, sheetData.resolved)
       let parentId: string | null = null
       let label = sheetData.graph.name || sheetId
       if (sheetId !== 'root') {
@@ -51,15 +71,7 @@ export async function buildRenderOutput(parsed: ParsedTopology): Promise<Topolog
       edgeCount: parsed.graph.links.length,
     }
   }
-  const output: EmbeddableRenderOutput = renderEmbeddable(
-    {
-      graph: parsed.graph,
-      layout: parsed.layout,
-      resolved: parsed.resolved,
-      iconDimensions: parsed.iconDimensions,
-    },
-    { hierarchical: false, toolbar: false },
-  )
+  const output = await renderStaticOutput(parsed.graph, parsed.resolved)
   return {
     id: parsed.id,
     name: parsed.name,

--- a/bun.lock
+++ b/bun.lock
@@ -26,9 +26,9 @@
       },
       "devDependencies": {
         "@shumoku/core": "workspace:*",
+        "@shumoku/renderer": "workspace:*",
         "@shumoku/renderer-html": "workspace:*",
         "@shumoku/renderer-png": "workspace:*",
-        "@shumoku/renderer-svg": "workspace:*",
       },
     },
     "apps/docs": {
@@ -115,6 +115,7 @@
         "@hono/zod-openapi": "^1.5.2",
         "@shumoku/catalog": "workspace:*",
         "@shumoku/core": "workspace:*",
+        "@shumoku/renderer": "workspace:*",
         "@shumoku/renderer-html": "workspace:*",
         "@shumoku/renderer-svg": "workspace:*",
         "adm-zip": "^0.6.0",
@@ -230,12 +231,16 @@
       "peerDependencies": {
         "svelte": "^5.0.0",
       },
+      "optionalPeers": [
+        "svelte",
+      ],
     },
     "libs/@shumoku/renderer-html": {
       "name": "@shumoku/renderer-html",
       "version": "0.2.25",
       "dependencies": {
         "@shumoku/core": "^0.2.23",
+        "@shumoku/renderer": "^0.1.0",
         "@shumoku/renderer-svg": "^0.2.25",
       },
     },
@@ -245,6 +250,7 @@
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",
         "@shumoku/core": "^0.2.23",
+        "@shumoku/renderer": "^0.1.0",
         "@shumoku/renderer-svg": "^0.2.25",
       },
     },
@@ -253,6 +259,7 @@
       "version": "0.2.25",
       "dependencies": {
         "@shumoku/core": "^0.2.23",
+        "@shumoku/renderer": "^0.1.0",
       },
     },
     "libs/plugins/arista-cv-cue": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -487,8 +487,8 @@ flowchart TB
     COR[core<br/>models, layout, parser]
     CAT[catalog<br/>device/service catalog]
     SDK[plugin-sdk<br/>HTTP client, pagination]
-    RND[renderer<br/>Svelte SVG]
-    RSV[renderer-svg<br/>SSR SVG]
+    RND[renderer<br/>Svelte + static SVG]
+    RSV[renderer-svg<br/>compatibility SVG]
     RHT[renderer-html<br/>embeddable]
     RPN[renderer-png<br/>resvg]
     SHU[shumoku<br/>umbrella]
@@ -513,7 +513,7 @@ flowchart TB
   DOC --> RHT
 
   CLI --> COR
-  CLI --> RSV
+  CLI --> RND
   CLI --> RPN
   CLI --> RHT
 
@@ -525,7 +525,10 @@ flowchart TB
   CAT --> COR
   RND --> COR
   RSV --> COR
+  RSV --> RND
   RHT --> RSV
+  RHT --> RND
+  RPN --> RND
   RPN --> RSV
   SHU --> COR
   SHU --> RSV
@@ -550,11 +553,17 @@ flowchart TB
   anywhere.
 - **Renderers depend on `core`** — never on editor. Core models are
   the lingua franca.
-- **Editor depends on core + catalog + renderer** — plus
-  `renderer-svg` for SVG export.
-- **Server consumes renderers, not just core** — the API side uses
-  `renderer-svg` / `renderer-html` for baked layouts and static
-  export; the web side uses the Svelte `renderer`.
+- **Editor depends on core + catalog + renderer** — its `renderer-svg`
+  export facade now delegates to the canonical static renderer.
+- **Server consumes renderers, not just core** — API static export and
+  the web UI use the canonical `renderer`; legacy icon preparation still
+  uses the compatibility renderer.
+- **CLI SVG, PNG, and standalone HTML share the canonical static renderer** —
+  `renderer-html` adds the navigation, tooltip, and pan/zoom runtime shell
+  without regenerating resolved SVG geometry.
+- **Playground and public SVG pipeline functions use the same path** — the
+  old `SVGRenderer` / synchronous `svg.render` surface is isolated as a
+  deprecated `LayoutResult` compatibility layer.
 - **Apps don't cross-depend** — editor doesn't import from docs, etc.
 
 The **canonical data shape** at every boundary is `NetworkGraph`

--- a/libs/@shumoku/renderer-html/README.md
+++ b/libs/@shumoku/renderer-html/README.md
@@ -1,6 +1,6 @@
 # @shumoku/renderer-html
 
-Interactive HTML renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Wraps the [`@shumoku/renderer-svg`](../renderer-svg) pipeline to produce a self-contained HTML page with pan, zoom, tooltips, and — for large networks — multi-sheet navigation.
+Interactive HTML renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Wraps the canonical [`@shumoku/renderer`](../renderer) static SVG output in a self-contained page with pan, zoom, tooltips, and — for large networks — multi-sheet navigation. Legacy prepared layouts without `ResolvedLayout` remain compatible through `@shumoku/renderer-svg`.
 
 ## Install
 
@@ -35,7 +35,10 @@ const html = await renderGraphToHtml(graph, { title: 'My Network', toolbar: true
 | `title` | string | Page / document title |
 | `branding` | boolean | Show the Shumoku mark |
 | `toolbar` | boolean | Show the pan/zoom toolbar |
+| `theme` | `'light' \| 'dark'` | Override `graph.settings.theme` |
 | `sheets` | `Map<string, SheetData>` | Pre-computed hierarchical sheets (skips recomputation) |
+
+The one-liner and prepared-render pipelines use `ResolvedLayout` and the same SVG geometry as CLI, PNG, server output, and the Svelte renderer. The generated SVG retains node, port, link, and sheet data attributes required by the tooltip and navigation runtime.
 
 ### Embedding
 

--- a/libs/@shumoku/renderer-html/package.json
+++ b/libs/@shumoku/renderer-html/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@shumoku/core": "^0.2.23",
+    "@shumoku/renderer": "^0.1.0",
     "@shumoku/renderer-svg": "^0.2.25"
   },
   "devDependencies": {},

--- a/libs/@shumoku/renderer-html/src/html/index.test.ts
+++ b/libs/@shumoku/renderer-html/src/html/index.test.ts
@@ -1,0 +1,94 @@
+import { computeNetworkLayout, DeviceType, type NetworkGraph } from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import { render, renderHierarchical } from './index.js'
+
+const graph: NetworkGraph = {
+  version: '1',
+  name: 'HTML renderer',
+  nodes: [
+    {
+      id: 'router',
+      label: 'Router',
+      parent: 'site',
+      spec: {
+        kind: 'hardware',
+        type: DeviceType.Router,
+        vendor: 'Shumoku',
+        model: 'R1',
+      },
+      ports: [{ id: 'uplink', label: 'Gi0/1', connectors: [] }],
+    },
+    {
+      id: 'switch',
+      label: 'Switch',
+      parent: 'site',
+      ports: [{ id: 'uplink', label: 'Gi0/48', connectors: [] }],
+    },
+  ],
+  links: [
+    {
+      id: 'uplink',
+      from: { node: 'router', port: 'uplink' },
+      to: { node: 'switch', port: 'uplink' },
+      vlan: [10],
+    },
+  ],
+  subgraphs: [{ id: 'site', label: 'Site', file: 'site.yaml' }],
+}
+
+describe('standalone HTML themes', () => {
+  it('emits shared theme variables and activates the dark theme', async () => {
+    const { layout, resolved } = await computeNetworkLayout(graph)
+
+    const html = render(graph, layout, { resolved, theme: 'dark' })
+
+    expect(html).toContain('<body class="dark">')
+    expect(html).toContain('--shumoku-text-secondary: #94a3b8;')
+  })
+
+  it('uses the canonical static SVG while preserving interactive DOM metadata', async () => {
+    const { layout, resolved } = await computeNetworkLayout(graph)
+
+    const html = render(graph, layout, { resolved })
+
+    expect(html).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
+    expect(html).toContain('style="background: transparent;"')
+    expect(html).toContain('data-device-vendor="Shumoku"')
+    expect(html).toContain('data-device-model="R1"')
+    expect(html).toContain('data-port-device="router"')
+    expect(html).toContain('data-link-from="router:uplink"')
+    expect(html).toContain('data-link-to="switch:uplink"')
+    expect(html).toContain('data-link-vlan="10"')
+    expect(html).toContain('class="link-hit link-hit-area"')
+    expect(html).toContain('class="port-hit"')
+    expect(html).toContain('data-has-sheet="true"')
+    expect(html).toContain('data-sheet-id="site"')
+  })
+
+  it('uses the canonical renderer for every resolved hierarchical sheet', async () => {
+    const graphWithoutFile: NetworkGraph = {
+      ...graph,
+      subgraphs: graph.subgraphs?.map(({ file: _file, ...subgraph }) => subgraph),
+    }
+    const root = await computeNetworkLayout(graphWithoutFile)
+    const childGraph: NetworkGraph = {
+      ...graph,
+      name: 'Child',
+      subgraphs: undefined,
+      nodes: graph.nodes.map((node) => ({ ...node, parent: undefined })),
+    }
+    const child = await computeNetworkLayout(childGraph)
+
+    const html = renderHierarchical(
+      new Map([
+        ['root', { graph: graphWithoutFile, layout: root.layout, resolved: root.resolved }],
+        ['site', { graph: childGraph, layout: child.layout, resolved: child.resolved }],
+      ]),
+    )
+
+    expect(html.match(/style="background: transparent;"/g)).toHaveLength(2)
+    expect(html).toContain('data-sheet-id="root"')
+    expect(html).toContain('data-sheet-id="site"')
+    expect(html).toContain('data-has-sheet="true"')
+  })
+})

--- a/libs/@shumoku/renderer-html/src/html/index.ts
+++ b/libs/@shumoku/renderer-html/src/html/index.ts
@@ -12,9 +12,12 @@ import type {
   LayoutResult,
   NetworkGraph,
   ResolvedLayout,
+  ThemeType,
 } from '@shumoku/core'
+import { darkTheme, lightTheme } from '@shumoku/core'
+import { renderSvgString } from '@shumoku/renderer/static'
 import type { HTMLRendererOptions } from '@shumoku/renderer-svg'
-import { BRANDING_ICON_SVG, SVGRenderer } from '@shumoku/renderer-svg'
+import { BRANDING_ICON_SVG, generateThemeCSS, SVGRenderer } from '@shumoku/renderer-svg'
 import {
   generateNavigationToolbar,
   getNavigationScript,
@@ -48,6 +51,8 @@ export function getIIFE(): string {
 }
 
 export interface RenderOptions extends HTMLRendererOptions {
+  /** Theme variables applied to the standalone page. */
+  theme?: ThemeType
   /**
    * Enable hierarchical navigation UI
    */
@@ -69,7 +74,7 @@ export interface RenderOptions extends HTMLRendererOptions {
   iconDimensions?: Map<string, { width: number; height: number }>
 
   /**
-   * ResolvedLayout for new render path (uses renderResolved)
+   * ResolvedLayout for the canonical static SVG render path.
    */
   resolved?: ResolvedLayout
 }
@@ -78,26 +83,32 @@ const DEFAULT_OPTIONS = {
   branding: true,
   toolbar: true,
   hierarchical: false,
+  theme: 'light' as ThemeType,
 }
 
 /**
  * Render a complete standalone HTML page from NetworkGraph
  */
 export function render(graph: NetworkGraph, layout: LayoutResult, options?: RenderOptions): string {
-  const opts = { ...DEFAULT_OPTIONS, ...options }
+  const opts = {
+    ...DEFAULT_OPTIONS,
+    theme: graph.settings?.theme ?? DEFAULT_OPTIONS.theme,
+    ...options,
+  }
 
   // Auto-detect hierarchical mode if not explicitly set
   if (options?.hierarchical === undefined) {
     opts.hierarchical = hasHierarchicalContent(graph)
   }
 
-  const svgRenderer = new SVGRenderer({
-    renderMode: 'interactive',
-    iconDimensions: options?.iconDimensions,
-  })
   const svg = options?.resolved
-    ? svgRenderer.renderResolved(graph, options.resolved)
-    : svgRenderer.render(graph, layout)
+    ? renderSvgString(options.resolved, {
+        theme: opts.theme === 'dark' ? darkTheme : lightTheme,
+      })
+    : new SVGRenderer({
+        renderMode: 'interactive',
+        iconDimensions: options?.iconDimensions,
+      }).render(graph, layout)
   const title = options?.title || graph.name || 'Network Diagram'
 
   // Build navigation state if hierarchical
@@ -118,6 +129,19 @@ export interface SheetData {
   resolved?: ResolvedLayout
 }
 
+function withNavigableSubgraphs(
+  layout: ResolvedLayout,
+  sheetIds: ReadonlySet<string>,
+): ResolvedLayout {
+  const subgraphs = new Map(
+    [...layout.subgraphs].map(([id, subgraph]) => [
+      id,
+      sheetIds.has(id) && !subgraph.file ? { ...subgraph, file: id } : subgraph,
+    ]),
+  )
+  return { ...layout, subgraphs }
+}
+
 /**
  * Render a hierarchical HTML page with multiple embedded sheets
  */
@@ -130,20 +154,22 @@ export function renderHierarchical(
   const sheetSvgs = new Map<string, string>()
   const sheetInfos = new Map<string, SheetInfo>()
   const rootSheet = sheets.get('root')
+  const navigableSheetIds = new Set([...sheets.keys()].filter((sheetId) => sheetId !== 'root'))
 
   // Render child sheets for navigation (detail view when clicking subgraphs)
   for (const [sheetId, data] of sheets) {
     if (sheetId === 'root') continue // Skip root for now
 
     // Render child sheet
-    const svgRenderer = new SVGRenderer({
-      renderMode: 'interactive',
-      sheetId,
-      iconDimensions: options?.iconDimensions,
-    })
     const svg = data.resolved
-      ? svgRenderer.renderResolved(data.graph, data.resolved)
-      : svgRenderer.render(data.graph, data.layout)
+      ? renderSvgString(data.resolved, {
+          theme: (options?.theme ?? data.graph.settings?.theme) === 'dark' ? darkTheme : lightTheme,
+        })
+      : new SVGRenderer({
+          renderMode: 'interactive',
+          sheetId,
+          iconDimensions: options?.iconDimensions,
+        }).render(data.graph, data.layout)
     sheetSvgs.set(sheetId, svg)
     sheetInfos.set(sheetId, {
       id: sheetId,
@@ -154,14 +180,16 @@ export function renderHierarchical(
 
   // Render root sheet (ELK handles hierarchical layout natively, no embedding needed)
   if (rootSheet) {
-    const rootRenderer = new SVGRenderer({
-      renderMode: 'interactive',
-      sheetId: 'root',
-      iconDimensions: options?.iconDimensions,
-    })
     const rootSvg = rootSheet.resolved
-      ? rootRenderer.renderResolved(rootSheet.graph, rootSheet.resolved)
-      : rootRenderer.render(rootSheet.graph, rootSheet.layout)
+      ? renderSvgString(withNavigableSubgraphs(rootSheet.resolved, navigableSheetIds), {
+          theme:
+            (options?.theme ?? rootSheet.graph.settings?.theme) === 'dark' ? darkTheme : lightTheme,
+        })
+      : new SVGRenderer({
+          renderMode: 'interactive',
+          sheetId: 'root',
+          iconDimensions: options?.iconDimensions,
+        }).render(rootSheet.graph, rootSheet.layout)
     sheetSvgs.set('root', rootSvg)
     sheetInfos.set('root', {
       id: 'root',
@@ -300,6 +328,7 @@ function generateHtml(svg: string, title: string, options: Required<RenderOption
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${escapeHtml(title)}</title>
   <style>
+    ${generateThemeCSS()}
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body { background: #fafafa; min-height: 100vh; font-family: system-ui, -apple-system, sans-serif; }
     .toolbar { display: flex; align-items: center; justify-content: space-between; padding: 8px 16px; background: white; border-bottom: 1px solid #e5e7eb; }
@@ -325,7 +354,7 @@ function generateHtml(svg: string, title: string, options: Required<RenderOption
     ${navStyles}
   </style>
 </head>
-<body>
+<body class="${options.theme === 'dark' ? 'dark' : ''}">
   ${toolbarHtml}
   ${navToolbarHtml}
   <div class="container" id="container">
@@ -629,6 +658,7 @@ function generateHierarchicalHtml(
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${escapeHtml(title)}</title>
   <style>
+    ${generateThemeCSS()}
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body { background: #fafafa; min-height: 100vh; font-family: system-ui, -apple-system, sans-serif; }
     .toolbar { display: flex; align-items: center; justify-content: space-between; padding: 8px 16px; background: white; border-bottom: 1px solid #e5e7eb; }
@@ -655,7 +685,7 @@ function generateHierarchicalHtml(
     .subgraph[data-has-sheet]:hover > rect { filter: brightness(0.95); }
   </style>
 </head>
-<body>
+<body class="${options.theme === 'dark' ? 'dark' : ''}">
   ${toolbarHtml}
   <div class="container" id="container">
     ${sheetContainers.join('\n    ')}

--- a/libs/@shumoku/renderer-html/src/pipeline.test.ts
+++ b/libs/@shumoku/renderer-html/src/pipeline.test.ts
@@ -1,0 +1,19 @@
+import type { NetworkGraph } from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import { renderGraphToHtml } from './pipeline.js'
+
+describe('HTML pipeline', () => {
+  it('forwards the resolved layout to the canonical renderer', async () => {
+    const graph: NetworkGraph = {
+      version: '1',
+      name: 'Pipeline',
+      nodes: [{ id: 'node', label: 'Node' }],
+      links: [],
+    }
+
+    const html = await renderGraphToHtml(graph)
+
+    expect(html).toContain('style="background: transparent;"')
+    expect(html).toContain('data-id="node"')
+  })
+})

--- a/libs/@shumoku/renderer-html/src/pipeline.ts
+++ b/libs/@shumoku/renderer-html/src/pipeline.ts
@@ -12,6 +12,7 @@ import {
   createNetworkLayoutEngine,
   type NetworkGraph,
   type SheetData,
+  type ThemeType,
 } from '@shumoku/core'
 import type { PreparedRender } from '@shumoku/renderer-svg'
 import { prepareRender } from '@shumoku/renderer-svg'
@@ -24,6 +25,8 @@ export interface HTMLRenderOptions {
   title?: string
   branding?: boolean
   toolbar?: boolean
+  /** Theme override. Defaults to graph.settings.theme, then light. */
+  theme?: ThemeType
   /** Pre-computed hierarchical sheets (skips buildHierarchicalSheets) */
   sheets?: Map<string, SheetData>
 }
@@ -32,7 +35,7 @@ export interface HTMLRenderOptions {
  * Render prepared data to interactive HTML
  */
 export function renderHtml(prepared: PreparedRender, options?: HTMLRenderOptions): string {
-  return html.render(prepared.graph, prepared.layout, options)
+  return html.render(prepared.graph, prepared.layout, { ...options, resolved: prepared.resolved })
 }
 
 /**
@@ -45,6 +48,8 @@ export async function renderHtmlHierarchical(
   const sheets =
     options?.sheets ??
     (await buildHierarchicalSheets(prepared.graph, prepared.layout, createNetworkLayoutEngine()))
+  const root = sheets.get('root')
+  if (root && prepared.resolved) sheets.set('root', { ...root, resolved: prepared.resolved })
   return html.renderHierarchical(sheets, options)
 }
 

--- a/libs/@shumoku/renderer-png/README.md
+++ b/libs/@shumoku/renderer-png/README.md
@@ -1,6 +1,6 @@
 # @shumoku/renderer-png
 
-PNG renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Renders the [`@shumoku/renderer-svg`](../renderer-svg) output to a raster image with [`@resvg/resvg-js`](https://github.com/yisibl/resvg-js).
+PNG renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Rasterizes canonical static SVG output from [`@shumoku/renderer`](../renderer) with [`@resvg/resvg-js`](https://github.com/yisibl/resvg-js). Legacy graph/prepared entry points remain compatible with `@shumoku/renderer-svg` while consumers migrate.
 
 > **Node.js only** — depends on the native `@resvg/resvg-js` binding, so it does not run in the browser.
 
@@ -27,10 +27,11 @@ writeFileSync('diagram.png', png)
 
 | Function | Description |
 |----------|-------------|
-| `renderGraphToPng(graph, options?)` | `async` → `Buffer`. Convenience: `prepareRender` + `renderPng` |
-| `renderPng(prepared, options?)` | `async` → `Buffer`. Renders an existing `PreparedRender` |
+| `renderGraphToPng(graph, options?)` | `async` → `Buffer`. Canonical graph path: computes `ResolvedLayout` and renders the shared static SVG |
+| `renderPng(prepared, options?)` | `async` → `Buffer`. Deprecated compatibility API for an existing legacy `PreparedRender` |
+| `png.renderResolved(layout, options?)` | `async` → `Buffer`. Canonical path for an existing `ResolvedLayout`; supports `theme` and `scale` |
 
-`PNGRenderOptions` has a single field, `scale` (default `2`), the output resolution multiplier. External CDN icons are automatically embedded as base64 before rasterizing.
+`PNGRenderOptions` supports `scale` (default `2`), `theme`, `loadSystemFonts`, and `iconTimeout`. If `theme` is omitted, `renderGraphToPng` honors `graph.settings.theme` and otherwise uses the light theme. External CDN icons are automatically embedded as base64 before rasterizing.
 
 ## License
 

--- a/libs/@shumoku/renderer-png/package.json
+++ b/libs/@shumoku/renderer-png/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@resvg/resvg-js": "^2.6.2",
     "@shumoku/core": "^0.2.23",
+    "@shumoku/renderer": "^0.1.0",
     "@shumoku/renderer-svg": "^0.2.25"
   },
   "devDependencies": {},

--- a/libs/@shumoku/renderer-png/src/index.test.ts
+++ b/libs/@shumoku/renderer-png/src/index.test.ts
@@ -1,0 +1,46 @@
+import { darkTheme, type NetworkGraph } from '@shumoku/core'
+import { prepareRender } from '@shumoku/renderer-svg'
+import { describe, expect, it } from 'vitest'
+import { renderGraphToPng, renderPng } from './index.js'
+
+const graph: NetworkGraph = {
+  version: '1',
+  name: 'PNG renderer',
+  nodes: [
+    { id: 'a', label: 'Router A', rank: 0 },
+    { id: 'b', label: 'Switch B', rank: 1 },
+  ],
+  links: [{ id: 'uplink', from: { node: 'a' }, to: { node: 'b' }, label: 'Uplink' }],
+}
+
+describe('renderGraphToPng', () => {
+  it('renders a graph through the canonical resolved-layout path', async () => {
+    const output = await renderGraphToPng(graph, { scale: 1, loadSystemFonts: false })
+
+    expect(output.subarray(0, 8)).toEqual(
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    )
+  })
+
+  it('honors graph theme and an explicit theme override', async () => {
+    const darkFromGraph = await renderGraphToPng(
+      { ...graph, settings: { ...graph.settings, theme: 'dark' } },
+      { scale: 1, loadSystemFonts: false },
+    )
+    const darkFromOption = await renderGraphToPng(graph, {
+      scale: 1,
+      loadSystemFonts: false,
+      theme: darkTheme,
+    })
+
+    expect(darkFromGraph).toEqual(darkFromOption)
+  })
+
+  it('uses the canonical renderer for prepared resolved layouts', async () => {
+    const prepared = await prepareRender(graph)
+    const fromPrepared = await renderPng(prepared, { scale: 1, loadSystemFonts: false })
+    const fromGraph = await renderGraphToPng(graph, { scale: 1, loadSystemFonts: false })
+
+    expect(fromPrepared).toEqual(fromGraph)
+  })
+})

--- a/libs/@shumoku/renderer-png/src/index.ts
+++ b/libs/@shumoku/renderer-png/src/index.ts
@@ -7,9 +7,14 @@
  * Node.js only (requires @resvg/resvg-js)
  */
 
-import type { NetworkGraph } from '@shumoku/core'
-import type { PreparedRender, PrepareOptions } from '@shumoku/renderer-svg'
-import { prepareRender } from '@shumoku/renderer-svg'
+import {
+  computeNetworkLayout,
+  darkTheme,
+  lightTheme,
+  type NetworkGraph,
+  type Theme,
+} from '@shumoku/core'
+import { type PreparedRender, type PrepareOptions, prepareRender } from '@shumoku/renderer-svg'
 import * as png from './png.js'
 
 export type { PngOptions } from './png.js'
@@ -21,18 +26,39 @@ export { png }
 export interface PNGRenderOptions {
   /** Scale factor (default: 2) */
   scale?: number
+  /** Load system fonts (default: true) */
+  loadSystemFonts?: boolean
+  /** Fetch timeout for external icon URLs in milliseconds (default: 3000) */
+  iconTimeout?: number
+  /** Theme override. Defaults to graph.settings.theme, then light. */
+  theme?: Theme
 }
+
+/**
+ * Graph rendering options. Legacy prepare options are accepted so existing
+ * callers can migrate without a flag day.
+ */
+export type PNGGraphRenderOptions = PNGRenderOptions & PrepareOptions
 
 /**
  * Render PNG from prepared data (Node.js only)
  *
  * Uses resvg-js for high-quality SVG to PNG conversion.
  * Automatically embeds external CDN images as base64.
+ *
+ * Prefer renderGraphToPng(graph) for new callers. Prepared data with a
+ * ResolvedLayout uses the canonical static renderer; legacy LayoutResult-only
+ * data remains supported as a compatibility fallback.
  */
 export async function renderPng(
   prepared: PreparedRender,
   options?: PNGRenderOptions,
 ): Promise<Buffer> {
+  if (prepared.resolved) {
+    const theme =
+      options?.theme ?? (prepared.graph.settings?.theme === 'dark' ? darkTheme : lightTheme)
+    return png.renderResolved(prepared.resolved, { ...options, theme })
+  }
   return png.render(prepared.graph, prepared.layout, {
     scale: options?.scale,
     iconDimensions: prepared.iconDimensions ?? undefined,
@@ -41,12 +67,18 @@ export async function renderPng(
 
 /**
  * Render network graph directly to PNG buffer.
- * Convenience function that combines prepareRender + renderPng.
+ * This is the canonical graph entry point: it computes ResolvedLayout once and
+ * rasterizes the same static SVG used by the CLI, server, and Svelte renderer.
  */
 export async function renderGraphToPng(
   graph: NetworkGraph,
-  options?: PrepareOptions & PNGRenderOptions,
+  options: PNGGraphRenderOptions = {},
 ): Promise<Buffer> {
-  const prepared = await prepareRender(graph, options)
-  return renderPng(prepared, options)
+  if (options.layout || options.iconDimensions) {
+    const prepared = await prepareRender(graph, options)
+    return renderPng(prepared, options)
+  }
+  const { resolved } = await computeNetworkLayout(graph)
+  const theme = options.theme ?? (graph.settings?.theme === 'dark' ? darkTheme : lightTheme)
+  return png.renderResolved(resolved, { ...options, theme })
 }

--- a/libs/@shumoku/renderer-png/src/png.ts
+++ b/libs/@shumoku/renderer-png/src/png.ts
@@ -8,7 +8,8 @@
  */
 
 import { Resvg } from '@resvg/resvg-js'
-import type { LayoutResult, NetworkGraph } from '@shumoku/core'
+import type { LayoutResult, NetworkGraph, ResolvedLayout, Theme } from '@shumoku/core'
+import { renderSvgString } from '@shumoku/renderer/static'
 import {
   collectIconUrls,
   fetchIconAsDataUrl,
@@ -26,6 +27,8 @@ export interface PngOptions {
   iconTimeout?: number
   /** Pre-resolved icon dimensions (skips fetching if provided) */
   iconDimensions?: Map<string, IconDimensions>
+  /** Theme used by the canonical static renderer. */
+  theme?: Theme
 }
 
 /**
@@ -33,8 +36,9 @@ export interface PngOptions {
  * This is required for resvg which cannot fetch external resources
  */
 async function embedExternalImages(svgString: string, timeout = 3000): Promise<string> {
-  // Find all image href attributes with http(s) URLs
-  const imageUrlRegex = /<image\s+[^>]*href="(https?:\/\/[^"]+)"[^>]*>/g
+  // All Shumoku renderers emit href as the first image attribute. Matching the
+  // fixed prefix avoids overlapping wildcard repetitions on untrusted SVG.
+  const imageUrlRegex = /<image href="(https?:\/\/[^"]+)"/g
   const matches = [...svgString.matchAll(imageUrlRegex)]
 
   if (matches.length === 0) return svgString
@@ -92,6 +96,25 @@ export async function render(
     font: { loadSystemFonts },
   })
 
+  return resvg.render().asPng()
+}
+
+/**
+ * Render a resolved layout with the canonical renderer shared by Svelte, CLI, and SSR.
+ */
+export async function renderResolved(
+  layout: ResolvedLayout,
+  options: Omit<PngOptions, 'iconDimensions'> = {},
+): Promise<Buffer> {
+  const scale = options.scale ?? 2
+  const loadSystemFonts = options.loadSystemFonts ?? true
+  let svgString = renderSvgString(layout, { theme: options.theme })
+  svgString = await embedExternalImages(svgString, options.iconTimeout)
+
+  const resvg = new Resvg(svgString, {
+    fitTo: { mode: 'zoom', value: scale },
+    font: { loadSystemFonts },
+  })
   return resvg.render().asPng()
 }
 

--- a/libs/@shumoku/renderer-svg/README.md
+++ b/libs/@shumoku/renderer-svg/README.md
@@ -1,6 +1,6 @@
 # @shumoku/renderer-svg
 
-SVG renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Provides the **unified render pipeline** — layout, icon-dimension resolution, and SVG generation — and is the foundation that [`@shumoku/renderer-html`](../renderer-html) and [`@shumoku/renderer-png`](../renderer-png) build on.
+SVG compatibility and pipeline package for [Shumoku](https://github.com/konoe-akitoshi/shumoku). Its public pipeline functions render `ResolvedLayout` through the canonical [`@shumoku/renderer`](../renderer) static SVG implementation shared by CLI, HTML, PNG, server output, Editor export, and Playground. The older `LayoutResult` renderer remains available as an explicitly deprecated compatibility layer.
 
 ## Install
 
@@ -29,8 +29,8 @@ const svg2 = await renderSvg(prepared)
 | Function | Description |
 |----------|-------------|
 | `prepareRender(graph, options?)` | → `PreparedRender`. Resolves icon dimensions (CDN fetch + cache) and computes layout |
-| `renderSvg(prepared, options?)` | → SVG string |
-| `renderGraphToSvg(graph, options?)` | Convenience: `prepareRender` + `renderSvg` |
+| `renderSvg(prepared, options?)` | → canonical SVG when `prepared.resolved` is available; legacy fallback otherwise |
+| `renderGraphToSvg(graph, options?)` | Canonical graph-to-SVG convenience API |
 | `renderEmbeddable(prepared, options?)` | → `{ svg, css, … }` for embedding in a web app with scoped styles |
 
 All four are `async` (icon resolution may fetch over the network).
@@ -39,7 +39,7 @@ All four are `async` (icon resolution may fetch over the network).
 
 `resolveAllIconDimensions`, `fetchIconAsDataUrl`, `fetchImageDimensions`, `clearIconCache`, `DEFAULT_ICON_FETCH_TIMEOUT`, and `collectIconUrls` are exported for callers that manage icon fetching themselves (e.g. a server resolving dimensions ahead of time).
 
-> The removed class-based API (`new SvgRenderer()`) is gone. A lower-level `SVGRenderer` is still exported for advanced use, but prefer the pipeline functions above.
+> `SVGRenderer` / `LegacySVGRenderer` and the synchronous `svg.render(graph, layout)` namespace API are deprecated compatibility surfaces for callers that only have the old `LayoutResult`. New code should use the pipeline functions above or `@shumoku/renderer/static` directly.
 
 ## License
 

--- a/libs/@shumoku/renderer-svg/package.json
+++ b/libs/@shumoku/renderer-svg/package.json
@@ -36,7 +36,8 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@shumoku/core": "^0.2.23"
+    "@shumoku/core": "^0.2.23",
+    "@shumoku/renderer": "^0.1.0"
   },
   "devDependencies": {},
   "publishConfig": {

--- a/libs/@shumoku/renderer-svg/src/index.ts
+++ b/libs/@shumoku/renderer-svg/src/index.ts
@@ -28,13 +28,14 @@ export type {
 } from './pipeline.js'
 // Unified render pipeline
 export {
+  generateThemeCSS,
   prepareRender,
   renderEmbeddable,
   renderGraphToSvg,
   renderSvg,
 } from './pipeline.js'
 // Re-export collectIconUrls for server-side icon dimension resolution
-export { collectIconUrls, SVGRenderer } from './svg.js'
+export { collectIconUrls, SVGRenderer, SVGRenderer as LegacySVGRenderer } from './svg.js'
 // Types
 export type {
   DataAttributeOptions,

--- a/libs/@shumoku/renderer-svg/src/pipeline.test.ts
+++ b/libs/@shumoku/renderer-svg/src/pipeline.test.ts
@@ -1,0 +1,26 @@
+import { darkTheme, type NetworkGraph } from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import { prepareRender, renderEmbeddable, renderGraphToSvg, renderSvg } from './pipeline.js'
+
+const graph: NetworkGraph = {
+  version: '1',
+  name: 'SVG pipeline',
+  nodes: [{ id: 'node', label: 'Node' }],
+  links: [],
+}
+
+describe('canonical SVG pipeline', () => {
+  it('uses the canonical renderer from the graph convenience API', async () => {
+    const svg = await renderGraphToSvg(graph, { theme: darkTheme })
+
+    expect(svg).toContain('style="background: transparent;"')
+    expect(svg).toContain(darkTheme.colors.textSecondary)
+  })
+
+  it('uses the canonical renderer for prepared and embeddable resolved layouts', async () => {
+    const prepared = await prepareRender(graph)
+
+    expect(await renderSvg(prepared)).toContain('style="background: transparent;"')
+    expect(renderEmbeddable(prepared).svg).toContain('style="background: transparent;"')
+  })
+})

--- a/libs/@shumoku/renderer-svg/src/pipeline.ts
+++ b/libs/@shumoku/renderer-svg/src/pipeline.ts
@@ -17,7 +17,9 @@ import {
   type NetworkGraph,
   type ResolvedLayout,
   type SurfaceToken,
+  type Theme,
 } from '@shumoku/core'
+import { renderSvgString } from '@shumoku/renderer/static'
 import { type IconDimensions, resolveAllIconDimensions } from './icon-dims.js'
 import { collectIconUrls, SVGRenderer } from './svg.js'
 
@@ -51,6 +53,8 @@ export interface PrepareOptions {
 export interface SVGRenderOptions {
   /** Render mode */
   renderMode?: 'static' | 'interactive'
+  /** Theme override. Defaults to graph.settings.theme, then light. */
+  theme?: Theme
 }
 
 /**
@@ -121,15 +125,15 @@ export async function renderSvg(
   prepared: PreparedRender,
   options?: SVGRenderOptions,
 ): Promise<string> {
-  const renderer = new SVGRenderer({
+  if (prepared.resolved) {
+    const theme =
+      options?.theme ?? (prepared.graph.settings?.theme === 'dark' ? darkTheme : lightTheme)
+    return renderSvgString(prepared.resolved, { theme })
+  }
+  return new SVGRenderer({
     renderMode: options?.renderMode ?? 'static',
     iconDimensions: prepared.iconDimensions ?? undefined,
-  })
-  // Use resolved layout directly (no conversion) when available
-  if (prepared.resolved) {
-    return renderer.renderResolved(prepared.graph, prepared.resolved)
-  }
-  return renderer.render(prepared.graph, prepared.layout)
+  }).render(prepared.graph, prepared.layout)
 }
 
 /**
@@ -158,14 +162,14 @@ export function renderEmbeddable(
   prepared: PreparedRender,
   options?: EmbeddableRenderOptions,
 ): EmbeddableRenderOutput {
-  // Render SVG with interactive mode (includes data attributes)
-  const renderer = new SVGRenderer({
-    renderMode: 'interactive',
-    iconDimensions: prepared.iconDimensions ?? undefined,
-  })
   const svg = prepared.resolved
-    ? renderer.renderResolved(prepared.graph, prepared.resolved)
-    : renderer.render(prepared.graph, prepared.layout)
+    ? renderSvgString(prepared.resolved, {
+        theme: prepared.graph.settings?.theme === 'dark' ? darkTheme : lightTheme,
+      })
+    : new SVGRenderer({
+        renderMode: 'interactive',
+        iconDimensions: prepared.iconDimensions ?? undefined,
+      }).render(prepared.graph, prepared.layout)
 
   // Build CSS for interactivity
   const css = generateEmbeddableCSS(options?.toolbar ?? false)
@@ -238,11 +242,9 @@ function generateThemeVars(theme: typeof lightTheme): string {
   return lines.map((l) => `  ${l}`).join('\n')
 }
 
-/**
- * Generate CSS for embeddable SVG interactivity
- */
-function generateEmbeddableCSS(toolbar: boolean): string {
-  const themeCSS = `
+/** Theme variables shared by embeddable and standalone HTML consumers. */
+export function generateThemeCSS(): string {
+  return `
 /* Shumoku Theme Variables */
 :root {
 ${generateThemeVars(lightTheme)}
@@ -251,6 +253,13 @@ ${generateThemeVars(lightTheme)}
 ${generateThemeVars(darkTheme)}
 }
 `
+}
+
+/**
+ * Generate CSS for embeddable SVG interactivity
+ */
+function generateEmbeddableCSS(toolbar: boolean): string {
+  const themeCSS = generateThemeCSS()
 
   const baseCSS = `
 /* Shumoku Embeddable Styles */
@@ -384,7 +393,8 @@ ${generateThemeVars(darkTheme)}
 
 /**
  * Render network graph directly to SVG string.
- * Convenience function that combines prepareRender + renderSvg.
+ * Uses the canonical ResolvedLayout-based static renderer by default.
+ * Explicit legacy layout/icon-dimension options retain the compatibility path.
  *
  * @example
  * ```typescript
@@ -393,8 +403,13 @@ ${generateThemeVars(darkTheme)}
  */
 export async function renderGraphToSvg(
   graph: NetworkGraph,
-  options?: PrepareOptions & SVGRenderOptions,
+  options: PrepareOptions & SVGRenderOptions = {},
 ): Promise<string> {
+  if (!options.layout && !options.iconDimensions) {
+    const { resolved } = await computeNetworkLayout(graph)
+    const theme = options.theme ?? (graph.settings?.theme === 'dark' ? darkTheme : lightTheme)
+    return renderSvgString(resolved, { theme })
+  }
   const prepared = await prepareRender(graph, options)
   return renderSvg(prepared, options)
 }

--- a/libs/@shumoku/renderer-svg/src/svg.ts
+++ b/libs/@shumoku/renderer-svg/src/svg.ts
@@ -223,6 +223,13 @@ const DEFAULT_OPTIONS: Required<SVGRendererOptions> = {
 // SVG Renderer
 // ============================================
 
+/**
+ * Legacy LayoutResult renderer retained for compatibility and specialized
+ * synchronous rendering. Prefer renderGraphToSvg(), renderSvg(), or
+ * @shumoku/renderer/static for new code.
+ *
+ * @deprecated Use the ResolvedLayout-based pipeline APIs.
+ */
 export class SVGRenderer {
   private options: Required<SVGRendererOptions>
   private theme: Theme = lightTheme
@@ -1680,6 +1687,8 @@ export interface RenderOptions extends SVGRendererOptions {}
 
 /**
  * Render NetworkGraph to SVG string (sync)
+ *
+ * @deprecated Use renderGraphToSvg() or renderSvg() from the package root.
  */
 export function render(graph: NetworkGraph, layout: LayoutResult, options?: RenderOptions): string {
   const renderer = new SVGRenderer(options)

--- a/libs/@shumoku/renderer/README.md
+++ b/libs/@shumoku/renderer/README.md
@@ -1,13 +1,22 @@
 # @shumoku/renderer
 
-Interactive [Svelte](https://svelte.dev) renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku) diagrams. Provides the building blocks for a live, manipulable topology view — pan/zoom camera, coordinate helpers, layout serialization, and overlay hooks — used by the [editor](../../../apps/editor) and the [server](../../../apps/server) web UI.
+Canonical renderer for [Shumoku](https://github.com/konoe-akitoshi/shumoku) diagrams. It provides both the live [Svelte](https://svelte.dev) renderer used by the editor and server UI, and a framework-free static SVG entry point used by CLI, PNG, and SSR consumers.
 
-> Requires Svelte 5 (peer dependency). For static, non-interactive SVG output use [`@shumoku/renderer-svg`](../renderer-svg) instead.
+> The interactive entry requires Svelte 5. Static consumers should import `@shumoku/renderer/static`; it does not mount or compile a Svelte component.
 
 ## Install
 
 ```bash
 npm install @shumoku/renderer @shumoku/core svelte
+```
+
+For static-only consumers, Svelte is not required at runtime:
+
+```typescript
+import { renderGraphToSvg, renderSvgString } from '@shumoku/renderer/static'
+
+const svg = await renderGraphToSvg(graph)
+const svgFromExistingLayout = renderSvgString(resolvedLayout, { theme })
 ```
 
 ## What it provides
@@ -19,7 +28,7 @@ npm install @shumoku/renderer @shumoku/core svelte
 | **Colors** | `themeToColors` — turn a Shumoku theme into a resolved color map |
 | **SVG coordinates** | `screenToSvg`, `svgToScreen`, `svgPointToContainer`, `svgRectToContainer`, `bezierEdgePath`, `bezierOffsetPath`, `computePortLabelPosition`, `getNodeLabel`, `getVlanStroke` |
 | **Overlays** | typed snippet hooks for custom node / link / port / subgraph rendering (`RendererOverlaySnippets`) |
-| **Static SVG** | `renderGraphToSvg`, `renderSvgString` — server-side / SSR fallback |
+| **Static SVG** | `renderGraphToSvg`, `renderSvgString` from `@shumoku/renderer/static` — CLI, PNG, and SSR |
 
 ## License
 

--- a/libs/@shumoku/renderer/package.json
+++ b/libs/@shumoku/renderer/package.json
@@ -65,5 +65,10 @@
   },
   "peerDependencies": {
     "svelte": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "svelte": {
+      "optional": true
+    }
   }
 }

--- a/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
+++ b/libs/@shumoku/renderer/src/components/svg/SvgPort.svelte
@@ -52,7 +52,7 @@
   // keeps the small tab + chip.
   const couplingBar = $derived(port.coupling === true)
   const onSide = $derived(port.side === 'left' || port.side === 'right')
-  const barLen = $derived(Math.max(32, Math.min(56, portLabelLength(port.label) + 16)))
+  const barLen = $derived(Math.max(32, Math.min(56, portLabelLength(port.label ?? '') + 16)))
   const pw = $derived(couplingBar ? (onSide ? 14 : barLen) : port.size.width)
   const ph = $derived(couplingBar ? (onSide ? barLen : 14) : port.size.height)
   const labelPos = $derived(computePortLabelPosition(port))
@@ -64,7 +64,7 @@
   // Full label, never truncated. The width comes from the SAME
   // deterministic metric the layout used for collision boxes and
   // corridors (port-geometry) — one size authority, no canvas drift.
-  const labelWidth = $derived(portLabelLength(port.label))
+  const labelWidth = $derived(portLabelLength(port.label ?? ''))
   const labelHeight = 12
   const bgX = $derived(() => {
     if (labelPos.textAnchor === 'middle') return labelPos.x - labelWidth / 2

--- a/libs/@shumoku/renderer/src/parity.test.ts
+++ b/libs/@shumoku/renderer/src/parity.test.ts
@@ -1,0 +1,145 @@
+import {
+  computeNetworkLayout,
+  DeviceType,
+  darkTheme,
+  lightTheme,
+  type NetworkGraph,
+  type ResolvedLayout,
+  type Theme,
+} from '@shumoku/core'
+import { render } from 'svelte/server'
+import { describe, expect, it } from 'vitest'
+import SvgCanvas from './components/svg/SvgCanvas.svelte'
+import { themeToColors } from './lib/render-colors.js'
+import { renderSvgString } from './static.js'
+
+function elementAfter(markup: string, selector: string, tag: string): string {
+  const selectorStart = markup.indexOf(selector)
+  expect(selectorStart).toBeGreaterThanOrEqual(0)
+  const start = markup.indexOf(`<${tag}`, selectorStart)
+  expect(start).toBeGreaterThanOrEqual(0)
+  return markup.slice(start, markup.indexOf('>', start) + 1)
+}
+
+function attribute(element: string, name: string): string {
+  const match = element.match(new RegExp(`${name}="([^"]*)"`))
+  expect(match?.[1], `${name} missing from ${element}`).toBeDefined()
+  return match?.[1] ?? ''
+}
+
+function primaryLinkPath(markup: string, edgeId: string): string {
+  return elementAfter(markup, `data-link-id="${edgeId}"`, 'path')
+}
+
+function portBox(markup: string, portId: string): string {
+  const groupStart = markup.indexOf(`data-port="${portId}"`)
+  expect(groupStart).toBeGreaterThanOrEqual(0)
+  const classStart = markup.indexOf('class="port-box"', groupStart)
+  expect(classStart).toBeGreaterThanOrEqual(0)
+  const start = markup.lastIndexOf('<rect', classStart)
+  return markup.slice(start, markup.indexOf('>', classStart) + 1)
+}
+
+function haHullPath(markup: string): string {
+  return elementAfter(markup, 'class="ha-hull"', 'path')
+}
+
+function renderInteractive(layout: ResolvedLayout, theme: Theme): string {
+  return render(SvgCanvas, {
+    props: {
+      nodes: layout.nodes,
+      ports: layout.ports,
+      edges: layout.edges,
+      subgraphs: layout.subgraphs,
+      bounds: layout.bounds,
+      colors: themeToColors(theme),
+      theme,
+    },
+  }).body
+}
+
+describe('static and interactive renderer parity', () => {
+  it.each([
+    ['light', lightTheme],
+    ['dark', darkTheme],
+  ] as const)('keeps resolved geometry and semantic elements aligned in %s mode', async (_name, theme) => {
+    const graph: NetworkGraph = {
+      version: '1',
+      name: 'Parity topology',
+      nodes: [
+        {
+          id: 'router-a',
+          label: ['Router A', 'Primary'],
+          rank: 0,
+          spec: { kind: 'hardware', type: DeviceType.Router },
+          ports: [
+            { id: 'ha', label: 'HA', connectors: [] },
+            { id: 'lan', label: 'Gi0/1', connectors: [] },
+          ],
+        },
+        {
+          id: 'router-b',
+          label: 'Router B',
+          rank: 0,
+          spec: { kind: 'hardware', type: DeviceType.Router },
+          ports: [{ id: 'ha', label: 'HA', connectors: [] }],
+        },
+        {
+          id: 'switch',
+          label: 'Access Switch',
+          rank: 1,
+          spec: { kind: 'hardware', type: DeviceType.L2Switch },
+          ports: [{ id: 'uplink', label: 'Gi0/48', connectors: [] }],
+        },
+      ],
+      links: [
+        {
+          id: 'ha-link',
+          from: { node: 'router-a', port: 'ha' },
+          to: { node: 'router-b', port: 'ha' },
+          label: 'Heartbeat',
+          redundancy: 'ha',
+        },
+        {
+          id: 'uplink',
+          from: { node: 'router-a', port: 'lan' },
+          to: { node: 'switch', port: 'uplink' },
+          label: 'Uplink',
+          vlan: [10, 20],
+        },
+      ],
+    }
+    const { resolved } = await computeNetworkLayout(graph, { composite: true })
+    const interactive = renderInteractive(resolved, theme)
+    const staticallyRendered = renderSvgString(resolved, { theme })
+
+    expect(resolved.edges.get('ha-link')?.coupling).toBe(true)
+    for (const node of resolved.nodes.values()) {
+      expect(interactive).toContain(`data-id="${node.id}"`)
+      expect(staticallyRendered).toContain(`data-id="${node.id}"`)
+    }
+    for (const port of resolved.ports.values()) {
+      const selector = `data-port="${port.id}"`
+      expect(interactive).toContain(selector)
+      expect(staticallyRendered).toContain(selector)
+      const interactivePort = portBox(interactive, port.id)
+      const staticPort = portBox(staticallyRendered, port.id)
+      for (const name of ['x', 'y', 'width', 'height', 'rx']) {
+        expect(attribute(staticPort, name)).toBe(attribute(interactivePort, name))
+      }
+    }
+    for (const edge of resolved.edges.values()) {
+      const interactivePath = primaryLinkPath(interactive, edge.id)
+      const staticPath = primaryLinkPath(staticallyRendered, edge.id)
+      for (const name of ['d', 'stroke', 'stroke-width']) {
+        expect(attribute(staticPath, name)).toBe(attribute(interactivePath, name))
+      }
+    }
+
+    const interactiveHull = haHullPath(interactive)
+    const staticHull = haHullPath(staticallyRendered)
+    expect(attribute(staticHull, 'd')).toBe(attribute(interactiveHull, 'd'))
+    expect(interactive).toContain('class="ha-hull"')
+    expect(staticallyRendered).toContain('class="ha-hull"')
+  })
+})

--- a/libs/@shumoku/renderer/src/static.test.ts
+++ b/libs/@shumoku/renderer/src/static.test.ts
@@ -1,0 +1,68 @@
+import {
+  DeviceType,
+  darkTheme,
+  type Node,
+  type ResolvedLayout,
+  type ResolvedPort,
+} from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import { renderSvgString } from './static.js'
+
+describe('renderSvgString', () => {
+  it('renders a legacy resolved port whose label is missing', () => {
+    const port: ResolvedPort = {
+      id: 'node:legacy-port',
+      nodeId: 'node',
+      label: undefined as unknown as string,
+      absolutePosition: { x: 10, y: 10 },
+      side: 'top',
+      size: { width: 8, height: 8 },
+    }
+    const layout: ResolvedLayout = {
+      nodes: new Map(),
+      ports: new Map([[port.id, port]]),
+      edges: new Map(),
+      subgraphs: new Map(),
+      bounds: { x: 0, y: 0, width: 20, height: 20 },
+      metadata: { algorithm: 'test', duration: 0 },
+    }
+
+    expect(renderSvgString(layout)).toContain('data-port="node:legacy-port"')
+  })
+
+  it.each([
+    ['URL', 'https://example.com/device.svg', '<image href="https://example.com/device.svg"'],
+    ['inline', '<path d="M1 1h22v22H1z"/>', '<path d="M1 1h22v22H1z"/>'],
+  ])('uses the resolved %s icon just like the interactive renderer', (_kind, icon, expected) => {
+    const node: Node = {
+      id: 'router',
+      label: 'Router',
+      position: { x: 50, y: 50 },
+      size: { width: 100, height: 80 },
+      spec: { kind: 'hardware', type: DeviceType.Router, icon },
+    }
+    const layout: ResolvedLayout = {
+      nodes: new Map([[node.id, node]]),
+      ports: new Map(),
+      edges: new Map(),
+      subgraphs: new Map(),
+      bounds: { x: 0, y: 0, width: 100, height: 100 },
+    }
+
+    const svg = renderSvgString(layout)
+    expect(svg).toContain(expected)
+    expect(svg).toContain('data-device-type="router"')
+  })
+
+  it('applies the requested theme to static output', () => {
+    const layout: ResolvedLayout = {
+      nodes: new Map(),
+      ports: new Map(),
+      edges: new Map(),
+      subgraphs: new Map(),
+      bounds: { x: 0, y: 0, width: 100, height: 100 },
+    }
+
+    expect(renderSvgString(layout, { theme: darkTheme })).toContain(darkTheme.colors.textSecondary)
+  })
+})

--- a/libs/@shumoku/renderer/src/static.ts
+++ b/libs/@shumoku/renderer/src/static.ts
@@ -18,12 +18,17 @@ import type {
   Theme,
 } from '@shumoku/core'
 import {
+  buildHaHullPath,
   createEngine,
   DEFAULT_ICON_SIZE,
-  getDeviceIcon,
+  darkTheme,
+  groupCouplingPairs,
   ICON_LABEL_GAP,
   LABEL_LINE_HEIGHT,
   lightTheme,
+  portLabelLength,
+  resolveNodeSize as resolveCoreNodeSize,
+  resolveIcon,
   type SurfaceToken,
   specDeviceType,
 } from '@shumoku/core'
@@ -36,14 +41,19 @@ const resolveNodeSize = (n: {
 }) => n.size ?? engine.nodeBodySize(n as Parameters<typeof engine.nodeBodySize>[0])
 
 import { type RenderColors, themeToColors } from './lib/render-colors'
-import { bezierEdgePath, computePortLabelPosition, getVlanStroke } from './lib/svg-coords'
+import {
+  bezierEdgePath,
+  computePortLabelPosition,
+  getVlanStroke,
+  polylinePath,
+} from './lib/svg-coords'
 
 // ============================================================================
 // Escape helper
 // ============================================================================
 
-function esc(s: string): string {
-  return s
+function esc(s: string | null | undefined): string {
+  return (s ?? '')
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
@@ -163,9 +173,9 @@ function renderNode(node: Node, colors: RenderColors): string {
   )
 
   // Icon
-  const iconPath = getDeviceIcon(specDeviceType(node.spec))
+  const icon = resolveIcon(node.spec)
   const iconSize = DEFAULT_ICON_SIZE
-  const iconHeight = iconPath ? iconSize : 0
+  const iconHeight = icon ? iconSize : 0
   const gap = iconHeight > 0 ? ICON_LABEL_GAP : 0
 
   // Labels
@@ -176,9 +186,14 @@ function renderNode(node: Node, colors: RenderColors): string {
   const labelStartY = contentTop + iconHeight + gap + LABEL_LINE_HEIGHT * 0.7
 
   let fg = ''
-  if (iconPath) {
+  if (icon) {
+    const label = esc(specDeviceType(node.spec) ?? 'icon')
+    const iconMarkup =
+      icon.kind === 'inline'
+        ? `<svg width="${iconSize}" height="${iconSize}" viewBox="0 0 24 24" fill="currentColor" role="img" aria-label="${label}">${icon.svg}</svg>`
+        : `<image href="${esc(icon.url)}" width="${iconSize}" height="${iconSize}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="${label}"/>`
     fg += `<g class="node-icon" transform="translate(${cx - iconSize / 2}, ${contentTop})">
-  <svg width="${iconSize}" height="${iconSize}" viewBox="0 0 24 24" fill="currentColor">${iconPath}</svg>
+  ${iconMarkup}
 </g>\n`
   }
   for (const [i, line] of labels.entries()) {
@@ -193,7 +208,22 @@ function renderNode(node: Node, colors: RenderColors): string {
     fg += `<text x="${cx}" y="${labelStartY + i * LABEL_LINE_HEIGHT}" class="${cls}" text-anchor="middle">${esc(clean)}</text>\n`
   }
 
-  return `<g class="node" data-id="${node.id}" filter="url(#node-shadow)">
+  const dataAttributes = [`data-id="${esc(node.id)}"`]
+  const deviceType = specDeviceType(node.spec)
+  if (deviceType) dataAttributes.push(`data-device-type="${esc(deviceType)}"`)
+  if (node.spec?.vendor) dataAttributes.push(`data-device-vendor="${esc(node.spec.vendor)}"`)
+  if (node.spec?.kind === 'hardware' && node.spec.model) {
+    dataAttributes.push(`data-device-model="${esc(node.spec.model)}"`)
+  }
+  if (node.spec?.kind === 'service') {
+    dataAttributes.push(`data-device-service="${esc(node.spec.service)}"`)
+    if (node.spec.resource) {
+      dataAttributes.push(`data-device-resource="${esc(node.spec.resource)}"`)
+    }
+  }
+  if (node.parent) dataAttributes.push(`data-parent="${esc(node.parent)}"`)
+
+  return `<g class="node" ${dataAttributes.join(' ')} filter="url(#node-shadow)">
   <g class="node-bg">${bg}</g>
   <g class="node-fg">${fg}</g>
 </g>`
@@ -201,58 +231,48 @@ function renderNode(node: Node, colors: RenderColors): string {
 
 function renderPort(port: ResolvedPort, colors: RenderColors): string {
   const { absolutePosition: pos, size } = port
+  const couplingBar = port.coupling === true
+  const onSide = port.side === 'left' || port.side === 'right'
+  const barLength = Math.max(32, Math.min(56, portLabelLength(port.label ?? '') + 16))
+  const width = couplingBar ? (onSide ? 14 : barLength) : size.width
+  const height = couplingBar ? (onSide ? barLength : 14) : size.height
   const labelPos = computePortLabelPosition(port)
-  const labelWidth = engine.text.measure(port.label, 'port') + 4
+  const labelWidth = portLabelLength(port.label ?? '')
   const labelHeight = 12
+  const hasLabel = (port.label ?? '').trim().length > 0
+  const verticalLabel =
+    port.labelOrientation === 'vertical' && (port.side === 'top' || port.side === 'bottom')
 
   let bgX = labelPos.x - 2
   if (labelPos.textAnchor === 'middle') bgX = labelPos.x - labelWidth / 2
   else if (labelPos.textAnchor === 'end') bgX = labelPos.x - labelWidth + 2
   const bgY = labelPos.y - labelHeight + 3
 
-  return `<g class="port" data-port="${port.id}">
-  <rect class="port-box" x="${pos.x - size.width / 2}" y="${pos.y - size.height / 2}" width="${size.width}" height="${size.height}" fill="${colors.portFill}" stroke="${colors.portStroke}" stroke-width="1" rx="2"/>
-  <rect class="port-label-bg" x="${bgX}" y="${bgY}" width="${labelWidth}" height="${labelHeight}" rx="2" fill="${colors.portLabelBg}"/>
-  <text class="port-label" x="${labelPos.x}" y="${labelPos.y}" text-anchor="${labelPos.textAnchor}" font-size="9" fill="${colors.portLabelColor}">${esc(port.label)}</text>
-</g>`
-}
-
-/**
- * Right-angle polyline with light corner rounding, mirroring the
- * interactive renderer in `components/svg/SvgEdge.svelte`. Kept inline
- * here (rather than a shared util) because static SSR has no DOM and
- * the two contexts don't otherwise overlap on path helpers.
- */
-function polylineSvgPath(pts: ReadonlyArray<{ x: number; y: number }>): string {
-  if (pts.length === 0) return ''
-  if (pts.length === 1) return `M ${pts[0]?.x ?? 0} ${pts[0]?.y ?? 0}`
-  const r = 6
-  let d = `M ${pts[0]?.x ?? 0} ${pts[0]?.y ?? 0}`
-  for (let i = 1; i < pts.length - 1; i++) {
-    const prev = pts[i - 1]
-    const curr = pts[i]
-    const next = pts[i + 1]
-    if (!prev || !curr || !next) continue
-    const dxIn = curr.x - prev.x
-    const dyIn = curr.y - prev.y
-    const dxOut = next.x - curr.x
-    const dyOut = next.y - curr.y
-    const lenIn = Math.hypot(dxIn, dyIn)
-    const lenOut = Math.hypot(dxOut, dyOut)
-    if (lenIn < 1 || lenOut < 1) {
-      d += ` L ${curr.x} ${curr.y}`
-      continue
-    }
-    const ri = Math.min(r, lenIn / 2, lenOut / 2)
-    const inX = curr.x - (dxIn / lenIn) * ri
-    const inY = curr.y - (dyIn / lenIn) * ri
-    const outX = curr.x + (dxOut / lenOut) * ri
-    const outY = curr.y + (dyOut / lenOut) * ri
-    d += ` L ${inX} ${inY} Q ${curr.x} ${curr.y} ${outX} ${outY}`
+  let labelMarkup = ''
+  if (hasLabel && couplingBar) {
+    const transform = onSide
+      ? ` transform="rotate(${port.side === 'right' ? -90 : 90} ${pos.x} ${pos.y})"`
+      : ''
+    labelMarkup = `
+  <g${transform} pointer-events="none">
+    <text class="port-label-text" x="${pos.x}" y="${pos.y + 3}" text-anchor="middle" font-size="8.5" fill="${colors.portLabelColor}">${esc(port.label)}</text>
+  </g>`
+  } else if (hasLabel && verticalLabel) {
+    labelMarkup = `
+  <g transform="rotate(${port.side === 'top' ? -90 : 90} ${pos.x} ${pos.y})" pointer-events="none">
+    <rect class="port-label-bg" x="${pos.x + 10}" y="${pos.y - labelHeight + 3}" width="${labelWidth}" height="${labelHeight}" rx="2" fill="${colors.portLabelBg}"/>
+    <text class="port-label-text" x="${pos.x + 12}" y="${pos.y}" text-anchor="start" font-size="9" fill="${colors.portLabelColor}">${esc(port.label)}</text>
+  </g>`
+  } else if (hasLabel) {
+    labelMarkup = `
+  <rect class="port-label-bg" x="${bgX}" y="${bgY}" width="${labelWidth}" height="${labelHeight}" rx="2" fill="${colors.portLabelBg}" pointer-events="none"/>
+  <text class="port-label-text" x="${labelPos.x}" y="${labelPos.y}" text-anchor="${labelPos.textAnchor}" font-size="9" fill="${colors.portLabelColor}">${esc(port.label)}</text>`
   }
-  const last = pts[pts.length - 1]
-  if (last) d += ` L ${last.x} ${last.y}`
-  return d
+
+  return `<g class="port" data-port="${esc(port.id)}" data-port-device="${esc(port.nodeId)}">
+  <rect class="port-hit" x="${pos.x - 12}" y="${pos.y - 12}" width="24" height="24" fill="transparent"/>
+  <rect class="port-box" x="${pos.x - width / 2}" y="${pos.y - height / 2}" width="${width}" height="${height}" fill="${colors.portFill}" stroke="${colors.portStroke}" stroke-width="1" rx="${couplingBar ? 4 : 2}" pointer-events="none"/>${labelMarkup}
+</g>`
 }
 
 function renderEdge(edge: ResolvedEdge, colors: RenderColors): string {
@@ -260,7 +280,7 @@ function renderEdge(edge: ResolvedEdge, colors: RenderColors): string {
   // polylines with light corner rounding; everything else falls back
   // to the standard port-anchored Bezier.
   const pathD = edge.route
-    ? polylineSvgPath(edge.route.points)
+    ? polylinePath(edge.route.points)
     : edge.fromPort && edge.toPort
       ? bezierEdgePath(
           { ...edge.fromPort, lateralOffset: edge.fromLateralOffset },
@@ -270,6 +290,8 @@ function renderEdge(edge: ResolvedEdge, colors: RenderColors): string {
   const link = edge.link
   const stroke = link?.style?.stroke ?? getVlanStroke(link?.vlan) ?? colors.linkStroke
   const dasharray = link?.type === 'dashed' ? '5 3' : (link?.style?.strokeDasharray ?? '')
+  const coupling = link?.redundancy !== undefined || edge.coupling === true
+  const strokeOpacity = edge.emphasis === 'secondary' ? 0.45 : 1
 
   let line: string
   if (link?.type === 'double') {
@@ -278,18 +300,19 @@ function renderEdge(edge: ResolvedEdge, colors: RenderColors): string {
   <path d="${pathD}" fill="none" stroke="white" stroke-width="${Math.max(1, edge.width)}" stroke-linecap="round" pointer-events="none"/>
   <path d="${pathD}" fill="none" stroke="${stroke}" stroke-width="${Math.max(1, edge.width - Math.round(gap * 0.8))}" stroke-linecap="round" pointer-events="none"/>`
   } else {
-    line = `<path class="link" d="${pathD}" fill="none" stroke="${stroke}" stroke-width="${edge.width}" stroke-linecap="round"${dasharray ? ` stroke-dasharray="${dasharray}"` : ''} pointer-events="none"/>`
+    line = `<path class="${coupling ? 'link link-ha' : 'link'}" d="${pathD}" fill="none" stroke="${stroke}" stroke-width="${edge.width}" stroke-opacity="${strokeOpacity}" stroke-linecap="round"${dasharray ? ` stroke-dasharray="${dasharray}"` : ''} pointer-events="none"/>`
   }
 
   // Labels
   let labels = ''
-  if (edge.points.length >= 2) {
+  if (edge.labelAnchor || edge.points.length >= 2) {
     const midIdx = Math.floor(edge.points.length / 2)
     const a = edge.points[midIdx - 1]
     const b = edge.points[midIdx]
-    if (a && b) {
-      const mx = (a.x + b.x) / 2
-      const my = (a.y + b.y) / 2
+    const midpoint =
+      edge.labelAnchor ?? (a && b ? { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 } : null)
+    if (midpoint) {
+      const { x: mx, y: my } = midpoint
       let yOff = -8
       if (link?.label) {
         const labelText = Array.isArray(link.label) ? link.label.join(' / ') : link.label
@@ -304,9 +327,93 @@ function renderEdge(edge: ResolvedEdge, colors: RenderColors): string {
     }
   }
 
-  return `<g class="link-group" data-link-id="${edge.id}">
-  ${line}${labels}
+  const from = edge.fromEndpoint.port
+    ? `${edge.fromEndpoint.node}:${edge.fromEndpoint.port}`
+    : edge.fromEndpoint.node
+  const to = edge.toEndpoint.port
+    ? `${edge.toEndpoint.node}:${edge.toEndpoint.port}`
+    : edge.toEndpoint.node
+  const dataAttributes = [
+    `data-link-id="${esc(edge.id)}"`,
+    `data-link-from="${esc(from)}"`,
+    `data-link-to="${esc(to)}"`,
+  ]
+  const fromStandard = link?.from.plug?.module?.standard
+  const toStandard = link?.to.plug?.module?.standard
+  if (fromStandard) dataAttributes.push(`data-link-from-standard="${esc(fromStandard)}"`)
+  if (toStandard) dataAttributes.push(`data-link-to-standard="${esc(toStandard)}"`)
+  if (link?.vlan && link.vlan.length > 0) {
+    dataAttributes.push(`data-link-vlan="${esc(link.vlan.join(','))}"`)
+  }
+  if (link?.redundancy) {
+    dataAttributes.push(`data-link-redundancy="${esc(link.redundancy)}"`)
+  }
+  const destinationDevice = link?.metadata?.['_destDevice']
+  const destinationPort = link?.metadata?.['_destPort']
+  if (destinationDevice) {
+    dataAttributes.push(`data-link-dest-device="${esc(String(destinationDevice))}"`)
+    if (destinationPort) {
+      dataAttributes.push(`data-link-dest-port="${esc(String(destinationPort))}"`)
+    }
+  }
+
+  const hitArea = `<path class="link-hit link-hit-area" d="${pathD}" fill="none" stroke="transparent" stroke-width="${Math.max(edge.width + 12, 16)}" stroke-linecap="round"/>`
+
+  return `<g class="link-group" ${dataAttributes.join(' ')}>
+  ${line}
+  ${hitArea}${labels}
 </g>`
+}
+
+function pairKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`
+}
+
+function renderHaHulls(layout: ResolvedLayout, colors: RenderColors): string[] {
+  const pairs: Array<{ a: string; b: string; kind?: string }> = []
+  const seamYByPair = new Map<string, number>()
+  for (const edge of layout.edges.values()) {
+    if (!edge.coupling) continue
+    pairs.push({ a: edge.fromNodeId, b: edge.toNodeId, kind: edge.link.redundancy })
+    seamYByPair.set(
+      pairKey(edge.fromNodeId, edge.toNodeId),
+      (edge.fromPort.absolutePosition.y + edge.toPort.absolutePosition.y) / 2,
+    )
+  }
+
+  const rendered: string[] = []
+  for (const group of groupCouplingPairs(pairs)) {
+    const placed: Array<{ id: string; x: number; y: number; width: number; height: number }> = []
+    for (const id of group.members) {
+      const node = layout.nodes.get(id)
+      if (!node?.position) continue
+      const size = resolveCoreNodeSize(node)
+      placed.push({
+        id,
+        x: node.position.x - size.width / 2,
+        y: node.position.y - size.height / 2,
+        width: size.width,
+        height: size.height,
+      })
+    }
+    if (placed.length === 0) continue
+    placed.sort((a, b) => a.x + a.width / 2 - (b.x + b.width / 2))
+
+    const seams: Array<{ y: number }> = []
+    for (const [index, left] of placed.entries()) {
+      const right = placed[index + 1]
+      if (!right) continue
+      const y = seamYByPair.get(pairKey(left.id, right.id))
+      seams.push({ y: y ?? (left.y + left.height / 2 + right.y + right.height / 2) / 2 })
+    }
+
+    const hull = buildHaHullPath({ members: placed, seams })
+    rendered.push(`<g class="ha-hull" pointer-events="none">
+  <path d="${hull.d}" fill="${colors.haHullFill}"/>
+  <text class="ha-hull-label" x="${hull.bounds.x + 2}" y="${hull.bounds.y - 6}" font-size="9" letter-spacing="0.08em" fill="${colors.textSecondary}">${esc((group.kind ?? 'ha').toUpperCase())}</text>
+</g>`)
+  }
+  return rendered
 }
 
 function renderSubgraph(sg: Subgraph, theme: Theme, colors: RenderColors): string {
@@ -318,7 +425,14 @@ function renderSubgraph(sg: Subgraph, theme: Theme, colors: RenderColors): strin
   const bw = sg.bounds?.width ?? 0
   const bh = sg.bounds?.height ?? 0
 
-  return `<g class="subgraph" data-id="${sg.id}">
+  const hasSheet = Boolean(sg.file || (sg.pins && sg.pins.length > 0))
+  const sheetAttributes = hasSheet
+    ? ` data-has-sheet="true" data-sheet-id="${esc(sg.id)}" data-bounds="${esc(
+        JSON.stringify({ x: bx, y: by, width: bw, height: bh }),
+      )}"`
+    : ''
+
+  return `<g class="subgraph" data-id="${esc(sg.id)}"${sheetAttributes}>
   <rect x="${bx}" y="${by}" width="${bw}" height="${bh}" rx="12" ry="12" fill="${surface.fill}" stroke="${surface.stroke}" stroke-width="${strokeWidth}"${dasharray ? ` stroke-dasharray="${dasharray}"` : ''}/>
   <text x="${bx + 10}" y="${by + 20}" class="subgraph-label" text-anchor="start" fill="${surface.text}">${esc(sg.label)}</text>
 </g>`
@@ -334,7 +448,8 @@ export interface StaticRenderOptions {
 
 /**
  * Render a ResolvedLayout to SVG string.
- * Produces identical output to the Svelte SVG components.
+ * Produces the same visual geometry and styling as the Svelte SVG components,
+ * including transparent hit areas required by HTML wrappers, but without event bindings.
  */
 export function renderSvgString(layout: ResolvedLayout, options?: StaticRenderOptions): string {
   const theme = options?.theme ?? lightTheme
@@ -370,12 +485,17 @@ export function renderSvgString(layout: ResolvedLayout, options?: StaticRenderOp
   .node-icon { color: ${colors.nodeTextSecondary}; }
   .subgraph-label { font-family: ${sansFont}; font-size: 11px; font-weight: 700; fill: ${colors.subgraphText}; text-transform: uppercase; letter-spacing: 0.05em; }
   .link-label { font-family: ${monoFont}; font-size: 10px; fill: ${colors.textSecondary}; }
+  .port-label-text { font-family: ${monoFont}; }
+  .ha-hull-label { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-weight: 600; }
 </style>`)
 
   // Subgraphs (background)
   for (const sg of layout.subgraphs.values()) {
     parts.push(renderSubgraph(sg, theme, colors))
   }
+
+  // HA / stack hulls (behind edges + nodes, above subgraph fills)
+  parts.push(...renderHaHulls(layout, colors))
 
   // Edges
   for (const edge of layout.edges.values()) {
@@ -403,5 +523,6 @@ export async function renderGraphToSvg(
 ): Promise<string> {
   const { computeNetworkLayout } = await import('@shumoku/core')
   const { resolved } = await computeNetworkLayout(graph)
-  return renderSvgString(resolved, options)
+  const theme = options?.theme ?? (graph.settings?.theme === 'dark' ? darkTheme : lightTheme)
+  return renderSvgString(resolved, { ...options, theme })
 }

--- a/libs/@shumoku/renderer/vitest.config.ts
+++ b/libs/@shumoku/renderer/vitest.config.ts
@@ -1,10 +1,12 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 import { defineConfig } from 'vitest/config'
 
 const dir = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  plugins: [svelte()],
   resolve: {
     alias: {
       '@shumoku/core': path.resolve(dir, '../core/src/index.ts'),

--- a/libs/shumoku/README.md
+++ b/libs/shumoku/README.md
@@ -34,7 +34,7 @@ const html = await renderGraphToHtml(graph, { title: 'Edge', toolbar: true })
 
 - **Everything in `@shumoku/core`** — `YamlParser`, `HierarchicalParser`, `computeNetworkLayout`, models, `lightTheme` / `darkTheme`, the plugin kit, and plugin types.
 - **HTML rendering** — `renderGraphToHtml`, `renderHtml`, hierarchical variants, `initInteractive`, and the `INTERACTIVE_IIFE` bundle for embedding.
-- **SVG access** — the `svg` namespace re-exported from [`@shumoku/renderer-svg`](../@shumoku/renderer-svg) (`svg.renderGraphToSvg`, `svg.prepareRender`, …).
+- **Legacy SVG access** — the synchronous `svg.render(graph, layout)` namespace retained for `LayoutResult` compatibility. Prefer the dedicated canonical SVG API below for new code.
 
 Need standalone SVG or PNG output? Depend on the dedicated renderers directly:
 


### PR DESCRIPTION
## Summary

- make the ResolvedLayout-based framework-free renderer the canonical SVG path for CLI, Server API, Playground, and public SVG/PNG/HTML graph APIs
- preserve LayoutResult-only callers behind deprecated compatibility exports and fallbacks
- align static output with the Svelte renderer for HA hulls, routes, ports, icons, themes, metadata, tooltips, and hierarchical navigation
- document the canonical and compatibility APIs in English and Japanese
- add patch changesets for @shumoku/cli, @shumoku/renderer, @shumoku/renderer-svg, @shumoku/renderer-html, @shumoku/renderer-png, and shumoku

## Validation

- bun run typecheck (40/40 tasks)
- bun run lint (40/40 tasks; existing Svelte accessibility warnings only)
- renderer tests: 18 passed
- renderer-svg tests: 2 passed
- renderer-html tests: 4 passed
- renderer-png tests: 3 passed
- docs production build: passed
- CLI smoke test: SVG, hierarchical HTML, and PNG generated successfully
- bun install --frozen-lockfile: passed
- changeset status: all six public packages scheduled for patch releases