### PR TITLE
refactor(renderer): isolate legacy SVG implementation

### DIFF
--- a/.changeset/clean-legacy-renderer-boundary.md
+++ b/.changeset/clean-legacy-renderer-boundary.md
@@ -1,0 +1,7 @@
+---
+'@shumoku/renderer-svg': patch
+'@shumoku/renderer-html': patch
+'@shumoku/renderer-png': patch
+---
+
+Isolate the deprecated LayoutResult SVG renderer behind an explicit legacy compatibility boundary.

--- a/libs/@shumoku/renderer-html/src/html/index.ts
+++ b/libs/@shumoku/renderer-html/src/html/index.ts
@@ -17,7 +17,8 @@ import type {
 import { darkTheme, lightTheme } from '@shumoku/core'
 import { renderSvgString } from '@shumoku/renderer/static'
 import type { HTMLRendererOptions } from '@shumoku/renderer-svg'
-import { BRANDING_ICON_SVG, generateThemeCSS, SVGRenderer } from '@shumoku/renderer-svg'
+import { BRANDING_ICON_SVG, generateThemeCSS } from '@shumoku/renderer-svg'
+import { SVGRenderer } from '@shumoku/renderer-svg/legacy'
 import {
   generateNavigationToolbar,
   getNavigationScript,

--- a/libs/@shumoku/renderer-png/src/png.ts
+++ b/libs/@shumoku/renderer-png/src/png.ts
@@ -15,8 +15,8 @@ import {
   fetchIconAsDataUrl,
   type IconDimensions,
   resolveAllIconDimensions,
-  svg,
 } from '@shumoku/renderer-svg'
+import { svg } from '@shumoku/renderer-svg/legacy'
 
 export interface PngOptions {
   /** Scale factor for output resolution (default: 2) */

--- a/libs/@shumoku/renderer-svg/README.md
+++ b/libs/@shumoku/renderer-svg/README.md
@@ -39,7 +39,18 @@ All four are `async` (icon resolution may fetch over the network).
 
 `resolveAllIconDimensions`, `fetchIconAsDataUrl`, `fetchImageDimensions`, `clearIconCache`, `DEFAULT_ICON_FETCH_TIMEOUT`, and `collectIconUrls` are exported for callers that manage icon fetching themselves (e.g. a server resolving dimensions ahead of time).
 
-> `SVGRenderer` / `LegacySVGRenderer` and the synchronous `svg.render(graph, layout)` namespace API are deprecated compatibility surfaces for callers that only have the old `LayoutResult`. New code should use the pipeline functions above or `@shumoku/renderer/static` directly.
+> `SVGRenderer` / `LegacySVGRenderer` and the synchronous `svg.render(graph, layout)` namespace API are deprecated compatibility surfaces for callers that only have the old `LayoutResult`. They now live behind the explicit `@shumoku/renderer-svg/legacy` boundary. Root re-exports remain temporarily for source compatibility. New code should use the pipeline functions above or `@shumoku/renderer/static` directly.
+
+## Legacy removal boundary
+
+The old `LayoutResult` renderer is isolated in `src/svg.ts` and exported only through
+`src/legacy.ts`. Canonical icon discovery lives separately, so server and pipeline callers do not
+depend on the old renderer for utility functions. HTML and PNG compatibility fallbacks import the
+explicit `/legacy` subpath; their normal `ResolvedLayout` paths use `@shumoku/renderer/static`.
+
+Once root compatibility can be broken, removal is limited to deleting the `/legacy` export and
+fallback branches, followed by deleting `src/legacy.ts` and `src/svg.ts`. The boundary test prevents
+new direct imports of the implementation.
 
 ## License
 

--- a/libs/@shumoku/renderer-svg/package.json
+++ b/libs/@shumoku/renderer-svg/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./legacy": {
+      "types": "./dist/legacy.d.ts",
+      "import": "./dist/legacy.js"
+    },
     "./iife-string": {
       "types": "./dist/iife-string.d.ts",
       "import": "./dist/iife-string.js"

--- a/libs/@shumoku/renderer-svg/src/icon-urls.ts
+++ b/libs/@shumoku/renderer-svg/src/icon-urls.ts
@@ -1,0 +1,26 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import type { NetworkGraph } from '@shumoku/core'
+
+/**
+ * Collect URL-form icons that need dimension or byte resolution.
+ *
+ * This utility is intentionally independent of the legacy SVG renderer so
+ * canonical layout/render pipelines do not need to pull that implementation in.
+ */
+export function collectIconUrls(graph: NetworkGraph): string[] {
+  const urls = new Set<string>()
+  const isUrl = (icon: string | undefined): icon is string => !!icon && !icon.trim().startsWith('<')
+
+  for (const node of graph.nodes) {
+    if (isUrl(node.spec?.icon)) urls.add(node.spec.icon)
+  }
+
+  for (const subgraph of graph.subgraphs ?? []) {
+    if (isUrl(subgraph.spec?.icon)) urls.add(subgraph.spec.icon)
+  }
+
+  return [...urls]
+}

--- a/libs/@shumoku/renderer-svg/src/index.ts
+++ b/libs/@shumoku/renderer-svg/src/index.ts
@@ -6,8 +6,6 @@
  * @shumoku/renderer-svg - SVG renderer for network diagrams
  */
 
-import * as svg from './svg.js'
-
 // Brand
 export { BRANDING_ICON_SVG, LOGO_PATHS, LOGO_VIEWBOX } from './brand.js'
 export type { IconDimensions } from './icon-dims.js'
@@ -19,6 +17,10 @@ export {
   fetchImageDimensions,
   resolveAllIconDimensions,
 } from './icon-dims.js'
+export { collectIconUrls } from './icon-urls.js'
+// Deprecated root exports retained until the legacy compatibility unit is removed.
+// New compatibility consumers should use the explicit `./legacy` subpath.
+export { LegacySVGRenderer, SVGRenderer, svg } from './legacy.js'
 export type {
   EmbeddableRenderOptions,
   EmbeddableRenderOutput,
@@ -34,8 +36,6 @@ export {
   renderGraphToSvg,
   renderSvg,
 } from './pipeline.js'
-// Re-export collectIconUrls for server-side icon dimension resolution
-export { collectIconUrls, SVGRenderer, SVGRenderer as LegacySVGRenderer } from './svg.js'
 // Types
 export type {
   DataAttributeOptions,
@@ -48,4 +48,3 @@ export type {
   PortInfo,
   RenderMode,
 } from './types.js'
-export { svg }

--- a/libs/@shumoku/renderer-svg/src/legacy-boundary.test.ts
+++ b/libs/@shumoku/renderer-svg/src/legacy-boundary.test.ts
@@ -1,0 +1,45 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { SVGRenderer as RootSVGRenderer, svg as rootSvg } from './index.js'
+import { SVGRenderer as LegacySVGRenderer, svg as legacySvg } from './legacy.js'
+
+const sourceRoot = import.meta.dirname
+const allowedDirectImports = new Set(['legacy.ts'])
+
+function sourceFiles(directory: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry)
+    if (statSync(path).isDirectory()) {
+      files.push(...sourceFiles(path))
+    } else if (path.endsWith('.ts')) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+describe('legacy renderer boundary', () => {
+  it('preserves deprecated root exports through the explicit legacy entry', () => {
+    expect(RootSVGRenderer).toBe(LegacySVGRenderer)
+    expect(rootSvg).toBe(legacySvg)
+  })
+
+  it('keeps direct legacy implementation imports inside legacy.ts', () => {
+    const violations: string[] = []
+    for (const file of sourceFiles(sourceRoot)) {
+      const name = relative(sourceRoot, file)
+      if (allowedDirectImports.has(name) || name.endsWith('.test.ts')) continue
+      const source = readFileSync(file, 'utf8')
+      if (source.includes("from './svg.js'") || source.includes("from './svg'")) {
+        violations.push(name)
+      }
+    }
+    expect(violations).toEqual([])
+  })
+})

--- a/libs/@shumoku/renderer-svg/src/legacy.ts
+++ b/libs/@shumoku/renderer-svg/src/legacy.ts
@@ -1,0 +1,16 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+// For commercial licensing, contact: contact@shumoku.dev
+
+/**
+ * Legacy LayoutResult renderer compatibility boundary.
+ *
+ * New code must use `@shumoku/renderer/static` or the canonical pipeline from
+ * `@shumoku/renderer-svg`. Keeping every old renderer export behind this file
+ * makes the implementation removable as one compatibility unit.
+ */
+import * as svg from './svg.js'
+
+export type { RenderOptions, SVGRendererOptions } from './svg.js'
+export { render, renderAsync, SVGRenderer, SVGRenderer as LegacySVGRenderer } from './svg.js'
+export { svg }

--- a/libs/@shumoku/renderer-svg/src/pipeline.ts
+++ b/libs/@shumoku/renderer-svg/src/pipeline.ts
@@ -21,7 +21,8 @@ import {
 } from '@shumoku/core'
 import { renderSvgString } from '@shumoku/renderer/static'
 import { type IconDimensions, resolveAllIconDimensions } from './icon-dims.js'
-import { collectIconUrls, SVGRenderer } from './svg.js'
+import { collectIconUrls } from './icon-urls.js'
+import { SVGRenderer } from './legacy.js'
 
 /**
  * Prepared render data containing resolved icon dimensions and computed layout

--- a/libs/@shumoku/renderer-svg/src/svg.ts
+++ b/libs/@shumoku/renderer-svg/src/svg.ts
@@ -40,8 +40,8 @@ import {
   specDeviceType,
   type Theme,
 } from '@shumoku/core'
-
 import { type IconDimensions, resolveAllIconDimensions } from './icon-dims.js'
+import { collectIconUrls } from './icon-urls.js'
 import type { DataAttributeOptions, RenderMode } from './types.js'
 
 // ============================================
@@ -1693,28 +1693,6 @@ export interface RenderOptions extends SVGRendererOptions {}
 export function render(graph: NetworkGraph, layout: LayoutResult, options?: RenderOptions): string {
   const renderer = new SVGRenderer(options)
   return renderer.render(graph, layout)
-}
-
-/**
- * Collect every URL-form icon referenced by the graph, so a caller can
- * pre-resolve their dimensions (or fetch their bytes) before rendering.
- * Inline SVG icons (`<...>`) are skipped — they don't need fetching.
- */
-export function collectIconUrls(graph: NetworkGraph): string[] {
-  const urls = new Set<string>()
-  const isUrl = (icon: string | undefined): icon is string => !!icon && !icon.trim().startsWith('<')
-
-  for (const node of graph.nodes) {
-    if (isUrl(node.spec?.icon)) urls.add(node.spec.icon as string)
-  }
-
-  if (graph.subgraphs) {
-    for (const sg of graph.subgraphs) {
-      if (isUrl(sg.spec?.icon)) urls.add(sg.spec.icon as string)
-    }
-  }
-
-  return Array.from(urls)
 }
 
 /**


### PR DESCRIPTION
## Summary
- isolate the deprecated LayoutResult renderer behind the explicit @shumoku/renderer-svg/legacy entry point
- separate active icon URL discovery from the legacy renderer implementation
- route HTML and PNG compatibility fallbacks through the legacy boundary while preserving existing root exports
- add a boundary guard, removal documentation, and patch changesets

## Verification
- renderer-svg tests: 4 passed
- renderer-html tests: 4 passed
- renderer-png tests: 3 passed
- repository lint: 40/40 tasks passed
- repository typecheck: 40/40 tasks passed
- renderer-svg, renderer-html, and renderer-png builds passed