### PR TITLE
fix(editor): stabilize floor-plan icon placement and cable lengths

### DIFF
--- a/apps/editor/src/lib/components/scene/SceneCanvas.svelte
+++ b/apps/editor/src/lib/components/scene/SceneCanvas.svelte
@@ -13,7 +13,7 @@
   import { cableSegmentLengths, visibleCableSegments } from '$lib/scene/cable-length'
   import {
     effectiveNodeSize,
-    nodeCenterFromTopLeft,
+    mapMarkerFlowScale,
     pickSideForDirection,
     sceneNodeSize,
   } from '$lib/scene/node-geometry'
@@ -132,12 +132,12 @@
     return node?.position ?? { x: 100, y: 100 }
   }
 
-  // Per-scene visual tuning. Node size is computed via the shared
-  // `effectiveNodeSize` helper so length math sees identical
-  // dimensions; here we just keep the wire-scale resolver (no
-  // analogous helper in node-geometry — wires aren't placeable
-  // shapes, so the scale lookup lives at the call site).
+  // Per-scene visual tuning. Node size is display-only; physical
+  // anchors and cable-length math deliberately ignore it. Wires
+  // aren't placeable shapes, so their scale lookup stays here.
   const sceneWireScale = $derived(scene.display?.wireScale ?? 1)
+  let viewportZoom = $state(1)
+  const markerFlowScale = $derived(mapMarkerFlowScale(viewportZoom))
 
   function effectiveWireScale(link: { metadata?: Record<string, unknown> }): number {
     const ov = link.metadata?.wireScale
@@ -150,23 +150,27 @@
   // handles and computes sourceX/Y / targetX/Y itself; SceneNode just
   // fills the wrapper with `w-full h-full`.
   function effSize(nodeId: string): { w: number; h: number } {
-    return effectiveNodeSize(scene, diagramState.nodes.get(nodeId))
+    const size = effectiveNodeSize(scene, diagramState.nodes.get(nodeId))
+    return { w: size.w * markerFlowScale, h: size.h * markerFlowScale }
   }
 
-  // Center of a node-or-termination's icon in flow coords. Used for
+  function onViewportMove(
+    _event: MouseEvent | TouchEvent | null,
+    viewport: { x: number; y: number; zoom: number },
+  ) {
+    viewportZoom = viewport.zoom
+  }
+
+  // Physical anchor of a node-or-termination in flow coords. Used for
   // via waypoint positions — Svelte Flow doesn't expose those
   // automatically (they're not edge endpoints). Terminations no
   // longer live in `diagram.nodes`; resolve them through the
   // registry and the position they carry on themselves.
   function centerOf(nodeId: string): { x: number; y: number } {
     const real = diagramState.nodes.get(nodeId)
-    if (real) return nodeCenterFromTopLeft(scene, real, positionFor(nodeId))
+    if (real) return positionFor(nodeId)
     const term = diagramState.terminations.find((t) => t.id === nodeId)
-    if (term?.position) {
-      const shadow = { id: term.id, label: term.label, termination: { role: term.role } } as Node
-      return nodeCenterFromTopLeft(scene, shadow, term.position)
-    }
-    return nodeCenterFromTopLeft(scene, undefined, { x: 0, y: 0 })
+    return term?.position ?? { x: 0, y: 0 }
   }
 
   // Reverse lookup so the drag / delete intercepts can tell whether
@@ -256,6 +260,7 @@
         id: n.id,
         type: 'scene',
         position: positionFor(n.id),
+        origin: [0.5, 0.5],
         // Svelte Flow uses width/height to size the wrapper and
         // anchor handles — no need to also push the size into data.
         width: w,
@@ -268,8 +273,8 @@
           editableLabel: isBend ? '' : baseLabel,
           spec: n.spec,
           termination: n.termination,
-          baseW: base.w,
-          baseH: base.h,
+          baseW: base.w * markerFlowScale,
+          baseH: base.h * markerFlowScale,
           onOpenRouting: isDevice
             ? () => {
                 routingNodeId = n.id
@@ -317,24 +322,26 @@
     // their own global array rather than per-link.
     for (const t of diagramState.terminations) {
       if (!t.position) continue
-      const size =
-        t.role === 'eps'
-          ? { w: 22, h: 32 }
-          : t.role === 'outlet'
-            ? { w: 28, h: 28 }
-            : { w: 44, h: 22 }
+      const shadow = { termination: { role: t.role }, metadata: t.metadata } as Node
+      const base = sceneNodeSize(shadow)
+      const nominalSize = effectiveNodeSize(scene, shadow)
+      const size = {
+        w: nominalSize.w * markerFlowScale,
+        h: nominalSize.h * markerFlowScale,
+      }
       out.push({
         id: t.id,
         type: 'scene',
         position: { x: t.position.x, y: t.position.y },
+        origin: [0.5, 0.5],
         width: size.w,
         height: size.h,
         data: {
           label: t.label,
           editableLabel: t.label,
           termination: { role: t.role },
-          baseW: size.w,
-          baseH: size.h,
+          baseW: base.w * markerFlowScale,
+          baseH: base.h * markerFlowScale,
           onDelete: () => diagramState.removeTermination(t.id),
           onRename: (label: string) =>
             diagramState.updateTermination(t.id, { label: label || t.label }),
@@ -358,13 +365,14 @@
           id: b.id,
           type: 'scene',
           position: { x: b.x, y: b.y },
-          width: 16,
-          height: 16,
+          origin: [0.5, 0.5],
+          width: 16 * markerFlowScale,
+          height: 16 * markerFlowScale,
           data: {
             label: '',
             termination: { role: 'bend' },
-            baseW: 16,
-            baseH: 16,
+            baseW: 16 * markerFlowScale,
+            baseH: 16 * markerFlowScale,
           },
           draggable: interactive,
           selectable: true,
@@ -625,6 +633,7 @@
     onnodedrag={onNodeDrag}
     onnodedragstop={onNodeDragStop}
     onconnect={onConnect}
+    onmove={onViewportMove}
     onpaneclick={onPaneClick}
     ondelete={({ nodes, edges }: { nodes: SfNode[]; edges: Edge[] }) => {
       // Native Backspace/Delete keyboard path. Each Svelte Flow

--- a/apps/editor/src/lib/context.svelte.ts
+++ b/apps/editor/src/lib/context.svelte.ts
@@ -60,6 +60,7 @@ import {
   inheritProductIconFromCatalog,
   migrateBendNodesToLinkBends,
   migrateLegacyWireRoutes,
+  migrateScenePositionsToCenterAnchors,
   migrateTerminationNodesToGraphTerminations,
 } from './migrations'
 import { projectsDb } from './persistence/projects-store'
@@ -1173,6 +1174,7 @@ export const diagramState = {
       const scene: Scene = {
         id: newId('scene'),
         name,
+        placementOrigin: 'center',
         nodePlacements: [],
         scopeSubgraphId,
       }
@@ -2106,6 +2108,15 @@ async function applyProject(data: Partial<NetedProject>) {
     nodes: diagram.nodes,
     terminations: diagram.terminations,
     scenes: scenesStore.list,
+  })
+  // Scene placements used to store the icon's top-left corner. That
+  // made the physical position and cable length move whenever an icon
+  // was resized. Convert persisted positions once, after the legacy
+  // termination migrations have recovered their final coordinates.
+  migrateScenePositionsToCenterAnchors({
+    scenes: scenesStore.list,
+    nodes: diagram.nodes,
+    terminations: diagram.terminations,
   })
 }
 

--- a/apps/editor/src/lib/migrations/README.md
+++ b/apps/editor/src/lib/migrations/README.md
@@ -37,6 +37,7 @@ in its file header so the next reader doesn't have to dig.
 | `Scene.wireRoutes[].controlPoints` → bend Nodes + `Link.via` | `legacy-wire-routes.ts` |
 | catalog → `Product.icon` inheritance for products with no icon | `product-icon-inheritance.ts` |
 | `Node.spec.icon` resync from bound Product | (inline in `applyProject`, candidate to move) |
+| scene top-left positions → center anchors | `scene-center-anchors.ts` |
 | `ensureProductSnapshot` (port template materialization) | `context.svelte.ts` — also used by `addProduct`, not load-only |
 | `migrateLinkEndpointPortsForNode` (port id format) | `context.svelte.ts` — runtime invariant, fires per port edit |
 

--- a/apps/editor/src/lib/migrations/index.ts
+++ b/apps/editor/src/lib/migrations/index.ts
@@ -10,6 +10,10 @@ export {
 export { type LegacyScene, migrateLegacyWireRoutes } from './legacy-wire-routes'
 export { inheritProductIconFromCatalog } from './product-icon-inheritance'
 export {
+  migrateScenePositionsToCenterAnchors,
+  type SceneAnchorMigrationStats,
+} from './scene-center-anchors'
+export {
   migrateTerminationNodesToGraphTerminations,
   type TerminationMigrationStats,
 } from './termination-nodes-to-graph-terminations'

--- a/apps/editor/src/lib/migrations/scene-center-anchors.test.ts
+++ b/apps/editor/src/lib/migrations/scene-center-anchors.test.ts
@@ -1,0 +1,82 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { Node, Termination } from '@shumoku/core'
+import { describe, expect, test } from 'vitest'
+import type { Scene } from '../types'
+import { migrateScenePositionsToCenterAnchors } from './scene-center-anchors'
+
+function device(id: string, displayScale?: number): Node {
+  return {
+    id,
+    label: id,
+    metadata: displayScale ? { displayScale } : undefined,
+  } as Node
+}
+
+describe('migrateScenePositionsToCenterAnchors', () => {
+  test('preserves the rendered center of legacy device placements', () => {
+    const nodes = new Map<string, Node>([['switch', device('switch')]])
+    const scene: Scene = {
+      id: 'floor',
+      name: 'Floor',
+      nodePlacements: [{ nodeId: 'switch', position: { x: 100, y: 200 } }],
+    }
+
+    const stats = migrateScenePositionsToCenterAnchors({
+      scenes: [scene],
+      nodes,
+      terminations: [],
+    })
+
+    expect(scene.placementOrigin).toBe('center')
+    expect(scene.nodePlacements[0]?.position).toEqual({ x: 126, y: 226 })
+    expect(stats).toEqual({
+      scenesMigrated: 1,
+      placementsMigrated: 1,
+      terminationsMigrated: 0,
+    })
+  })
+
+  test('uses the legacy scene and per-node display scales during conversion', () => {
+    const nodes = new Map<string, Node>([['switch', device('switch', 2)]])
+    const scene: Scene = {
+      id: 'floor',
+      name: 'Floor',
+      display: { nodeScale: 3 },
+      nodePlacements: [{ nodeId: 'switch', position: { x: 10, y: 20 } }],
+    }
+
+    migrateScenePositionsToCenterAnchors({ scenes: [scene], nodes, terminations: [] })
+
+    expect(scene.nodePlacements[0]?.position).toEqual({ x: 62, y: 72 })
+  })
+
+  test('moves fixed-size terminations once and is idempotent', () => {
+    const scene: Scene = { id: 'floor', name: 'Floor', nodePlacements: [] }
+    const terminations: Termination[] = [
+      { id: 'eps', role: 'eps', label: 'EPS', position: { x: 40, y: 50 } },
+      { id: 'outlet', role: 'outlet', label: 'Outlet', position: { x: 10, y: 20 } },
+    ]
+
+    const first = migrateScenePositionsToCenterAnchors({
+      scenes: [scene],
+      nodes: new Map(),
+      terminations,
+    })
+    const second = migrateScenePositionsToCenterAnchors({
+      scenes: [scene],
+      nodes: new Map(),
+      terminations,
+    })
+
+    expect(terminations[0]?.position).toEqual({ x: 51, y: 66 })
+    expect(terminations[1]?.position).toEqual({ x: 24, y: 34 })
+    expect(first.terminationsMigrated).toBe(2)
+    expect(second).toEqual({
+      scenesMigrated: 0,
+      placementsMigrated: 0,
+      terminationsMigrated: 0,
+    })
+  })
+})

--- a/apps/editor/src/lib/migrations/scene-center-anchors.ts
+++ b/apps/editor/src/lib/migrations/scene-center-anchors.ts
@@ -1,0 +1,69 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { Node, Termination } from '@shumoku/core'
+import { nodeCenterFromTopLeft, sceneNodeSize } from '../scene/node-geometry'
+import type { Scene } from '../types'
+
+export interface SceneAnchorMigrationStats {
+  scenesMigrated: number
+  placementsMigrated: number
+  terminationsMigrated: number
+}
+
+/**
+ * Convert legacy scene positions from an icon's top-left corner to a
+ * physical center anchor. The migration mutates the load-time store
+ * objects in place, matching the other editor data migrations.
+ *
+ * Termination positions live on the graph rather than in individual
+ * scenes. They used fixed role dimensions in the legacy renderer, so
+ * they are shifted once whenever at least one legacy scene is found.
+ * Link bends are deliberately excluded: their x/y already represented
+ * the routed polyline point even though the old bend glyph was offset.
+ */
+export function migrateScenePositionsToCenterAnchors({
+  scenes,
+  nodes,
+  terminations,
+}: {
+  scenes: Scene[]
+  nodes: Map<string, Node>
+  terminations: Termination[]
+}): SceneAnchorMigrationStats {
+  const legacyScenes = scenes.filter((scene) => scene.placementOrigin !== 'center')
+  let placementsMigrated = 0
+
+  for (const scene of legacyScenes) {
+    scene.nodePlacements = scene.nodePlacements.map((placement) => {
+      const node = nodes.get(placement.nodeId)
+      if (!node) return placement
+      placementsMigrated++
+      return {
+        ...placement,
+        position: nodeCenterFromTopLeft(scene, node, placement.position),
+      }
+    })
+    scene.placementOrigin = 'center'
+  }
+
+  if (legacyScenes.length > 0) {
+    for (const termination of terminations) {
+      if (!termination.position) continue
+      const { w, h } = sceneNodeSize({ termination: { role: termination.role } })
+      termination.position = {
+        x: termination.position.x + w / 2,
+        y: termination.position.y + h / 2,
+      }
+    }
+  }
+
+  return {
+    scenesMigrated: legacyScenes.length,
+    placementsMigrated,
+    terminationsMigrated:
+      legacyScenes.length > 0
+        ? terminations.filter((termination) => termination.position !== undefined).length
+        : 0,
+  }
+}

--- a/apps/editor/src/lib/scene/cable-length.test.ts
+++ b/apps/editor/src/lib/scene/cable-length.test.ts
@@ -1,0 +1,41 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { Link, Node } from '@shumoku/core'
+import { describe, expect, test } from 'vitest'
+import type { Scene } from '../types'
+import { cableLengthMeters } from './cable-length'
+
+const link: Link = {
+  id: 'wire',
+  from: { node: 'a', port: 'a-port' },
+  to: { node: 'b', port: 'b-port' },
+}
+
+function nodesWithScales(aScale: number, bScale: number): Map<string, Node> {
+  return new Map([
+    ['a', { id: 'a', label: 'A', metadata: { displayScale: aScale } } as Node],
+    ['b', { id: 'b', label: 'B', metadata: { displayScale: bScale } } as Node],
+  ])
+}
+
+describe('cableLengthMeters', () => {
+  test('measures center anchors independently of rendered icon sizes', () => {
+    const scene: Scene = {
+      id: 'floor',
+      name: 'Floor',
+      placementOrigin: 'center',
+      calibration: { pxPerMeter: 10 },
+      nodePlacements: [
+        { nodeId: 'a', position: { x: 100, y: 100 } },
+        { nodeId: 'b', position: { x: 200, y: 100 } },
+      ],
+    }
+
+    const smallToLarge = cableLengthMeters(link, [scene], nodesWithScales(0.5, 3))
+    const largeToSmall = cableLengthMeters(link, [scene], nodesWithScales(3, 0.5))
+
+    expect(smallToLarge).toEqual({ meters: 10, source: 'scene' })
+    expect(largeToSmall).toEqual({ meters: 10, source: 'scene' })
+  })
+})

--- a/apps/editor/src/lib/scene/cable-length.ts
+++ b/apps/editor/src/lib/scene/cable-length.ts
@@ -3,7 +3,6 @@
 
 import type { Link, Node, Termination } from '@shumoku/core'
 import type { Scene } from '../types'
-import { nodeCenterFromTopLeft } from './node-geometry'
 import { viaLookup } from './via-lookup'
 
 /**
@@ -16,13 +15,12 @@ export function formatMeters(m: number): string {
 }
 
 /**
- * Endpoint position in a scene as the **icon center** — matches
- * exactly where SceneCanvas anchors wires. Without the center
- * offset, two different-sized nodes would have their length-math
- * endpoints at mismatched corners, putting the reported cable length
- * out of sync with the polyline that's actually drawn.
+ * Endpoint position in a scene as its physical anchor. Scene
+ * placements use center-origin coordinates, so icon dimensions never
+ * participate in cable-length math. Resizing an icon therefore cannot
+ * move the represented device or change the reported cable length.
  *
- * Top-left priority:
+ * Anchor priority:
  *   1. explicit placement (user dragged the pin somewhere)
  *   2. Node.position fallback (auto-layout coords)
  *
@@ -40,9 +38,7 @@ function endpointPos(
 ): { x: number; y: number } | null {
   const node = nodes.get(nodeId)
   const placement = scene.nodePlacements.find((p) => p.nodeId === nodeId)
-  const tl = placement?.position ?? node?.position
-  if (!tl) return null
-  return nodeCenterFromTopLeft(scene, node, tl)
+  return placement?.position ?? node?.position ?? null
 }
 
 /**

--- a/apps/editor/src/lib/scene/node-geometry.test.ts
+++ b/apps/editor/src/lib/scene/node-geometry.test.ts
@@ -1,0 +1,18 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, expect, test } from 'vitest'
+import { mapMarkerFlowScale } from './node-geometry'
+
+describe('mapMarkerFlowScale', () => {
+  test('keeps screen-space marker scale within the readable range', () => {
+    expect(mapMarkerFlowScale(0.1) * 0.1).toBeCloseTo(0.5)
+    expect(mapMarkerFlowScale(1) * 1).toBeCloseTo(1)
+    expect(mapMarkerFlowScale(4) * 4).toBeCloseTo(1.5)
+  })
+
+  test('falls back safely for invalid zoom values', () => {
+    expect(mapMarkerFlowScale(0)).toBe(1)
+    expect(mapMarkerFlowScale(Number.NaN)).toBe(1)
+  })
+})

--- a/apps/editor/src/lib/scene/node-geometry.ts
+++ b/apps/editor/src/lib/scene/node-geometry.ts
@@ -18,6 +18,19 @@ export type SceneSizedNode = WithTermination & WithScaleOverride
 export const WIRE_CORNER_RADIUS = 8
 
 /**
+ * Flow-space multiplier that gives scene pins a map-marker-like screen
+ * size. At ordinary zoom levels pins still grow and shrink slightly,
+ * but they cannot become unreadably tiny or overwhelm the floor plan.
+ * The multiplier affects rendering only; stored anchors and distance
+ * calculations remain in unscaled scene coordinates.
+ */
+export function mapMarkerFlowScale(zoom: number): number {
+  const safeZoom = Number.isFinite(zoom) && zoom > 0 ? zoom : 1
+  const screenScale = Math.max(0.5, Math.min(1.5, safeZoom))
+  return screenScale / safeZoom
+}
+
+/**
  * Pixel dimensions of a SceneNode for its role. Devices are larger
  * pins; termination points (outlet / EPS / panel) are role-specific
  * smaller glyphs; bends are tiny anchor dots. Returned width/height
@@ -64,12 +77,10 @@ export function effectiveNodeSize(
 }
 
 /**
- * Icon center given a top-left point. Convenience over inlining
- * `tl.x + w/2, tl.y + h/2` at every call site, and keeps the
- * top-left → center conversion paired with the size math it depends
- * on. Pass whatever you already have for the top-left — SceneCanvas
- * uses a derived Map for hot-path performance, cable-length walks
- * `nodePlacements` directly, both feed in here.
+ * Convert a legacy top-left placement to the current center anchor.
+ * Runtime geometry must not call this: physical positions and cable
+ * lengths are intentionally independent of rendered icon size. It is
+ * kept here for the one-shot project-load migration only.
  */
 export function nodeCenterFromTopLeft(
   scene: Scene,

--- a/apps/editor/src/lib/types.ts
+++ b/apps/editor/src/lib/types.ts
@@ -168,8 +168,15 @@ export interface Scene {
   /** Optional background image (floor plan / blueprint / photo). */
   background?: SceneBackground
   /**
-   * Position overrides. Sparse — every diagram node renders in this
-   * scene at its `Node.position` unless an entry here overrides it.
+   * Coordinate origin used by `nodePlacements`. Current scenes store
+   * the physical anchor at the icon center. Missing means a legacy
+   * top-left placement and is migrated when the project is loaded.
+   */
+  placementOrigin?: 'center'
+  /**
+   * Physical anchor overrides. Sparse — every diagram node renders in
+   * this scene at its `Node.position` unless an entry here overrides it.
+   * The anchor is independent of the icon's rendered dimensions.
    */
   nodePlacements: NodePlacement[]
   /** Node ids explicitly hidden from this scene. */


### PR DESCRIPTION
## Summary

- store scene placements as center-based physical anchors
- keep cable-length calculations independent of rendered icon dimensions
- clamp scene marker screen size across extreme zoom levels
- migrate legacy top-left placements and termination coordinates on load
- add regression coverage for migration, zoom scaling, and size-independent lengths

## Validation

- Editor test suite: 13 files, 65 tests passed
- svelte-check: 0 errors
- Biome check: passed for all changed files
- production build: passed

## Release

No changeset is required because the Editor package is private.