### PR TITLE
fix(docs): remove navigation redirects and update HP docs links

### DIFF
--- a/apps/docs/DEPLOYMENT.md
+++ b/apps/docs/DEPLOYMENT.md
@@ -17,17 +17,21 @@ scope. A docs deployment does not require the website's runtime variables.
 - Website: the existing Vercel `shumoku-docs` project, with Root Directory
   `apps/website` and the Next.js preset. The project name is historical.
 - Docs: Cloudflare Pages `shumoku-docs`, with custom domain `docs.shumoku.dev`.
-- Initial Docs production branch: `codex/docs-astro-foundation`. Switch to `main`
-  only after the migration branch has been reviewed and merged; `main` does not
-  yet contain the website/docs split. Do not merge unrelated local changes to deploy.
+- Docs production branch: `main` (the website/docs split has been merged).
 - Cloudflare root: repository root; output: `apps/docs/dist`; `BUN_VERSION=1.3.4`.
   Build command: `bun install --frozen-lockfile && bun x turbo run build --filter=@shumoku/docs --env-mode=loose`.
   Building through Turbo builds the workspace dependencies before reference generation.
+
 - Bootstrap publication uses `next`. Existing Server releases do not yet have docs
   artifacts. Enable GitHub release discovery only after a release provides one;
   never relabel working-tree docs as a published Server release.
 - Changing Vercel's root affects future builds, not the already-serving deployment.
-  Until the split lands on `main`, use the migration branch to verify Website builds.
+
+Docs uses Astro `build.format: 'file'` and extensionless URLs without trailing
+slashes. Cloudflare Pages serves these directly; directory output would add a
+redirect to every navigation. The layout normalizes Astro's build-time `.html`
+pathname for navigation, language/version switching, and Pagefind result URLs.
+Sidebar links prefetch on hover/focus using Astro, without a client-side router.
 
 ## Vercel preview (optional alternative for Docs)
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -4,4 +4,6 @@ export default defineConfig({
   site: 'https://docs.shumoku.dev',
   output: 'static',
   trailingSlash: 'never',
+  build: { format: 'file' },
+  prefetch: { defaultStrategy: 'hover' },
 })

--- a/apps/docs/src/components/DocsNavLink.astro
+++ b/apps/docs/src/components/DocsNavLink.astro
@@ -8,7 +8,7 @@ const { href, label, pathname } = Astro.props
 const current = pathname.replace(/\/$/, '') === href.replace(/\/$/, '')
 ---
 
-<a href={href} aria-current={current ? 'page' : undefined}>{label}</a>
+<a href={href} data-astro-prefetch aria-current={current ? 'page' : undefined}>{label}</a>
 <style>
   a {
     position: relative;

--- a/apps/docs/src/components/ui/LinkDropdown.astro
+++ b/apps/docs/src/components/ui/LinkDropdown.astro
@@ -13,7 +13,7 @@ const { label, value, links } = Astro.props
   </summary>
   <nav aria-label={label}>
     {links.map((link) => (
-      <a href={link.href} aria-current={link.current ? 'page' : undefined}>
+      <a href={link.href} data-astro-prefetch aria-current={link.current ? 'page' : undefined}>
         {link.label}<span aria-hidden="true">{link.current ? '✓' : ''}</span>
       </a>
     ))}

--- a/apps/docs/src/layouts/DocsLayout.astro
+++ b/apps/docs/src/layouts/DocsLayout.astro
@@ -23,11 +23,11 @@ interface Props {
 }
 
 const { title, description, lang, server, canonicalPath, searchable = true } = Astro.props
-const canonicalUrl = new URL(canonicalPath ?? Astro.url.pathname, Astro.site)
+// File output uses .html during build; public Cloudflare URLs are extensionless.
+const pathname = Astro.url.pathname.replace(/\.html$/, '').replace(/\/$/, '') || '/'
+const canonicalUrl = new URL(canonicalPath ?? pathname, Astro.site)
 const alternatePath =
-  lang === 'en'
-    ? Astro.url.pathname.replace(/^\/en/, '/ja')
-    : Astro.url.pathname.replace(/^\/ja/, '/en')
+  lang === 'en' ? pathname.replace(/^\/en/, '/ja') : pathname.replace(/^\/ja/, '/en')
 const versions = await loadServerVersions()
 const repositoryDocs = await loadRepositoryDocs()
 const serverEntry = server
@@ -36,13 +36,11 @@ const serverEntry = server
 const serverArtifact = server
   ? versions.versions.find(({ release }) => release.version === server.routeVersion)
   : undefined
-const navigation = docsNavigation(Astro.url.pathname, lang, repositoryDocs, serverArtifact)
+const navigation = docsNavigation(pathname, lang, repositoryDocs, serverArtifact)
 const sections = docsSections(lang, serverEntry)
 const activeSection =
   sections.find(({ pathPrefixes }) =>
-    pathPrefixes.some(
-      (prefix) => Astro.url.pathname === prefix || Astro.url.pathname.startsWith(`${prefix}/`),
-    ),
+    pathPrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)),
   ) ?? sections[0]
 const policyPages = repositoryDocs.pages.filter(
   ({ kind, publication }) => kind === 'policy' && publication !== 'private',
@@ -53,7 +51,7 @@ const versionPicker = server
       links: versions.versions.map((target) => ({
         label: target.release.version === 'next' ? 'next' : target.release.productVersion,
         href: serverArtifact
-          ? correspondingServerPage(Astro.url.pathname, lang, serverArtifact, target)
+          ? correspondingServerPage(pathname, lang, serverArtifact, target)
           : `/${lang}/server/${target.release.version}`,
         current: target.release.version === server.routeVersion,
       })),
@@ -85,7 +83,7 @@ const versionPicker = server
     <div class="shell">
       <DocsSidebar
         lang={lang}
-        pathname={Astro.url.pathname}
+        pathname={pathname}
         activeSection={activeSection}
         sections={sections.map((section) => ({ ...section, current: section === activeSection }))}
         items={navigation}
@@ -95,6 +93,7 @@ const versionPicker = server
         id="main-content"
         tabindex="-1"
         data-pagefind-body
+        data-pagefind-meta={`url:${canonicalUrl.pathname}`}
         data-pagefind-ignore={searchable ? undefined : true}
         data-pagefind-filter={server
           ? `search-scope:${server.routeVersion === versions.aliases.latest || (!versions.aliases.latest && server.routeVersion === versions.aliases.beta) ? 'default' : server.channel === 'stable' ? 'archive' : 'prerelease'}`

--- a/apps/website/components/home/BottomSection.tsx
+++ b/apps/website/components/home/BottomSection.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { cn } from '@/lib/cn'
+import { docsUrl } from '@/lib/docs-url'
 import { ArrowRightIcon, GitHubIcon } from './icons'
 import { backgrounds, buttonStyles, sectionStyles } from './styles'
 import { homeTranslations, type Locale } from './translations'
@@ -81,7 +82,7 @@ export function BottomSection({ locale }: { locale: string }) {
         <div className="text-center">
           <h2 className={cn(sectionStyles.title, 'mb-6 sm:mb-8')}>{t.cta.title}</h2>
           <div className="flex flex-wrap gap-3 justify-center">
-            <Link href={`/${locale}/docs/server`} className={cn(...buttonStyles.primaryLarge)}>
+            <Link href={docsUrl(locale, 'server')} className={cn(...buttonStyles.primaryLarge)}>
               {t.cta.deploy}
               <ArrowRightIcon className="w-4 h-4" />
             </Link>

--- a/apps/website/components/home/GettingStartedSection.tsx
+++ b/apps/website/components/home/GettingStartedSection.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { cn } from '@/lib/cn'
+import { docsUrl } from '@/lib/docs-url'
 import { ArrowRightIcon } from './icons'
 import { buttonStyles, sectionStyles } from './styles'
 import { homeTranslations, type Locale } from './translations'
@@ -49,7 +50,7 @@ export function GettingStartedSection({ locale }: { locale: Locale }) {
             </div>
             <div className="px-5 pb-5 pt-5">
               <Link
-                href={`/${locale}/docs/server`}
+                href={docsUrl(locale, 'server')}
                 className={cn(...buttonStyles.secondary, 'text-sm')}
               >
                 {t.community.cta}

--- a/apps/website/components/home/HeroSection.tsx
+++ b/apps/website/components/home/HeroSection.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { cn } from '@/lib/cn'
+import { docsUrl } from '@/lib/docs-url'
 import { ArrowRightIcon, GitHubIcon } from './icons'
 import { backgrounds, buttonStyles } from './styles'
 import { homeTranslations, type Locale } from './translations'
@@ -30,7 +31,7 @@ export function HeroSection({ locale }: { locale: string }) {
             </p>
 
             <div className="flex flex-wrap items-center gap-3 mt-6 sm:mt-7">
-              <Link href={`/${locale}/docs/server`} className={cn(...buttonStyles.primary)}>
+              <Link href={docsUrl(locale, 'server')} className={cn(...buttonStyles.primary)}>
                 {t.deploy}
                 <ArrowRightIcon className="w-4 h-4" />
               </Link>

--- a/apps/website/components/home/PlatformSection.tsx
+++ b/apps/website/components/home/PlatformSection.tsx
@@ -1,6 +1,7 @@
 import { Layers, PencilRuler, Server, Terminal } from 'lucide-react'
 import Link from 'next/link'
 import { cn } from '@/lib/cn'
+import { docsUrl } from '@/lib/docs-url'
 import { sectionStyles } from './styles'
 import { homeTranslations, type Locale } from './translations'
 
@@ -12,7 +13,11 @@ const layerIcons = [
 ]
 
 function LayerCta({ href, label, locale }: { href: string; label: string; locale: string }) {
-  const normalizedHref = href.startsWith('/') ? `/${locale}${href}` : href
+  const normalizedHref = href.startsWith('/docs/')
+    ? docsUrl(locale, href.slice('/docs/'.length))
+    : href.startsWith('/')
+      ? `/${locale}${href}`
+      : href
   const isExternal = normalizedHref.startsWith('http')
   const className =
     'text-xs font-medium text-emerald-600 dark:text-emerald-400 hover:underline mt-3 inline-flex items-center gap-1'

--- a/apps/website/components/home/translations.ts
+++ b/apps/website/components/home/translations.ts
@@ -263,14 +263,14 @@ export const homeTranslations = {
           description:
             'Models, parsers, layout, themes, plugin types, and shared helpers. The renderer-agnostic foundation used across Shumoku.',
           cta: 'Core docs',
-          href: '/docs/npm',
+          href: '/docs/library',
         },
         {
           title: 'CLI / npm packages',
           description:
             'Render YAML or JSON topology to SVG, interactive HTML, or PNG for Markdown, documentation, CI, and product embedding.',
           cta: 'CLI docs',
-          href: '/docs/npm/cli',
+          href: '/docs/cli',
         },
         {
           title: 'Server',
@@ -535,14 +535,14 @@ export const homeTranslations = {
           description:
             'モデル、パーサ、レイアウト、テーマ、plugin types、共有 helper を提供する中核。レンダラに依存しない共通基盤です。',
           cta: 'Core ドキュメント',
-          href: '/docs/npm',
+          href: '/docs/library',
         },
         {
           title: 'CLI / npm packages',
           description:
             'YAML / JSON のトポロジーを SVG、interactive HTML、PNG に変換し、Markdown、ドキュメント、CI、製品組み込みで使えます。',
           cta: 'CLI ドキュメント',
-          href: '/docs/npm/cli',
+          href: '/docs/cli',
         },
         {
           title: 'Server',

--- a/apps/website/lib/docs-url.ts
+++ b/apps/website/lib/docs-url.ts
@@ -1,0 +1,5 @@
+/** Public documentation has its own origin; never include a Server release number here. */
+export function docsUrl(locale: string, section = ''): string {
+  const lang = locale === 'ja' ? 'ja' : 'en'
+  return `https://docs.shumoku.dev/${lang}${section ? `/${section}` : ''}`
+}

--- a/apps/website/lib/layout.shared.tsx
+++ b/apps/website/lib/layout.shared.tsx
@@ -1,4 +1,5 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared'
+import { docsUrl } from './docs-url'
 
 const navTitle = <img src="/logo-horizontal.svg" alt="Shumoku" className="h-8 w-auto" />
 
@@ -11,7 +12,8 @@ export function baseOptions(locale: string): BaseLayoutProps {
     links: [
       {
         text: 'Docs',
-        url: `/${locale}/docs/server`,
+        url: docsUrl(locale),
+        external: true,
       },
       {
         text: 'Playground',

--- a/tooling/docs/src/check-multiple-versions.ts
+++ b/tooling/docs/src/check-multiple-versions.ts
@@ -72,7 +72,7 @@ try {
       if (!exists.some(Boolean)) throw new Error(`${file}: broken link ${href}`)
     }
   }
-  const apiPage = await readFile(path.join(docs, 'dist/ja/server/0.0.1/api/index.html'), 'utf8')
+  const apiPage = await readFile(path.join(docs, 'dist/ja/server/0.0.1/api.html'), 'utf8')
   if (!apiPage.includes('href="/ja/server/0.0.2/api"'))
     throw new Error('Version switch lost API page')
   console.log('[docs] Multiple-version build, switch links, and internal links passed')

--- a/tooling/docs/src/check-server-versions.ts
+++ b/tooling/docs/src/check-server-versions.ts
@@ -70,7 +70,7 @@ for (const artifact of artifacts) {
     throw new Error(`${version}: source links must use an immutable tag or commit`)
   }
   for (const lang of ['en', 'ja']) {
-    const landing = path.join(docsDist, lang, 'server', version, 'index.html')
+    const landing = path.join(docsDist, lang, 'server', `${version}.html`)
     if (!(await exists(landing))) throw new Error(`${version}: missing ${lang} Server landing`)
     const html = await readFile(landing, 'utf8')
     if (!html.includes(`server-version:${version}`)) {
@@ -90,13 +90,13 @@ for (const artifact of artifacts) {
 }
 
 for (const lang of ['en', 'ja']) {
-  const entryPath = path.join(docsDist, lang, 'server', 'index.html')
+  const entryPath = path.join(docsDist, lang, 'server.html')
   if (!(await exists(entryPath))) throw new Error(`Server: missing ${lang} product entry`)
 }
 
 if (aliasRecord['beta']) {
   for (const lang of ['en', 'ja']) {
-    const aliasPath = path.join(docsDist, lang, 'server', 'beta', 'index.html')
+    const aliasPath = path.join(docsDist, lang, 'server', 'beta.html')
     if (!(await exists(aliasPath))) throw new Error(`beta: missing ${lang} alias page`)
   }
 }

--- a/tooling/docs/src/check.ts
+++ b/tooling/docs/src/check.ts
@@ -111,14 +111,12 @@ function parseMigrationRoutes(value: unknown): MigrationRoute[] {
 }
 
 async function resolvesInDist(pathname: string): Promise<boolean> {
-  const relativePath = pathname.replace(/^\/+/, '')
-  const candidates = pathname.endsWith('/')
-    ? [path.join(docsDist, relativePath, 'index.html')]
-    : [
-        path.join(docsDist, relativePath),
-        path.join(docsDist, `${relativePath}.html`),
-        path.join(docsDist, relativePath, 'index.html'),
-      ]
+  const relativePath = pathname.replace(/^\/+|\/+$/g, '')
+  const candidates = [
+    path.join(docsDist, relativePath),
+    path.join(docsDist, `${relativePath}.html`),
+    path.join(docsDist, relativePath, 'index.html'),
+  ]
   for (const candidate of candidates) {
     if (await exists(candidate)) return true
   }

--- a/tooling/docs/src/website-docs-url.test.ts
+++ b/tooling/docs/src/website-docs-url.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'bun:test'
+import { docsUrl } from '../../../apps/website/lib/docs-url'
+
+test('homepage documentation links use the public origin and preserve language', () => {
+  for (const locale of ['en', 'ja']) {
+    expect(docsUrl(locale)).toBe(`https://docs.shumoku.dev/${locale}`)
+    for (const section of ['library', 'cli', 'server']) {
+      expect(docsUrl(locale, section)).toBe(`https://docs.shumoku.dev/${locale}/${section}`)
+    }
+  }
+  expect(docsUrl('fr')).toBe('https://docs.shumoku.dev/en')
+})


### PR DESCRIPTION
## Summary
- Serve extensionless HTML directly on Cloudflare Pages and prefetch sidebar links on hover/focus.
- Normalize build-time paths for navigation, language/version switching and Pagefind results.
- Update homepage Docs links to docs.shumoku.dev with locale and product destinations.

## Validation
- Docs build and internal links (1,457 pages)
- Multiple-version build and page-preserving version switch
- 10 tests, 39 assertions
- Full monorepo lint and typecheck via commit hooks

Production changes take effect after review and merge.