### PR TITLE
fix(docs): recover redirect caches and enable Astro client navigation

### DIFF
--- a/apps/docs/DEPLOYMENT.md
+++ b/apps/docs/DEPLOYMENT.md
@@ -31,7 +31,25 @@ Docs uses Astro `build.format: 'file'` and extensionless URLs without trailing
 slashes. Cloudflare Pages serves these directly; directory output would add a
 redirect to every navigation. The layout normalizes Astro's build-time `.html`
 pathname for navigation, language/version switching, and Pagefind result URLs.
-Sidebar links prefetch on hover/focus using Astro, without a client-side router.
+Astro ClientRouter swaps documents without full browser reloads. Visible sidebar
+links prefetch on viewport entry; other internal links prefetch on hover/focus.
+Search destroys its Pagefind UI and document listeners before each swap, while
+the responsive sidebar refreshes on `astro:page-load`. No transition animation
+is added to delay reading.
+
+### Recovery from pre-migration redirect caches
+
+The earlier directory build permanently redirected `/path` to `/path/`; file
+output redirects in the opposite direction. Returning browsers may cache the old
+308 and loop even though a fresh browser works. Do not reverse this URL policy
+again or add another redirect as a workaround.
+
+Open `https://docs.shumoku.dev/recover` directly in the affected browser. Its
+`Clear-Site-Data: "cache"` header requests clearing only this origin's HTTP cache,
+not cookies or storage. The page is outside ClientRouter, not linked for prefetch,
+and uses `no-store`. If the browser does not support cache clearing, clear cached
+files manually. This is a recovery step, not a header to apply to every page.
+Cloudflare cache purges do not clear redirects stored in visitors' browsers.
 
 ## Vercel preview (optional alternative for Docs)
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -5,5 +5,5 @@ export default defineConfig({
   output: 'static',
   trailingSlash: 'never',
   build: { format: 'file' },
-  prefetch: { defaultStrategy: 'hover' },
+  prefetch: { prefetchAll: true, defaultStrategy: 'hover' },
 })

--- a/apps/docs/public/_headers
+++ b/apps/docs/public/_headers
@@ -5,5 +5,9 @@
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
 
+/recover
+  Clear-Site-Data: "cache"
+  Cache-Control: no-store
+
 /pagefind/*
   Cache-Control: public, max-age=31536000, immutable

--- a/apps/docs/src/components/DocsNavLink.astro
+++ b/apps/docs/src/components/DocsNavLink.astro
@@ -8,7 +8,9 @@ const { href, label, pathname } = Astro.props
 const current = pathname.replace(/\/$/, '') === href.replace(/\/$/, '')
 ---
 
-<a href={href} data-astro-prefetch aria-current={current ? 'page' : undefined}>{label}</a>
+<a href={href} data-astro-prefetch="viewport" aria-current={current ? 'page' : undefined}
+  >{label}</a
+>
 <style>
   a {
     position: relative;

--- a/apps/docs/src/components/DocsSidebar.astro
+++ b/apps/docs/src/components/DocsSidebar.astro
@@ -58,6 +58,7 @@ const currentLink = items
       sidebar.open = !viewport.matches
   }
   update()
+  document.addEventListener('astro:page-load', update)
   viewport.addEventListener('change', update)
 </script>
 <style>

--- a/apps/docs/src/components/Search.astro
+++ b/apps/docs/src/components/Search.astro
@@ -55,12 +55,25 @@ const label = lang === 'ja' ? '検索' : 'Search'
   {lang === 'ja' ? '検索にはJavaScriptが必要です。' : 'Search requires JavaScript.'}
 </noscript>
 
-<script is:inline define:vars={{ lang, serverVersion, dev: import.meta.env.DEV }}>
+<script is:inline data-astro-rerun define:vars={{ lang, serverVersion, dev: import.meta.env.DEV }}>
   ;(() => {
     const dialog = document.getElementById('search-dialog')
     const trigger = document.getElementById('search-open')
     const status = document.getElementById('search-status')
     let loading = null
+    let ui = null
+    let disposed = false
+    const controller = new AbortController()
+    document.addEventListener(
+      'astro:before-swap',
+      () => {
+        disposed = true
+        controller.abort()
+        ui?.destroy()
+        document.documentElement.classList.remove('search-open')
+      },
+      { once: true },
+    )
     const focusInput = () => {
       if (dialog.open) dialog.querySelector('input')?.focus()
     }
@@ -70,14 +83,16 @@ const label = lang === 'ja' ? '検索' : 'Search'
       css.rel = 'stylesheet'
       css.href = '/pagefind/pagefind-ui.css'
       document.head.append(css)
-      await new Promise((resolve, reject) => {
-        const script = document.createElement('script')
-        script.src = '/pagefind/pagefind-ui.js'
-        script.onload = resolve
-        script.onerror = reject
-        document.head.append(script)
-      })
-      const ui = new window.PagefindUI({
+      if (!window.PagefindUI)
+        await new Promise((resolve, reject) => {
+          const script = document.createElement('script')
+          script.src = '/pagefind/pagefind-ui.js'
+          script.onload = resolve
+          script.onerror = reject
+          document.head.append(script)
+        })
+      if (disposed) return
+      ui = new window.PagefindUI({
         element: '#search',
         showSubResults: true,
         showImages: false,
@@ -109,6 +124,11 @@ const label = lang === 'ja' ? '検索' : 'Search'
       trigger.focus()
     })
     dialog.addEventListener('click', (event) => {
+      // Same-page hash links do not trigger a router swap.
+      if (event.target instanceof Element && event.target.closest('a[href]')) {
+        dialog.close()
+        return
+      }
       if (event.target !== dialog) return
       const bounds = dialog.getBoundingClientRect()
       if (
@@ -119,13 +139,17 @@ const label = lang === 'ja' ? '検索' : 'Search'
       )
         dialog.close()
     })
-    document.addEventListener('keydown', (event) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
-        event.preventDefault()
-        if (dialog.open) dialog.close()
-        else open()
-      }
-    })
+    document.addEventListener(
+      'keydown',
+      (event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+          event.preventDefault()
+          if (dialog.open) dialog.close()
+          else open()
+        }
+      },
+      { signal: controller.signal },
+    )
     if (!/Mac|iPhone|iPad/.test(navigator.platform))
       trigger.querySelector('kbd').textContent = 'Ctrl K'
   })()

--- a/apps/docs/src/layouts/DocsLayout.astro
+++ b/apps/docs/src/layouts/DocsLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from 'astro:transitions'
 import DocsFooter from '../components/DocsFooter.astro'
 import DocsHeader from '../components/DocsHeader.astro'
 import DocsSidebar from '../components/DocsSidebar.astro'
@@ -62,6 +63,7 @@ const versionPicker = server
 <!doctype html>
 <html lang={lang}>
   <head>
+    <ClientRouter />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width">
     <meta name="description" content={description}>
@@ -75,7 +77,7 @@ const versionPicker = server
     <link rel="alternate" hreflang={lang} href={canonicalUrl}>
     <title>{title} · Shumoku Docs</title>
   </head>
-  <body>
+  <body transition:animate="none">
     <a class="skip-link" href="#main-content"
       >{lang === 'ja' ? '本文へスキップ' : 'Skip to content'}</a
     >

--- a/apps/docs/src/pages/recover.astro
+++ b/apps/docs/src/pages/recover.astro
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <meta name="robots" content="noindex">
+    <title>Docs キャッシュの復旧 / Cache recovery</title>
+  </head>
+  <body>
+    <h1>Docs キャッシュの復旧 / Cache recovery</h1>
+    <p>
+      このページは、対応ブラウザにDocsの古いキャッシュの削除を要求します。Cookieや保存データは削除しません。
+    </p>
+    <p>This page requests clearing this Docs origin’s HTTP cache only, not cookies or storage.</p>
+    <p><a href="/ja">日本語のDocsへ</a> · <a href="/en">English docs</a></p>
+    <p>まだ転送エラーが出る場合は、ブラウザのキャッシュを削除して再度開いてください。</p>
+    <p>If redirect errors persist, clear your browser’s cached files and try again.</p>
+  </body>
+</html>

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -8,6 +8,13 @@
   "trailingSlash": false,
   "headers": [
     {
+      "source": "/recover",
+      "headers": [
+        { "key": "Clear-Site-Data", "value": "\"cache\"" },
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },


### PR DESCRIPTION
## Summary
- Add /recover with Clear-Site-Data: "cache" and no-store to clear cached pre-migration redirects without cookies/storage deletion. Affected users must open this endpoint once after deployment; browsers without support need manual cache clearing.
- Enable Astro ClientRouter without a transition animation, viewport prefetch for sidebar links and hover prefetch for other internal links.
- Clean up Pagefind and keyboard listeners on navigation; refresh responsive sidebar after swaps.

## Validation
- Docs build, typecheck and 1,458-page internal link check
- Multiple-version build and page-preserving switch checks
- 10 model/URL tests
- Browser: page navigation, Japanese search results, Japanese-English-Japanese navigation and search reinitialization
- Biome commit hooks

HTTPS recovery header still needs deployment verification. Do not add cache clearing to ordinary page responses.