### PR TITLE
feat(docs): generate LLM-readable Markdown and discovery indexes

### DIFF
--- a/apps/docs/DEPLOYMENT.md
+++ b/apps/docs/DEPLOYMENT.md
@@ -1,5 +1,20 @@
 # Website and docs deployment boundary
 
+## Machine-readable discovery
+
+The Docs build automatically emits `sitemap.xml`, a concise `/llms.txt`, scoped
+language/product/Server-version indexes, and a `.md` mirror for each canonical
+documentation page (for example `/ja/library.md`). Markdown is converted from
+the rendered main content, including code, tables, source links and release
+warnings, not from an independently maintained summary. HTML advertises its
+Markdown alternate. Redirects and noindex recovery pages are excluded.
+
+Server versions remain separate; `next` is never labelled as stable. No combined
+all-version context dump is generated. Library/CLI track current source. These
+files help retrieval tools; they do not guarantee AI citations or search ranking.
+Existing crawler policy remains unchanged. Check the Cloudflare/WAF bot policy
+separately if a specific crawler cannot retrieve otherwise public pages.
+
 The two applications are separate deployable units. Do not configure a deployment
 from the repository root.
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -21,6 +21,7 @@
     "@biomejs/biome": "^2.4.8",
     "@shumoku/docs-tooling": "workspace:*",
     "pagefind": "^1.4.0",
+    "schema-dts": "^2.0.0",
     "typescript": "^5.9.3"
   }
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "docs:generate": "bun --cwd ../../tooling/docs generate",
-    "build": "bun run docs:generate && astro build && pagefind --site dist",
+    "build": "bun run docs:generate && astro build && bun ../../tooling/docs/src/generate-machine-docs.ts && pagefind --site dist",
     "check": "bun run build && bun --cwd ../../tooling/docs check",
     "dev": "bun run docs:generate && astro dev",
     "preview": "astro preview",

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Allow: /
+Sitemap: https://docs.shumoku.dev/sitemap.xml

--- a/apps/docs/src/components/PageActions.astro
+++ b/apps/docs/src/components/PageActions.astro
@@ -1,0 +1,38 @@
+---
+interface Props {
+  lang: 'en' | 'ja'
+  pathname: string
+  sourceUrl?: string
+}
+const { lang, pathname, sourceUrl } = Astro.props
+---
+
+<nav
+  class="page-actions"
+  aria-label={lang === 'ja' ? 'ページの取得と出典' : 'Page formats and source'}
+>
+  <a href={`${pathname}.md`} data-astro-reload data-astro-prefetch="false">Markdown ↗</a>
+  <a href={sourceUrl ?? 'https://github.com/konoe-akitoshi/shumoku'}>
+    {sourceUrl ? (lang === 'ja' ? 'GitHubで原文を見る' : 'View source on GitHub') : 'GitHub'}
+    ↗
+  </a>
+</nav>
+<style>
+  .page-actions {
+    display: flex;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    font-size: 0.8rem;
+  }
+  a {
+    color: var(--muted);
+    text-decoration: none;
+  }
+  a:hover,
+  a:focus-visible {
+    color: var(--text);
+    text-decoration: underline;
+  }
+</style>

--- a/apps/docs/src/components/PageMetadata.astro
+++ b/apps/docs/src/components/PageMetadata.astro
@@ -1,0 +1,30 @@
+---
+import type { WebPage, WithContext } from 'schema-dts'
+
+interface Props {
+  title: string
+  description: string
+  lang: string
+  url: string
+  sourceUrl?: string
+}
+const { title, description, lang, url, sourceUrl } = Astro.props
+const metadata: WithContext<WebPage> = {
+  '@context': 'https://schema.org',
+  '@type': 'WebPage',
+  '@id': url,
+  url,
+  name: title,
+  description,
+  inLanguage: lang,
+  isPartOf: {
+    '@type': 'WebSite',
+    '@id': 'https://docs.shumoku.dev/#website',
+    name: 'Shumoku Docs',
+    url: 'https://docs.shumoku.dev/',
+  },
+  ...(sourceUrl ? { isBasedOn: sourceUrl } : {}),
+}
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(metadata).replaceAll('<', '\\u003c')} />

--- a/apps/docs/src/components/YamlReference.astro
+++ b/apps/docs/src/components/YamlReference.astro
@@ -36,7 +36,12 @@ const labels =
       }
 ---
 
-<DocsLayout lang={lang} title="YAML reference" description={labels.description}>
+<DocsLayout
+  lang={lang}
+  title="YAML reference"
+  description={labels.description}
+  sourceUrl={model.source.url}
+>
   <article class="api-reference">
     <div class="api-heading">
       <div>

--- a/apps/docs/src/layouts/DocsLayout.astro
+++ b/apps/docs/src/layouts/DocsLayout.astro
@@ -67,6 +67,8 @@ const versionPicker = server
     <meta name="description" content={description}>
     {server && <meta data-pagefind-filter={`server-version:${server.routeVersion}`} />}
     <link rel="canonical" href={canonicalUrl}>
+    <link rel="alternate" type="text/markdown" href={`${canonicalUrl.pathname}.md`}>
+    <link rel="describedby" type="text/plain" href="/llms.txt">
     <link
       rel="alternate"
       hreflang={lang === 'en' ? 'ja' : 'en'}
@@ -93,6 +95,9 @@ const versionPicker = server
         id="main-content"
         tabindex="-1"
         data-pagefind-body
+        data-docs-version={server?.routeVersion}
+        data-docs-product-version={server?.productVersion}
+        data-docs-channel={server?.channel}
         data-pagefind-meta={`url:${canonicalUrl.pathname}`}
         data-pagefind-ignore={searchable ? undefined : true}
         data-pagefind-filter={server

--- a/apps/docs/src/layouts/DocsLayout.astro
+++ b/apps/docs/src/layouts/DocsLayout.astro
@@ -2,6 +2,8 @@
 import DocsFooter from '../components/DocsFooter.astro'
 import DocsHeader from '../components/DocsHeader.astro'
 import DocsSidebar from '../components/DocsSidebar.astro'
+import PageActions from '../components/PageActions.astro'
+import PageMetadata from '../components/PageMetadata.astro'
 import VersionNotice from '../components/VersionNotice.astro'
 import { loadRepositoryDocs, loadServerVersions } from '../lib/docs-model'
 import { docsNavigation, docsSections } from '../lib/navigation'
@@ -20,6 +22,7 @@ interface Props {
   server?: ServerVersionContext
   canonicalPath?: string
   searchable?: boolean
+  sourceUrl?: string
 }
 
 const { title, description, lang, server, canonicalPath, searchable = true } = Astro.props
@@ -36,6 +39,16 @@ const serverEntry = server
 const serverArtifact = server
   ? versions.versions.find(({ release }) => release.version === server.routeVersion)
   : undefined
+const sourcePage = (serverArtifact?.pages ?? repositoryDocs.pages).find(
+  (page) => repositoryPagePath(page, lang, server?.routeVersion) === pathname,
+)
+const sourceFile = sourcePage ? localizedPage(sourcePage, lang).source.file : undefined
+const sourceRef = serverArtifact?.release.sourceCommit ?? repositoryDocs.sourceCommit
+const sourceUrl =
+  Astro.props.sourceUrl ??
+  (sourceFile
+    ? `https://github.com/konoe-akitoshi/shumoku/blob/${sourceRef}/${sourceFile}`
+    : undefined)
 const navigation = docsNavigation(pathname, lang, repositoryDocs, serverArtifact)
 const sections = docsSections(lang, serverEntry)
 const activeSection =
@@ -76,6 +89,13 @@ const versionPicker = server
     >
     <link rel="alternate" hreflang={lang} href={canonicalUrl}>
     <title>{title} · Shumoku Docs</title>
+    <PageMetadata
+      title={title}
+      description={description}
+      lang={lang}
+      url={canonicalUrl.href}
+      sourceUrl={sourceUrl}
+    />
   </head>
   <body>
     <a class="skip-link" href="#main-content"
@@ -104,6 +124,9 @@ const versionPicker = server
           ? `search-scope:${server.routeVersion === versions.aliases.latest || (!versions.aliases.latest && server.routeVersion === versions.aliases.beta) ? 'default' : server.channel === 'stable' ? 'archive' : 'prerelease'}`
           : 'search-scope:default'}
       >
+        <div data-pagefind-ignore data-machine-ignore>
+          <PageActions lang={lang} pathname={canonicalUrl.pathname} sourceUrl={sourceUrl} />
+        </div>
         {server && <VersionNotice lang={lang} channel={server.channel} />}
         <slot />
       </main>

--- a/apps/docs/src/pages/[lang]/cli/commands/[command].astro
+++ b/apps/docs/src/pages/[lang]/cli/commands/[command].astro
@@ -30,7 +30,7 @@ export async function getStaticPaths() {
 const { lang, command, packageName, packageVersion, source } = Astro.props
 ---
 
-<DocsLayout lang={lang} title={command.usage} description={command.summary}>
+<DocsLayout lang={lang} title={command.usage} description={command.summary} sourceUrl={source.url}>
   <CliCommand
     lang={lang}
     command={command}

--- a/apps/docs/src/pages/[lang]/library/api/[symbol].astro
+++ b/apps/docs/src/pages/[lang]/library/api/[symbol].astro
@@ -28,7 +28,12 @@ export async function getStaticPaths() {
 const { lang, symbol, packageName, packageVersion } = Astro.props
 ---
 
-<DocsLayout lang={lang} title={symbol.name} description={symbol.summary}>
+<DocsLayout
+  lang={lang}
+  title={symbol.name}
+  description={symbol.summary}
+  sourceUrl={symbol.source.url}
+>
   <CoreSymbol
     lang={lang}
     symbol={symbol}

--- a/apps/docs/src/pages/[lang]/server/[version]/api/[operation].astro
+++ b/apps/docs/src/pages/[lang]/server/[version]/api/[operation].astro
@@ -35,6 +35,7 @@ const { lang, artifact, operation, model } = Astro.props
   title={operation.summary}
   description={operation.summary}
   server={versionContext(artifact, model)}
+  sourceUrl={operation.source.url}
 >
   <ServerApiOperation
     lang={lang}

--- a/apps/docs/src/pages/[lang]/server/[version]/plugins/[plugin].astro
+++ b/apps/docs/src/pages/[lang]/server/[version]/plugins/[plugin].astro
@@ -35,6 +35,7 @@ const { lang, artifact, plugin, model } = Astro.props
   title={plugin.displayName}
   description={plugin.description || `${plugin.displayName} data source plugin`}
   server={versionContext(artifact, model)}
+  sourceUrl={plugin.source.url}
 >
   <PluginDetail lang={lang} plugin={plugin} />
 </DocsLayout>

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@biomejs/biome": "^2.4.8",
         "@shumoku/docs-tooling": "workspace:*",
         "pagefind": "^1.4.0",
+        "schema-dts": "^2.0.0",
         "typescript": "^5.9.3",
       },
     },
@@ -2040,6 +2041,10 @@
     "sax": ["sax@1.6.1", "", {}, "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "schema-dts": ["schema-dts@2.0.0", "", { "dependencies": { "schema-dts-lib": "^1.0.0" } }, "sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw=="],
+
+    "schema-dts-lib": ["schema-dts-lib@1.0.0", "", { "peerDependencies": { "typescript": ">=4.9.5" } }, "sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A=="],
 
     "scroll-into-view-if-needed": ["scroll-into-view-if-needed@3.1.0", "", { "dependencies": { "compute-scroll-into-view": "^3.0.2" } }, "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -188,7 +188,7 @@
     },
     "libs/@shumoku/catalog": {
       "name": "@shumoku/catalog",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "js-yaml": "^4.1.0",
@@ -199,7 +199,7 @@
     },
     "libs/@shumoku/core": {
       "name": "@shumoku/core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "js-yaml": "^4.1.0",
         "nanoid": "^5.1.9",
@@ -226,7 +226,7 @@
     },
     "libs/@shumoku/renderer": {
       "name": "@shumoku/renderer",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "d3-drag": "^3.0.0",
@@ -294,7 +294,7 @@
     },
     "libs/plugins/grafana": {
       "name": "shumoku-plugin-grafana",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "dependencies": {
         "@shumoku/core": "workspace:*",
       },
@@ -309,7 +309,7 @@
     },
     "libs/plugins/netbox": {
       "name": "shumoku-plugin-netbox",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "@shumoku/plugin-sdk": "workspace:*",
@@ -327,14 +327,14 @@
     },
     "libs/plugins/prometheus": {
       "name": "shumoku-plugin-prometheus",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "dependencies": {
         "@shumoku/core": "workspace:*",
       },
     },
     "libs/plugins/zabbix": {
       "name": "shumoku-plugin-zabbix",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "@shumoku/plugin-sdk": "workspace:*",
@@ -358,6 +358,10 @@
         "@shumoku/core": "workspace:*",
         "@shumoku/renderer": "workspace:*",
         "@types/bun": "^1.3.6",
+        "@types/turndown": "^5.0.6",
+        "cheerio": "^1.2.0",
+        "turndown": "^7.2.4",
+        "turndown-plugin-gfm": "^1.0.2",
         "typedoc": "^0.28.20",
         "typescript": "^5.9.3",
         "zod": "^4.4.3",
@@ -632,6 +636,8 @@
     "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.3", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -1083,6 +1089,8 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
+    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
@@ -1225,6 +1233,10 @@
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
@@ -1352,6 +1364,8 @@
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
@@ -1520,6 +1534,8 @@
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -1883,6 +1899,10 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -2157,6 +2177,10 @@
 
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
 
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "turndown-plugin-gfm": ["turndown-plugin-gfm@1.0.2", "", {}, "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="],
+
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
@@ -2275,6 +2299,10 @@
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "wheel-gestures": ["wheel-gestures@2.2.48", "", {}, "sha512-f+Gy33Oa5Z14XY9679Zze+7VFhbsQfBFXodnU2x589l4kxGM9L5Y8zETTmcMR5pWOPQyRv4Z0lNax6xCO0NSlA=="],
@@ -2387,6 +2415,12 @@
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "cheerio/undici": ["undici@7.29.1", "", {}, "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q=="],
+
+    "cheerio-select/css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "cheerio-select/css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
     "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -2395,6 +2429,8 @@
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
+    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "fumadocs-mdx/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "fumadocs-mdx/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
@@ -2402,6 +2438,8 @@
     "fumadocs-ui/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
     "glob/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "knip/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
@@ -2452,6 +2490,8 @@
     "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "vscode-languageserver/vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "widest-line/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 

--- a/tooling/docs/package.json
+++ b/tooling/docs/package.json
@@ -25,6 +25,10 @@
     "@shumoku/core": "workspace:*",
     "@shumoku/renderer": "workspace:*",
     "@types/bun": "^1.3.6",
+    "@types/turndown": "^5.0.6",
+    "cheerio": "^1.2.0",
+    "turndown": "^7.2.4",
+    "turndown-plugin-gfm": "^1.0.2",
     "typedoc": "^0.28.20",
     "typescript": "^5.9.3",
     "zod": "^4.4.3"

--- a/tooling/docs/src/check-multiple-versions.ts
+++ b/tooling/docs/src/check-multiple-versions.ts
@@ -46,6 +46,7 @@ const fixtures = ['0.0.1', '0.0.2', '0.0.3-beta.1'].map((version) => {
 try {
   await writeFile(modelPath, JSON.stringify(createVersionsModel(fixtures)))
   run(['x', '--no-install', 'astro', 'build'])
+  run(['src/generate-machine-docs.ts'], path.join(root, 'tooling/docs'))
   run(['x', '--no-install', 'pagefind', '--site', 'dist'])
   run(['src/check-server-versions.ts'], path.join(root, 'tooling/docs'))
   for await (const file of new Bun.Glob('**/*.html').scan(path.join(docs, 'dist'))) {

--- a/tooling/docs/src/generate-machine-docs.ts
+++ b/tooling/docs/src/generate-machine-docs.ts
@@ -1,0 +1,68 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { machinePage, xmlEscape } from './machine-page'
+
+const dist = fileURLToPath(new URL('../../../apps/docs/dist/', import.meta.url))
+async function htmlFiles(directory: string): Promise<string[]> {
+  const files: string[] = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const file = path.join(directory, entry.name)
+    if (entry.isDirectory()) files.push(...(await htmlFiles(file)))
+    else if (entry.name.endsWith('.html')) files.push(file)
+  }
+  return files.sort()
+}
+const pages = []
+for (const file of await htmlFiles(dist)) {
+  const page = machinePage(await readFile(file, 'utf8'))
+  if (!page) continue
+  const target = path.join(dist, `${page.pathname}.md`)
+  await mkdir(path.dirname(target), { recursive: true })
+  await writeFile(target, page.markdown)
+  pages.push(page)
+}
+if (!pages.length) throw new Error('No canonical documentation pages found')
+const groups = new Map<string, typeof pages>()
+for (const page of pages) {
+  const group = groups.get(page.scope) ?? []
+  group.push(page)
+  groups.set(page.scope, group)
+}
+const root = [
+  '# Shumoku documentation',
+  '',
+  '> Network topology visualization: libraries, CLI and Server.',
+  '',
+  'Markdown mirrors are generated from the same rendered body as the human documentation.',
+  'Library and CLI documentation follows the current source. Server versions are independent;',
+  'next is development, beta is prerelease, and neither implies a stable release.',
+  'Choose one language and one Server version. Do not combine APIs from different versions.',
+  '',
+  '## Documentation indexes',
+  '',
+]
+for (const [scope, entries] of [...groups].sort(([a], [b]) => a.localeCompare(b))) {
+  const url = `https://docs.shumoku.dev/${scope}/llms.txt`
+  const description = entries[0]?.channel ? ` (${entries[0].channel})` : ''
+  root.push(`- [${scope}${description}](${url}): ${entries.length} pages`)
+  const index = [
+    `# Shumoku ${scope}${description}`,
+    '',
+    '> Canonical Markdown documentation index.',
+    '',
+  ]
+  for (const page of entries)
+    index.push(`- [${page.title.replace(/[[\]\n]/g, '')}](${page.url}.md)`)
+  const target = path.join(dist, scope, 'llms.txt')
+  await mkdir(path.dirname(target), { recursive: true })
+  await writeFile(target, `${index.join('\n')}\n`)
+}
+await writeFile(path.join(dist, 'llms.txt'), `${root.join('\n')}\n`)
+await writeFile(
+  path.join(dist, 'sitemap.xml'),
+  `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${pages.map((page) => `  <url><loc>${xmlEscape(page.url)}</loc></url>`).join('\n')}\n</urlset>\n`,
+)
+console.log(
+  `[docs] Machine discovery generated (${pages.length} Markdown pages, ${groups.size} indexes, sitemap)`,
+)

--- a/tooling/docs/src/machine-page.test.ts
+++ b/tooling/docs/src/machine-page.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'bun:test'
+import { machinePage, xmlEscape } from './machine-page'
+
+const document = (body: string, head = '') =>
+  `<html lang="ja"><head><title>Guide · Shumoku Docs</title><link rel="canonical" href="https://docs.shumoku.dev/ja/server/next/guide">${head}</head><body><nav>DO NOT INCLUDE</nav><main data-pagefind-body data-docs-version="next" data-docs-product-version="0.1.0" data-docs-channel="development">${body}</main></body></html>`
+
+test('Markdown preserves version, code, tables and absolute citations without navigation', () => {
+  const page = machinePage(
+    document(
+      '<h1>Guide</h1><pre><code class="language-ts">const x = 1 &lt; 2</code></pre><a href="./api#auth">API</a><table><thead><tr><th>Field</th></tr></thead><tbody><tr><td>name</td></tr></tbody></table>',
+    ),
+  )
+  expect(page?.scope).toBe('ja/server/next')
+  expect(page?.markdown).toContain('Channel: development')
+  expect(page?.markdown).toContain('```ts')
+  expect(page?.markdown).toContain('const x = 1 < 2')
+  expect(page?.markdown).toContain('https://docs.shumoku.dev/ja/server/next/api#auth')
+  expect(page?.markdown).toContain('| Field |')
+  expect(page?.markdown).not.toContain('DO NOT INCLUDE')
+})
+
+test('recovery, aliases and non-document pages are not indexed', () => {
+  expect(machinePage(document('text', '<meta name="robots" content="noindex">'))).toBeUndefined()
+  expect(machinePage('<html><body>redirect</body></html>')).toBeUndefined()
+})
+
+test('sitemap escapes URL query characters', () => {
+  expect(xmlEscape('https://example.com/?a=1&b=2')).toBe('https://example.com/?a=1&amp;b=2')
+})

--- a/tooling/docs/src/machine-page.ts
+++ b/tooling/docs/src/machine-page.ts
@@ -1,0 +1,52 @@
+import { load } from 'cheerio'
+import TurndownService from 'turndown'
+import { gfm } from 'turndown-plugin-gfm'
+
+const markdown = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' })
+markdown.use(gfm)
+
+export function machinePage(html: string) {
+  const $ = load(html)
+  if ($('meta[name="robots"]').attr('content')?.includes('noindex')) return undefined
+  const main = $('main[data-pagefind-body]')
+  const canonical = $('link[rel="canonical"]').attr('href')
+  if (!main.length || !canonical) return undefined
+  const url = new URL(canonical)
+  const lang = $('html').attr('lang') ?? 'en'
+  const title = $('title')
+    .text()
+    .replace(/ · Shumoku Docs$/, '')
+  const version = main.attr('data-docs-version')
+  const channel = main.attr('data-docs-channel')
+  const productVersion = main.attr('data-docs-product-version')
+  main.find('script, style, button, [aria-hidden="true"]').remove()
+  main.find('[href], [src]').each((_index, element) => {
+    for (const attribute of ['href', 'src']) {
+      const value = $(element).attr(attribute)
+      if (value) $(element).attr(attribute, new URL(value, url).href)
+    }
+  })
+  const body = markdown.turndown(main.html() ?? '')
+  const scope = version
+    ? `${lang}/server/${version}`
+    : `${lang}/${url.pathname.split('/')[2] === 'library' ? 'library' : url.pathname.split('/')[2] === 'cli' ? 'cli' : 'overview'}`
+  return {
+    url: url.href,
+    pathname: url.pathname,
+    lang,
+    title,
+    version,
+    channel,
+    scope,
+    markdown: `# ${title}\n\nCanonical: ${url.href}\nLanguage: ${lang}\n${version ? `Server documentation version: ${version}\nProduct version: ${productVersion}\nChannel: ${channel}\n` : ''}\n${body}\n`,
+  }
+}
+
+export function xmlEscape(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}

--- a/tooling/docs/src/machine-page.ts
+++ b/tooling/docs/src/machine-page.ts
@@ -19,7 +19,7 @@ export function machinePage(html: string) {
   const version = main.attr('data-docs-version')
   const channel = main.attr('data-docs-channel')
   const productVersion = main.attr('data-docs-product-version')
-  main.find('script, style, button, [aria-hidden="true"]').remove()
+  main.find('script, style, button, [aria-hidden="true"], [data-machine-ignore]').remove()
   main.find('[href], [src]').each((_index, element) => {
     for (const attribute of ['href', 'src']) {
       const value = $(element).attr(attribute)

--- a/tooling/docs/src/turndown-plugin-gfm.d.ts
+++ b/tooling/docs/src/turndown-plugin-gfm.d.ts
@@ -1,0 +1,4 @@
+declare module 'turndown-plugin-gfm' {
+  import type { Plugin } from 'turndown'
+  export const gfm: Plugin
+}


### PR DESCRIPTION
## Summary
- Generate Markdown mirrors from rendered canonical main content, preserving code, tables, source links and Server release context.
- Generate a concise llms.txt plus language/product/version-scoped indexes; avoid mixing releases in one context dump.
- Generate canonical sitemap.xml, advertise it in robots.txt, and expose Markdown alternate links in HTML.
- Exclude redirects and noindex pages. No manual duplicate documentation, crawler-policy changes or ranking guarantees.

## Validation
- Docs build and internal link check (1,459 HTML pages)
- 632 Markdown pages and 8 scoped indexes generated
- 13 tests / 49 assertions including conversion and noindex exclusions
- Docs/tooling typecheck and full commit lint/typecheck hooks
- HP generated types regenerated after transient build artifact error