### PR TITLE
fix(sites): follow browser language at website and docs entry

### DIFF
--- a/apps/docs/DEPLOYMENT.md
+++ b/apps/docs/DEPLOYMENT.md
@@ -104,6 +104,19 @@ the current `main` checkout as `latest`.
 
 ## Cloudflare Pages
 
+Only the unprefixed `/` entry runs a Pages Function (`functions/index.ts` at the
+repository root). `public/_routes.json` restricts invocation to that route; localized
+documents, search and assets remain static. Do not add a blanket `/*` invocation.
+The static root page is a browser-language fallback for local Astro previews or
+Pages fail-open behavior, with explicit language links when JavaScript is disabled.
+
+Language preference is shared with the website through the non-sensitive
+`shumoku_language` cookie on `shumoku.dev`. Explicit language URLs always win;
+only manual language selection saves a preference. The entry prefers that cookie,
+then weighted `Accept-Language`, then English. Redirects are private/no-store.
+Preview and localhost cookies are host-only. Clearing the preference restores
+browser-language detection; no IP/geolocation or automatic per-page redirects are used.
+
 Use the repository-root build settings above so workspace packages are available
 before reference generation. `public/_headers` carries the static cache and security
 headers.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,6 +14,7 @@
     "format": "biome check --write ."
   },
   "dependencies": {
+    "@shumoku/site-i18n": "workspace:*",
     "astro": "^5.13.5"
   },
   "devDependencies": {

--- a/apps/docs/public/_routes.json
+++ b/apps/docs/public/_routes.json
@@ -1,0 +1,1 @@
+{ "version": 1, "include": ["/"], "exclude": [] }

--- a/apps/docs/src/components/DocsHeader.astro
+++ b/apps/docs/src/components/DocsHeader.astro
@@ -14,12 +14,26 @@ const { lang, alternatePath, serverVersion } = Astro.props
     <a class="brand" href={`/${lang}`}>Shumoku <span>Docs</span></a>
     <div class="header-actions">
       <Search lang={lang} serverVersion={serverVersion} />
-      <a class="language" href={alternatePath} lang={lang === 'ja' ? 'en' : 'ja'}
+      <a
+        class="language"
+        data-language-preference={lang === 'ja' ? 'en' : 'ja'}
+        href={alternatePath}
+        lang={lang === 'ja' ? 'en' : 'ja'}
         >{lang === 'ja' ? 'English' : '日本語'}</a
       >
     </div>
   </div>
 </header>
+<script>
+  import { isLocale, rememberLanguage } from '@shumoku/site-i18n'
+
+  document.addEventListener('click', (event) => {
+    const link =
+      event.target instanceof Element ? event.target.closest('a[data-language-preference]') : null
+    const locale = link?.getAttribute('data-language-preference')
+    if (isLocale(locale)) rememberLanguage(locale)
+  })
+</script>
 <style>
   .docs-header {
     position: sticky;

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -2,11 +2,17 @@
 <html lang="en" data-pagefind-ignore>
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=/en">
     <meta name="robots" content="noindex">
     <title>Shumoku Docs</title>
   </head>
   <body>
-    <p><a href="/en">Open Shumoku Docs</a></p>
+    <p><a href="/en" lang="en">English</a> · <a href="/ja" lang="ja">日本語</a></p>
+    <script>
+      // Static-only previews/fail-open fallback. Production negotiates before HTML is served.
+      import { preferredLanguage } from '@shumoku/site-i18n'
+
+      const locale = preferredLanguage(navigator.languages.join(','), document.cookie)
+      location.replace(`/${locale}${location.search}${location.hash}`)
+    </script>
   </body>
 </html>

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -16,6 +16,12 @@ Home and Playground pages are prerendered. The legacy layout API remains a Verce
 function; Playground computes locally and does not depend on it. HTML export's
 standalone runtime is lazy loaded and is not part of the homepage bundle.
 
+The unprefixed `/` is a runtime-only 307 language selector. It uses the saved manual
+preference, then weighted `Accept-Language`, then English, with `private, no-store`
+and `Vary: Accept-Language, Cookie`. Explicit `/ja` and `/en` URLs stay static and
+are never overridden. `@shumoku/site-i18n` shares the policy with Docs; manual
+selection saves a one-year preference across `shumoku.dev` (host-only on previews).
+
 ## Compatibility
 
 `src/lib/legacy.ts` uses `tooling/docs/migration.routes.json`. Ready documentation

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run src/lib"
   },
   "dependencies": {
+    "@shumoku/site-i18n": "workspace:*",
     "@lucide/svelte": "^1.41.0",
     "@shumoku/core": "workspace:*",
     "@shumoku/renderer": "workspace:*",

--- a/apps/website/src/lib/home/Header.svelte
+++ b/apps/website/src/lib/home/Header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Languages, Menu, Moon, Search, Sun } from '@lucide/svelte'
+  import { rememberLanguage } from '@shumoku/site-i18n'
   import { onMount } from 'svelte'
   import Icon from './Icon.svelte'
 
@@ -65,10 +66,18 @@
         <div
           class="absolute right-0 top-9 grid min-w-32 gap-3 rounded-lg border border-neutral-200 bg-white p-3 shadow-lg dark:border-neutral-800 dark:bg-neutral-950"
         >
-          <a href={`/en${path}`} lang="en" aria-current={locale === 'en' ? 'page' : undefined}
+          <a
+            href={`/en${path}`}
+            onclick={() => rememberLanguage('en')}
+            lang="en"
+            aria-current={locale === 'en' ? 'page' : undefined}
             >English</a
           >
-          <a href={`/ja${path}`} lang="ja" aria-current={locale === 'ja' ? 'page' : undefined}
+          <a
+            href={`/ja${path}`}
+            onclick={() => rememberLanguage('ja')}
+            lang="ja"
+            aria-current={locale === 'ja' ? 'page' : undefined}
             >日本語</a
           >
         </div>

--- a/apps/website/src/routes/+page.server.ts
+++ b/apps/website/src/routes/+page.server.ts
@@ -1,3 +1,0 @@
-import { redirect } from '@sveltejs/kit'
-export const prerender = true
-export const load = () => redirect(307, '/en')

--- a/apps/website/src/routes/+server.ts
+++ b/apps/website/src/routes/+server.ts
@@ -1,0 +1,6 @@
+import { languageRedirect } from '@shumoku/site-i18n'
+import type { RequestHandler } from './$types'
+
+export const prerender = false
+export const GET: RequestHandler = ({ request }) => languageRedirect(request)
+export const HEAD = GET

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
       "name": "@shumoku/docs",
       "version": "0.0.0",
       "dependencies": {
+        "@shumoku/site-i18n": "workspace:*",
         "astro": "^5.13.5",
       },
       "devDependencies": {
@@ -158,13 +159,14 @@
     },
     "apps/website": {
       "name": "@shumoku/website",
-      "version": "0.0.0",
+      "version": "0.2.25",
       "dependencies": {
         "@lucide/svelte": "^1.41.0",
         "@shumoku/core": "workspace:*",
         "@shumoku/renderer": "workspace:*",
         "@shumoku/renderer-html": "workspace:*",
         "@shumoku/renderer-svg": "workspace:*",
+        "@shumoku/site-i18n": "workspace:*",
         "@shumoku/website-content": "workspace:*",
         "clsx": "^2.1.1",
         "tailwind-merge": "^3.6.0",
@@ -361,6 +363,14 @@
         "typedoc": "^0.28.20",
         "typescript": "^5.9.3",
         "zod": "^4.4.3",
+      },
+    },
+    "tooling/site-i18n": {
+      "name": "@shumoku/site-i18n",
+      "version": "0.0.0",
+      "devDependencies": {
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.17",
       },
     },
     "tooling/website-content": {
@@ -860,6 +870,8 @@
     "@shumoku/server-api": ["@shumoku/server-api@workspace:apps/server/api"],
 
     "@shumoku/server-web": ["@shumoku/server-web@workspace:apps/server/web"],
+
+    "@shumoku/site-i18n": ["@shumoku/site-i18n@workspace:tooling/site-i18n"],
 
     "@shumoku/website": ["@shumoku/website@workspace:apps/website"],
 

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1,0 +1,6 @@
+// Cloudflare Pages project root is the repository root. Only / invokes this function.
+import { languageRedirect } from '../tooling/site-i18n/index'
+export const onRequest = ({ request }: { request: Request }) =>
+  request.method === 'GET' || request.method === 'HEAD'
+    ? languageRedirect(request)
+    : new Response('Method not allowed', { status: 405, headers: { allow: 'GET, HEAD' } })

--- a/knip.json
+++ b/knip.json
@@ -21,6 +21,7 @@
     "apps/website": {},
     "apps/docs": {},
     "tooling/website-content": {},
+    "tooling/site-i18n": { "entry": ["index.ts", "../../functions/index.ts"] },
     "tooling/docs": {
       "entry": ["src/upload-server-docs.ts", "scripts/collect-legacy.mjs"]
     },

--- a/tooling/site-i18n/index.test.ts
+++ b/tooling/site-i18n/index.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { onRequest } from '../../functions/index'
+import { languagePreferenceCookie, languageRedirect, preferredLanguage } from './index'
+
+describe('entry language negotiation', () => {
+  it.each([
+    ['ja-JP,ja;q=0.9,en;q=0.8', 'ja'],
+    ['en-US,en;q=0.9,ja;q=0.5', 'en'],
+    ['fr-FR,ja;q=0.9,en;q=0.8', 'ja'],
+    ['en;q=0.2,ja;q=0.9', 'ja'],
+    ['ja;q=0,en;q=0.8', 'en'],
+    ['en;q=0,*;q=0.8', 'ja'],
+    ['ja;q=oops,en', 'en'],
+    ['fr', 'en'],
+    ['', 'en'],
+  ])('%s → %s', (header, expected) => expect(preferredLanguage(header, null)).toBe(expected))
+  it('gives the explicit preference priority and ignores invalid cookies', () => {
+    expect(preferredLanguage('ja', 'other=x; shumoku_language=en')).toBe('en')
+    expect(preferredLanguage('ja', 'shumoku_language=fr')).toBe('ja')
+  })
+  it('shares production preference without setting a domain on preview or localhost', () => {
+    expect(languagePreferenceCookie('ja', new URL('https://docs.shumoku.dev'))).toContain(
+      '; Secure; Domain=shumoku.dev',
+    )
+    expect(languagePreferenceCookie('en', new URL('https://preview.vercel.app'))).not.toContain(
+      'Domain=',
+    )
+    expect(languagePreferenceCookie('en', new URL('http://localhost:4340'))).not.toContain('Secure')
+  })
+  it('does not cache a personalized redirect or set an inferred preference', () => {
+    const response = languageRedirect(
+      new Request('https://www.shumoku.dev/?source=example', {
+        headers: { 'accept-language': 'ja' },
+      }),
+    )
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('/ja?source=example')
+    expect(response.headers.get('cache-control')).toBe('private, no-store')
+    expect(response.headers.get('vary')).toBe('Accept-Language, Cookie')
+    expect(response.headers.has('set-cookie')).toBe(false)
+  })
+  it('uses the same response on Cloudflare', () => {
+    const response = onRequest({
+      request: new Request('https://docs.shumoku.dev/', { headers: { 'accept-language': 'ja' } }),
+    })
+    expect(response.headers.get('location')).toBe('/ja')
+    expect(response.headers.get('cache-control')).toContain('no-store')
+  })
+})

--- a/tooling/site-i18n/index.ts
+++ b/tooling/site-i18n/index.ts
@@ -1,0 +1,67 @@
+export type Locale = 'en' | 'ja'
+export const languageCookie = 'shumoku_language'
+export function isLocale(value: unknown): value is Locale {
+  return value === 'en' || value === 'ja'
+}
+
+export function savedLanguage(cookies: string | null): Locale | null {
+  for (const part of (cookies ?? '').split(';')) {
+    const [name, value] = part.trim().split('=')
+    if (name === languageCookie && isLocale(value)) return value
+  }
+  return null
+}
+
+/** Negotiate only the unprefixed entry point; explicit localized URLs always win. */
+export function preferredLanguage(acceptLanguage: string | null, cookies: string | null): Locale {
+  const saved = savedLanguage(cookies)
+  if (saved) return saved
+  const ranges = (acceptLanguage ?? '').split(',').flatMap((item, order) => {
+    const match = item
+      .trim()
+      .match(/^([a-z]{2,8}(?:-[a-z0-9]{1,8})*|\*)(?:\s*;\s*q=(0(?:\.\d{0,3})?|1(?:\.0{0,3})?))?$/i)
+    if (!match?.[1]) return []
+    return [{ language: match[1].toLowerCase().split('-')[0], q: Number(match[2] ?? 1), order }]
+  })
+  const candidates = (['en', 'ja'] as const)
+    .map((locale) => {
+      const specific = ranges.filter((range) => range.language === locale)
+      const matches = specific.length ? specific : ranges.filter((range) => range.language === '*')
+      const best = matches.sort((a, b) => b.q - a.q || a.order - b.order)[0]
+      return { locale, q: best?.q ?? 0, order: best?.order ?? Infinity }
+    })
+    .filter((candidate) => candidate.q > 0)
+    .sort((a, b) => b.q - a.q || a.order - b.order)
+  return candidates[0]?.locale ?? 'en'
+}
+
+export function languagePreferenceCookie(locale: Locale, url: URL): string {
+  const shared = url.hostname === 'shumoku.dev' || url.hostname.endsWith('.shumoku.dev')
+  return `${languageCookie}=${locale}; Path=/; Max-Age=31536000; SameSite=Lax${url.protocol === 'https:' ? '; Secure' : ''}${shared ? '; Domain=shumoku.dev' : ''}`
+}
+
+/** Called only for explicit selection, never just because a localized URL was visited. */
+export function rememberLanguage(locale: Locale): void {
+  try {
+    // biome-ignore lint/suspicious/noDocumentCookie: Save synchronously before the native link navigates, including browsers without Cookie Store.
+    document.cookie = languagePreferenceCookie(locale, new URL(window.location.href))
+  } catch {
+    /* Explicit links still work when cookies are unavailable. */
+  }
+}
+
+export function languageRedirect(request: Request): Response {
+  const locale = preferredLanguage(
+    request.headers.get('accept-language'),
+    request.headers.get('cookie'),
+  )
+  const url = new URL(request.url)
+  return new Response(null, {
+    status: 307,
+    headers: {
+      location: `/${locale}${url.search}`,
+      'cache-control': 'private, no-store',
+      vary: 'Accept-Language, Cookie',
+    },
+  })
+}

--- a/tooling/site-i18n/package.json
+++ b/tooling/site-i18n/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@shumoku/site-i18n",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "lint": "biome check ."
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.17"
+  }
+}

--- a/tooling/site-i18n/tsconfig.json
+++ b/tooling/site-i18n/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "noEmit": true, "lib": ["ES2022", "DOM"] },
+  "include": ["*.ts", "../../functions/index.ts"]
+}


### PR DESCRIPTION
## Summary
- Negotiate only the unprefixed root: saved manual language preference, weighted Accept-Language, then English. Explicit /ja and /en URLs always win.
- Share a small tested policy package between the website and Docs. Manual selection saves a one-year non-sensitive language cookie across shumoku.dev; preview/localhost preferences remain host-only.
- Website root uses a runtime 307 response with private/no-store and Vary; localized homepage and Playground pages remain prerendered.
- Docs uses a root-only Cloudflare Pages Function, with _routes.json excluding all other paths from invocation. Articles, assets and Pagefind remain static. Static-only previews have a browser-language fallback and no-JS language links.

## Verification
- 13 language-policy tests, typecheck and repository pre-commit checks passed.
- Website production build and Docs build (1460 pages) passed; Docs contracts and targeted knip passed.
- Cloudflare Functions compiled with Wrangler and were tested locally.
- HTTP checks on both runtimes confirmed ja preference, saved en override, unsupported-language fallback, no-store/Vary and explicit language URLs remaining 200.

## Deployment
- No dashboard setting changes required: Cloudflare Pages already uses the repository root, where functions/index.ts is located.
- Only / invokes a Pages Function. Do not broaden _routes.json to /*.
- Not deployed to production yet; review the Vercel and Cloudflare previews before merging.