### PR TITLE
feat(website): add GA4 and Vercel Web Analytics with shared consent

### DIFF
--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -58,6 +58,54 @@ live at `/{lang}/support`, reusing the original sections and translated copy.
 
 ## Deployment / rollback
 
+### Vercel Web Analytics
+
+- Uses `@vercel/analytics/sveltekit` for initial and client-side page views; do not add manual pageview listeners.
+- Shares GA4's deferred initialization, production-host guard, region policy and saved analytics choice.
+- The SDK initializes once. `beforeSend` blocks rejected/custom events and removes query strings and hashes.
+- Enable **Web Analytics** for the existing HP project in the Vercel dashboard before deploying this PR. No new Vercel project, paid upgrade or Speed Insights is required by this code.
+- After deployment verify `/_vercel/insights/*` requests and page views in the dashboard, including SPA navigation and rejection. Local/preview visits intentionally send nothing.
+- Dashboard enablement and live ingestion cannot be validated by the local build. GA4 and Vercel may report different totals due to their different counting methods.
+
+### GA4 and regional analytics preferences
+
+The website uses `vanilla-cookieconsent` and Google tag `G-SHX2VE8F8F`.
+The localized layout schedules the optional client chunk after window load and
+browser idle (2-second idle deadline). Consent JS/CSS is dynamically imported;
+neither the policy request nor Google tag blocks initial rendering.
+Pages remain prerendered. Only `/api/analytics-policy` is a runtime endpoint.
+It reads Vercel's country header and returns no-store, private responses; do not
+cache its result globally, infer location from language, or accept country query overrides.
+
+- Only a production build on www.shumoku.dev / shumoku.dev and a production
+  Vercel policy response can enable collection. Local/preview never loads Google.
+- JP: opt-out without an automatic banner. Saved rejections always take priority.
+- Other/unknown countries: Basic consent gating; no Google tag before acceptance.
+- Policy failure/timeout (1.5 seconds): no tracking and no automatic banner.
+- Choices expire after 180 days. Region is rechecked once per full document load,
+  not on SPA navigation. An implicit JP default is not saved as explicit consent.
+- Preferences remain accessible from the footer and /{lang}/privacy. Revoking
+  analytics clears host-only GA cookies and reloads to remove loaded tag listeners.
+- Signals, advertising storage and personalization are disabled. No custom events
+  containing Playground contents or uploaded file names are implemented.
+
+**GA4 dashboard setup before launch:** keep Enhanced Measurement Page Views
+enabled, including “Page changes based on browser history events”. This is the
+sole page-view producer: do not add afterNavigate page_view calls, a duplicate
+gtag snippet or a GTM history trigger. Other Enhanced Measurement options
+(especially site search, forms and file downloads) should be reviewed/disabled
+if their URL or filename data is not needed. Confirm retention and data-sharing
+settings in the property, and review the privacy notice and JP opt-out policy
+against your actual processing obligations; this implementation is not a legal determination.
+
+After deployment verify a single initial/SPA page_view in GA4 DebugView and
+network behavior for JP, non-JP, unknown country, saved rejection and withdrawal.
+The local preference dialog can be opened via the footer without sending to Google.
+Library/controller tests mock Google; they do not pollute the production property.
+Official references:
+[SPA tracking](https://developers.google.com/analytics/devguides/collection/ga4/single-page-applications),
+[CookieConsent configuration](https://cookieconsent.orestbida.com/reference/configuration-reference.html).
+
 Keep Vercel shumoku-docs Root Directory at `apps/website`. `vercel.json` overrides
 the old framework/build settings with SvelteKit and builds workspace dependencies
 through Turbo. Leave Output Directory automatic; remove any dashboard .next

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -15,15 +15,17 @@
     "test": "vitest run src/lib"
   },
   "dependencies": {
-    "@shumoku/site-i18n": "workspace:*",
     "@lucide/svelte": "^1.41.0",
     "@shumoku/core": "workspace:*",
     "@shumoku/renderer": "workspace:*",
-    "@shumoku/renderer-svg": "workspace:*",
     "@shumoku/renderer-html": "workspace:*",
+    "@shumoku/renderer-svg": "workspace:*",
+    "@shumoku/site-i18n": "workspace:*",
     "@shumoku/website-content": "workspace:*",
+    "@vercel/analytics": "^2.0.1",
     "clsx": "^2.1.1",
-    "tailwind-merge": "^3.6.0"
+    "tailwind-merge": "^3.6.0",
+    "vanilla-cookieconsent": "3.1.0"
   },
   "devDependencies": {
     "vitest": "^4.0.17",

--- a/apps/website/src/lib/analytics/Analytics.svelte
+++ b/apps/website/src/lib/analytics/Analytics.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { isWebsiteHost } from './policy'
+
+  let { locale }: { locale: 'en' | 'ja' } = $props()
+  let client = $state<typeof import('./client')>()
+
+  onMount(() => {
+    if (!isWebsiteHost(new URL(location.href), import.meta.env.PROD)) return
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let idle: number | undefined
+    const start = async () => {
+      try {
+        const module = await import('./client')
+        if (cancelled) return
+        client = module
+        await module.initializeAnalytics()
+      } catch {
+        // Optional analytics must never interrupt the website.
+      }
+    }
+    const schedule = () => {
+      if ('requestIdleCallback' in window) {
+        idle = window.requestIdleCallback(
+          () => {
+            void start()
+          },
+          { timeout: 2000 },
+        )
+      } else {
+        timer = setTimeout(() => {
+          void start()
+        }, 500)
+      }
+    }
+    if (document.readyState === 'complete') schedule()
+    else window.addEventListener('load', schedule, { once: true })
+    return () => {
+      cancelled = true
+      window.removeEventListener('load', schedule)
+      if (idle !== undefined) window.cancelIdleCallback(idle)
+      if (timer !== undefined) clearTimeout(timer)
+    }
+  })
+  $effect(() => {
+    void client?.setAnalyticsLanguage(locale).catch(() => {})
+  })
+</script>

--- a/apps/website/src/lib/analytics/AnalyticsSettings.svelte
+++ b/apps/website/src/lib/analytics/AnalyticsSettings.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  let { locale }: { locale: 'en' | 'ja' } = $props()
+  let busy = $state(false)
+  let failed = $state(false)
+  async function open() {
+    busy = true
+    failed = false
+    try {
+      const client = await import('./client')
+      await client.openAnalyticsPreferences()
+    } catch {
+      failed = true
+    } finally {
+      busy = false
+    }
+  }
+</script>
+<button type="button" onclick={open} disabled={busy}>
+  {locale === 'ja' ? 'アクセス解析の設定' : 'Analytics preferences'}
+</button>
+{#if failed}
+  <span role="status"
+    >{locale === 'ja' ? '読み込めませんでした。もう一度お試しください。' : 'Unable to load. Please try again.'}</span
+  >
+{/if}
+<style>
+  button {
+    font: inherit;
+    color: var(--site-muted);
+    cursor: pointer;
+    text-align: left;
+    padding-block: 0.5rem;
+    text-underline-offset: 4px;
+  }
+  button:hover {
+    text-decoration: underline;
+  }
+  button:disabled {
+    cursor: wait;
+  }
+  span {
+    display: block;
+    font-size: 0.875rem;
+  }
+</style>

--- a/apps/website/src/lib/analytics/client.test.ts
+++ b/apps/website/src/lib/analytics/client.test.ts
@@ -1,0 +1,84 @@
+import type { CookieConsentConfig } from 'vanilla-cookieconsent'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  run: vi.fn(),
+  validConsent: vi.fn(),
+  acceptedCategory: vi.fn(),
+  setLanguage: vi.fn(),
+  showPreferences: vi.fn(),
+  setGoogleAnalytics: vi.fn(),
+}))
+vi.mock('vanilla-cookieconsent', () => mocks)
+vi.mock('./google', () => ({ setGoogleAnalytics: mocks.setGoogleAnalytics }))
+vi.mock('./vercel', () => ({ setVercelAnalytics: vi.fn() }))
+const fetcher = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  vi.stubEnv('PROD', true)
+  vi.stubGlobal('window', { location: { href: 'https://www.shumoku.dev/ja' } })
+  vi.stubGlobal('document', { documentElement: { lang: 'ja' } })
+  vi.stubGlobal('fetch', fetcher)
+  fetcher.mockResolvedValue(Response.json({ enabled: true, requiresConsent: false }))
+  mocks.validConsent.mockReturnValue(false)
+  mocks.acceptedCategory.mockReturnValue(false)
+  mocks.run.mockResolvedValue(undefined)
+  mocks.setLanguage.mockResolvedValue(true)
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+describe('consent integration', () => {
+  it('initializes once in Japan, without displaying or blocking the page', async () => {
+    const client = await import('./client')
+    await Promise.all([client.initializeAnalytics(), client.initializeAnalytics()])
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(mocks.run).toHaveBeenCalledTimes(1)
+    expect(mocks.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoShow: false,
+        mode: 'opt-out',
+        disablePageInteraction: false,
+      }),
+    )
+    expect(mocks.setGoogleAnalytics).toHaveBeenLastCalledWith(true)
+  })
+  it('respects a saved rejection in Japan', async () => {
+    mocks.validConsent.mockReturnValue(true)
+    const client = await import('./client')
+    await client.initializeAnalytics()
+    expect(mocks.setGoogleAnalytics).toHaveBeenLastCalledWith(false)
+  })
+  it('waits for consent outside Japan and handles rejection afterwards', async () => {
+    fetcher.mockResolvedValue(Response.json({ enabled: true, requiresConsent: true }))
+    const client = await import('./client')
+    await client.initializeAnalytics()
+    expect(mocks.setGoogleAnalytics).toHaveBeenLastCalledWith(false)
+    const config = mocks.run.mock.calls[0]?.[0] as CookieConsentConfig
+    expect(config.autoShow).toBe(true)
+    expect(config.mode).toBe('opt-in')
+    mocks.validConsent.mockReturnValue(true)
+    mocks.acceptedCategory.mockReturnValue(true)
+    // The callback reads the library's saved state rather than defaulting by country.
+    const callback = config.onConsent as () => void
+    callback()
+    expect(mocks.setGoogleAnalytics).toHaveBeenLastCalledWith(true)
+    mocks.acceptedCategory.mockReturnValue(false)
+    const changed = config.onChange as () => void
+    changed()
+    expect(mocks.setGoogleAnalytics).toHaveBeenLastCalledWith(false)
+  })
+  it('opens preferences locally without requesting policy or sending analytics', async () => {
+    vi.stubGlobal('window', { location: { href: 'http://127.0.0.1:4340/ja' } })
+    const client = await import('./client')
+    await client.openAnalyticsPreferences()
+    expect(fetcher).not.toHaveBeenCalled()
+    expect(mocks.setGoogleAnalytics).toHaveBeenLastCalledWith(false)
+    expect(mocks.showPreferences).toHaveBeenCalledOnce()
+    expect(mocks.setLanguage).toHaveBeenCalledWith('ja')
+  })
+})

--- a/apps/website/src/lib/analytics/client.ts
+++ b/apps/website/src/lib/analytics/client.ts
@@ -1,0 +1,66 @@
+import * as consent from 'vanilla-cookieconsent'
+import 'vanilla-cookieconsent/dist/cookieconsent.css'
+import { setGoogleAnalytics } from './google'
+import { fetchPolicy, isWebsiteHost, shouldMeasure } from './policy'
+import { consentTranslation } from './translations'
+import { setVercelAnalytics } from './vercel'
+
+let initialization: Promise<void> | undefined
+const currentLanguage = () => (document.documentElement.lang === 'ja' ? 'ja' : 'en')
+
+/** Shared by the idle bootstrap and preferences button, including concurrent calls. */
+export function initializeAnalytics() {
+  initialization ??= initialize().catch((error: unknown) => {
+    initialization = undefined
+    throw error
+  })
+  return initialization
+}
+
+async function initialize() {
+  const eligible = isWebsiteHost(new URL(window.location.href), import.meta.env.PROD)
+  const policy = eligible ? await fetchPolicy(fetch) : { enabled: false, requiresConsent: true }
+  const synchronize = () => {
+    const saved = consent.validConsent() ? consent.acceptedCategory('analytics') : undefined
+    const allowed = shouldMeasure(policy, saved)
+    setVercelAnalytics(allowed)
+    setGoogleAnalytics(allowed)
+  }
+  await consent.run({
+    revision: 1,
+    mode: policy.requiresConsent ? 'opt-in' : 'opt-out',
+    autoShow: policy.enabled && policy.requiresConsent,
+    disablePageInteraction: false,
+    lazyHtmlGeneration: true,
+    manageScriptTags: false,
+    cookie: { name: 'shumoku_consent', expiresAfterDays: 180 },
+    guiOptions: {
+      consentModal: { layout: 'box inline', position: 'bottom right', equalWeightButtons: true },
+      preferencesModal: { layout: 'box', equalWeightButtons: true },
+    },
+    categories: {
+      necessary: { enabled: true, readOnly: true },
+      analytics: { enabled: !policy.requiresConsent },
+    },
+    language: {
+      default: currentLanguage(),
+      translations: { en: consentTranslation('en'), ja: consentTranslation('ja') },
+    },
+    onConsent: synchronize,
+    onChange: synchronize,
+  })
+  synchronize()
+}
+
+export async function openAnalyticsPreferences() {
+  await initializeAnalytics()
+  await consent.setLanguage(currentLanguage())
+  consent.showPreferences()
+}
+
+export async function setAnalyticsLanguage(locale: 'en' | 'ja') {
+  if (initialization) {
+    await initialization
+    await consent.setLanguage(locale)
+  }
+}

--- a/apps/website/src/lib/analytics/google.test.ts
+++ b/apps/website/src/lib/analytics/google.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const append = vi.fn()
+const reload = vi.fn()
+let target: { dataLayer?: unknown[]; 'ga-disable-G-SHX2VE8F8F'?: boolean }
+
+beforeEach(() => {
+  vi.resetModules()
+  append.mockReset()
+  reload.mockReset()
+  target = {}
+  vi.stubGlobal('window', Object.assign(target, { location: { reload } }))
+  vi.stubGlobal('document', { cookie: '', createElement: () => ({}), head: { append } })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('Google tag lifecycle', () => {
+  it('does not create a tag or queue when disabled', async () => {
+    const { setGoogleAnalytics } = await import('./google')
+    setGoogleAnalytics(false)
+    expect(append).not.toHaveBeenCalled()
+    expect(target.dataLayer).toBeUndefined()
+    expect(reload).not.toHaveBeenCalled()
+  })
+  it('initializes once without a second manual page-view stream', async () => {
+    const { setGoogleAnalytics } = await import('./google')
+    setGoogleAnalytics(true)
+    setGoogleAnalytics(true)
+    const commands = target.dataLayer?.map((item) => Array.from(item as IArguments))
+    expect(commands?.map((item) => item[0])).toEqual(['consent', 'js', 'config'])
+    expect(commands?.[0]?.[2]).toMatchObject({
+      analytics_storage: 'granted',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    })
+    expect(commands?.[2]?.[2]).toMatchObject({
+      allow_google_signals: false,
+      allow_ad_personalization_signals: false,
+      cookie_domain: 'none',
+    })
+    expect(append).toHaveBeenCalledTimes(1)
+    expect(append).toHaveBeenCalledWith(
+      expect.objectContaining({
+        async: true,
+        src: 'https://www.googletagmanager.com/gtag/js?id=G-SHX2VE8F8F',
+      }),
+    )
+  })
+  it('disables tracking and reloads on withdrawal without sending a denied ping', async () => {
+    const { setGoogleAnalytics } = await import('./google')
+    setGoogleAnalytics(true)
+    setGoogleAnalytics(false)
+    expect(target['ga-disable-G-SHX2VE8F8F']).toBe(true)
+    expect(reload).toHaveBeenCalledOnce()
+    expect(target.dataLayer).toHaveLength(3)
+  })
+})

--- a/apps/website/src/lib/analytics/google.ts
+++ b/apps/website/src/lib/analytics/google.ts
@@ -1,0 +1,52 @@
+import { measurementId } from './policy'
+
+type GoogleWindow = Window & {
+  dataLayer?: unknown[]
+  gtag?: (...args: unknown[]) => void
+  'ga-disable-G-SHX2VE8F8F'?: boolean
+}
+
+let started = false
+
+/** Called only after production and consent gates pass. No module-level network activity. */
+export function setGoogleAnalytics(allowed: boolean) {
+  const target = window as GoogleWindow
+  target['ga-disable-G-SHX2VE8F8F'] = !allowed
+  if (!allowed) {
+    for (const name of ['_ga', '_ga_SHX2VE8F8F']) {
+      // biome-ignore lint/suspicious/noDocumentCookie: synchronous host-only cookie removal before reload, including browsers without Cookie Store
+      document.cookie = `${name}=; Max-Age=0; Path=/; SameSite=Lax; Secure`
+    }
+    // Remove Google's installed history listeners as well as its cookies on withdrawal.
+    // The consent library saves the rejection before invoking this callback.
+    if (started) window.location.reload()
+    return
+  }
+  if (started) return
+  started = true
+  const queue = target.dataLayer ?? []
+  target.dataLayer = queue
+  target.gtag = function (..._args: unknown[]) {
+    // biome-ignore lint/complexity/noArguments: gtag's documented dataLayer command protocol uses an Arguments object
+    queue.push(arguments)
+  }
+  target.gtag('consent', 'default', {
+    analytics_storage: 'granted',
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+  })
+  target.gtag('js', new Date())
+  // One page-view owner: GA4 Enhanced Measurement (including History API changes).
+  target.gtag('config', measurementId, {
+    allow_google_signals: false,
+    allow_ad_personalization_signals: false,
+    cookie_domain: 'none',
+    cookie_expires: 60 * 60 * 24 * 180,
+    cookie_update: false,
+  })
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`
+  document.head.append(script)
+}

--- a/apps/website/src/lib/analytics/policy.test.ts
+++ b/apps/website/src/lib/analytics/policy.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+import { analyticsPolicy, fetchPolicy, isWebsiteHost, shouldMeasure } from './policy'
+
+describe('analytics policy', () => {
+  it('enables opt-out only for Japan in production', () => {
+    expect(analyticsPolicy('JP', true)).toEqual({ enabled: true, requiresConsent: false })
+    for (const country of ['DE', 'US', 'jp', '', null]) {
+      expect(analyticsPolicy(country, true)).toEqual({ enabled: true, requiresConsent: true })
+    }
+    expect(analyticsPolicy('JP', false).enabled).toBe(false)
+  })
+  it('always respects a saved rejection, including in Japan', () => {
+    expect(shouldMeasure(analyticsPolicy('JP', true), false)).toBe(false)
+    expect(shouldMeasure(analyticsPolicy('JP', true), undefined)).toBe(true)
+    expect(shouldMeasure(analyticsPolicy('DE', true), undefined)).toBe(false)
+    expect(shouldMeasure(analyticsPolicy('DE', true), true)).toBe(true)
+    expect(shouldMeasure(analyticsPolicy('JP', false), true)).toBe(false)
+  })
+  it('does not activate on local, preview, docs or editor hosts', () => {
+    for (const url of [
+      'http://127.0.0.1:4340/ja',
+      'https://preview.vercel.app',
+      'https://docs.shumoku.dev',
+      'https://editor.shumoku.dev',
+      'https://www.shumoku.dev.evil.test',
+      'http://www.shumoku.dev',
+    ]) {
+      expect(isWebsiteHost(new URL(url), true)).toBe(false)
+    }
+    expect(isWebsiteHost(new URL('https://www.shumoku.dev'), false)).toBe(false)
+    expect(isWebsiteHost(new URL('https://www.shumoku.dev'), true)).toBe(true)
+  })
+  it('fails closed on network errors and malformed policy responses', async () => {
+    const fallback = { enabled: false, requiresConsent: true }
+    const fetcher = vi.fn<typeof fetch>()
+    fetcher.mockRejectedValueOnce(new Error('timeout'))
+    expect(await fetchPolicy(fetcher)).toEqual(fallback)
+    fetcher.mockResolvedValueOnce(Response.json({ enabled: true }))
+    expect(await fetchPolicy(fetcher)).toEqual(fallback)
+    fetcher.mockResolvedValueOnce(new Response('', { status: 500 }))
+    expect(await fetchPolicy(fetcher)).toEqual(fallback)
+    fetcher.mockResolvedValueOnce(Response.json({ enabled: true, requiresConsent: false }))
+    expect(await fetchPolicy(fetcher)).toEqual({ enabled: true, requiresConsent: false })
+    expect(fetcher).toHaveBeenCalledWith(
+      '/api/analytics-policy',
+      expect.objectContaining({ cache: 'no-store', signal: expect.any(AbortSignal) }),
+    )
+  })
+})

--- a/apps/website/src/lib/analytics/policy.ts
+++ b/apps/website/src/lib/analytics/policy.ts
@@ -1,0 +1,46 @@
+export const measurementId = 'G-SHX2VE8F8F'
+export interface AnalyticsPolicy {
+  enabled: boolean
+  requiresConsent: boolean
+}
+
+export function isWebsiteHost(url: URL, productionBuild: boolean): boolean {
+  return (
+    productionBuild &&
+    url.protocol === 'https:' &&
+    ['www.shumoku.dev', 'shumoku.dev'].includes(url.hostname)
+  )
+}
+
+/** JP is the only opt-out jurisdiction configured; unknown locations fail closed. */
+export function analyticsPolicy(country: string | null, production: boolean): AnalyticsPolicy {
+  return { enabled: production, requiresConsent: country !== 'JP' }
+}
+
+export function shouldMeasure(policy: AnalyticsPolicy, savedChoice: boolean | undefined) {
+  return policy.enabled && (savedChoice ?? !policy.requiresConsent)
+}
+
+export async function fetchPolicy(fetcher: typeof fetch): Promise<AnalyticsPolicy> {
+  try {
+    const response = await fetcher('/api/analytics-policy', {
+      cache: 'no-store',
+      signal: AbortSignal.timeout(1500),
+    })
+    if (!response.ok) throw new Error('Policy unavailable')
+    const value: unknown = await response.json()
+    if (
+      !value ||
+      typeof value !== 'object' ||
+      !('enabled' in value) ||
+      typeof value.enabled !== 'boolean' ||
+      !('requiresConsent' in value) ||
+      typeof value.requiresConsent !== 'boolean'
+    ) {
+      throw new Error('Invalid policy')
+    }
+    return { enabled: value.enabled, requiresConsent: value.requiresConsent }
+  } catch {
+    return { enabled: false, requiresConsent: true }
+  }
+}

--- a/apps/website/src/lib/analytics/translations.ts
+++ b/apps/website/src/lib/analytics/translations.ts
@@ -1,0 +1,40 @@
+import type { Translation } from 'vanilla-cookieconsent'
+
+export function consentTranslation(locale: 'en' | 'ja'): Translation {
+  const ja = locale === 'ja'
+  return {
+    consentModal: {
+      title: ja ? 'アクセス解析について' : 'Website analytics',
+      description: ja
+        ? 'サイト改善のため、Google AnalyticsとVercel Web Analyticsを使用します。許可するとGoogleの解析用Cookieを使用し、利用情報をGoogleとVercelへ送信します。拒否してもサイトの機能は変わりません。'
+        : 'We use Google Analytics and Vercel Web Analytics to improve this site. Allowing analytics enables Google analytics cookies and sends usage information to Google and Vercel. Rejecting does not affect site functionality.',
+      acceptAllBtn: ja ? '許可する' : 'Allow analytics',
+      acceptNecessaryBtn: ja ? '拒否する' : 'Reject analytics',
+      showPreferencesBtn: ja ? '設定を見る' : 'Preferences',
+      footer: `<a href="/${locale}/privacy">${ja ? 'プライバシーについて' : 'Privacy information'}</a>`,
+    },
+    preferencesModal: {
+      title: ja ? 'アクセス解析の設定' : 'Analytics preferences',
+      acceptAllBtn: ja ? '解析を許可' : 'Allow analytics',
+      acceptNecessaryBtn: ja ? '解析を拒否' : 'Reject analytics',
+      savePreferencesBtn: ja ? '設定を保存' : 'Save preferences',
+      closeIconLabel: ja ? '閉じる' : 'Close',
+      sections: [
+        {
+          title: ja ? 'サイトの基本設定' : 'Site preferences',
+          description: ja
+            ? '言語・表示テーマ・解析の選択を保存します。'
+            : 'Stores your language, display theme and analytics choices.',
+          linkedCategory: 'necessary',
+        },
+        {
+          title: 'Google Analytics / Vercel Web Analytics',
+          description: ja
+            ? '閲覧ページ、参照元、端末情報などをGoogleとVercelへ送信します。日本からのアクセスでは初期状態で有効です。ここからいつでも停止できます。停止時は計測を止めるためページを再読み込みします。'
+            : 'Sends page visits, referrers and device information to Google and Vercel. Enabled by default for visits from Japan. You can disable it here at any time; disabling reloads the page to stop tracking.',
+          linkedCategory: 'analytics',
+        },
+      ],
+    },
+  }
+}

--- a/apps/website/src/lib/analytics/vercel.test.ts
+++ b/apps/website/src/lib/analytics/vercel.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const injectAnalytics = vi.hoisted(() => vi.fn())
+vi.mock('@vercel/analytics/sveltekit', () => ({ injectAnalytics }))
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+it('does not load until permitted and initializes only once', async () => {
+  const client = await import('./vercel')
+  client.setVercelAnalytics(false)
+  expect(injectAnalytics).not.toHaveBeenCalled()
+  client.setVercelAnalytics(true)
+  client.setVercelAnalytics(true)
+  expect(injectAnalytics).toHaveBeenCalledTimes(1)
+  expect(injectAnalytics).toHaveBeenCalledWith(
+    expect.objectContaining({ mode: 'production', debug: false }),
+  )
+})
+
+it('redacts query/hash and blocks events after withdrawal', async () => {
+  const client = await import('./vercel')
+  const event = { type: 'pageview' as const, url: 'https://www.shumoku.dev/en?secret=value#input' }
+  client.setVercelAnalytics(true)
+  expect(client.filterVercelEvent(event)?.url).toBe('https://www.shumoku.dev/en')
+  expect(event.url).toContain('secret')
+  expect(client.filterVercelEvent({ type: 'event', url: event.url })).toBeNull()
+  expect(client.filterVercelEvent({ type: 'pageview', url: 'invalid' })).toBeNull()
+  client.setVercelAnalytics(false)
+  expect(client.filterVercelEvent(event)).toBeNull()
+})

--- a/apps/website/src/lib/analytics/vercel.ts
+++ b/apps/website/src/lib/analytics/vercel.ts
@@ -1,0 +1,24 @@
+import { type BeforeSendEvent, injectAnalytics } from '@vercel/analytics/sveltekit'
+
+let enabled = false
+let started = false
+
+export function filterVercelEvent(event: BeforeSendEvent): BeforeSendEvent | null {
+  if (!enabled || event.type !== 'pageview') return null
+  try {
+    const url = new URL(event.url)
+    url.search = ''
+    url.hash = ''
+    return { ...event, url: url.toString() }
+  } catch {
+    return null
+  }
+}
+
+/** Called only after the shared production/region/consent policy has been resolved. */
+export function setVercelAnalytics(allowed: boolean) {
+  enabled = allowed
+  if (!allowed || started) return
+  injectAnalytics({ mode: 'production', debug: false, beforeSend: filterVercelEvent })
+  started = true
+}

--- a/apps/website/src/lib/layout/SiteFooter.svelte
+++ b/apps/website/src/lib/layout/SiteFooter.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import AnalyticsSettings from '$lib/analytics/AnalyticsSettings.svelte'
   import { docsUrl, editorOrigin, type Locale } from '$lib/site'
 
   let { locale }: { locale: Locale } = $props()
@@ -37,6 +38,10 @@
     <div>
       <a href={`/${locale}`} class="footer-name">Shumoku</a>
       <p>AGPL-3.0 · Open source</p>
+      <div class="privacy-links">
+        <a href={`/${locale}/privacy`}>{locale === 'ja' ? 'プライバシー' : 'Privacy'}</a>
+        <AnalyticsSettings {locale} />
+      </div>
     </div>
     {#each columns as column}
       <nav aria-label={column.title}>
@@ -62,6 +67,14 @@
   .footer-name {
     font-size: 1.25rem;
     font-weight: 600;
+  }
+  .privacy-links {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    margin-top: 1rem;
+    font-size: 0.8125rem;
+    color: var(--site-muted);
   }
   p {
     color: var(--site-muted);

--- a/apps/website/src/lib/site.test.ts
+++ b/apps/website/src/lib/site.test.ts
@@ -18,7 +18,9 @@ describe('site page registry', () => {
   it.each(locales)('uses localized labels and links for %s', (locale) => {
     const links = siteNavigation(locale)
     expect(links[0]?.href).toBe(docsUrl(locale))
-    for (const entry of sitePages.filter((entry) => entry.path)) {
+    for (const entry of sitePages.filter(
+      (entry) => entry.path && !('navigation' in entry && !entry.navigation),
+    )) {
       expect(links).toContainEqual({
         href: `/${locale}${entry.path}`,
         label: entry.label[locale],

--- a/apps/website/src/lib/site.ts
+++ b/apps/website/src/lib/site.ts
@@ -12,13 +12,19 @@ export const sitePages = [
   { path: '/playground', label: { en: 'Playground', ja: 'Playground' }, mode: 'workspace' },
   { path: '/about', label: { en: 'About', ja: 'Shumokuについて' }, mode: 'content' },
   { path: '/support', label: { en: 'Support', ja: 'サポート' }, mode: 'content' },
+  {
+    path: '/privacy',
+    label: { en: 'Privacy', ja: 'プライバシー' },
+    mode: 'content',
+    navigation: false,
+  },
 ] as const
 
 export function siteNavigation(locale: Locale) {
   return [
     { href: docsUrl(locale), label: 'Docs', path: null },
     ...sitePages
-      .filter((entry) => entry.path)
+      .filter((entry) => entry.path && !('navigation' in entry && !entry.navigation))
       .map((entry) => ({
         href: `/${locale}${entry.path}`,
         label: entry.label[locale],

--- a/apps/website/src/routes/[lang=lang]/+layout.svelte
+++ b/apps/website/src/routes/[lang=lang]/+layout.svelte
@@ -2,6 +2,7 @@
   import '../website.css'
   import type { Snippet } from 'svelte'
   import { page } from '$app/state'
+  import Analytics from '$lib/analytics/Analytics.svelte'
   import SiteFooter from '$lib/layout/SiteFooter.svelte'
   import SiteHeader from '$lib/layout/SiteHeader.svelte'
   import { sitePages } from '$lib/site'
@@ -18,6 +19,7 @@
 </script>
 
 <div class="site-shell">
+  <Analytics locale={data.lang} />
   <a class="sr-only focus:not-sr-only" href="#main"
     >{data.lang === 'ja' ? '本文へ' : 'Skip to content'}</a
   >

--- a/apps/website/src/routes/[lang=lang]/privacy/+page.svelte
+++ b/apps/website/src/routes/[lang=lang]/privacy/+page.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import AnalyticsSettings from '$lib/analytics/AnalyticsSettings.svelte'
+  import PageHeading from '$lib/layout/PageHeading.svelte'
+  import PageMeta from '$lib/PageMeta.svelte'
+  import type { PageData } from './$types'
+
+  let { data }: { data: PageData } = $props()
+  const ja = $derived(data.lang === 'ja')
+  const title = $derived(ja ? 'プライバシーとアクセス解析' : 'Privacy and website analytics')
+  const description = $derived(
+    ja
+      ? 'このウェブサイトの解析と保存される設定について。'
+      : 'Analytics and preferences stored by this website.',
+  )
+</script>
+<PageMeta {title} {description} />
+<main id="main">
+  <PageHeading {title} {description} />
+  <div class="site-container privacy-content">
+    {#if ja}
+      <h2>Google Analytics</h2>
+      <p>
+        Shumokuのウェブサイトでは、利用状況の把握と改善のためGoogle Analytics
+        4（G-SHX2VE8F8F）を利用します。有効な場合、閲覧URL、参照元、ブラウザ・端末情報、操作イベント、Cookieによる識別子などがGoogleへ送信されます。通信にはIPアドレスが伴います。
+      </p>
+      <p>
+        この実装ではGoogleシグナルと広告パーソナライズを無効にし、氏名・メールアドレス・Playgroundの入力内容を独自イベントとして送信しません。URLには秘密情報を含めないでください。
+      </p>
+      <h2>Vercel Web Analytics</h2>
+      <p>
+        Vercel Web
+        Analyticsでも閲覧状況を計測します。解析用Cookieは使用せず、ページ、参照元、端末や地域などの情報を扱います。この実装では送信する閲覧URLからクエリとハッシュを除き、独自イベントは送信しません。下記の地域判定と許可・拒否は両方の解析に適用します。
+        <a href="https://vercel.com/docs/analytics/privacy-policy">Vercelの解析とプライバシー</a>
+      </p>
+      <h2>地域による動作と選択</h2>
+      <p>
+        VercelがIPアドレスから推定した国情報を使います。日本からのアクセスでは、拒否の保存がなければ解析を有効にします。それ以外、または国が不明な場合は、許可するまでGoogleの解析タグを読み込みません。地域判定の通信に失敗した場合も計測しません。
+      </p>
+      <p>
+        許可・拒否の選択はこのサイトに180日間保存します。日本でも下の設定から拒否できます。解析を停止すると、タグによる計測を終了するためページを再読み込みします。拒否してもサイトの機能は利用できます。
+      </p>
+      <h2>保存する情報</h2>
+      <p>
+        解析用Cookie（_ga、_ga_SHX2VE8F8F）の有効期間は最大180日です。同意設定はshumoku_consentに保存します。ほかに、手動で選んだ言語をCookie、表示テーマをlocalStorageに保存します。これらの設定は解析への同意とは独立しています。
+      </p>
+      <p>
+        Googleによる情報の利用については、<a href="https://policies.google.com/privacy"
+          >Googleのプライバシーポリシー</a
+        >と<a href="https://policies.google.com/technologies/partner-sites"
+          >Googleのサービスを使用するサイトからの情報の扱い</a
+        >をご確認ください。
+      </p>
+      <p>
+        この説明はwww.shumoku.devとshumoku.devのHPに適用します。DocsとEditorには、この変更によるGA4の追加は行っていません。
+      </p>
+      <p>お問い合わせ：<a href="mailto:contact@shumoku.dev">contact@shumoku.dev</a></p>
+    {:else}
+      <h2>Google Analytics</h2>
+      <p>
+        The Shumoku website uses Google Analytics 4 (G-SHX2VE8F8F) to understand usage and improve
+        the site. When enabled, page URLs, referrers, browser and device information, interaction
+        events and cookie identifiers are sent to Google. Network requests include your IP address.
+      </p>
+      <p>
+        This integration disables Google signals and advertising personalization. It does not send
+        names, email addresses or Playground input as custom events. Do not include confidential
+        information in URLs.
+      </p>
+      <h2>Vercel Web Analytics</h2>
+      <p>
+        We also use Vercel Web Analytics for page visits, referrers, device and regional
+        information, without analytics cookies. This integration removes query strings and hashes
+        from page URLs and sends no custom events. The regional policy and your analytics choice
+        below apply to both services.
+        <a href="https://vercel.com/docs/analytics/privacy-policy"
+          >Vercel analytics privacy information</a
+        >
+      </p>
+      <h2>Regional behavior and your choice</h2>
+      <p>
+        We use the country estimated by Vercel from your IP address. For visits from Japan,
+        analytics is enabled unless a rejection has been saved. For other or unknown countries, the
+        Google analytics tag is not loaded until you allow it. If the region request fails,
+        analytics remains disabled.
+      </p>
+      <p>
+        Your choice is saved on this site for 180 days. You can reject analytics below, including in
+        Japan. Disabling analytics reloads the page to stop the loaded tag. Rejecting does not
+        affect website functionality.
+      </p>
+      <h2>Stored preferences</h2>
+      <p>
+        Analytics cookies (_ga and _ga_SHX2VE8F8F) expire after at most 180 days. The
+        shumoku_consent cookie stores your analytics choice. Your manually selected language is also
+        saved in a cookie, and the display theme in localStorage, independently of analytics
+        consent.
+      </p>
+      <p>
+        See <a href="https://policies.google.com/privacy">Google’s Privacy Policy</a> and
+        <a href="https://policies.google.com/technologies/partner-sites"
+          >how Google uses information from partner sites</a
+        >
+        for details of its data processing.
+      </p>
+      <p>
+        This notice covers the homepage application on www.shumoku.dev and shumoku.dev. This
+        integration does not add GA4 to Docs or Editor.
+      </p>
+      <p>Questions: <a href="mailto:contact@shumoku.dev">contact@shumoku.dev</a></p>
+    {/if}
+    <AnalyticsSettings locale={data.lang} />
+  </div>
+</main>
+<style>
+  .privacy-content {
+    padding-bottom: 4rem;
+  }
+  h2 {
+    margin-top: 2rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+  p {
+    margin-top: 1rem;
+    max-width: 48rem;
+    line-height: 1.9;
+  }
+  a {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+</style>

--- a/apps/website/src/routes/[lang=lang]/privacy/+page.ts
+++ b/apps/website/src/routes/[lang=lang]/privacy/+page.ts
@@ -1,0 +1,2 @@
+export const prerender = true
+export const entries = () => [{ lang: 'en' }, { lang: 'ja' }]

--- a/apps/website/src/routes/api/analytics-policy/+server.ts
+++ b/apps/website/src/routes/api/analytics-policy/+server.ts
@@ -1,0 +1,17 @@
+import { env } from '$env/dynamic/private'
+import { analyticsPolicy } from '$lib/analytics/policy'
+import type { RequestHandler } from './$types'
+
+export const prerender = false
+export const GET: RequestHandler = ({ request }) => {
+  const production = env.VERCEL === '1' && env.VERCEL_ENV === 'production'
+  const country = production ? request.headers.get('x-vercel-ip-country') : null
+  return Response.json(analyticsPolicy(country, production), {
+    headers: {
+      'cache-control': 'private, no-store',
+      'cdn-cache-control': 'no-store',
+      'vercel-cdn-cache-control': 'no-store',
+      vary: 'x-vercel-ip-country',
+    },
+  })
+}

--- a/bun.lock
+++ b/bun.lock
@@ -168,8 +168,10 @@
         "@shumoku/renderer-svg": "workspace:*",
         "@shumoku/site-i18n": "workspace:*",
         "@shumoku/website-content": "workspace:*",
+        "@vercel/analytics": "^2.0.1",
         "clsx": "^2.1.1",
         "tailwind-merge": "^3.6.0",
+        "vanilla-cookieconsent": "3.1.0",
       },
       "devDependencies": {
         "@sveltejs/adapter-vercel": "^6.3.3",
@@ -992,6 +994,8 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@vercel/analytics": ["@vercel/analytics@2.0.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "nuxt": ">= 3", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "nuxt", "react", "svelte", "vue", "vue-router"] }, "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g=="],
 
     "@vercel/nft": ["@vercel/nft@1.10.2", "", { "dependencies": { "@mapbox/node-pre-gyp": "^2.0.0", "@rollup/pluginutils": "^5.1.3", "acorn": "^8.6.0", "acorn-import-attributes": "^1.9.5", "async-sema": "^3.1.1", "bindings": "^1.4.0", "estree-walker": "2.0.2", "glob": "^13.0.0", "graceful-fs": "^4.2.9", "node-gyp-build": "^4.2.2", "picomatch": "^4.0.2", "resolve-from": "^5.0.0" }, "bin": { "nft": "out/cli.js" } }, "sha512-w+WyX5Ulmj4dtTZrxaulqrjaLZHSbnPzx75SJsTNYmotKsqn1JlLnDJa+lz5hn90HJofhl/2MAtw0mCrgM3qYw=="],
 
@@ -1994,6 +1998,8 @@
     "unstorage": ["unstorage@1.17.5", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.10", "lru-cache": "^11.2.7", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg=="],
 
     "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
+
+    "vanilla-cookieconsent": ["vanilla-cookieconsent@3.1.0", "", {}, "sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 


### PR DESCRIPTION
## Summary
- Add GA4 G-SHX2VE8F8F and official @vercel/analytics SvelteKit integration to the HP only.
- Preserve static pages; defer analytics until after load/idle and resolve production-only regional policy once.
- Japan defaults to analytics on unless rejected; other/unknown countries require consent. Policy failures and local/preview environments do not track.
- Share consent controls across both providers, redact Vercel page URL query/hash, prevent duplicate SDK initialization, and add localized privacy/settings UI.

## Validation
- 27 website tests passed
- Website production build and typecheck passed
- Repository pre-commit lint and typecheck passed
- Browser visual QA and live ingestion are not yet verified

## Before production rollout
- Enable Web Analytics in the existing HP Vercel project dashboard (not performed by this PR).
- Verify GA4 enhanced measurement history-change page views; no manual pageview tracking is added.
- Verify initial/SPA page views and consent withdrawal after deployment.
- Review privacy notice and GA property retention/data-sharing settings.

No deployment or paid plan changes have been made.