### PR TITLE
feat(helm): 初期管理者パスワードをvaluesから指定可能にする

### DIFF
--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Render default configuration
         run: helm template shumoku apps/server/chart/shumoku > /dev/null
+
+      - name: Validate bootstrap administrator configuration
+        run: bash apps/server/chart/shumoku/tests/bootstrap-admin.sh

--- a/apps/server/chart/shumoku/templates/_helpers.tpl
+++ b/apps/server/chart/shumoku/templates/_helpers.tpl
@@ -58,3 +58,25 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/* Resolve a bootstrap Secret and reject ambiguous/invalid chart-managed input. */}}
+{{- define "shumoku.bootstrapAdminSecretName" -}}
+{{- $password := .Values.auth.bootstrapAdminPassword -}}
+{{- if not (kindIs "string" $password) -}}
+{{- fail "auth.bootstrapAdminPassword must be a string" -}}
+{{- end -}}
+{{- if and .Values.auth.existingSecret $password -}}
+{{- fail "Set only one of auth.existingSecret or auth.bootstrapAdminPassword" -}}
+{{- end -}}
+{{- if $password -}}
+{{- if lt (len $password) 8 -}}
+{{- fail "auth.bootstrapAdminPassword must be at least 8 characters" -}}
+{{- end -}}
+{{- if not .Values.auth.passwordKey -}}
+{{- fail "auth.passwordKey must not be empty" -}}
+{{- end -}}
+{{- printf "%s-bootstrap-admin" (include "shumoku.fullname" . | trunc 47 | trimSuffix "-") -}}
+{{- else -}}
+{{- .Values.auth.existingSecret -}}
+{{- end -}}
+{{- end -}}

--- a/apps/server/chart/shumoku/templates/bootstrap-admin-secret.yaml
+++ b/apps/server/chart/shumoku/templates/bootstrap-admin-secret.yaml
@@ -1,0 +1,12 @@
+{{- $bootstrapSecret := include "shumoku.bootstrapAdminSecretName" . -}}
+{{- if .Values.auth.bootstrapAdminPassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $bootstrapSecret }}
+  labels:
+    {{- include "shumoku.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.auth.passwordKey | quote }}: {{ .Values.auth.bootstrapAdminPassword | b64enc | quote }}
+{{- end }}

--- a/apps/server/chart/shumoku/templates/deployment.yaml
+++ b/apps/server/chart/shumoku/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $bootstrapSecret := include "shumoku.bootstrapAdminSecretName" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,7 +54,7 @@ spec:
               value: {{ .Values.auth.secureCookies | quote }}
             - name: SHUMOKU_TRUST_PROXY
               value: {{ .Values.auth.trustProxy | quote }}
-            {{- if .Values.auth.existingSecret }}
+            {{- if $bootstrapSecret }}
             - name: SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE
               value: /run/secrets/shumoku-admin/password
             {{- end }}
@@ -89,7 +90,7 @@ spec:
             {{- end }}
             - name: tmp
               mountPath: /tmp
-            {{- if .Values.auth.existingSecret }}
+            {{- if $bootstrapSecret }}
             - name: bootstrap-admin
               mountPath: /run/secrets/shumoku-admin
               readOnly: true
@@ -109,10 +110,10 @@ spec:
         {{- end }}
         - name: tmp
           emptyDir: {}
-        {{- if .Values.auth.existingSecret }}
+        {{- if $bootstrapSecret }}
         - name: bootstrap-admin
           secret:
-            secretName: {{ .Values.auth.existingSecret }}
+            secretName: {{ $bootstrapSecret | quote }}
             items:
               - key: {{ .Values.auth.passwordKey }}
                 path: password

--- a/apps/server/chart/shumoku/tests/bootstrap-admin.sh
+++ b/apps/server/chart/shumoku/tests/bootstrap-admin.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+chart=$(cd "$(dirname "$0")/.." && pwd)
+render() { helm template test "$chart" "$@"; }
+# All values below are public test fixtures, never production passwords.
+default=$(render)
+! grep -q 'kind: Secret' <<< "$default"
+! grep -q 'SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE' <<< "$default"
+existing=$(render --set auth.existingSecret=external-admin)
+! grep -q 'kind: Secret' <<< "$existing"
+grep -q 'secretName: "external-admin"' <<< "$existing"
+grep -q 'SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE' <<< "$existing"
+managed=$(render --set-string auth.bootstrapAdminPassword=fixture-password --set auth.passwordKey=custom-key)
+grep -q 'kind: Secret' <<< "$managed"
+grep -q 'name: test-shumoku-bootstrap-admin' <<< "$managed"
+grep -q 'secretName: "test-shumoku-bootstrap-admin"' <<< "$managed"
+grep -q '"custom-key": "Zml4dHVyZS1wYXNzd29yZA=="' <<< "$managed"
+grep -q 'key: custom-key' <<< "$managed"
+grep -q 'SHUMOKU_BOOTSTRAP_ADMIN_PASSWORD_FILE' <<< "$managed"
+! grep -q 'fixture-password' <<< "$managed"
+long=$(render --set-string auth.bootstrapAdminPassword=fixture-password --set fullnameOverride=abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk)
+grep -q 'secretName: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstu-bootstrap-admin"' <<< "$long"
+expect_failure() {
+  local message=$1; shift
+  local output
+  if output=$(render "$@" 2>&1); then
+    echo 'Expected helm template to fail' >&2; exit 1
+  fi
+  grep -q "$message" <<< "$output"
+}
+expect_failure 'Set only one' --set auth.existingSecret=external-admin --set-string auth.bootstrapAdminPassword=fixture-password
+expect_failure 'at least 8' --set-string auth.bootstrapAdminPassword=short
+expect_failure 'must be a string' --set auth.bootstrapAdminPassword=12345678
+expect_failure 'must not be empty' --set-string auth.bootstrapAdminPassword=fixture-password --set auth.passwordKey=
+echo 'Bootstrap administrator rendering checks passed'

--- a/apps/server/chart/shumoku/values.yaml
+++ b/apps/server/chart/shumoku/values.yaml
@@ -62,8 +62,12 @@ demoMode: false
 
 auth:
   # Existing Kubernetes Secret containing the one-time bootstrap administrator
-  # password. Required for a fresh non-loopback deployment.
+  # password. Use this OR bootstrapAdminPassword for a fresh deployment.
   existingSecret: ""
+  # Create a chart-managed Secret for first-time setup (at least 8 characters).
+  # Values are retained in Helm release metadata. Prefer existingSecret when possible.
+  # Changing this value does not reset an already configured administrator.
+  bootstrapAdminPassword: ""
   passwordKey: admin-password
   secureCookies: false
   trustProxy: false

--- a/apps/server/docs/helm-chart.md
+++ b/apps/server/docs/helm-chart.md
@@ -84,7 +84,8 @@ config:
 
 | Parameter | Description | Default |
 |---|---|---|
-| `auth.existingSecret` | 初回管理者パスワードを持つ既存Secret名（新規環境では必須） | `""` |
+| `auth.existingSecret` | 初回管理者パスワードを持つ既存Secret名（`auth.bootstrapAdminPassword`と排他） | `""` |
+| `auth.bootstrapAdminPassword` | ChartでSecretを作る場合の初回管理者パスワード（8文字以上）。設定済みの管理者には適用しない | `""` |
 | `auth.passwordKey` | Secret内のパスワードkey | `admin-password` |
 | `auth.secureCookies` | 管理者Cookieへ常に`Secure`を付与 | `false` |
 | `auth.trustProxy` | proxyのクライアントIPヘッダーをログイン制限に利用 | `false` |
@@ -110,8 +111,8 @@ config:
 
 ### 初回管理者Secret
 
-新しい環境では、Chartをインストールする前に管理者パスワードをSecretとして作成します。
-SecretはConfigMapやvaluesファイルへ平文で書かず、既存Secretの名前だけをChartへ渡します。
+新しい環境では初回管理者パスワードを指定します。推奨する方式は、Chartの外でSecretを作成し、
+その名前だけを`auth.existingSecret`へ渡す方法です。
 
 ```bash
 kubectl create namespace shumoku
@@ -129,6 +130,37 @@ helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku \
 `demoMode: true`はサンプルデータ投入だけを行い、認証を無効化しません。公開デモを構築する
 場合は、visitorごとの使い捨てreleaseと固有の管理者Secretを外部ランチャーから作成し、
 通常のログインフローを利用してください。
+
+### valuesから初回管理者パスワードを指定する
+
+簡易デプロイでは、代わりに`auth.bootstrapAdminPassword`を指定できます。
+Chartが`<release fullname>-bootstrap-admin`というSecretを作成し、既存Secret方式と同じ
+読み取り専用ファイルとしてPodにマウントします。長いfullnameはSecret名の63文字制限に合わせて短縮します。
+
+```yaml
+# values.local.yaml (Gitにはコミットしない)
+auth:
+  existingSecret: ""
+  bootstrapAdminPassword: "replace-with-a-unique-long-password"
+  passwordKey: admin-password
+```
+
+```bash
+helm upgrade --install shumoku oci://ghcr.io/konoe-akitoshi/charts/shumoku \
+  --namespace shumoku --create-namespace -f values.local.yaml
+```
+
+この項目を含むchartバージョンを使用してください。パスワードは8文字以上の文字列を指定し、
+`auth.existingSecret`との同時指定はできません。どちらも未指定の場合、ChartはSecretを作成せず、
+新規の非loopback環境ではアプリ側で初期パスワードが必要になります。
+
+**初回の管理者設定にのみ有効です。** 値を変更してupgradeやPod再起動を行っても、
+DBに設定済みのパスワードは上書きしません。パスワード変更はShumokuの管理者設定から行います。
+永続データを削除すると新規環境になり、その時点の初期パスワードが再び使われます。
+
+valuesと生成SecretはHelmリリース情報に保存されます。Secretのbase64は暗号化ではありません。
+valuesファイルや`helm template`の出力を共有・コミットしないでください。
+外部のSecret管理を使う環境では`auth.existingSecret`を選択してください。
 
 ### Ingress を有効にして TLS 設定
 


### PR DESCRIPTION
## 変更内容

公式Helm chartの`auth.bootstrapAdminPassword`から、初回管理者パスワードを指定できるようにします。非公開のvaluesファイルに値を設定すると、chartがSecretを作成し、既存の初期パスワード用ファイルとしてPodにマウントします。

- 既存の`auth.existingSecret`方式と既定の動作を維持
- パスワードと既存Secretの同時指定、文字列以外の入力、短すぎるパスワード、空のSecretキーを拒否
- カスタムSecretキーと、長いrelease名に対応したSecret名の生成
- 両方の指定方法、Helmリリース情報への保存、初回のみ有効であることをドキュメントに記載
- Helm Chart CIに、生成結果と不正な設定の検証を追加

**すでにDBに設定済みの管理者パスワードは、valuesの変更やupgradeで上書きしません。** アプリ本体の認証処理とリリースバージョンは変更していません。

## 検証

- `helm lint apps/server/chart/shumoku`
- `bash apps/server/chart/shumoku/tests/bootstrap-admin.sh`
  - 既定値、既存Secret、chart生成Secret、カスタムキー、長い名前、不正入力を確認
- 変更ファイルに対して`bun x biome check --no-errors-on-unmatched`を実行（今回のYAML・Helmテンプレート・シェル・MarkdownはBiomeの対象形式外）
- `git diff --check`
- GitHub Actionsのchart検証・lint・型チェック・テスト・ビルド・スキャンが成功

このchart変更について、実クラスタへの適用や初回ログインは実施していません。
