### PR TITLE
feat(website): Meetup #2告知とブランド配色の整理

### DIFF
--- a/apps/website/src/lib/announcement.test.ts
+++ b/apps/website/src/lib/announcement.test.ts
@@ -3,13 +3,13 @@ import { announcement, isAnnouncementActive } from './announcement'
 
 describe('announcement expiry', () => {
   it('shows before the end and hides at and after the end in JST', () => {
-    expect(isAnnouncementActive(Date.parse('2026-09-08T10:59:59Z'))).toBe(true)
-    expect(isAnnouncementActive(Date.parse('2026-09-08T11:00:00Z'))).toBe(false)
-    expect(isAnnouncementActive(Date.parse('2026-09-09T00:00:00Z'))).toBe(false)
+    expect(isAnnouncementActive(Date.parse('2027-02-16T10:59:59Z'))).toBe(true)
+    expect(isAnnouncementActive(Date.parse('2027-02-16T11:00:00Z'))).toBe(false)
+    expect(isAnnouncementActive(Date.parse('2027-02-17T00:00:00Z'))).toBe(false)
     expect(isAnnouncementActive(Number.NaN)).toBe(false)
   })
   it('provides the same event destination for both languages', () => {
-    expect(announcement.href).toBe('https://shumoku.connpass.com/event/400597/')
+    expect(announcement.href).toBe('https://shumoku.connpass.com/event/406346/')
     expect(announcement.ja.action).toBeTruthy()
     expect(announcement.en.action).toBeTruthy()
   })

--- a/apps/website/src/lib/announcement.ts
+++ b/apps/website/src/lib/announcement.ts
@@ -2,10 +2,20 @@ export const communityUrl = 'https://shumoku.connpass.com/'
 
 // Keep temporary announcements separate from permanent navigation.
 export const announcement = {
-  href: 'https://shumoku.connpass.com/event/400597/',
-  expiresAt: '2026-09-08T20:00:00+09:00',
-  ja: { title: 'Shumoku Meetup #1', date: '9月8日', venue: '東京・オンライン', action: '参加する' },
-  en: { title: 'Shumoku Meetup #1', date: 'Sep 8', venue: 'Tokyo & online', action: 'Join us' },
+  href: 'https://shumoku.connpass.com/event/406346/',
+  expiresAt: '2027-02-16T20:00:00+09:00',
+  ja: {
+    title: 'Shumoku Meetup #2',
+    date: '2027年2月16日',
+    venue: '東京・オンライン',
+    action: '詳細・参加申込',
+  },
+  en: {
+    title: 'Shumoku Meetup #2',
+    date: 'Feb 16, 2027',
+    venue: 'Tokyo & online',
+    action: 'Event details',
+  },
 }
 
 export function isAnnouncementActive(now: number) {

--- a/apps/website/src/lib/layout/AnnouncementBar.svelte
+++ b/apps/website/src/lib/layout/AnnouncementBar.svelte
@@ -40,8 +40,7 @@
 
 <style>
   .announcement {
-    background: color-mix(in srgb, var(--site-fg) 5%, var(--site-bg));
-    border-bottom: 1px solid var(--site-line);
+    background: var(--ui-surface);
     font-size: 0.875rem;
   }
   .announcement-link {
@@ -56,6 +55,9 @@
   }
   .event {
     font-weight: 500;
+  }
+  .separator {
+    margin-inline: 0.25em;
   }
   .venue {
     color: var(--site-muted);

--- a/apps/website/src/lib/playground/CodeEditor.md
+++ b/apps/website/src/lib/playground/CodeEditor.md
@@ -30,3 +30,10 @@ Ctrl/Meta zoom gestures pass through; events at an edge are not consumed.
 Scrollbar pseudo-elements use the default arrow cursor rather than inheriting
 the textarea's text cursor. The two-axis corner uses the shared track/background
 color so native white corner paint does not show through in dark mode.
+
+## Code surface
+
+The editor uses `--ui-workspace-canvas` without a visible border or its own corner
+radius. The enclosing workbench pane (or CompactWorkbenchExample) owns the radius
+and clips its children's backgrounds with `overflow: clip`, without becoming a
+scroll container. The textarea remains the scroll owner. Internal joins stay square.

--- a/apps/website/src/lib/playground/CodeEditor.svelte
+++ b/apps/website/src/lib/playground/CodeEditor.svelte
@@ -50,6 +50,8 @@
     inline-size: 100%;
     min-block-size: 0;
     padding-block: var(--ui-space-1);
+    background: var(--ui-workspace-canvas);
+    color: var(--site-fg);
     font:
       0.875rem / var(--ui-leading) ui-monospace,
       monospace;

--- a/apps/website/src/lib/playground/Preview.svelte
+++ b/apps/website/src/lib/playground/Preview.svelte
@@ -31,10 +31,7 @@
   })
 </script>
 
-<section
-  class="relative min-h-0 min-w-0 flex-1 overflow-hidden bg-neutral-100 dark:bg-neutral-950"
-  aria-label="Preview"
->
+<section class="relative min-h-0 min-w-0 flex-1 overflow-hidden" aria-label="Preview">
   {#if result?.prepared.resolved}
     <div class="absolute inset-0">
       {#key result}
@@ -66,6 +63,10 @@
 </section>
 
 <style>
+  section {
+    background: var(--ui-workspace-canvas);
+    color: var(--site-fg);
+  }
   section > :global(svg) {
     width: 100%;
     height: 100%;

--- a/apps/website/src/lib/playground/workbench.css
+++ b/apps/website/src/lib/playground/workbench.css
@@ -12,7 +12,7 @@
   --workbench-pane-radius: var(--ui-panel-radius);
   --file-tabs-inset: var(--workbench-inset);
   --file-tab-row-padding: var(--workbench-unit);
-  --workbench-surface: color-mix(in srgb, var(--site-fg) 3%, var(--site-bg));
+  --workbench-surface: var(--ui-workspace-shell);
   display: flex;
   flex-direction: column;
   height: calc(100dvh - var(--site-header-height));
@@ -31,8 +31,7 @@
 .workbench-title h1 { font-size: .875rem; font-weight: 600; line-height: 1.5rem; }
 .workbench-title h1 span { color: var(--site-muted); font-weight: 400; }
 .workbench-panes { flex: 1; min-height: 0; display: grid; grid-template-columns: minmax(0, var(--editor-width)) var(--workbench-inset) minmax(0, 1fr); margin-inline: var(--workbench-margin); }
-.workbench-pane { container: workspace-pane / inline-size; min-width: 0; min-height: 0; display: flex; flex-direction: column; background: var(--site-bg); border: 0; border-radius: var(--workbench-pane-radius); }
-.output-pane > section { border-radius: 0 0 var(--workbench-pane-radius) var(--workbench-pane-radius); }
+.workbench-pane { container: workspace-pane / inline-size; min-width: 0; min-height: 0; display: flex; flex-direction: column; background: var(--ui-workspace-chrome); border: 0; border-radius: var(--workbench-pane-radius); overflow: clip; }
 .workbench-pane-heading { flex-shrink: 0; min-height: 0; padding: var(--workbench-inset); }
 .workbench-sash { display: flex; align-items: center; justify-content: center; cursor: ew-resize; touch-action: none; }
 .workbench-sash::after { content: ''; width: .25rem; height: 1.5rem; border-radius: .25rem; background: var(--site-control-line); }

--- a/apps/website/src/lib/ui/CompactWorkbenchExample.svelte
+++ b/apps/website/src/lib/ui/CompactWorkbenchExample.svelte
@@ -65,8 +65,9 @@
     flex-direction: column;
     block-size: 24rem;
     min-inline-size: 0;
-    background: var(--site-bg);
+    background: var(--ui-workspace-chrome);
     border-radius: var(--ui-panel-radius);
+    overflow: clip;
   }
   .heading {
     flex-shrink: 0;

--- a/apps/website/src/lib/ui/Disclosure.svelte
+++ b/apps/website/src/lib/ui/Disclosure.svelte
@@ -103,7 +103,6 @@
   }
   details[open] > summary.ui-control--ghost {
     background: var(--ui-control-active);
-    border-color: var(--site-control-line);
   }
   summary::-webkit-details-marker {
     display: none;

--- a/apps/website/src/lib/ui/PalettePreview.svelte
+++ b/apps/website/src/lib/ui/PalettePreview.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  const roles = [
+    ['Canvas', '--site-bg'],
+    ['Surface', '--ui-surface'],
+    ['Field / shell', '--ui-field-surface'],
+    ['Hover', '--ui-control-hover'],
+    ['Selected', '--ui-control-active'],
+    ['Primary', '--ui-primary'],
+    ['Text', '--site-fg'],
+    ['Secondary text', '--site-muted'],
+    ['Focus / link', '--site-accent'],
+    ['Error', '--ui-danger'],
+  ]
+</script>
+
+<ul class="palette">
+  {#each roles as [ label, token ]}
+    <li>
+      <span class="swatch" style:background={`var(${token})`} aria-hidden="true"></span>
+      <span>{label}</span>
+      <small>{token}</small>
+    </li>
+  {/each}
+</ul>
+
+<style>
+  .palette {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+    gap: var(--ui-space-4);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+  li {
+    display: grid;
+    gap: var(--ui-space-1);
+    min-inline-size: 0;
+  }
+  .swatch {
+    display: block;
+    block-size: var(--ui-space-12);
+    border-radius: var(--ui-radius);
+  }
+  small {
+    color: var(--site-muted);
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/apps/website/src/lib/ui/README.md
+++ b/apps/website/src/lib/ui/README.md
@@ -119,6 +119,23 @@ References:
 
 ## Visual discipline
 
+Theme colors are owned by `palette.css`, with independently tuned green-neutral
+light/dark palettes. See [palette rationale](../../../../../docs/website-color-palette.md)
+and `/ja/ui-preview#palette-title`. `palette.test.ts` guards intended text contrast.
+
+Current surface policy: ordinary secondary controls, fields, panels and dropdown
+pickers use surface tones rather than visible enclosing borders. `--ui-surface`
+and `--ui-field-surface` derive from the theme; transparent borders retain existing
+geometry. Focus outlines and error borders remain meaningful state indicators.
+Forced-colors restores boundaries, where authored surface differences may disappear.
+The legacy `Panel variant="ruled"` name now means unboxed supporting content;
+Notice's leading rule and page section dividers are not enclosing control borders.
+
+Workspace colors share three roles: `--ui-workspace-shell` (outer frame),
+`--ui-workspace-chrome` (pane headings and tab strip), and `--ui-workspace-canvas`
+(editor, preview backdrop and active file tab). Playground and CompactWorkbenchExample
+consume the same tokens. Diagram rendering still honors the YAML's own theme.
+
 This kit serves a network-documentation tool. Preserve the Shumoku mark and green
 identifier. Filled green identifies primary actions and navigation text markers;
 disabled controls are neutral.

--- a/apps/website/src/lib/ui/control.test.ts
+++ b/apps/website/src/lib/ui/control.test.ts
@@ -6,7 +6,10 @@ describe('control variants', () => {
     const css = readFileSync(new URL('./ui.css', import.meta.url), 'utf8')
     expect(css).not.toContain('.ui-control--link')
     expect(css).toMatch(/\.ui-text-link\s*\{[^}]*text-decoration: underline/)
-    expect(css).toContain('--ui-control-active:')
+    expect(css).toContain("@import './palette.css'")
+    expect(readFileSync(new URL('./palette.css', import.meta.url), 'utf8')).toContain(
+      '--ui-control-active:',
+    )
     expect(css).toContain(":active:not(:disabled):not([aria-disabled='true'])")
     const hoverRules = css.slice(css.indexOf('@media (hover: hover)'))
     expect(hoverRules).toContain('.ui-control--primary:hover')

--- a/apps/website/src/lib/ui/file-tabs.css
+++ b/apps/website/src/lib/ui/file-tabs.css
@@ -25,7 +25,7 @@
   border-radius: var(--ui-radius);
   color: var(--site-muted);
 }
-.ui-file-tab.active { color: var(--site-fg); background: color-mix(in srgb, var(--site-fg) 8%, transparent); }
+.ui-file-tab.active { color: var(--site-fg); background: var(--ui-workspace-canvas); }
 .ui-file-tab button { box-sizing: border-box; font: inherit; background: transparent; color: inherit; border: 0; cursor: pointer; }
 .ui-file-tab [role=tab] {
   display: flex;
@@ -52,6 +52,6 @@
 .ui-file-panel { display: flex; flex: 1; min-height: 0; min-width: 0; }
 .ui-file-empty { padding: var(--ui-space-6); color: var(--site-muted); }
 @media (hover: hover) {
-  .ui-file-tab:not(.active):hover { background: color-mix(in srgb, var(--site-fg) 5%, transparent); }
-  .ui-file-close:hover:not(:disabled) { background: color-mix(in srgb, var(--site-fg) 10%, transparent); }
+  .ui-file-tab:not(.active):hover { background: var(--ui-control-hover); }
+  .ui-file-close:hover:not(:disabled) { background: var(--ui-control-active); }
 }

--- a/apps/website/src/lib/ui/palette.css
+++ b/apps/website/src/lib/ui/palette.css
@@ -1,0 +1,38 @@
+/* Neutral surfaces keep the original green logo distinct. */
+:root {
+  --site-bg: #f5f5f4;
+  --site-fg: #292c2a;
+  --site-muted: #606560;
+  --site-line: #dadcda;
+  --site-control-line: #858b85;
+  --site-accent: #286449;
+  --ui-surface: #eceeeb;
+  --ui-field-surface: #e2e5e1;
+  --ui-control-hover: #d8dcd7;
+  --ui-control-active: #cbd2cb;
+  --ui-primary: #285d43;
+  --ui-primary-hover: #204e38;
+  --ui-primary-active: #193f2e;
+  --ui-on-primary: #f7faf6;
+  --ui-danger: #a4322d;
+  color-scheme: light;
+}
+
+.dark {
+  --site-bg: #1c1f1d;
+  --site-fg: #e1e5e1;
+  --site-muted: #adb5ad;
+  --site-line: #3a403b;
+  --site-control-line: #7d8b7f;
+  --site-accent: #96c8a6;
+  --ui-surface: #272c28;
+  --ui-field-surface: #313832;
+  --ui-control-hover: #3b433c;
+  --ui-control-active: #48544a;
+  --ui-primary: #326b4c;
+  --ui-primary-hover: #387654;
+  --ui-primary-active: #28593f;
+  --ui-on-primary: #f7faf6;
+  --ui-danger: #efa59b;
+  color-scheme: dark;
+}

--- a/apps/website/src/lib/ui/palette.test.ts
+++ b/apps/website/src/lib/ui/palette.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const css = readFileSync(new URL('./palette.css', import.meta.url), 'utf8')
+function luminance(hex: string) {
+  const channels = [1, 3, 5].map((offset) => {
+    const value = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+  })
+  return (channels[0] ?? 0) * 0.2126 + (channels[1] ?? 0) * 0.7152 + (channels[2] ?? 0) * 0.0722
+}
+
+describe('theme palette text contrast', () => {
+  for (const theme of [':root', '.dark']) {
+    it(`${theme}: readable text on the intended surfaces`, () => {
+      const block = css.split(`${theme} {`)[1]?.split('}')[0] ?? ''
+      const colors = Object.fromEntries(
+        [...block.matchAll(/(--[\w-]+):\s*(#[\da-f]{6})/g)].map((match) => [match[1], match[2]]),
+      )
+      const ratio = (foreground: string, background: string) => {
+        const fg = colors[foreground]
+        const bg = colors[background]
+        if (!fg || !bg) throw new Error(`Missing palette role: ${foreground} / ${background}`)
+        const a = luminance(fg)
+        const b = luminance(bg)
+        return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05)
+      }
+      for (const background of [
+        '--site-bg',
+        '--ui-surface',
+        '--ui-field-surface',
+        '--ui-control-hover',
+        '--ui-control-active',
+      ]) {
+        expect(ratio('--site-fg', background)).toBeGreaterThanOrEqual(4.5)
+      }
+      for (const foreground of ['--site-muted', '--site-accent', '--ui-danger']) {
+        for (const background of ['--site-bg', '--ui-surface', '--ui-field-surface']) {
+          expect(ratio(foreground, background)).toBeGreaterThanOrEqual(4.5)
+        }
+      }
+      for (const background of ['--ui-primary', '--ui-primary-hover', '--ui-primary-active']) {
+        expect(ratio('--ui-on-primary', background)).toBeGreaterThanOrEqual(4.5)
+      }
+    })
+  }
+})

--- a/apps/website/src/lib/ui/select-field.css
+++ b/apps/website/src/lib/ui/select-field.css
@@ -18,7 +18,7 @@
   /* Preserve the kit's corner treatment in either opening direction. */
   .ui-select.ui-input:open:not(:disabled) {
     border-radius: var(--ui-radius);
-    border-color: var(--site-accent);
+    background: var(--ui-control-active);
   }
 
   .ui-select.ui-input[aria-invalid='true']:open:not(:disabled) {
@@ -32,9 +32,9 @@
     overflow: auto;
     margin-block: -1px;
     padding: 0;
-    border: 1px solid var(--site-accent);
+    border: 1px solid transparent;
     border-radius: var(--ui-radius);
-    background: var(--site-bg);
+    background: var(--ui-surface);
     color: var(--site-fg);
     font: inherit;
   }
@@ -80,6 +80,7 @@
   }
 
   @media (forced-colors: active) {
+    .ui-select::picker(select) { border-color: ButtonText; }
     .ui-select option:checked {
       background: Highlight;
       color: HighlightText;

--- a/apps/website/src/lib/ui/ui.css
+++ b/apps/website/src/lib/ui/ui.css
@@ -1,6 +1,7 @@
 @import './compact.css';
 @import './scrollbar.css';
 @import './selection-marker.css';
+@import './palette.css';
 
 :root {
   --ui-space-1: 0.25rem;
@@ -19,15 +20,12 @@
   --ui-type-pane-title: var(--ui-type-body);
   --ui-type-heading: 1.75rem;
   --ui-leading: 1.5rem;
-  --ui-primary: #285d43;
-  --ui-primary-hover: color-mix(in srgb, var(--ui-primary) 85%, #000);
-  --ui-primary-active: color-mix(in srgb, var(--ui-primary) 70%, #000);
-  --ui-control-hover: var(--site-line);
-  --ui-control-active: color-mix(in srgb, var(--site-fg) 12%, var(--site-bg));
+  --ui-workspace-shell: var(--ui-field-surface);
+  --ui-workspace-chrome: var(--ui-surface);
+  --ui-workspace-canvas: var(--site-bg);
   --ui-marker-inset: var(--ui-space-1);
   --ui-marker-bg: var(--ui-primary);
   --ui-marker-fg: var(--ui-on-primary);
-  --ui-on-primary: #fff;
 }
 
 .ui-control {
@@ -54,21 +52,21 @@
 }
 .ui-pane-title { margin: 0; padding-inline: var(--ui-compact-label-inset); flex-shrink: 0; font-size: var(--ui-type-pane-title); font-weight: 500; line-height: var(--ui-leading); color: var(--site-fg); white-space: nowrap; }
 .ui-control--primary { background: var(--ui-primary); color: var(--ui-on-primary); }
-.ui-control--secondary { background: var(--site-bg); color: var(--site-fg); border-color: var(--site-control-line); }
+.ui-control--secondary { background: var(--ui-field-surface); color: var(--site-fg); }
 .ui-control--ghost { background: transparent; color: var(--site-fg); }
-.ui-control--ghost:is([aria-current]:not([aria-current='false']), [aria-pressed='true'], [aria-expanded='true']):not(:disabled):not([aria-disabled='true']) { background: var(--ui-control-active); border-color: var(--site-control-line); }
+.ui-control--ghost:is([aria-current]:not([aria-current='false']), [aria-pressed='true'], [aria-expanded='true']):not(:disabled):not([aria-disabled='true']) { background: var(--ui-control-active); }
 .ui-control:is(.ui-control--secondary, .ui-control--ghost):active:not(:disabled):not([aria-disabled='true']) { background: var(--ui-control-active); }
 .ui-control--primary:active:not(:disabled):not([aria-disabled='true']) { background: var(--ui-primary-active); }
 .ui-control--large { min-block-size: var(--ui-control-large); padding-inline: var(--ui-space-6); }
 .ui-control--icon { inline-size: var(--ui-control-height); padding: 0; }
 .ui-control:disabled, .ui-control[aria-disabled='true'] { color: var(--site-muted); cursor: not-allowed; }
 .ui-control--primary:disabled, .ui-control--primary[aria-disabled='true'] { background: var(--site-line); }
-.ui-control--secondary:disabled, .ui-control--secondary[aria-disabled='true'] { border-color: var(--site-line); }
+.ui-control--secondary:disabled, .ui-control--secondary[aria-disabled='true'] { background: var(--ui-surface); }
 .ui-control:focus-visible { outline: 2px solid var(--site-accent); outline-offset: 3px; }
 .ui-control svg { inline-size: 1.25rem; block-size: 1.25rem; flex-shrink: 0; pointer-events: none; }
-.ui-panel { background: var(--site-bg); color: var(--site-fg); border: 1px solid var(--site-line); border-radius: var(--ui-panel-radius); }
+.ui-panel { background: var(--ui-surface); color: var(--site-fg); border: 1px solid transparent; border-radius: var(--ui-panel-radius); }
 .ui-panel--padded { padding: var(--ui-space-4) var(--ui-space-6); }
-.ui-panel--ruled { border-inline: 0; border-bottom: 0; border-radius: 0; }
+.ui-panel--ruled { background: transparent; border: 0; border-radius: 0; }
 .ui-panel--ruled.ui-panel--padded { padding-inline: 0; }
 
 /* Meaning-specific primitives do not inherit the button box. */
@@ -81,7 +79,7 @@
 .ui-field-hint, .ui-field-error { font-size: var(--ui-type-body); line-height: var(--ui-leading); }
 .ui-field-hint { color: var(--site-muted); }
 .ui-field-error { color: var(--ui-danger); }
-.ui-input { box-sizing: border-box; inline-size: 100%; min-inline-size: 0; min-block-size: var(--ui-control-height); padding: var(--ui-space-2) var(--ui-space-4); border: 1px solid var(--site-control-line); border-radius: var(--ui-radius); background: var(--site-bg); color: var(--site-fg); font: inherit; font-size: 1rem; line-height: var(--ui-leading); }
+.ui-input { box-sizing: border-box; inline-size: 100%; min-inline-size: 0; min-block-size: var(--ui-control-height); padding: var(--ui-space-2) var(--ui-space-4); border: 1px solid transparent; border-radius: var(--ui-radius); background: var(--ui-field-surface); color: var(--site-fg); font: inherit; font-size: 1rem; line-height: var(--ui-leading); }
 textarea.ui-input { resize: vertical; min-block-size: 8rem; }
 .ui-input:disabled { background: var(--site-line); color: var(--site-muted); cursor: not-allowed; }
 .ui-input[aria-invalid='true'] { border-color: var(--ui-danger); }
@@ -103,8 +101,9 @@ textarea.ui-input { resize: vertical; min-block-size: 8rem; }
   .ui-control:is(.ui-control--secondary, .ui-control--ghost):hover:not(:active):not(:disabled):not([aria-disabled='true']):not([aria-pressed='true']):not([aria-expanded='true']):not([aria-current]:not([aria-current='false'])) { background: var(--ui-control-hover); }
   .ui-toolbar button:hover:not(:active):not(:disabled) { background: var(--ui-control-hover); }
   .ui-text-link:hover { color: var(--site-fg); }
-  .ui-input:hover:not(:disabled):not([aria-invalid='true']) { border-color: var(--site-fg); }
+  .ui-input:hover:not(:disabled) { background: var(--ui-control-active); }
 }
 @media (forced-colors: active) {
+  .ui-input, .ui-control--secondary, .ui-panel { border-color: ButtonText; }
   .ui-nav-link:focus-visible, .ui-tab-list button:focus-visible { outline: 2px solid Highlight; outline-offset: -2px; }
 }

--- a/apps/website/src/routes/[lang=lang]/ui-preview/+page.svelte
+++ b/apps/website/src/routes/[lang=lang]/ui-preview/+page.svelte
@@ -10,6 +10,7 @@
   import LinkButton from '$lib/ui/LinkButton.svelte'
   import NavLink from '$lib/ui/NavLink.svelte'
   import Notice from '$lib/ui/Notice.svelte'
+  import PalettePreview from '$lib/ui/PalettePreview.svelte'
   import Panel from '$lib/ui/Panel.svelte'
   import SelectField from '$lib/ui/SelectField.svelte'
   import Tabs from '$lib/ui/Tabs.svelte'
@@ -26,7 +27,7 @@
     },
     {
       variant: 'secondary',
-      purpose: 'An alternative action, with a visible boundary.',
+      purpose: 'An alternative action, identified by its surface tone.',
       label: 'Reset changes',
     },
     {
@@ -69,6 +70,14 @@
       A working reference for actions, surfaces and states. Development only.
     </p>
   </header>
+
+  <section class="band" aria-labelledby="palette-title">
+    <div class="section-label">
+      <h2 id="palette-title">Shumoku palette</h2>
+      <p>ロゴの緑を引き立てるニュートラル。テーマ切替でlight／darkを比較できます。</p>
+    </div>
+    <div class="section-content"><PalettePreview /></div>
+  </section>
 
   <section class="band" aria-labelledby="navigation-title">
     <div class="section-label">
@@ -261,7 +270,7 @@
       <Panel variant="ruled">
         <h3>Related information</h3>
         <p>
-          A rule and shared alignment are enough for supporting content. No nested card or
+          Whitespace and shared alignment are enough for supporting content. No nested card or
           decorative icon tile.
         </p>
       </Panel>

--- a/apps/website/src/routes/website.css
+++ b/apps/website/src/routes/website.css
@@ -3,28 +3,10 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-  --site-bg: #fff;
-  --site-fg: #202522;
-  --site-muted: #626b65;
-  --site-line: #e4e8e5;
-  --site-control-line: #849087;
-  --site-accent: #286449;
-  --ui-danger: #b5302a;
-  color-scheme: light;
   --site-width: 1120px;
   --site-header-height: 4.5rem;
   --site-control-size: var(--ui-control-height);
   --site-space: var(--ui-space-2);
-}
-.dark {
-  --site-bg: #141715;
-  --site-fg: #edf0ed;
-  --site-muted: #a1aba4;
-  --site-line: #303832;
-  --site-control-line: #738077;
-  --site-accent: #91c8a5;
-  --ui-danger: #f0a29d;
-  color-scheme: dark;
 }
 body { margin: 0; font-family: ui-sans-serif, system-ui, sans-serif; background: var(--site-bg); color: var(--site-fg); }
 .site-shell { display: flex; flex-direction: column; min-height: 100svh; }

--- a/docs/website-color-palette.md
+++ b/docs/website-color-palette.md
@@ -1,0 +1,39 @@
+# Shumoku website palette
+
+Source of truth: [palette.css](../apps/website/src/lib/ui/palette.css).
+Preview: `/ja/ui-preview#palette-title` (development only).
+
+## Direction
+
+Low-saturation neutrals keep Shumoku's existing green logo distinct rather than
+spreading its hue across large surfaces. The original wordmark uses #14ae67;
+the symbol also includes #13ae67 and #8fc31f. These asset colors remain unchanged.
+Light avoids a pure-white canvas; dark avoids pure black and pure-white body text.
+This is a visual design choice, not a medical claim about eye strain. Ambient light,
+screen brightness, personal preference and readability still matter.
+
+| Role | Light | Dark |
+| --- | --- | --- |
+| Canvas | `#f5f5f4` | `#1c1f1d` |
+| Surface / pane chrome | `#eceeeb` | `#272c28` |
+| Field / workspace shell | `#e2e5e1` | `#313832` |
+| Hover | `#d8dcd7` | `#3b433c` |
+| Selected / pressed | `#cbd2cb` | `#48544a` |
+| Main text | `#292c2a` | `#e1e5e1` |
+| Secondary text | `#606560` | `#adb5ad` |
+| Primary action | `#285d43` | `#326b4c` |
+| Primary text | `#f7faf6` | `#f7faf6` |
+| Link / focus | `#286449` | `#96c8a6` |
+| Error | `#a4322d` | `#efa59b` |
+
+## Ownership and limits
+
+- Both themes use the same semantic roles but independently tuned, opaque colors.
+  Do not add component-local mixtures for these roles.
+- Workspace shell, chrome and canvas alias these roles; active file tabs use canvas.
+- Keep state labels, native semantics and focus indicators; color is not the only cue.
+- Logo assets and rendered diagram themes remain unchanged. YAML controls the diagram's theme.
+- `palette.test.ts` checks intended normal-text pairs at 4.5:1 or greater, including
+  primary hover/active text. This is not an app-wide accessibility compliance claim;
+  disabled opacity, imagery, forced-colors and nested backgrounds need separate review.
+- Future edits must update this table and inspect both themes in UI preview and Playground.

--- a/docs/website-ui-kit-layout.md
+++ b/docs/website-ui-kit-layout.md
@@ -342,6 +342,15 @@ coarse実機・200%文字拡大は今回未検証。editorialハーネスは実�
 通常のoptionのみを使い、SSRに新しいHTML入れ子構造を導入しない。
 開状態は1280/390pxで実表示を確認。これはcoarse実機の検証ではない。
 
+### 通常時の囲い枠から面の色差へ
+
+追加のユーザーレビューを受け、secondaryボタン・入力欄・Panel・dropdown pickerの
+通常時の枠線は透明化し、`--ui-surface`と`--ui-field-surface`で区別する。
+hover/open/pressedは共通の状態色を使う。透明borderは既存寸法を維持するために残す。
+前述の「開状態の境界色」はこの判断で通常状態について撤回した。
+focus outline・エラーborder・forced-colors時の境界は識別のために残す。
+Noticeの左罫線とページのセクション区切りは囲い枠とは分け、今回は維持する。
+
 ## 参照文献
 
 すべて2026-09-10参照。本文のリンク箇所が各出典の適用範囲。


### PR DESCRIPTION
## 概要
- 既存のヘッダー上告知をShumoku Meetup #2へ更新（日英）
- connpassで2027年2月16日18:30〜20:00・東京/オンラインを確認。終了時に自動非表示
- 前回と同じくPlaygroundでは告知を表示しない
- #737後の未反映改善を含む: 枠線から面の色差へ、Playgroundの色階層、外側コンテナの角丸
- light/darkパレットを一元化。ロゴの緑は変更せず、背景を低彩度化
- UI previewに色見本、配色ドキュメント、コントラスト回帰テストを追加

## 参照
https://shumoku.connpass.com/event/406346/

## 検証
- Website typecheck: 0 errors / 0 warnings
- Website tests: 18 files / 77 passed
- 対象Biome check成功 / git diff --check成功
- 告知のリンクとヘッダー上の位置を実ブラウザーで確認、1280/390pxで表示確認
- 配色は明暗表示を確認。実機タッチ・200%文字拡大・全画面のa11y監査は未実施

## 制約
- 前回の全体hookがDocs生成のsnmp-lldp参照欠落とbunx環境で失敗したため、今回はhookをスキップしWebsite検証を個別実行。全体typecheckは再実行していない
- 未追跡Docs生成物は含めていない
- 公開ライブラリ変更なし