### PR TITLE
fix: align API contracts and automate release PR validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,21 +12,18 @@ updates:
     ignore:
       # TypeScript 7 removes the legacy compiler API. svelte2tsx emitDts rejects
       # it; svelte-check and TypeDoc support only TS 5/6 (#768).
-      # Upgrade after the Svelte packaging and documentation tools support TS 7.
+      # Resume when the Svelte/TypeDoc migration checklist in #771 is satisfied.
       - dependency-name: "typescript"
         versions: ["7.x"]
-      # 1.5.3 already enforces response inference (see #761); 1.6 also needs an
-      # observation input-contract migration. Keep 1.5.2 until both are reviewed.
-      - dependency-name: "@hono/zod-openapi"
-        versions: ["1.5.3", "1.6.x"]
       - dependency-name: "undici"
+        # Public Node runtime migration and minimum-version CI: #773.
         update-types: ["version-update:semver-major"]
       # Nano ID 6 drops Node 18/20 in the public core package (#762).
-      # Adopt it with an explicit library runtime-support migration.
+      # Adopt it with the explicit library runtime-support migration in #773.
       - dependency-name: "nanoid"
         versions: ["6.x"]
       # js-yaml 5 changes default schemas, merge keys and empty-input handling,
-      # as well as ESM exports (#765). Migrate saved YAML compatibility first.
+      # as well as ESM exports (#765). Saved YAML compatibility checklist: #772.
       - dependency-name: "js-yaml"
         versions: ["5.x"]
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       id-token: write
@@ -54,3 +55,15 @@ jobs:
           # Emit npm provenance attestations (requires id-token: write above).
           # Links each published package to this source commit and build.
           NPM_CONFIG_PROVENANCE: "true"
+
+      # GITHUB_TOKEN updates do not automatically run ordinary PR validation.
+      # workflow_dispatch is supported with this token and needs no extra secret.
+      # These workflows validate the release branch; neither publishes on dispatch.
+      - name: Validate release pull request
+        if: steps.changesets.outputs.pr-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh workflow run ci.yml --ref changeset-release/main
+          gh workflow run server-release.yml --ref changeset-release/main

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -1,6 +1,7 @@
 name: Server Release
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -17,7 +17,7 @@
     "format": "biome check --write ."
   },
   "dependencies": {
-    "@hono/zod-openapi": "1.5.2",
+    "@hono/zod-openapi": "^1.6.3",
     "@shumoku/catalog": "workspace:*",
     "@shumoku/core": "workspace:*",
     "@shumoku/renderer": "workspace:*",

--- a/apps/server/api/src/app/services.ts
+++ b/apps/server/api/src/app/services.ts
@@ -201,6 +201,17 @@ export interface DisplaySettingsView {
   hideDisconnected: boolean
 }
 
+// The observation API predates the core graph model and deliberately accepts
+// opaque node/link records, optional versions and upstream-specific fields.
+export interface ObservationGraphInput {
+  version?: string
+  name?: string
+  nodes: object[]
+  links: object[]
+  subgraphs?: object[]
+  settings?: object
+}
+
 export interface TopologyObservationApplicationService {
   list(topologyId: string, limit: number): ObservationSummaryView[]
   get(observationId: string): TopologyObservationView | null
@@ -208,7 +219,7 @@ export interface TopologyObservationApplicationService {
   record(
     topologyId: string,
     sourceId: string,
-    graph: NetworkGraph,
+    graph: ObservationGraphInput,
     status: TopologyObservationView['status'],
   ): Promise<TopologyObservationView>
   resolved(topologyId: string): Promise<{ graph: NetworkGraph; snapshotCount: number } | null>
@@ -227,7 +238,7 @@ export interface TopologySourceApplicationService {
   list(topologyId: string): TopologySourceMutationResult<TopologyDataSource[]>
   add(
     topologyId: string,
-    input: TopologyDataSourceInput & { type?: string },
+    input: TopologyDataSourceInput | { type: 'manual'; purpose?: 'topology' | 'metrics' },
   ): Promise<TopologySourceMutationResult<TopologyDataSource | { dataSourceId: string }>>
   update(
     topologyId: string,

--- a/apps/server/api/src/app/topology-observations.ts
+++ b/apps/server/api/src/app/topology-observations.ts
@@ -37,7 +37,10 @@ export function createTopologyObservationApplicationService(
         sourceId,
         capturedAt: Date.now(),
         status,
-        graph,
+        // Preserve the established permissive wire contract at the legacy
+        // ingestion boundary. Requiring core fields here would reject existing
+        // observations (including graphs without a version); do not strip them.
+        graph: graph as NetworkGraph,
       })
       if (observation.contributionChanged) {
         topologies.clearCacheEntry(topologyId)

--- a/apps/server/api/src/app/topology-sources.ts
+++ b/apps/server/api/src/app/topology-sources.ts
@@ -42,7 +42,7 @@ export function createTopologySourceApplicationService(dependencies: {
     },
     async add(topologyId, input) {
       if (!topologies.get(topologyId)) return failure(404, 'Topology not found')
-      if (input.type === 'manual') {
+      if ('type' in input && input.type === 'manual') {
         try {
           return {
             ok: true,
@@ -53,7 +53,7 @@ export function createTopologySourceApplicationService(dependencies: {
           return failure(500, errorMessage(error, 'Failed to attach Manual'))
         }
       }
-      if (!input.dataSourceId || !input.purpose) {
+      if (!('dataSourceId' in input) || !input.dataSourceId || !input.purpose) {
         return failure(400, 'dataSourceId and purpose are required')
       }
       if (!dataSources.get(input.dataSourceId)) return failure(404, 'Data source not found')

--- a/apps/server/api/src/modules/auth/routes.test.ts
+++ b/apps/server/api/src/modules/auth/routes.test.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AuthApplicationService } from '../../app/services.js'
+import { ErrorSchema } from '../../openapi/common.js'
 import { createAuthApi } from './routes.js'
 
 function createService(overrides: Partial<AuthApplicationService> = {}): AuthApplicationService {
@@ -30,6 +31,24 @@ function createApp(service = createService()): OpenAPIHono {
 
 describe('OpenAPI authentication routes', () => {
   afterEach(() => vi.unstubAllEnvs())
+
+  it('returns the declared error envelope while preserving the legacy error alias', async () => {
+    const response = await createApp(
+      createService({ verifyPassword: vi.fn(async () => false) }),
+    ).request('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'wrong-password' }),
+    })
+    expect(response.status).toBe(401)
+    const error = ErrorSchema.parse(await response.json())
+    expect(error).toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: 'Invalid password',
+      error: 'Invalid password',
+    })
+    expect(response.headers.get('X-Request-ID')).toBe(error.requestId)
+  })
 
   it('reports setup and session status', async () => {
     const response = await createApp().request('/auth/status', {

--- a/apps/server/api/src/modules/auth/routes.ts
+++ b/apps/server/api/src/modules/auth/routes.ts
@@ -7,7 +7,12 @@ import { ANONYMOUS_PRINCIPAL, hasPermission, permissionsForRole } from '../../au
 import { isProxyAuthEnabled } from '../../auth/proxy-auth.js'
 import { resolveRequestPrincipal } from '../../auth/resolve-principal.js'
 import { isWebSetupEnabled } from '../../auth-config.js'
-import { badRequestResponse, createOpenAPIApp, ErrorSchema } from '../../openapi/common.js'
+import {
+  apiErrorPayload,
+  badRequestResponse,
+  createOpenAPIApp,
+  ErrorSchema,
+} from '../../openapi/common.js'
 import {
   AuthStatusSchema,
   AuthSuccessSchema,
@@ -139,31 +144,39 @@ export function createAuthApi(services: Pick<AppServices, 'auth'>): OpenAPIHono 
   })
   app.openapi(setupRoute, async (c) => {
     if (isProxyAuthEnabled())
-      return c.json({ error: 'Local authentication is disabled in proxy mode' }, 400)
+      return c.json(apiErrorPayload(c, 'Local authentication is disabled in proxy mode', 400), 400)
     if (!isWebSetupEnabled()) {
       return c.json(
-        { error: 'Browser-driven setup is disabled; configure an administrator Secret' },
+        apiErrorPayload(
+          c,
+          'Browser-driven setup is disabled; configure an administrator Secret',
+          403,
+        ),
         403,
       )
     }
     if (!(await service.setInitialPassword(c.req.valid('json').password))) {
-      return c.json({ error: 'Setup already completed' }, 400)
+      return c.json(apiErrorPayload(c, 'Setup already completed', 400), 400)
     }
     setSessionCookie(c, service.createSession())
     return c.json({ success: true as const }, 200)
   })
   app.openapi(loginRoute, async (c) => {
     if (isProxyAuthEnabled())
-      return c.json({ error: 'Local authentication is disabled in proxy mode' }, 400)
-    if (!service.isSetupComplete()) return c.json({ error: 'Setup not completed' }, 400)
+      return c.json(apiErrorPayload(c, 'Local authentication is disabled in proxy mode', 400), 400)
+    if (!service.isSetupComplete())
+      return c.json(apiErrorPayload(c, 'Setup not completed', 400), 400)
     const id = clientIp(c)
     const lockoutSeconds = service.checkRateLimit(id)
     if (lockoutSeconds > 0) {
-      return c.json({ error: `Too many attempts. Try again in ${lockoutSeconds} seconds.` }, 429)
+      return c.json(
+        apiErrorPayload(c, `Too many attempts. Try again in ${lockoutSeconds} seconds.`, 429),
+        429,
+      )
     }
     if (!(await service.verifyPassword(c.req.valid('json').password))) {
       service.recordFailedAttempt(id)
-      return c.json({ error: 'Invalid password' }, 401)
+      return c.json(apiErrorPayload(c, 'Invalid password', 401), 401)
     }
     service.clearAttempts(id)
     setSessionCookie(c, service.createSession())
@@ -171,16 +184,17 @@ export function createAuthApi(services: Pick<AppServices, 'auth'>): OpenAPIHono 
   })
   app.openapi(changePasswordRoute, async (c) => {
     if (isProxyAuthEnabled())
-      return c.json({ error: 'Local authentication is disabled in proxy mode' }, 400)
-    if (!service.isSetupComplete()) return c.json({ error: 'Setup not completed' }, 400)
+      return c.json(apiErrorPayload(c, 'Local authentication is disabled in proxy mode', 400), 400)
+    if (!service.isSetupComplete())
+      return c.json(apiErrorPayload(c, 'Setup not completed', 400), 400)
     const token = getCookie(c, SESSION_COOKIE)
     const principal = token ? service.getSessionPrincipal(token) : null
     if (!principal || !hasPermission(principal, 'admin:manage')) {
-      return c.json({ error: 'Authentication required' }, 401)
+      return c.json(apiErrorPayload(c, 'Authentication required', 401), 401)
     }
     const body = c.req.valid('json')
     if (!(await service.verifyPassword(body.currentPassword))) {
-      return c.json({ error: 'Current password is incorrect' }, 401)
+      return c.json(apiErrorPayload(c, 'Current password is incorrect', 401), 401)
     }
     await service.setPassword(body.newPassword)
     service.deleteAllSessions()

--- a/apps/server/api/src/modules/dashboards/routes.ts
+++ b/apps/server/api/src/modules/dashboards/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -138,36 +139,48 @@ export function createDashboardApi(services: Pick<AppServices, 'dashboards'>): O
   app.openapi(listRoute, (c) => c.json(service.list(), 200))
   app.openapi(getRoute, (c) => {
     const dashboard = service.get(c.req.valid('param').id)
-    return dashboard ? c.json(dashboard, 200) : c.json({ error: 'Dashboard not found' }, 404)
+    return dashboard
+      ? c.json(dashboard, 200)
+      : c.json(apiErrorPayload(c, 'Dashboard not found', 404), 404)
   })
   app.openapi(createDashboardRoute, async (c) => {
     try {
       return c.json(await service.create(c.req.valid('json')), 201)
     } catch (error) {
-      return c.json({ error: error instanceof Error ? error.message : String(error) }, 400)
+      return c.json(
+        apiErrorPayload(c, error instanceof Error ? error.message : String(error), 400),
+        400,
+      )
     }
   })
   app.openapi(updateRoute, (c) => {
     try {
       const dashboard = service.update(c.req.valid('param').id, c.req.valid('json'))
-      return dashboard ? c.json(dashboard, 200) : c.json({ error: 'Dashboard not found' }, 404)
+      return dashboard
+        ? c.json(dashboard, 200)
+        : c.json(apiErrorPayload(c, 'Dashboard not found', 404), 404)
     } catch (error) {
-      return c.json({ error: error instanceof Error ? error.message : String(error) }, 400)
+      return c.json(
+        apiErrorPayload(c, error instanceof Error ? error.message : String(error), 400),
+        400,
+      )
     }
   })
   app.openapi(shareRoute, async (c) => {
     const shareToken = await service.share(c.req.valid('param').id)
-    return shareToken ? c.json({ shareToken }, 200) : c.json({ error: 'Dashboard not found' }, 404)
+    return shareToken
+      ? c.json({ shareToken }, 200)
+      : c.json(apiErrorPayload(c, 'Dashboard not found', 404), 404)
   })
   app.openapi(unshareRoute, (c) =>
     service.unshare(c.req.valid('param').id)
       ? c.json({ success: true as const }, 200)
-      : c.json({ error: 'Dashboard not found' }, 404),
+      : c.json(apiErrorPayload(c, 'Dashboard not found', 404), 404),
   )
   app.openapi(deleteRoute, (c) =>
     service.delete(c.req.valid('param').id)
       ? c.json({ success: true as const }, 200)
-      : c.json({ error: 'Dashboard not found' }, 404),
+      : c.json(apiErrorPayload(c, 'Dashboard not found', 404), 404),
   )
   return app
 }

--- a/apps/server/api/src/modules/data-sources/operations.ts
+++ b/apps/server/api/src/modules/data-sources/operations.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
 import {
+  apiErrorPayload,
   createOpenAPIApp,
   ErrorSchema,
   protectedRouteSecurity,
@@ -138,7 +139,7 @@ export function createDataSourceOperationsApi(services: {
   app.openapi(configOptionsRoute, async (c) => {
     const { id, key } = c.req.valid('param')
     const options = await service.getConfigOptions(id, key)
-    if (!options) return c.json({ error: 'Data source not found' }, 404)
+    if (!options) return c.json(apiErrorPayload(c, 'Data source not found', 404), 404)
     return c.json({ options }, 200)
   })
   app.openapi(connectionInfoRoute, (c) => {
@@ -148,7 +149,7 @@ export function createDataSourceOperationsApi(services: {
   })
   app.openapi(attachedTopologiesRoute, (c) => {
     const topologies = service.listAttachedTopologies(c.req.valid('param').id)
-    if (!topologies) return c.json({ error: 'Data source not found' }, 404)
+    if (!topologies) return c.json(apiErrorPayload(c, 'Data source not found', 404), 404)
     return c.json(topologies, 200)
   })
   app.openapi(testConnectionRoute, async (c) =>

--- a/apps/server/api/src/modules/data-sources/routes.ts
+++ b/apps/server/api/src/modules/data-sources/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -126,7 +127,7 @@ export function createDataSourceCrudApi(services: {
 
   app.openapi(getRoute, (c) => {
     const dataSource = service.get(c.req.valid('param').id)
-    if (!dataSource) return c.json({ error: 'Data source not found' }, 404)
+    if (!dataSource) return c.json(apiErrorPayload(c, 'Data source not found', 404), 404)
     return c.json(dataSource, 200)
   })
 
@@ -135,24 +136,24 @@ export function createDataSourceCrudApi(services: {
       return c.json(await service.create(c.req.valid('json')), 201)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      return c.json({ error: message }, 400)
+      return c.json(apiErrorPayload(c, message, 400), 400)
     }
   })
 
   app.openapi(updateRoute, async (c) => {
     try {
       const dataSource = await service.update(c.req.valid('param').id, c.req.valid('json'))
-      if (!dataSource) return c.json({ error: 'Data source not found' }, 404)
+      if (!dataSource) return c.json(apiErrorPayload(c, 'Data source not found', 404), 404)
       return c.json(dataSource, 200)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      return c.json({ error: message }, 400)
+      return c.json(apiErrorPayload(c, message, 400), 400)
     }
   })
 
   app.openapi(deleteRoute, (c) => {
     if (!service.delete(c.req.valid('param').id)) {
-      return c.json({ error: 'Data source not found' }, 404)
+      return c.json(apiErrorPayload(c, 'Data source not found', 404), 404)
     }
     return c.json({ success: true as const }, 200)
   })

--- a/apps/server/api/src/modules/data-sources/runtime.ts
+++ b/apps/server/api/src/modules/data-sources/runtime.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -172,7 +173,7 @@ export function createDataSourceRuntimeApi(services: {
     try {
       return c.json(await service.getHosts(c.req.valid('param').id), 200)
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
   app.openapi(hostItemsRoute, async (c) => {
@@ -180,7 +181,7 @@ export function createDataSourceRuntimeApi(services: {
       const { id, hostId } = c.req.valid('param')
       return c.json(await service.getHostItems(id, hostId), 200)
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
   app.openapi(neighborsRoute, async (c) => {
@@ -188,7 +189,7 @@ export function createDataSourceRuntimeApi(services: {
       const { id, hostId } = c.req.valid('param')
       return c.json(await service.getInterfaceNeighbors(id, hostId), 200)
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
   app.openapi(metricsRoute, async (c) => {
@@ -196,40 +197,44 @@ export function createDataSourceRuntimeApi(services: {
       const { id, hostId } = c.req.valid('param')
       return c.json(await service.discoverMetrics(id, hostId), 200)
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
   app.openapi(filterOptionsRoute, async (c) => {
     try {
       const options = await service.getFilterOptions(c.req.valid('param').id)
       if (!options) {
-        return c.json({ error: 'Filter options not supported for this data source type' }, 400)
+        return c.json(
+          apiErrorPayload(c, 'Filter options not supported for this data source type', 400),
+          400,
+        )
       }
       return c.json(options, 200)
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
   app.openapi(alertsRoute, async (c) => {
     try {
       const alerts = await service.getAlerts(c.req.valid('param').id, c.req.valid('query'))
-      if (!alerts) return c.json({ error: 'Data source does not support alerts' }, 400)
+      if (!alerts)
+        return c.json(apiErrorPayload(c, 'Data source does not support alerts', 400), 400)
       return c.json(alerts, 200)
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
   app.openapi(nativeRoute, async (c) => {
     if (process.env['NODE_ENV'] !== 'development') {
-      return c.json({ error: 'Not found' }, 404)
+      return c.json(apiErrorPayload(c, 'Not found', 404), 404)
     }
     try {
       const { method, params } = c.req.valid('json')
       const result = await service.callNative(c.req.valid('param').id, method, params)
-      if (!result.ok) return c.json({ error: result.error }, result.status)
+      if (!result.ok) return c.json(apiErrorPayload(c, result.error, result.status), result.status)
       return c.json({ result: result.result }, 200)
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
 

--- a/apps/server/api/src/modules/data-sources/scan.ts
+++ b/apps/server/api/src/modules/data-sources/scan.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -55,7 +56,7 @@ export function createDataSourceScanApi(services: {
         c.req.valid('param').id,
         c.req.valid('json') ?? {},
       )
-      if (!result.ok) return c.json({ error: result.error }, result.status)
+      if (!result.ok) return c.json(apiErrorPayload(c, result.error, result.status), result.status)
       return c.json(
         result.observation
           ? { snapshot: result.snapshot, observation: result.observation }
@@ -63,7 +64,10 @@ export function createDataSourceScanApi(services: {
         200,
       )
     } catch (error) {
-      return c.json({ error: error instanceof Error ? error.message : String(error) }, 500)
+      return c.json(
+        apiErrorPayload(c, error instanceof Error ? error.message : String(error), 500),
+        500,
+      )
     }
   })
 

--- a/apps/server/api/src/modules/discovery-policy/routes.ts
+++ b/apps/server/api/src/modules/discovery-policy/routes.ts
@@ -33,7 +33,6 @@
 
 import { createRoute, type OpenAPIHono, z } from '@hono/zod-openapi'
 import {
-  type Attachment,
   type DiscoveryMode,
   type EffectiveDiscoveryPolicy,
   type NodeExclusion,
@@ -46,6 +45,7 @@ import type {
   DeepReadConfigView,
 } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -302,8 +302,8 @@ function effectiveOf(cfg: DeepReadConfigView | undefined): EffectiveDiscoveryPol
 }
 
 /** Attachment-shaped rendering of a config row, for the edit panel. */
-function configToAttachments(cfg: DeepReadConfigView): Attachment[] {
-  const out: Attachment[] = []
+function configToAttachments(cfg: DeepReadConfigView): z.infer<typeof DiscoveryAttachmentSchema>[] {
+  const out: z.infer<typeof DiscoveryAttachmentSchema>[] = []
   if (cfg.community !== undefined) {
     out.push({ kind: 'access', protocol: 'snmp', community: cfg.community })
   }
@@ -326,26 +326,29 @@ export function createDiscoveryPolicyApi(
   app.openapi(getPolicyRoute, async (c) => {
     const id = c.req.param('id')
     const graph = await service.getParsedGraph(id)
-    if (!graph) return c.json({ error: 'Topology not found' }, 404)
+    if (!graph) return c.json(apiErrorPayload(c, 'Topology not found', 404), 404)
 
     const configRows = service.listConfigs(id)
     const nodes: Record<string, EffectiveDiscoveryPolicy> = {}
-    const configs: Record<string, Attachment[]> = {}
+    const configs: Record<string, z.infer<typeof DiscoveryAttachmentSchema>[]> = {}
     for (const node of graph.nodes) {
       const cfg = configRows.get(node.id)
       nodes[node.id] = effectiveOf(cfg)
       if (cfg) configs[node.id] = configToAttachments(cfg)
     }
 
-    return c.json({
-      // Shape kept for the UI: there is no topology default any more — every
-      // node's config is its own row (bulk-set writes them all).
-      topologyDefault: null,
-      runtimeDefault: RUNTIME_DEFAULT,
-      nodes,
-      configs,
-      subgraphs: {},
-    })
+    return c.json(
+      {
+        // Shape kept for the UI: there is no topology default any more — every
+        // node's config is its own row (bulk-set writes them all).
+        topologyDefault: null,
+        runtimeDefault: RUNTIME_DEFAULT,
+        nodes,
+        configs,
+        subgraphs: {},
+      },
+      200,
+    )
   })
 
   app.openapi(patchPolicyRoute, async (c) => {
@@ -353,38 +356,41 @@ export function createDiscoveryPolicyApi(
     const body: PatchBody = c.req.valid('json')
 
     if (body.scope !== 'topology' && body.scope !== 'node') {
-      return c.json({ error: "scope must be 'topology' or 'node'" }, 400)
+      return c.json(apiErrorPayload(c, "scope must be 'topology' or 'node'", 400), 400)
     }
     if (body.scope === 'node' && !body.id) {
-      return c.json({ error: "id is required when scope is 'node'" }, 400)
+      return c.json(apiErrorPayload(c, "id is required when scope is 'node'", 400), 400)
     }
 
     const topology = service.getTopology(topologyId)
-    if (!topology) return c.json({ error: 'Topology not found' }, 404)
+    if (!topology) return c.json(apiErrorPayload(c, 'Topology not found', 404), 404)
 
     // ── Access / policy → deep_read_config ──────────────────────────────
     const attachmentsProvided = body.attachments !== undefined
     let configPatch: DeepReadConfigPatchView | undefined
     if (attachmentsProvided) {
       const parsedPatch = attachmentsToConfigPatch(body.attachments)
-      if ('error' in parsedPatch) return c.json({ error: parsedPatch.error }, 400)
+      if ('error' in parsedPatch) return c.json(apiErrorPayload(c, parsedPatch.error, 400), 400)
       configPatch = parsedPatch.patch
     }
 
     if (body.scope === 'topology') {
       if (!configPatch) {
-        return c.json({ error: 'nothing to update: provide attachments' }, 400)
+        return c.json(apiErrorPayload(c, 'nothing to update: provide attachments', 400), 400)
       }
       service.bulkSetConfig(topologyId, configPatch)
       service.clearCache(topologyId)
-      return c.json({
-        effective: effectiveOf({
-          entityId: '*',
-          ...(configPatch.community != null ? { community: configPatch.community } : {}),
-          ...(configPatch.mode != null ? { mode: configPatch.mode } : {}),
-          ...(configPatch.intervalMs != null ? { intervalMs: configPatch.intervalMs } : {}),
-        }),
-      })
+      return c.json(
+        {
+          effective: effectiveOf({
+            entityId: '*',
+            ...(configPatch.community != null ? { community: configPatch.community } : {}),
+            ...(configPatch.mode != null ? { mode: configPatch.mode } : {}),
+            ...(configPatch.intervalMs != null ? { intervalMs: configPatch.intervalMs } : {}),
+          }),
+        },
+        200,
+      )
     }
 
     // ── scope === 'node' ────────────────────────────────────────────────
@@ -394,7 +400,7 @@ export function createDiscoveryPolicyApi(
     let labelTrimmed = ''
     if (labelProvided) {
       if (body.label !== null && typeof body.label !== 'string') {
-        return c.json({ error: 'label must be a string or null' }, 400)
+        return c.json(apiErrorPayload(c, 'label must be a string or null', 400), 400)
       }
       labelTrimmed = typeof body.label === 'string' ? body.label.trim() : ''
     }
@@ -404,12 +410,15 @@ export function createDiscoveryPolicyApi(
     if (suppressedProvided) {
       const raw = body.suppressedAttachments
       if (raw !== null && !Array.isArray(raw)) {
-        return c.json({ error: 'suppressedAttachments must be an array or null' }, 400)
+        return c.json(
+          apiErrorPayload(c, 'suppressedAttachments must be an array or null', 400),
+          400,
+        )
       }
       const keys = Array.isArray(raw) ? raw : []
       for (const k of keys) {
         if (typeof k !== 'string' || !isValidAttachmentKey(k)) {
-          return c.json({ error: `invalid attachment key: ${String(k)}` }, 400)
+          return c.json(apiErrorPayload(c, `invalid attachment key: ${String(k)}`, 400), 400)
         }
       }
       suppressed = keys.length > 0 ? (keys as string[]) : undefined
@@ -417,7 +426,11 @@ export function createDiscoveryPolicyApi(
 
     if (!configPatch && !labelProvided && !suppressedProvided) {
       return c.json(
-        { error: 'nothing to update: provide attachments, label, or suppressedAttachments' },
+        apiErrorPayload(
+          c,
+          'nothing to update: provide attachments, label, or suppressedAttachments',
+          400,
+        ),
         400,
       )
     }
@@ -426,7 +439,10 @@ export function createDiscoveryPolicyApi(
     if (configPatch) {
       const upserted = service.upsertConfig(topologyId, nodeId, configPatch)
       if (upserted === 'not-a-node') {
-        return c.json({ error: `node '${nodeId}' is not a node entity of this topology` }, 409)
+        return c.json(
+          apiErrorPayload(c, `node '${nodeId}' is not a node entity of this topology`, 409),
+          409,
+        )
       }
       resultCfg = upserted
     } else {
@@ -442,11 +458,15 @@ export function createDiscoveryPolicyApi(
         suppressedProvided,
         suppressed,
       })
-      if (overlayError) return c.json({ error: overlayError.error }, overlayError.status)
+      if (overlayError)
+        return c.json(
+          apiErrorPayload(c, overlayError.error, overlayError.status),
+          overlayError.status,
+        )
       service.clearCache(topologyId)
     }
 
-    return c.json({ effective: effectiveOf(resultCfg ?? undefined) })
+    return c.json({ effective: effectiveOf(resultCfg ?? undefined) }, 200)
   })
 
   /**
@@ -554,7 +574,7 @@ export function createDiscoveryPolicyApi(
     const topologyId = c.req.param('id')
     const ex: NodeExclusion = c.req.valid('json')
     const topology = service.getTopology(topologyId)
-    if (!topology) return c.json({ error: 'Topology not found' }, 404)
+    if (!topology) return c.json(apiErrorPayload(c, 'Topology not found', 404), 404)
     const authored = service.readOverlay(topologyId) ?? {
       version: '1' as const,
       name: topology.name,
@@ -565,22 +585,22 @@ export function createDiscoveryPolicyApi(
     if (!exclusions.some((e) => exclusionKey(e) === exclusionKey(ex))) exclusions.push(ex)
     await service.writeOverlay(topologyId, { ...authored, exclusions })
     service.clearCache(topologyId)
-    return c.json({ exclusions })
+    return c.json({ exclusions }, 200)
   })
 
   app.openapi(removeExclusionRoute, async (c) => {
     const topologyId = c.req.param('id')
     const ex: NodeExclusion = c.req.valid('json')
     const topology = service.getTopology(topologyId)
-    if (!topology) return c.json({ error: 'Topology not found' }, 404)
+    if (!topology) return c.json(apiErrorPayload(c, 'Topology not found', 404), 404)
     const authored = service.readOverlay(topologyId)
-    if (!authored) return c.json({ exclusions: [] })
+    if (!authored) return c.json({ exclusions: [] }, 200)
     const exclusions = (authored.exclusions ?? []).filter(
       (e) => exclusionKey(e) !== exclusionKey(ex),
     )
     await service.writeOverlay(topologyId, { ...authored, exclusions })
     service.clearCache(topologyId)
-    return c.json({ exclusions })
+    return c.json({ exclusions }, 200)
   })
 
   return app

--- a/apps/server/api/src/modules/plugins/routes.ts
+++ b/apps/server/api/src/modules/plugins/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices, PluginInfoView, PluginMutationResult } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -172,7 +173,7 @@ function errorResponse<T>(
   result: PluginMutationResult<T>,
 ) {
   if (result.ok) throw new Error('Expected plugin operation failure')
-  return c.json({ error: result.error }, result.status)
+  return c.json(apiErrorPayload(c, result.error, result.status), result.status)
 }
 
 export function createPluginApi(services: Pick<AppServices, 'plugins'>): OpenAPIHono {

--- a/apps/server/api/src/modules/settings/routes.ts
+++ b/apps/server/api/src/modules/settings/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -105,7 +106,7 @@ export function createSettingsApi(services: Pick<AppServices, 'settings'>): Open
     const { key } = c.req.valid('param')
     const value = service.get(key)
     return value === null
-      ? c.json({ error: 'Setting not found' }, 404)
+      ? c.json(apiErrorPayload(c, 'Setting not found', 404), 404)
       : c.json({ key, value }, 200)
   })
   app.openapi(setManyRoute, (c) => {
@@ -121,7 +122,7 @@ export function createSettingsApi(services: Pick<AppServices, 'settings'>): Open
   app.openapi(deleteRoute, (c) =>
     service.delete(c.req.valid('param').key)
       ? c.json({ success: true as const }, 200)
-      : c.json({ error: 'Setting not found' }, 404),
+      : c.json(apiErrorPayload(c, 'Setting not found', 404), 404),
   )
   return app
 }

--- a/apps/server/api/src/modules/share/routes.ts
+++ b/apps/server/api/src/modules/share/routes.ts
@@ -2,7 +2,7 @@ import { createRoute, type OpenAPIHono, z } from '@hono/zod-openapi'
 import type { Context } from 'hono'
 import { streamSSE } from 'hono/streaming'
 import type { AppServices, ShareApplicationService, ShareReadResult } from '../../app/services.js'
-import { createOpenAPIApp, ErrorSchema } from '../../openapi/common.js'
+import { apiErrorPayload, createOpenAPIApp, ErrorSchema } from '../../openapi/common.js'
 import { publicMetrics } from './projections.js'
 import {
   DashboardResourceParamsSchema,
@@ -186,7 +186,9 @@ const dashboardAlertsRoute = createRoute({
 })
 
 function respond<T>(c: Context, result: ShareReadResult<T>) {
-  return result.ok ? c.json(result.value, 200) : c.json({ error: result.error }, result.status)
+  return result.ok
+    ? c.json(result.value, 200)
+    : c.json(apiErrorPayload(c, result.error, result.status), result.status)
 }
 
 function streamTopologyMetrics(c: Context, service: ShareApplicationService, topologyId: string) {
@@ -234,9 +236,9 @@ function streamTopologyMetrics(c: Context, service: ShareApplicationService, top
 }
 
 function streamResponse(c: Context, service: ShareApplicationService, topologyId: string | null) {
-  if (!topologyId) return c.json({ error: 'Not found' }, 404)
+  if (!topologyId) return c.json(apiErrorPayload(c, 'Not found', 404), 404)
   if (service.liveSubscriberCount() >= MAX_SHARE_METRIC_STREAMS)
-    return c.json({ error: 'Too many concurrent streams' }, 503)
+    return c.json(apiErrorPayload(c, 'Too many concurrent streams', 503), 503)
   return streamTopologyMetrics(c, service, topologyId)
 }
 

--- a/apps/server/api/src/modules/topologies/routes.ts
+++ b/apps/server/api/src/modules/topologies/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -124,7 +125,7 @@ export function createTopologyCrudApi(services: Pick<AppServices, 'topologies'>)
 
   app.openapi(getRoute, (c) => {
     const topology = service.get(c.req.valid('param').id)
-    if (!topology) return c.json({ error: 'Topology not found' }, 404)
+    if (!topology) return c.json(apiErrorPayload(c, 'Topology not found', 404), 404)
     return c.json(topology, 200)
   })
 
@@ -133,24 +134,24 @@ export function createTopologyCrudApi(services: Pick<AppServices, 'topologies'>)
       return c.json(await service.create(c.req.valid('json')), 201)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      return c.json({ error: message }, 400)
+      return c.json(apiErrorPayload(c, message, 400), 400)
     }
   })
 
   app.openapi(updateRoute, async (c) => {
     try {
       const topology = await service.update(c.req.valid('param').id, c.req.valid('json'))
-      if (!topology) return c.json({ error: 'Topology not found' }, 404)
+      if (!topology) return c.json(apiErrorPayload(c, 'Topology not found', 404), 404)
       return c.json(topology, 200)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      return c.json({ error: message }, 400)
+      return c.json(apiErrorPayload(c, message, 400), 400)
     }
   })
 
   app.openapi(deleteRoute, (c) => {
     if (!service.delete(c.req.valid('param').id)) {
-      return c.json({ error: 'Topology not found' }, 404)
+      return c.json(apiErrorPayload(c, 'Topology not found', 404), 404)
     }
     return c.json({ success: true as const }, 200)
   })

--- a/apps/server/api/src/modules/topology-mappings/routes.ts
+++ b/apps/server/api/src/modules/topology-mappings/routes.ts
@@ -1,6 +1,11 @@
 import { createRoute, type OpenAPIHono, z } from '@hono/zod-openapi'
 import type { AppServices, TopologyMappingResult } from '../../app/services.js'
-import { createOpenAPIApp, ErrorSchema, protectedRouteSecurity } from '../../openapi/common.js'
+import {
+  apiErrorPayload,
+  createOpenAPIApp,
+  ErrorSchema,
+  protectedRouteSecurity,
+} from '../../openapi/common.js'
 import {
   AutoMapLinksResultSchema,
   AutoMapLinksSchema,
@@ -183,7 +188,9 @@ function respond<T>(
   c: Parameters<Parameters<OpenAPIHono['openapi']>[1]>[0],
   result: TopologyMappingResult<T>,
 ) {
-  return result.ok ? c.json(result.value, 200) : c.json({ error: result.error }, result.status)
+  return result.ok
+    ? c.json(result.value, 200)
+    : c.json(apiErrorPayload(c, result.error, result.status), result.status)
 }
 
 export function createTopologyMappingApi(

--- a/apps/server/api/src/modules/topology-observations/routes.test.ts
+++ b/apps/server/api/src/modules/topology-observations/routes.test.ts
@@ -1,0 +1,78 @@
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { describe, expect, it, vi } from 'vitest'
+import type { TopologyObservationApplicationService } from '../../app/services.js'
+import { ErrorSchema } from '../../openapi/common.js'
+import { createTopologyObservationApi } from './routes.js'
+
+function service(): TopologyObservationApplicationService {
+  return {
+    list: vi.fn(() => []),
+    get: vi.fn(() => null),
+    latest: vi.fn(() => null),
+    record: vi.fn(async () => ({
+      id: 'observation-1',
+      topologyId: 'topology-1',
+      sourceId: 'source-1',
+      capturedAt: 1,
+      createdAt: 1,
+      status: 'ok' as const,
+      graph: null,
+      nodeCount: 0,
+      linkCount: 0,
+      portCount: 0,
+    })),
+    resolved: vi.fn(async () => null),
+    getDisplaySettings: vi.fn(() => ({
+      edgeStyle: 'orthogonal' as const,
+      splineMode: 'sloppy' as const,
+      hideDisconnected: false,
+    })),
+    updateDisplaySettings: vi.fn(async () => ({ ok: true as const })),
+  }
+}
+
+function app(observations: TopologyObservationApplicationService) {
+  return new OpenAPIHono().route('/topologies', createTopologyObservationApi({ observations }))
+}
+
+const path = '/topologies/topology-1/sources/source-1/observation'
+
+describe('observation wire compatibility', () => {
+  it('preserves optional versions, opaque records, and upstream-specific fields', async () => {
+    const observations = service()
+    const graph = {
+      nodes: [{ upstreamDevice: 'device-1', custom: { enabled: true } }],
+      links: [{ upstreamLink: 'link-1' }],
+      customGraphField: ['keep', 'me'],
+    }
+    const response = await app(observations).request(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ graph }),
+    })
+    expect(response.status).toBe(201)
+    expect(observations.record).toHaveBeenCalledWith('topology-1', 'source-1', graph, 'ok')
+  })
+
+  it('still rejects malformed graph collections before recording', async () => {
+    const observations = service()
+    const response = await app(observations).request(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ graph: { nodes: 'invalid', links: [] } }),
+    })
+    expect(response.status).toBe(400)
+    expect(observations.record).not.toHaveBeenCalled()
+    const error = ErrorSchema.parse(await response.json())
+    expect(error.error).toBe(error.message)
+    expect(response.headers.get('X-Request-ID')).toBe(error.requestId)
+  })
+
+  it('returns schema-valid not-found errors with the legacy alias and matching request ID', async () => {
+    const response = await app(service()).request('/topologies/topology-1/observations/missing')
+    expect(response.status).toBe(404)
+    const error = ErrorSchema.parse(await response.json())
+    expect(error).toMatchObject({ code: 'NOT_FOUND', message: 'not found', error: 'not found' })
+    expect(response.headers.get('X-Request-ID')).toBe(error.requestId)
+  })
+})

--- a/apps/server/api/src/modules/topology-observations/routes.ts
+++ b/apps/server/api/src/modules/topology-observations/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono, z } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -162,7 +163,9 @@ export function createTopologyObservationApi(
   )
   app.openapi(getRoute, (c) => {
     const observation = service.get(c.req.valid('param').obsId)
-    return observation ? c.json(observation, 200) : c.json({ error: 'not found' }, 404)
+    return observation
+      ? c.json(observation, 200)
+      : c.json(apiErrorPayload(c, 'not found', 404), 404)
   })
   app.openapi(latestRoute, (c) => {
     const { topologyId, sourceId } = c.req.valid('param')
@@ -185,15 +188,15 @@ export function createTopologyObservationApi(
       const { graph, status } = c.req.valid('json')
       return c.json({ observation: await service.record(topologyId, sourceId, graph, status) }, 201)
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
   app.openapi(resolvedRoute, async (c) => {
     try {
       const result = await service.resolved(c.req.valid('param').id)
-      return result ? c.json(result, 200) : c.json({ error: 'not found' }, 404)
+      return result ? c.json(result, 200) : c.json(apiErrorPayload(c, 'not found', 404), 404)
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
   app.openapi(getDisplayRoute, (c) =>
@@ -206,7 +209,7 @@ export function createTopologyObservationApi(
         200,
       )
     } catch (error) {
-      return c.json({ error: errorMessage(error) }, 500)
+      return c.json(apiErrorPayload(c, errorMessage(error), 500), 500)
     }
   })
   return app

--- a/apps/server/api/src/modules/topology-queries/routes.test.ts
+++ b/apps/server/api/src/modules/topology-queries/routes.test.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono } from '@hono/zod-openapi'
 import { describe, expect, it, vi } from 'vitest'
 import type { TopologyQueryApplicationService } from '../../app/services.js'
+import { ErrorSchema } from '../../openapi/common.js'
 import { createTopologyQueryApi } from './routes.js'
 
 function createService(): TopologyQueryApplicationService {
@@ -33,6 +34,24 @@ function createApp(service: TopologyQueryApplicationService): OpenAPIHono {
 }
 
 describe('topology export route', () => {
+  it('preserves errorPhase and the legacy alias in a schema-valid export failure', async () => {
+    const service = createService()
+    service.export = vi.fn(async () => ({
+      kind: 'error' as const,
+      status: 422 as const,
+      error: 'Unable to lay out topology',
+      errorPhase: 'layout' as const,
+    }))
+    const response = await createApp(service).request('/topologies/topology-1/export?format=svg')
+    expect(response.status).toBe(422)
+    const body = await response.json()
+    expect(body.errorPhase).toBe('layout')
+    const error = ErrorSchema.parse(body)
+    expect(error.error).toBe('Unable to lay out topology')
+    expect(error.message).toBe(error.error)
+    expect(response.headers.get('X-Request-ID')).toBe(error.requestId)
+  })
+
   it('downloads a selected SVG sheet with safe attachment headers', async () => {
     const service = createService()
     const response = await createApp(service).request(

--- a/apps/server/api/src/modules/topology-queries/routes.ts
+++ b/apps/server/api/src/modules/topology-queries/routes.ts
@@ -1,11 +1,17 @@
 import { createRoute, type OpenAPIHono, z } from '@hono/zod-openapi'
+import type { Context } from 'hono'
 import type { ZodType } from 'zod'
 import type {
   AppServices,
   TopologyImmediateResult,
   TopologyReadResult,
 } from '../../app/services.js'
-import { createOpenAPIApp, ErrorSchema, protectedRouteSecurity } from '../../openapi/common.js'
+import {
+  apiErrorPayload,
+  createOpenAPIApp,
+  ErrorSchema,
+  protectedRouteSecurity,
+} from '../../openapi/common.js'
 import {
   DerivingSchema,
   ParsedTopologySchema,
@@ -142,15 +148,18 @@ const updateCompositionRoute = createRoute({
   },
 })
 
-function respond<T>(
-  c: Parameters<Parameters<OpenAPIHono['openapi']>[1]>[0],
-  result: TopologyReadResult<T>,
-) {
+function respond<T>(c: Context, result: TopologyReadResult<T>) {
   if (result.kind === 'ready') return c.json(result.value, 200)
+  return respondPendingOrError(c, result)
+}
+
+function respondPendingOrError(
+  c: Context,
+  result: Exclude<TopologyReadResult<unknown>, { kind: 'ready' }>,
+) {
   if (result.kind === 'deriving') return c.json({ deriving: true as const }, 202)
-  const body = result.errorPhase
-    ? { error: result.error, errorPhase: result.errorPhase }
-    : { error: result.error }
+  const payload = apiErrorPayload(c, result.error, result.status)
+  const body = result.errorPhase ? { ...payload, errorPhase: result.errorPhase } : payload
   return c.json(body, result.status)
 }
 
@@ -160,7 +169,7 @@ function respondImmediate<T>(
 ) {
   return result.kind === 'ready'
     ? c.json(result.value, 200)
-    : c.json({ error: result.error }, result.status)
+    : c.json(apiErrorPayload(c, result.error, result.status), result.status)
 }
 
 function encodedFilename(filename: string): string {
@@ -185,12 +194,12 @@ export function createTopologyQueryApi(
   app.openapi(viewRoute, async (c) => {
     const result = await service.serializedView(c.req.valid('param').id)
     if (result.kind === 'ready') return c.json(JSON.parse(result.value), 200)
-    return respond(c, result)
+    return respondPendingOrError(c, result)
   })
   app.openapi(renderRoute, async (c) => respond(c, await service.render(c.req.valid('param').id)))
   app.openapi(exportRoute, async (c) => {
     const result = await service.export(c.req.valid('param').id, c.req.valid('query'))
-    if (result.kind !== 'ready') return respond(c, result)
+    if (result.kind !== 'ready') return respondPendingOrError(c, result)
     const body =
       typeof result.value.body === 'string'
         ? result.value.body

--- a/apps/server/api/src/modules/topology-sources/routes.ts
+++ b/apps/server/api/src/modules/topology-sources/routes.ts
@@ -1,6 +1,7 @@
 import { createRoute, type OpenAPIHono, z } from '@hono/zod-openapi'
 import type { AppServices, TopologySourceMutationResult } from '../../app/services.js'
 import {
+  apiErrorPayload,
   badRequestResponse,
   createOpenAPIApp,
   ErrorSchema,
@@ -211,7 +212,7 @@ function respond200<T>(
   c: Parameters<Parameters<OpenAPIHono['openapi']>[1]>[0],
   result: TopologySourceMutationResult<T>,
 ) {
-  if (!result.ok) return c.json({ error: result.error }, result.status)
+  if (!result.ok) return c.json(apiErrorPayload(c, result.error, result.status), result.status)
   return c.json(result.value, 200)
 }
 
@@ -219,7 +220,7 @@ function respond201<T>(
   c: Parameters<Parameters<OpenAPIHono['openapi']>[1]>[0],
   result: TopologySourceMutationResult<T>,
 ) {
-  if (!result.ok) return c.json({ error: result.error }, result.status)
+  if (!result.ok) return c.json(apiErrorPayload(c, result.error, result.status), result.status)
   return c.json(result.value, 201)
 }
 

--- a/apps/server/api/src/modules/topology-sync/routes.ts
+++ b/apps/server/api/src/modules/topology-sync/routes.ts
@@ -1,6 +1,11 @@
 import { createRoute, type OpenAPIHono } from '@hono/zod-openapi'
 import type { AppServices, TopologySyncResult } from '../../app/services.js'
-import { createOpenAPIApp, ErrorSchema, protectedRouteSecurity } from '../../openapi/common.js'
+import {
+  apiErrorPayload,
+  createOpenAPIApp,
+  ErrorSchema,
+  protectedRouteSecurity,
+} from '../../openapi/common.js'
 import {
   ShareTopologyResultSchema,
   StartedSyncJobResultSchema,
@@ -117,13 +122,15 @@ function respond200<T>(
   c: Parameters<Parameters<OpenAPIHono['openapi']>[1]>[0],
   result: TopologySyncResult<T>,
 ) {
-  return result.ok ? c.json(result.value, 200) : c.json({ error: result.error }, result.status)
+  return result.ok
+    ? c.json(result.value, 200)
+    : c.json(apiErrorPayload(c, result.error, result.status), result.status)
 }
 function respondStart<T>(
   c: Parameters<Parameters<OpenAPIHono['openapi']>[1]>[0],
   result: TopologySyncResult<T>,
 ) {
-  if (!result.ok) return c.json({ error: result.error }, result.status)
+  if (!result.ok) return c.json(apiErrorPayload(c, result.error, result.status), result.status)
   return result.status === 409 ? c.json(result.value, 409) : c.json(result.value, 202)
 }
 

--- a/apps/server/api/src/modules/webhooks/routes.ts
+++ b/apps/server/api/src/modules/webhooks/routes.ts
@@ -1,6 +1,11 @@
 import { createRoute, type OpenAPIHono, z } from '@hono/zod-openapi'
 import type { AppServices } from '../../app/services.js'
-import { createOpenAPIApp, ErrorSchema, protectedRouteSecurity } from '../../openapi/common.js'
+import {
+  apiErrorPayload,
+  createOpenAPIApp,
+  ErrorSchema,
+  protectedRouteSecurity,
+} from '../../openapi/common.js'
 
 const WebhookParamsSchema = z.object({
   type: z
@@ -75,11 +80,13 @@ export function createWebhookApi(services: Pick<AppServices, 'webhooks'>): OpenA
   app.openapi(ingressRoute, async (c) => {
     const type = c.req.param('type')
     const id = c.req.param('id')
-    if (!type || !id) return c.json({ error: 'Invalid webhook path' }, 400)
+    if (!type || !id) return c.json(apiErrorPayload(c, 'Invalid webhook path', 400), 400)
     const secret = c.req.header('x-webhook-secret') ?? c.req.query('secret') ?? null
     const payload = await c.req.json().catch(() => undefined)
     const result = await services.webhooks.handle(type, id, secret, payload)
-    return result.ok ? c.json(result.value, 200) : c.json({ error: result.error }, result.status)
+    return result.ok
+      ? c.json(result.value, 200)
+      : c.json(apiErrorPayload(c, result.error, result.status), result.status)
   })
   app.openapi(healthRoute, (c) => c.json({ status: 'ok' as const }, 200))
   return app

--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,7 @@
       "name": "@shumoku/server-api",
       "version": "0.0.0",
       "dependencies": {
-        "@hono/zod-openapi": "1.5.2",
+        "@hono/zod-openapi": "^1.6.3",
         "@shumoku/catalog": "workspace:*",
         "@shumoku/core": "workspace:*",
         "@shumoku/renderer": "workspace:*",
@@ -188,7 +188,7 @@
     },
     "libs/@shumoku/catalog": {
       "name": "@shumoku/catalog",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "js-yaml": "^4.3.2",
@@ -199,7 +199,7 @@
     },
     "libs/@shumoku/core": {
       "name": "@shumoku/core",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "js-yaml": "^4.3.2",
         "nanoid": "^5.1.16",
@@ -219,14 +219,14 @@
     },
     "libs/@shumoku/plugin-sdk": {
       "name": "@shumoku/plugin-sdk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "undici": "^6.28.1",
       },
     },
     "libs/@shumoku/renderer": {
       "name": "@shumoku/renderer",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "d3-drag": "^3.0.0",
@@ -294,7 +294,7 @@
     },
     "libs/plugins/grafana": {
       "name": "shumoku-plugin-grafana",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "dependencies": {
         "@shumoku/core": "workspace:*",
       },
@@ -309,7 +309,7 @@
     },
     "libs/plugins/netbox": {
       "name": "shumoku-plugin-netbox",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "@shumoku/plugin-sdk": "workspace:*",
@@ -327,14 +327,14 @@
     },
     "libs/plugins/prometheus": {
       "name": "shumoku-plugin-prometheus",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "dependencies": {
         "@shumoku/core": "workspace:*",
       },
     },
     "libs/plugins/zabbix": {
       "name": "shumoku-plugin-zabbix",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "dependencies": {
         "@shumoku/core": "workspace:*",
         "@shumoku/plugin-sdk": "workspace:*",
@@ -381,7 +381,7 @@
     },
   },
   "packages": {
-    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@8.5.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q=="],
+    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@9.1.0", "", { "dependencies": { "openapi3-ts": "^4.6.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pLMeRgRYS7/vZIgAAkOe2P6+XGTifR1MT9pqDoxZ11EmcJJ+DPmdPqLN8ZZF4U8R9KHCCQCS9c2wtuE8wSrfkw=="],
 
     "@astrojs/check": ["@astrojs/check@0.9.10", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^18.0.0" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "./bin/astro-check.js" } }, "sha512-zgx/UQMozdjOa3bOxjgeCFdtpE3c9rRX6xHwa+2QXvy8z8Akifu2AtubHyv/zzC2znO8dl8fFWL4K+Ba9kS8HQ=="],
 
@@ -599,7 +599,7 @@
 
     "@hapi/topo": ["@hapi/topo@6.0.2", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg=="],
 
-    "@hono/zod-openapi": ["@hono/zod-openapi@1.5.2", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^8.5.0", "@hono/zod-validator": "^0.9.0", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.10.0", "zod": "^4.0.0" } }, "sha512-FPlspM6+qObGoMfux+0SSE0of0tGO+BVo3havhKzZMxRyz/ql89kuCd/7POd70aW3T4kz/aVL6gNZ6sVd0ItUQ=="],
+    "@hono/zod-openapi": ["@hono/zod-openapi@1.6.3", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^9.1.0", "@hono/zod-validator": "^0.9.1", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.10.0", "zod": "^4.0.0" } }, "sha512-VYR82Y60plu8g3pN60OUXMVKpmxh3R04Qs++3DY9vtwZ9/sA/BRY0PcRIR+Z37/3itWtM7pYwT9bKiH9JhqV6Q=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.9.1", "", { "peerDependencies": { "hono": ">=4.11.2", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-iiv6w0qrIc0arfvCtUqBWsvl4fXjzaTcQcCJTTtCnkawF9HHGE+KjEl0ox3gQJ6rKZEgE3mLExlQCF72M+mNuw=="],
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,6 +33,11 @@ npx @shumoku/cli render network.yaml -o network.svg
 ### Release Workflow Compatibility
 
 The npm workflows use Changesets CLI v3 with Action v2.1.2 and Node.js 24.
+After Changesets creates or updates its release PR, the Release workflow dispatches
+CI and Server container validation on `changeset-release/main`. This uses the
+built-in `GITHUB_TOKEN` with `actions: write`; no extra token or empty commit is
+needed. Dispatched validation never publishes packages or Server images. npm
+publication still requires merging the release PR into `main`.
 Use Node.js 24 locally for release commands as well; Bun continues to install
 workspace dependencies and run the package scripts. The Action, CLI, and workflow
 inputs are validated together in `scripts/release-workflow.test.ts`. Review that

--- a/scripts/release-workflow.test.ts
+++ b/scripts/release-workflow.test.ts
@@ -4,6 +4,9 @@ import { YAML } from 'bun'
 import manifest from '../package.json'
 
 interface ReleaseStep {
+  name?: string
+  if?: string
+  run?: string
   id?: string
   uses?: string
   with?: Record<string, unknown>
@@ -12,7 +15,10 @@ interface ReleaseStep {
 
 const workflow = YAML.parse(
   readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8'),
-) as { jobs: { release: { steps: ReleaseStep[] } } }
+) as {
+  on: Record<string, unknown>
+  jobs: { release: { permissions: Record<string, string>; steps: ReleaseStep[] } }
+}
 const changesets = workflow.jobs.release.steps.find((step) => step.id === 'changesets')
 
 describe('npm release workflow compatibility', () => {
@@ -36,6 +42,25 @@ describe('npm release workflow compatibility', () => {
     expect(changesets?.env?.GITHUB_TOKEN).toBeUndefined()
     // biome-ignore lint/suspicious/noTemplateCurlyInString: literal GitHub Actions expression
     expect(changesets?.env?.NODE_AUTH_TOKEN).toBe('${{ secrets.NPM_TOKEN }}')
+  })
+
+  test('dispatches validation only after creating or updating a release PR', () => {
+    expect(workflow.on).toEqual({ push: { branches: ['main'] } })
+    expect(workflow.jobs.release.permissions.actions).toBe('write')
+    const validation = workflow.jobs.release.steps.find(
+      (step) => step.name === 'Validate release pull request',
+    )
+    expect(validation?.if).toBe("steps.changesets.outputs.pr-number != ''")
+    expect(validation?.run?.trim().split('\n')).toEqual([
+      'gh workflow run ci.yml --ref changeset-release/main',
+      'gh workflow run server-release.yml --ref changeset-release/main',
+    ])
+    for (const filename of ['ci.yml', 'server-release.yml']) {
+      const validationWorkflow = YAML.parse(
+        readFileSync(new URL(`../.github/workflows/${filename}`, import.meta.url), 'utf8'),
+      ) as { on: Record<string, unknown> }
+      expect(validationWorkflow.on).toHaveProperty('workflow_dispatch')
+    }
   })
 
   test('keeps versioning separate from publishing', () => {

--- a/scripts/server-release-intent.test.ts
+++ b/scripts/server-release-intent.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from 'bun:test'
 import { resolveServerReleaseIntent } from './server-release-intent'
 
 describe('Server release intent', () => {
+  it('never publishes dispatched release-PR validation, even after a version change', () => {
+    for (const ref of ['refs/heads/changeset-release/main', 'refs/heads/main']) {
+      expect(resolveServerReleaseIntent('0.2.0', 'workflow_dispatch', ref, '0.1.0')).toMatchObject({
+        release: false,
+        tag: '',
+        platforms: '["linux/amd64"]',
+      })
+    }
+  })
   it('publishes a beta when its version change lands on main', () => {
     expect(
       resolveServerReleaseIntent('0.1.6-beta.2', 'push', 'refs/heads/main', '0.1.6-beta.1'),


### PR DESCRIPTION
Hono route handlers now construct the documented error envelope directly, retaining the legacy `error` alias, HTTP status, request ID header and extra diagnostics such as `errorPhase`. This resolves the response-inference failures that blocked @hono/zod-openapi updates and allows 1.6.3; remove its Dependabot hold.

Keep the existing observation wire schema unchanged. Give the application boundary an explicit permissive input type and preserve its legacy ingestion behavior, including optional versions and opaque upstream records. Model manual-source creation as its actual input union, and narrow discovery-policy projections to the fields they return. Generated OpenAPI and client files remain byte-for-byte unchanged.

After Changesets creates or updates a release PR, dispatch CI and Server container validation on `changeset-release/main` using the built-in token. Add only the actions permission needed for dispatch. npm publishing remains restricted to main pushes; dispatched Server validation cannot publish. No empty commits or additional secrets are required for future release PR validation.

Track deferred dependency migrations with explicit restart criteria: #771 (TypeScript 7 tooling), #772 (saved YAML compatibility), #773 (public Node runtime support). Link the corresponding ignores to these issues.

Validation: full build (22 tasks), typecheck (42), tests (44), workflow/release-intent tests, Biome, frozen lockfile and OpenAPI regeneration/check. Added regressions for error schema/header consistency, retained diagnostics and permissive observation inputs. Vercel configuration is unchanged.
