### PR TITLE
fix(server): validate observations before updating canonical topology

### DIFF
--- a/apps/server/api/src/app/services.ts
+++ b/apps/server/api/src/app/services.ts
@@ -20,6 +20,7 @@ import type {
 } from '@shumoku/core'
 import type { AuthPrincipal } from '../auth/principal.js'
 import type { Alert, AlertQueryOptions } from '../plugins/types.js'
+import type { ObservationGraphInput } from '../services/observation-graph.js'
 import type { BuildInfo, SystemInfo } from '../services/system-info.js'
 import type {
   CompositionMode,
@@ -101,7 +102,7 @@ export interface TopologyObservationView {
   capturedAt: number
   status: 'ok' | 'partial' | 'failed' | 'empty'
   statusMessage?: string
-  graph: NetworkGraph | null
+  graph: ObservationGraphInput | null
   nodeCount: number
   linkCount: number
   portCount: number
@@ -199,17 +200,6 @@ export interface DisplaySettingsView {
   edgeStyle: EdgeStyle
   splineMode: SplineMode
   hideDisconnected: boolean
-}
-
-// The observation API predates the core graph model and deliberately accepts
-// opaque node/link records, optional versions and upstream-specific fields.
-export interface ObservationGraphInput {
-  version?: string
-  name?: string
-  nodes: object[]
-  links: object[]
-  subgraphs?: object[]
-  settings?: object
 }
 
 export interface TopologyObservationApplicationService {

--- a/apps/server/api/src/app/topology-observations.ts
+++ b/apps/server/api/src/app/topology-observations.ts
@@ -37,10 +37,7 @@ export function createTopologyObservationApplicationService(
         sourceId,
         capturedAt: Date.now(),
         status,
-        // Preserve the established permissive wire contract at the legacy
-        // ingestion boundary. Requiring core fields here would reject existing
-        // observations (including graphs without a version); do not strip them.
-        graph: graph as NetworkGraph,
+        graph,
       })
       if (observation.contributionChanged) {
         topologies.clearCacheEntry(topologyId)

--- a/apps/server/api/src/app/topology-sources.ts
+++ b/apps/server/api/src/app/topology-sources.ts
@@ -184,7 +184,7 @@ export function createTopologySourceApplicationService(dependencies: {
       observations.updateHysteresis(
         topologyId,
         sourceId,
-        status === 'failed' ? 'failed' : 'ok',
+        observation.status === 'failed' ? 'failed' : 'ok',
         capturedAt,
       )
       if (observation.contributionChanged) {
@@ -196,7 +196,13 @@ export function createTopologySourceApplicationService(dependencies: {
         ok: true,
         value: {
           observation,
-          snapshot: { status, statusMessage, capturedAt, warnings, graph },
+          snapshot: {
+            status: observation.status,
+            statusMessage: observation.statusMessage,
+            capturedAt,
+            warnings,
+            graph: observation.status === 'failed' ? null : graph,
+          },
         },
       }
     },

--- a/apps/server/api/src/services/deep-read-service.ts
+++ b/apps/server/api/src/services/deep-read-service.ts
@@ -86,10 +86,11 @@ export async function runDeepRead(
   // A deep-read reads a subset; merge it into the source's prior snapshot so
   // reading three switches doesn't wipe the other twenty already known. Reuse
   // the same node-replace merge the probe path uses.
-  const prev = observations
-    .latestPerSource(topologyId)
-    .find((o) => o.sourceId === DEEP_READ_SOURCE_ID)
-  const merged = mergeReadIntoSnapshot(prev?.graph ?? null, result.graph, targets)
+  const merged = mergeReadIntoSnapshot(
+    observations.getContributionGraph(topologyId, DEEP_READ_SOURCE_ID),
+    result.graph,
+    targets,
+  )
 
   return observations.record({
     topologyId,

--- a/apps/server/api/src/services/observation-graph.test.ts
+++ b/apps/server/api/src/services/observation-graph.test.ts
@@ -1,0 +1,63 @@
+import { sampleNetwork, YamlParser } from '@shumoku/core'
+import { describe, expect, it } from 'vitest'
+import { normalizeObservationGraph } from './observation-graph.js'
+
+describe('observation graph boundary', () => {
+  it.each(sampleNetwork)('accepts the parsed core fixture $name', (file) => {
+    const graph = new YamlParser().parse(file.content).graph
+    const result = normalizeObservationGraph(graph)
+    if (!result.success) throw result.error
+    expect(result.data.nodes).toHaveLength(graph.nodes.length)
+    expect(result.data.links).toHaveLength(graph.links.length)
+  })
+  it('fills legacy defaults without mutating raw data or dropping extension fields', () => {
+    const raw = {
+      upstream: { revision: 7 },
+      nodes: [{ id: 'a', vendorField: true, ports: [{ id: 'eth0', vendorPort: 4 }] }, { id: 'b' }],
+      links: [{ from: { node: 'a' }, to: { node: 'b' }, vendorLink: 'x' }],
+    }
+    const before = structuredClone(raw)
+    const result = normalizeObservationGraph(raw)
+    expect(result.success).toBe(true)
+    if (!result.success) throw result.error
+    expect(result.data.version).toBe('1')
+    expect(result.data.nodes[0]).toMatchObject({
+      id: 'a',
+      label: 'a',
+      vendorField: true,
+      ports: [{ id: 'eth0', label: 'eth0', connectors: [], vendorPort: 4 }],
+    })
+    expect(result.data.links[0]).toMatchObject({ from: { node: 'a', port: '' }, vendorLink: 'x' })
+    expect(result.data.upstream).toEqual({ revision: 7 })
+    expect(raw).toEqual(before)
+  })
+
+  it.each([
+    { nodes: [{}], links: [] },
+    { nodes: [{ id: 'a', ports: {} }], links: [] },
+    { nodes: [{ id: 'a', ports: [null] }], links: [] },
+    { nodes: [{ id: 'a', identity: { vendorIds: { netbox: {} } } }], links: [] },
+    { nodes: [{ id: 'a', attachments: [null] }], links: [] },
+    { nodes: [{ id: 'a', suppressedAttachments: [4] }], links: [] },
+    { nodes: [{ id: 'a', spec: { kind: 'hardware', type: [] } }], links: [] },
+    { nodes: [{ id: 'a', ports: [{ id: 'p', connectors: 4 }] }], links: [] },
+    { nodes: [], links: [{}] },
+    { nodes: [], links: [{ from: null, to: { node: 'a' } }] },
+    { nodes: [], links: [], settings: { canvas: { width: 'bad' } } },
+    { nodes: [{ id: 'a' }, { id: 'a' }], links: [] },
+    { nodes: [{ id: 'a', parent: 'missing' }], links: [] },
+    {
+      nodes: [],
+      links: [],
+      subgraphs: [
+        { id: 'a', parent: 'b' },
+        { id: 'b', parent: 'a' },
+      ],
+    },
+    { nodes: [{ id: 'a', ports: [{ id: 'p' }, { id: 'p' }] }], links: [] },
+    { nodes: [{ id: '__exclusion_0' }], links: [] },
+    { nodes: [], links: [{ from: { node: 'a' }, to: { node: 'b' }, via: ['missing'] }] },
+  ])('rejects unsafe canonical data: %j', (graph) => {
+    expect(normalizeObservationGraph(graph).success).toBe(false)
+  })
+})

--- a/apps/server/api/src/services/observation-graph.ts
+++ b/apps/server/api/src/services/observation-graph.ts
@@ -1,0 +1,660 @@
+// Copyright (C) 2026-present Akitoshi Saeki
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import {
+  type AccessAttachment,
+  type ArrowType,
+  type Attachment,
+  type AttachmentMeta,
+  asEntityId,
+  type Bounds,
+  type CableGrade,
+  type CableMedium,
+  type CanvasSettings,
+  type ComputeSpec,
+  DeviceType,
+  type Direction,
+  type DiscoveryMode,
+  type EdgeStyle,
+  type EntityId,
+  type EthernetStandard,
+  type GraphSettings,
+  type HardwareSpec,
+  type Identity,
+  type LegendSettings,
+  type Link,
+  type LinkCable,
+  type LinkEndpoint,
+  type LinkModule,
+  type LinkPlug,
+  type LinkStyle,
+  type LinkType,
+  type MembershipCriterion,
+  type MetricsBindingAttachment,
+  type NetworkGraph,
+  type Node,
+  type NodeExclusion,
+  type NodePort,
+  type NodeShape,
+  type NodeSpec,
+  type NodeStyle,
+  type PaperOrientation,
+  type PaperSize,
+  type Pin,
+  type PolicyAttachment,
+  type PortConnector,
+  type PortRole,
+  type Position,
+  type Provenance,
+  type RegionIdentity,
+  type ServiceSpec,
+  type Size,
+  type SplineMode,
+  type Subgraph,
+  type SubgraphStyle,
+  type Termination,
+  type ThemeType,
+} from '@shumoku/core'
+import { z } from 'zod'
+
+// Require every model key, including optional keys, so a core model addition
+// cannot silently bypass validation. `satisfies ZodType<T>` also checks outputs.
+function modelObject<T>() {
+  return <S extends z.ZodRawShape & Record<keyof T, z.ZodType>>(shape: S) => z.looseObject(shape)
+}
+
+/** Runtime graph contract for observations, not the narrower YAML authoring format.
+ * Loose objects retain upstream extensions. Only absent legacy defaults are filled;
+ * malformed known fields fail the entire snapshot, never silently delete nodes. */
+const nodeShapeSchema = z.enum([
+  'rect',
+  'rounded',
+  'circle',
+  'diamond',
+  'hexagon',
+  'cylinder',
+  'stadium',
+  'trapezoid',
+]) satisfies z.ZodType<NodeShape>
+
+const nodeStyleSchema = modelObject<NodeStyle>()({
+  fill: z.string().optional(),
+  stroke: z.string().optional(),
+  strokeWidth: z.number().optional(),
+  strokeDasharray: z.string().optional(),
+  textColor: z.string().optional(),
+  fontSize: z.number().optional(),
+  fontWeight: z.enum(['normal', 'bold']).optional(),
+  opacity: z.number().optional(),
+}) satisfies z.ZodType<NodeStyle>
+
+const deviceTypeSchema = z.enum(DeviceType) satisfies z.ZodType<DeviceType>
+
+const hardwareSpecSchema = modelObject<HardwareSpec>()({
+  icon: z.string().optional(),
+  vendor: z.string().optional(),
+  kind: z.literal('hardware'),
+  type: deviceTypeSchema.optional(),
+  model: z.string().optional(),
+}) satisfies z.ZodType<HardwareSpec>
+
+const computeSpecSchema = modelObject<ComputeSpec>()({
+  icon: z.string().optional(),
+  vendor: z.string().optional(),
+  kind: z.literal('compute'),
+  type: deviceTypeSchema.optional(),
+  platform: z.string().optional(),
+}) satisfies z.ZodType<ComputeSpec>
+
+const serviceSpecSchema = modelObject<ServiceSpec>()({
+  icon: z.string().optional(),
+  vendor: z.string().optional(),
+  kind: z.literal('service'),
+  service: z.string(),
+  resource: z.string().optional(),
+}) satisfies z.ZodType<ServiceSpec>
+
+const nodeSpecSchema = z.union([
+  hardwareSpecSchema,
+  computeSpecSchema,
+  serviceSpecSchema,
+]) satisfies z.ZodType<NodeSpec>
+
+const portRoleSchema = z.enum([
+  'downlink',
+  'uplink',
+  'wan',
+  'lan',
+  'management',
+  'power',
+  'console',
+]) satisfies z.ZodType<PortRole>
+
+const portConnectorSchema = z.union([
+  z.literal('rj45'),
+  z.literal('sfp'),
+  z.literal('sfp+'),
+  z.literal('sfp28'),
+  z.literal('qsfp+'),
+  z.literal('qsfp28'),
+  z.string(),
+]) satisfies z.ZodType<PortConnector>
+
+const provenanceSchema = modelObject<Provenance>()({
+  source: z.string(),
+  state: z.enum(['confirmed', 'intrinsic-only', 'discovered-only', 'conflicting']).optional(),
+  observedAt: z.number().optional(),
+}) satisfies z.ZodType<Provenance>
+
+const identitySchema = modelObject<Identity>()({
+  mgmtIp: z.string().optional(),
+  chassisId: z.string().optional(),
+  sysName: z.string().optional(),
+  ifIndex: z.number().optional(),
+  ifName: z.string().optional(),
+  mac: z.string().optional(),
+  vendorIds: z.record(z.string(), z.string()).optional(),
+}) satisfies z.ZodType<Identity>
+
+const attachmentMetaSchema = modelObject<AttachmentMeta>()({
+  provenance: provenanceSchema.optional(),
+}) satisfies z.ZodType<AttachmentMeta>
+
+const accessAttachmentSchema = z.intersection(
+  z.union([
+    z.looseObject({
+      kind: z.literal('access'),
+      protocol: z.literal('snmp'),
+      community: z.string().optional(),
+      version: z.enum(['2c', '3']).optional(),
+    }),
+    z.looseObject({
+      kind: z.literal('access'),
+      protocol: z.literal('ssh'),
+      username: z.string().optional(),
+      port: z.number().optional(),
+    }),
+    z.looseObject({
+      kind: z.literal('access'),
+      protocol: z.enum(['netconf', 'http']),
+    }),
+  ]),
+  attachmentMetaSchema,
+) satisfies z.ZodType<AccessAttachment>
+
+const discoveryModeSchema = z.enum([
+  'auto',
+  'observe',
+  'disabled',
+]) satisfies z.ZodType<DiscoveryMode>
+
+const policyAttachmentSchema = modelObject<PolicyAttachment>()({
+  provenance: provenanceSchema.optional(),
+  kind: z.literal('policy'),
+  mode: discoveryModeSchema.optional(),
+  intervalMs: z.number().optional(),
+}) satisfies z.ZodType<PolicyAttachment>
+
+const metricsBindingAttachmentSchema = modelObject<MetricsBindingAttachment>()({
+  provenance: provenanceSchema.optional(),
+  kind: z.literal('metrics-binding'),
+  sourceId: z.string(),
+  hostId: z.string().optional(),
+  hostName: z.string().optional(),
+  interfaceIdentity: identitySchema.optional(),
+  interfaceName: z.string().optional(),
+  bandwidth: z.number().optional(),
+}) satisfies z.ZodType<MetricsBindingAttachment>
+
+const attachmentSchema = z.union([
+  accessAttachmentSchema,
+  policyAttachmentSchema,
+  metricsBindingAttachmentSchema,
+]) satisfies z.ZodType<Attachment>
+
+const entityIdSchema = z.string().transform(asEntityId) satisfies z.ZodType<EntityId>
+
+const nodePortSchema = modelObject<NodePort>()({
+  id: z
+    .string()
+    .min(1)
+    .refine((id) => !id.includes('\u001f'), 'Reserved identifier separator'),
+  label: z.string().optional(),
+  faceplateLabel: z.string().optional(),
+  interfaceName: z.string().optional(),
+  aliases: z.array(z.string()).optional(),
+  role: z.union([portRoleSchema, z.string()]).optional(),
+  speed: z.string().optional(),
+  connectors: z.array(portConnectorSchema).default([]),
+  poe: z.boolean().optional(),
+  source: z.enum(['catalog', 'custom']).optional(),
+  disabled: z.boolean().optional(),
+  notes: z.string().optional(),
+  placement: z
+    .looseObject({
+      side: z.enum(['top', 'bottom', 'left', 'right']).optional(),
+      order: z.number().optional(),
+    })
+    .optional(),
+  provenance: provenanceSchema.optional(),
+  identity: identitySchema.optional(),
+  attachments: z.array(attachmentSchema).optional(),
+  suppressedAttachments: z.array(z.string()).optional(),
+  entityId: entityIdSchema.optional(),
+}).transform((value) => ({
+  ...value,
+  label: value.label ?? value.id,
+})) satisfies z.ZodType<NodePort>
+
+const positionSchema = modelObject<Position>()({
+  x: z.number(),
+  y: z.number(),
+}) satisfies z.ZodType<Position>
+
+const sizeSchema = modelObject<Size>()({
+  width: z.number(),
+  height: z.number(),
+}) satisfies z.ZodType<Size>
+
+const nodeSchema = modelObject<Node>()({
+  id: z
+    .string()
+    .min(1)
+    .refine((id) => !id.includes('\u001f'), 'Reserved identifier separator'),
+  label: z.union([z.string(), z.array(z.string())]).optional(),
+  shape: nodeShapeSchema.optional(),
+  parent: z.string().optional(),
+  presence: z.enum(['scoop', 'anchor']).optional(),
+  rank: z.union([z.number(), z.string()]).optional(),
+  style: nodeStyleSchema.optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  spec: nodeSpecSchema.optional(),
+  productId: z.string().optional(),
+  ports: z.array(nodePortSchema).optional(),
+  position: positionSchema.optional(),
+  size: sizeSchema.optional(),
+  termination: z
+    .looseObject({
+      role: z.enum(['outlet', 'eps', 'panel', 'bend']),
+    })
+    .optional(),
+  provenance: provenanceSchema.optional(),
+  identity: identitySchema.optional(),
+  attachments: z.array(attachmentSchema).optional(),
+  fieldSources: z.record(z.string(), z.string()).optional(),
+  suppressedAttachments: z.array(z.string()).optional(),
+  entityId: entityIdSchema.optional(),
+}).transform((value) => ({ ...value, label: value.label ?? value.id })) satisfies z.ZodType<Node>
+
+const ethernetStandardSchema = z.union([
+  z.literal('10BASE-T'),
+  z.literal('100BASE-TX'),
+  z.literal('1000BASE-T'),
+  z.literal('2.5GBASE-T'),
+  z.literal('5GBASE-T'),
+  z.literal('10GBASE-T'),
+  z.literal('1000BASE-SX'),
+  z.literal('10GBASE-SR'),
+  z.literal('25GBASE-SR'),
+  z.literal('40GBASE-SR4'),
+  z.literal('100GBASE-SR4'),
+  z.literal('1000BASE-LX'),
+  z.literal('10GBASE-LR'),
+  z.literal('25GBASE-LR'),
+  z.literal('40GBASE-LR4'),
+  z.literal('100GBASE-LR4'),
+  z.literal('10GBASE-CR'),
+  z.literal('25GBASE-CR'),
+  z.literal('40GBASE-CR4'),
+  z.literal('100GBASE-CR4'),
+  z.literal('10G-AOC'),
+  z.literal('25G-AOC'),
+  z.literal('40G-AOC'),
+  z.literal('100G-AOC'),
+  z.string(),
+]) satisfies z.ZodType<EthernetStandard>
+
+const linkModuleSchema = modelObject<LinkModule>()({
+  standard: ethernetStandardSchema,
+  sku: z.string().optional(),
+  productId: z.string().optional(),
+}) satisfies z.ZodType<LinkModule>
+
+const linkPlugSchema = modelObject<LinkPlug>()({
+  cage: portConnectorSchema.optional(),
+  module: linkModuleSchema.optional(),
+}) satisfies z.ZodType<LinkPlug>
+
+const linkEndpointSchema = modelObject<LinkEndpoint>()({
+  node: z.string(),
+  port: z.string().default(''),
+  plug: linkPlugSchema.optional(),
+  ip: z.string().optional(),
+  pin: z.string().optional(),
+}) satisfies z.ZodType<LinkEndpoint>
+
+const linkTypeSchema = z.enum([
+  'solid',
+  'dashed',
+  'thick',
+  'double',
+  'invisible',
+]) satisfies z.ZodType<LinkType>
+
+const arrowTypeSchema = z.enum(['none', 'forward', 'back', 'both']) satisfies z.ZodType<ArrowType>
+
+const cableMediumSchema = z.enum([
+  'twisted-pair',
+  'fiber-mm',
+  'fiber-sm',
+  'dac',
+  'aoc',
+]) satisfies z.ZodType<CableMedium>
+
+const cableGradeSchema = z.enum([
+  'cat5e',
+  'cat6',
+  'cat6a',
+  'cat7',
+  'cat8',
+  'om3',
+  'om4',
+  'om5',
+  'os1',
+  'os2',
+  'dac',
+  'aoc',
+]) satisfies z.ZodType<CableGrade>
+
+const linkCableSchema = modelObject<LinkCable>()({
+  medium: cableMediumSchema.optional(),
+  category: cableGradeSchema.optional(),
+  length_m: z.number().optional(),
+  productId: z.string().optional(),
+}) satisfies z.ZodType<LinkCable>
+
+const linkStyleSchema = modelObject<LinkStyle>()({
+  stroke: z.string().optional(),
+  strokeWidth: z.number().optional(),
+  strokeDasharray: z.string().optional(),
+  opacity: z.number().optional(),
+  minLength: z.number().optional(),
+}) satisfies z.ZodType<LinkStyle>
+
+const linkSchema = modelObject<Link>()({
+  id: z.string().optional(),
+  from: linkEndpointSchema,
+  to: linkEndpointSchema,
+  via: z.array(z.string()).optional(),
+  bends: z
+    .array(
+      z.looseObject({
+        id: z.string(),
+        x: z.number(),
+        y: z.number(),
+        afterIndex: z.number(),
+      }),
+    )
+    .optional(),
+  label: z.union([z.string(), z.array(z.string())]).optional(),
+  type: linkTypeSchema.optional(),
+  arrow: arrowTypeSchema.optional(),
+  cable: linkCableSchema.optional(),
+  rateBps: z.number().optional(),
+  redundancy: z.enum(['ha', 'vc', 'vss', 'vpc', 'mlag', 'stack']).optional(),
+  vlan: z.array(z.number()).optional(),
+  style: linkStyleSchema.optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  presence: z.enum(['scoop', 'anchor']).optional(),
+  provenance: provenanceSchema.optional(),
+  entityId: entityIdSchema.optional(),
+}) satisfies z.ZodType<Link>
+
+const regionIdentitySchema = modelObject<RegionIdentity>()({
+  name: z.string().optional(),
+  keys: z.record(z.string(), z.string()).optional(),
+}) satisfies z.ZodType<RegionIdentity>
+
+const membershipCriterionSchema = modelObject<MembershipCriterion>()({
+  attr: z.enum(['name', 'subnet', 'metadata']),
+  value: z.string(),
+  key: z.string().optional(),
+}) satisfies z.ZodType<MembershipCriterion>
+
+const directionSchema = z.enum(['TB', 'BT', 'LR', 'RL']) satisfies z.ZodType<Direction>
+
+const subgraphStyleSchema = modelObject<SubgraphStyle>()({
+  fill: z.string().optional(),
+  stroke: z.string().optional(),
+  strokeWidth: z.number().optional(),
+  strokeDasharray: z.string().optional(),
+  labelPosition: z.enum(['top', 'bottom', 'left', 'right']).optional(),
+  labelFontSize: z.number().optional(),
+  padding: z.number().optional(),
+  nodeSpacing: z.number().optional(),
+  rankSpacing: z.number().optional(),
+}) satisfies z.ZodType<SubgraphStyle>
+
+const pinSchema = modelObject<Pin>()({
+  id: z.string(),
+  label: z.string().optional(),
+  device: z.string().optional(),
+  port: z.string().optional(),
+  direction: z.enum(['in', 'out', 'bidirectional']).optional(),
+  position: z.enum(['top', 'bottom', 'left', 'right']).optional(),
+}) satisfies z.ZodType<Pin>
+
+const boundsSchema = modelObject<Bounds>()({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+}) satisfies z.ZodType<Bounds>
+
+const subgraphSchema = modelObject<Subgraph>()({
+  id: z
+    .string()
+    .min(1)
+    .refine((id) => !id.includes('\u001f'), 'Reserved identifier separator'),
+  label: z.string().optional(),
+  identity: regionIdentitySchema.optional(),
+  membership: z.array(membershipCriterionSchema).optional(),
+  scope: z.literal('closed').optional(),
+  children: z.array(z.string()).optional(),
+  parent: z.string().optional(),
+  direction: directionSchema.optional(),
+  style: subgraphStyleSchema.optional(),
+  spec: nodeSpecSchema.optional(),
+  file: z.string().optional(),
+  pins: z.array(pinSchema).optional(),
+  bounds: boundsSchema.optional(),
+  provenance: provenanceSchema.optional(),
+  attachments: z.array(attachmentSchema).optional(),
+}).transform((value) => ({
+  ...value,
+  label: value.label ?? value.id,
+})) satisfies z.ZodType<Subgraph>
+
+const terminationSchema = modelObject<Termination>()({
+  id: z
+    .string()
+    .min(1)
+    .refine((id) => !id.includes('\u001f'), 'Reserved identifier separator'),
+  label: z.string(),
+  role: z.enum(['eps', 'outlet', 'panel']),
+  position: z
+    .looseObject({
+      x: z.number(),
+      y: z.number(),
+    })
+    .optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+}) satisfies z.ZodType<Termination>
+
+const themeTypeSchema = z.enum(['light', 'dark']) satisfies z.ZodType<ThemeType>
+
+const edgeStyleSchema = z.enum([
+  'polyline',
+  'orthogonal',
+  'splines',
+  'straight',
+]) satisfies z.ZodType<EdgeStyle>
+
+const splineModeSchema = z.enum([
+  'sloppy',
+  'conservative',
+  'conservative_soft',
+]) satisfies z.ZodType<SplineMode>
+
+const paperSizeSchema = z.enum([
+  'A0',
+  'A1',
+  'A2',
+  'A3',
+  'A4',
+  'B0',
+  'B1',
+  'B2',
+  'B3',
+  'B4',
+  'letter',
+  'legal',
+  'tabloid',
+]) satisfies z.ZodType<PaperSize>
+
+const paperOrientationSchema = z.enum([
+  'portrait',
+  'landscape',
+]) satisfies z.ZodType<PaperOrientation>
+
+const canvasSettingsSchema = modelObject<CanvasSettings>()({
+  preset: paperSizeSchema.optional(),
+  orientation: paperOrientationSchema.optional(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  dpi: z.number().optional(),
+  fit: z.boolean().optional(),
+  padding: z.number().optional(),
+}) satisfies z.ZodType<CanvasSettings>
+
+const legendSettingsSchema = modelObject<LegendSettings>()({
+  enabled: z.boolean().optional(),
+  position: z.enum(['top-left', 'top-right', 'bottom-left', 'bottom-right']).optional(),
+  showDeviceTypes: z.boolean().optional(),
+  showBandwidth: z.boolean().optional(),
+  showCableTypes: z.boolean().optional(),
+  showVlans: z.boolean().optional(),
+}) satisfies z.ZodType<LegendSettings>
+
+const graphSettingsSchema = modelObject<GraphSettings>()({
+  direction: directionSchema.optional(),
+  theme: themeTypeSchema.optional(),
+  edgeStyle: edgeStyleSchema.optional(),
+  splineMode: splineModeSchema.optional(),
+  nodeSpacing: z.number().optional(),
+  rankSpacing: z.number().optional(),
+  subgraphPadding: z.number().optional(),
+  canvas: canvasSettingsSchema.optional(),
+  legend: z.union([z.boolean(), legendSettingsSchema]).optional(),
+  hideDisconnected: z.boolean().optional(),
+}) satisfies z.ZodType<GraphSettings>
+
+const nodeExclusionSchema = modelObject<NodeExclusion>()({
+  mgmtIp: z.string().optional(),
+  chassisId: z.string().optional(),
+  sysName: z.string().optional(),
+}) satisfies z.ZodType<NodeExclusion>
+
+const networkGraphSchema = modelObject<NetworkGraph>()({
+  version: z.string().default('1'),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  nodes: z.array(nodeSchema),
+  links: z.array(linkSchema),
+  subgraphs: z.array(subgraphSchema).optional(),
+  terminations: z.array(terminationSchema).optional(),
+  settings: graphSettingsSchema.optional(),
+  pins: z.array(pinSchema).optional(),
+  attachments: z.array(attachmentSchema).optional(),
+  exclusions: z.array(nodeExclusionSchema).optional(),
+}) satisfies z.ZodType<NetworkGraph>
+
+/** Wire/audit data deliberately permits opaque upstream records. */
+export const observationGraphInputSchema = z.looseObject({
+  version: z.string().optional(),
+  name: z.string().optional(),
+  nodes: z.array(z.record(z.string(), z.unknown())),
+  links: z.array(z.record(z.string(), z.unknown())),
+  subgraphs: z.array(z.record(z.string(), z.unknown())).optional(),
+  settings: z.record(z.string(), z.unknown()).optional(),
+})
+
+export type ObservationGraphInput = z.infer<typeof observationGraphInputSchema>
+
+const contributionGraphSchema = networkGraphSchema.superRefine((graph, ctx) => {
+  const ids = new Set<string>()
+  for (const [kind, elements] of [
+    ['nodes', graph.nodes],
+    ['subgraphs', graph.subgraphs ?? []],
+    ['terminations', graph.terminations ?? []],
+  ] as const) {
+    for (const [index, element] of elements.entries()) {
+      if (ids.has(element.id) || element.id.startsWith('__exclusion_')) {
+        ctx.addIssue({
+          code: 'custom',
+          path: [kind, index, 'id'],
+          message: 'Duplicate or reserved element ID',
+        })
+      }
+      ids.add(element.id)
+    }
+  }
+  const parents = new Map((graph.subgraphs ?? []).map((group) => [group.id, group.parent]))
+  for (const [kind, elements] of [
+    ['nodes', graph.nodes],
+    ['subgraphs', graph.subgraphs ?? []],
+  ] as const) {
+    for (const [index, element] of elements.entries()) {
+      const visited = new Set<string>([element.id])
+      let parent = element.parent
+      while (parent !== undefined) {
+        if (!parents.has(parent) || visited.has(parent)) {
+          ctx.addIssue({
+            code: 'custom',
+            path: [kind, index, 'parent'],
+            message: 'Missing or cyclic parent',
+          })
+          break
+        }
+        visited.add(parent)
+        parent = parents.get(parent)
+      }
+    }
+  }
+  for (const [index, node] of graph.nodes.entries()) {
+    const ports = new Set<string>()
+    for (const [portIndex, port] of (node.ports ?? []).entries()) {
+      if (ports.has(port.id))
+        ctx.addIssue({
+          code: 'custom',
+          path: ['nodes', index, 'ports', portIndex, 'id'],
+          message: 'Duplicate port ID',
+        })
+      ports.add(port.id)
+    }
+  }
+  for (const [index, link] of graph.links.entries()) {
+    for (const [viaIndex, id] of (link.via ?? []).entries()) {
+      if (!ids.has(id))
+        ctx.addIssue({
+          code: 'custom',
+          path: ['links', index, 'via', viaIndex],
+          message: 'Missing termination',
+        })
+    }
+  }
+})
+
+export function normalizeObservationGraph(input: unknown) {
+  return contributionGraphSchema.safeParse(input)
+}

--- a/apps/server/api/src/services/observations.ts
+++ b/apps/server/api/src/services/observations.ts
@@ -24,8 +24,13 @@ import type { Database } from 'bun:sqlite'
 import { createHash } from 'node:crypto'
 import type { NetworkGraph } from '@shumoku/core'
 import { generateId, getDatabase, timestamp } from '../db/index.js'
-import { ingestGraph } from './contribution-store.js'
+import { buildGraph, ingestGraph } from './contribution-store.js'
 import { adoptOrMintForGraph, retireStaleEntities } from './entity-registry.js'
+import {
+  normalizeObservationGraph,
+  type ObservationGraphInput,
+  observationGraphInputSchema,
+} from './observation-graph.js'
 
 /**
  * Hash of a contribution's STRUCTURAL content: volatile per-scan fields
@@ -61,8 +66,8 @@ export interface TopologyObservation {
   capturedAt: number
   status: ObservationStatus
   statusMessage?: string
-  /** Parsed NetworkGraph — null when status === 'failed'. */
-  graph: NetworkGraph | null
+  /** Original wire graph for audit/history; never assume it is safe to render. */
+  graph: ObservationGraphInput | null
   nodeCount: number
   linkCount: number
   portCount: number
@@ -84,7 +89,7 @@ export interface RecordObservationInput {
   capturedAt: number
   status: ObservationStatus
   statusMessage?: string
-  graph: NetworkGraph | null
+  graph: ObservationGraphInput | NetworkGraph | null
 }
 
 interface ObservationRow {
@@ -109,7 +114,9 @@ function rowToObservation(row: ObservationRow): TopologyObservation {
     capturedAt: row.captured_at,
     status: row.status as ObservationStatus,
     statusMessage: row.status_message ?? undefined,
-    graph: row.graph_json ? (JSON.parse(row.graph_json) as NetworkGraph) : null,
+    graph: row.graph_json
+      ? (observationGraphInputSchema.safeParse(JSON.parse(row.graph_json)).data ?? null)
+      : null,
     nodeCount: row.node_count,
     linkCount: row.link_count,
     portCount: row.port_count,
@@ -121,7 +128,7 @@ function rowToObservation(row: ObservationRow): TopologyObservation {
  * Cheap counters that scan the parsed graph once. Stored on each row
  * so list endpoints don 't have to parse JSON.
  */
-function countGraph(graph: NetworkGraph | null): {
+function countGraph(graph: ObservationGraphInput | NetworkGraph | null): {
   nodeCount: number
   linkCount: number
   portCount: number
@@ -131,7 +138,7 @@ function countGraph(graph: NetworkGraph | null): {
   const linkCount = graph.links?.length ?? 0
   let portCount = 0
   for (const node of graph.nodes ?? []) {
-    portCount += node.ports?.length ?? 0
+    if ('ports' in node && Array.isArray(node.ports)) portCount += node.ports.length
   }
   return { nodeCount, linkCount, portCount }
 }
@@ -148,11 +155,30 @@ export class ObservationsService {
    * Retention / GC is handled separately (see `pruneOldObservations`).
    */
   async record(input: RecordObservationInput): Promise<TopologyObservation> {
+    // Preserve the raw audit payload, but only validated graphs may replace
+    // canonical state. Invalid is failed (not empty/partial): no retraction.
+    const rawGraph = input.graph ? observationGraphInputSchema.parse(input.graph) : null
+    const normalized = rawGraph === null ? null : normalizeObservationGraph(rawGraph)
+    const status = normalized && !normalized.success ? 'failed' : input.status
+    const statusMessage =
+      normalized && !normalized.success
+        ? [
+            input.statusMessage,
+            'Invalid observation graph: ' +
+              normalized.error.issues
+                .slice(0, 5)
+                .map((issue) => issue.path.join('.'))
+                .join(', '),
+          ]
+            .filter(Boolean)
+            .join('; ')
+        : input.statusMessage
+    const canonicalGraph: NetworkGraph | null = normalized?.success ? normalized.data : null
     const id = await generateId()
     const now = timestamp()
-    const { nodeCount, linkCount, portCount } = countGraph(input.graph)
+    const { nodeCount, linkCount, portCount } = countGraph(rawGraph)
 
-    const graphJson = input.graph ? JSON.stringify(input.graph) : null
+    const graphJson = rawGraph ? JSON.stringify(rawGraph) : null
 
     // Canonical contribution + audit row in ONE transaction so they can never
     // diverge: either both land or neither does. The contribution is the diagram's
@@ -161,7 +187,11 @@ export class ObservationsService {
     // both writes together.)
     let contributionChanged = false
     const persist = this.db.transaction(() => {
-      contributionChanged = this.materializeContribution(input)
+      contributionChanged = this.materializeContribution({
+        ...input,
+        status,
+        graph: canonicalGraph,
+      })
       this.db
         .query(
           `INSERT INTO topology_observations (
@@ -174,8 +204,8 @@ export class ObservationsService {
           input.topologyId,
           input.sourceId,
           input.capturedAt,
-          input.status,
-          input.statusMessage ?? null,
+          status,
+          statusMessage ?? null,
           graphJson,
           nodeCount,
           linkCount,
@@ -199,9 +229,9 @@ export class ObservationsService {
       topologyId: input.topologyId,
       sourceId: input.sourceId,
       capturedAt: input.capturedAt,
-      status: input.status,
-      statusMessage: input.statusMessage,
-      graph: input.graph,
+      status,
+      statusMessage,
+      graph: rawGraph,
       nodeCount,
       linkCount,
       portCount,
@@ -229,7 +259,9 @@ export class ObservationsService {
    * to an empty graph so a successful empty scan still retracts the source's prior
    * nodes (successful absence is real evidence).
    */
-  private materializeContribution(input: RecordObservationInput): boolean {
+  private materializeContribution(
+    input: Omit<RecordObservationInput, 'graph'> & { graph: NetworkGraph | null },
+  ): boolean {
     if (input.status === 'failed') return false
     const attach = this.db
       .query(
@@ -306,6 +338,12 @@ export class ObservationsService {
       retireStaleEntities(input.topologyId, input.sourceId, syncNow, this.db)
     }
     return true
+  }
+
+  /** Last-good canonical state for merges; audit snapshots may be invalid or failed. */
+  getContributionGraph(topologyId: string, sourceId: string): NetworkGraph | null {
+    const result = normalizeObservationGraph(buildGraph(topologyId, sourceId, this.db))
+    return result.success ? result.data : null
   }
 
   /**

--- a/apps/server/api/src/services/sync-job.ts
+++ b/apps/server/api/src/services/sync-job.ts
@@ -190,13 +190,13 @@ async function runSyncJob(
         deps.observationsService.updateHysteresis(
           topologyId,
           source.dataSourceId,
-          status === 'failed' ? 'failed' : 'ok',
+          recorded.status === 'failed' ? 'failed' : 'ok',
           capturedAt,
         )
         deps.topologySourcesService.updateLastSynced(source.id)
 
-        step.status = status === 'failed' ? 'failed' : 'done'
-        step.message = statusMessage
+        step.status = recorded.status === 'failed' ? 'failed' : 'done'
+        step.message = recorded.statusMessage
         step.nodeCount = graph?.nodes?.length ?? 0
         step.linkCount = graph?.links?.length ?? 0
       } catch (err) {

--- a/apps/server/api/src/services/sync-scheduler.ts
+++ b/apps/server/api/src/services/sync-scheduler.ts
@@ -129,7 +129,7 @@ export async function syncSource(
   deps.observationsService.updateHysteresis(
     topologyId,
     sourceId,
-    status === 'failed' ? 'failed' : 'ok',
+    recorded.status === 'failed' ? 'failed' : 'ok',
     capturedAt,
   )
   // No-change gate: a scheduled re-scan of an unchanged network must NOT bump
@@ -145,8 +145,8 @@ export async function syncSource(
   deps.topologySourcesService.updateLastSynced(attached.id)
 
   return {
-    status,
-    statusMessage,
+    status: recorded.status,
+    statusMessage: recorded.statusMessage,
     nodeCount: graph?.nodes?.length ?? 0,
     linkCount: graph?.links?.length ?? 0,
   }

--- a/apps/server/api/test/db/observation-boundary.test.ts
+++ b/apps/server/api/test/db/observation-boundary.test.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { buildGraph } from '../../src/services/contribution-store.ts'
+import { ObservationsService } from '../../src/services/observations.ts'
+import { TopologyService } from '../../src/services/topology.ts'
+import { attachSource, insertDataSource, setupTempDb, type TempDb } from './helper.ts'
+
+let temp: TempDb
+let observations: ObservationsService
+let topologies: TopologyService
+beforeAll(() => {
+  temp = setupTempDb()
+  observations = new ObservationsService()
+  topologies = new TopologyService()
+})
+afterAll(() => temp.teardown())
+
+describe('raw observation and canonical contribution', () => {
+  test('preserves raw history, retains last-good on invalid input, and still retracts on valid empty', async () => {
+    const topology = await topologies.create({ name: 'boundary' })
+    const source = insertDataSource('manual', 'boundary-source')
+    attachSource(topology.id, source, 'topology')
+    const raw = { nodes: [{ id: 'a', upstream: 'kept' }], links: [], extra: { revision: 7 } }
+    const base = { topologyId: topology.id, sourceId: source, status: 'ok' as const }
+    const good = await observations.record({ ...base, capturedAt: 1, graph: raw })
+    expect(good.status).toBe('ok')
+    expect(good.graph).toEqual(raw)
+    expect(observations.get(good.id)?.graph).toEqual(raw)
+    expect(buildGraph(topology.id, source)).toMatchObject({
+      version: '1',
+      nodes: [{ id: 'a', label: 'a', upstream: 'kept' }],
+      extra: { revision: 7 },
+    })
+    const before = buildGraph(topology.id, source)
+    const badRaw = { nodes: [{ id: 'a', ports: { secret: 'do-not-log' } }], links: [] }
+    const bad = await observations.record({ ...base, capturedAt: 2, graph: badRaw })
+    expect(bad.status).toBe('failed')
+    expect(bad.statusMessage).toContain('nodes.0.ports')
+    expect(bad.statusMessage).not.toContain('do-not-log')
+    expect(bad.contributionChanged).toBe(false)
+    expect(observations.get(bad.id)?.graph).toEqual(badRaw)
+    expect(observations.latestPerSource(topology.id)[0]?.status).toBe('failed')
+    expect(buildGraph(topology.id, source)).toEqual(before)
+    expect(observations.getContributionGraph(topology.id, source)?.nodes[0]?.id).toBe('a')
+    const empty = await observations.record({
+      ...base,
+      capturedAt: 3,
+      graph: { nodes: [], links: [] },
+      status: 'empty',
+    })
+    expect(empty.contributionChanged).toBe(true)
+    expect(buildGraph(topology.id, source)?.nodes).toEqual([])
+  })
+
+  test('opaque records are accepted as failed audit data even before a source is attached', async () => {
+    const topology = await topologies.create({ name: 'opaque' })
+    const source = insertDataSource('manual', 'opaque-source')
+    const graph = { nodes: [{ vendorOnly: true }], links: [{}] }
+    const result = await observations.record({
+      topologyId: topology.id,
+      sourceId: source,
+      capturedAt: 1,
+      status: 'ok',
+      graph,
+    })
+    expect(result.status).toBe('failed')
+    expect(result.graph).toEqual(graph)
+    expect(result.contributionChanged).toBe(false)
+    expect(result.portCount).toBe(0)
+    expect(observations.get(result.id)?.graph).toEqual(graph)
+  })
+})

--- a/apps/server/docs/design/db-native-persistence.md
+++ b/apps/server/docs/design/db-native-persistence.md
@@ -485,3 +485,21 @@ shared-Manual single-topology edit limitation (#362).
 - `topology-composition-store.md` — identity-keyed-store intent realized; observed-normalization YAGNI respected (per-source contributions, never merged entities).
 - `manual-source-unification.md` — #375 known-gap closed; residual "authored" wording to be purged.
 - `topology-ui-ia.md` — unaffected (UI reads the projected graph).
+
+
+### Observation input validation
+
+`ObservationsService.record()` keeps the received graph unchanged in the audit
+history. That payload is `ObservationGraphInput`, not a validated `NetworkGraph`.
+Before replacing a canonical contribution, `observation-graph.ts` validates all
+known core fields and structural identities/references. Upstream extension fields
+are retained. Missing legacy version, labels, port connectors and endpoint ports
+receive defaults only in the canonical graph; the audit payload is unchanged.
+
+An invalid graph is recorded with `status: failed` and field paths in
+`statusMessage` (never input values). It cannot replace the last-good contribution,
+retire entities, or trigger a layout bake. It must not be converted to an empty
+successful graph: successful empty snapshots still intentionally retract nodes.
+Sync status and hysteresis use the recorded outcome, including validation failure.
+Deep-read merges use the last-good canonical contribution, not the latest raw
+audit snapshot. No database migration or stricter HTTP request schema is required.


### PR DESCRIPTION
Observation requests previously passed opaque records into contribution storage as NetworkGraph, so malformed ports or endpoints could abort ingestion.

Keep the existing HTTP input schema and original audit payload, and validate a separate graph before replacing canonical state. Fill missing legacy defaults only in that canonical copy and retain upstream extension fields. Invalid snapshots are recorded as failed with diagnostic field paths, preserving the last-good contribution. Valid empty scans still retract nodes.

Propagate validation failures into sync status and hysteresis, and merge deep-read results against last-good canonical data. Runtime schemas check known core fields and require model keys at compile time. No database migration or public API definition change.

Validation: full monorepo build and typecheck; 184 API unit tests and 170 DB/integration tests; Biome and OpenAPI check. Tests cover shared fixtures, malformed nested data, raw-history preservation, last-good protection, and valid-empty retraction.
